### PR TITLE
ddwaf_result: add timeout flag and remove action field

### DIFF
--- a/examples/validate_schema.cpp
+++ b/examples/validate_schema.cpp
@@ -6,6 +6,7 @@
 
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/schema.h"
+#include "rapidjson/error/en.h"
 
 using namespace rapidjson;
 
@@ -46,9 +47,12 @@ int main(int argc, char* argv[])
 
     auto inputJson = read_file(argv[2]);
     Document d;
-    if (d.Parse(inputJson).HasParseError())
+    rapidjson::ParseResult result = d.Parse(inputJson);
+    if (!result)
     {
-        std::cout << "Failed to parse input json" << std::endl;
+        std::cout << "Failed to parse input json: " 
+                  << rapidjson::GetParseError_En(result.Code())
+                  << result.Offset() << std::endl;
         return EXIT_FAILURE;
     }
 

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -48,10 +48,9 @@ typedef enum
  **/
 typedef enum
 {
-    DDWAF_ERR_INTERNAL     = -4,
-    DDWAF_ERR_INVALID_OBJECT = -3,
-    DDWAF_ERR_INVALID_ARGUMENT = -2,
-    DDWAF_ERR_TIMEOUT      = -1,
+    DDWAF_ERR_INTERNAL     = -3,
+    DDWAF_ERR_INVALID_OBJECT = -2,
+    DDWAF_ERR_INVALID_ARGUMENT = -1,
     DDWAF_GOOD             = 0,
     DDWAF_MONITOR          = 1,
     DDWAF_BLOCK            = 2
@@ -122,14 +121,14 @@ struct _ddwaf_config
  **/
 struct _ddwaf_result
 {
-    /** Run result action **/
-    DDWAF_RET_CODE action;
+    /** Whether there has been a timeout during the operation **/
+    bool timeout;
+    /** Total run time in microseconds **/
+    uint32_t perfTotalRuntime;
     /** Run result in JSON format **/
     const char* data;
     /** Performance data in JSON format **/
     const char* perfData;
-    /** Total run time in microseconds **/
-    uint32_t perfTotalRuntime;
 };
 
 /**

--- a/src/PWAdditive.hpp
+++ b/src/PWAdditive.hpp
@@ -13,6 +13,7 @@
 #include <PowerWAF.hpp>
 #include <ddwaf.h>
 #include <utils.h>
+#include <optional>
 
 class PWAdditive
 {
@@ -31,7 +32,8 @@ public:
 
     PWAdditive(const PWAdditive&) = delete;
 
-    ddwaf_result run(ddwaf_object, uint64_t);
+    DDWAF_RET_CODE run(ddwaf_object, uint64_t);
+    DDWAF_RET_CODE run(ddwaf_object, std::optional<std::reference_wrapper<ddwaf_result>>, uint64_t);
 
     void flushCaches();
 

--- a/src/PWProcessor.cpp
+++ b/src/PWProcessor.cpp
@@ -75,7 +75,7 @@ void PWProcessor::runFlow(const std::string& name, const std::vector<std::string
     if (deadline <= now)
     {
         DDWAF_INFO("Ran out of time while running flow %s", name.c_str());
-        retManager.recordResult(DDWAF_ERR_TIMEOUT);
+        retManager.recordTimeout();
         return;
     }
 
@@ -146,7 +146,7 @@ void PWProcessor::runFlow(const std::string& name, const std::vector<std::string
             else if (matchingStatus == status::timeout)
             {
                 DDWAF_INFO("Ran out of time when processing %s", ruleID.c_str());
-                retManager.recordResult(DDWAF_ERR_TIMEOUT);
+                retManager.recordTimeout();
                 return;
             }
             else
@@ -193,7 +193,7 @@ void PWProcessor::runFlow(const std::string& name, const std::vector<std::string
         if (deadline <= now)
         {
             DDWAF_INFO("Ran out of time while running flow %s and rule %s", name.c_str(), ruleID.c_str());
-            retManager.recordResult(DDWAF_ERR_TIMEOUT);
+            retManager.recordTimeout();
             return;
         }
     }

--- a/src/PowerWAFInterface.cpp
+++ b/src/PowerWAFInterface.cpp
@@ -131,30 +131,18 @@ extern "C"
 
     DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object* data, ddwaf_result* result, uint64_t timeout)
     {
-        DDWAF_RET_CODE code = DDWAF_ERR_INTERNAL;
         try
         {
-            ddwaf_result res;
             if (context == nullptr || data == nullptr)
             {
                 DDWAF_WARN("Illegal WAF call: context or data was null");
-                res = returnErrorCode(DDWAF_ERR_INVALID_ARGUMENT);
-            }
-            else
-            {
-                PWAdditive* additive = reinterpret_cast<PWAdditive*>(context);
-                res                  = additive->run(*data, timeout);
+                return DDWAF_ERR_INVALID_ARGUMENT;
             }
 
-            code = res.action;
-            if (result != nullptr)
-            {
-                *result = res;
-            }
-            else
-            {
-                ddwaf_result_free(&res);
-            }
+            PWAdditive* additive = reinterpret_cast<PWAdditive*>(context);
+
+            return result ? additive->run(*data, *result, timeout) :
+                            additive->run(*data, timeout);
         }
         catch (const std::exception& e)
         {
@@ -166,7 +154,7 @@ extern "C"
             DDWAF_ERROR("unknown exception");
         }
 
-        return code;
+        return DDWAF_ERR_INTERNAL;
     }
 
     void ddwaf_context_destroy(ddwaf_context context)

--- a/src/PowerWAFInterface.cpp
+++ b/src/PowerWAFInterface.cpp
@@ -131,8 +131,6 @@ extern "C"
 
     DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object* data, ddwaf_result* result, uint64_t timeout)
     {
-        if (result != nullptr) { *result = {0}; }
-
         if (context == nullptr || data == nullptr)
         {
             DDWAF_WARN("Illegal WAF call: context or data was null");
@@ -141,7 +139,7 @@ extern "C"
         try
         {
             PWAdditive* additive = reinterpret_cast<PWAdditive*>(context);
-            return result ? additive->run(*data, *result, timeout) :
+            return result ? additive->run(*data, *result = {0}, timeout) :
                             additive->run(*data, timeout);
         }
         catch (const std::exception& e)

--- a/src/PowerWAFInterface.cpp
+++ b/src/PowerWAFInterface.cpp
@@ -131,16 +131,16 @@ extern "C"
 
     DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object* data, ddwaf_result* result, uint64_t timeout)
     {
+        if (result != nullptr) { *result = {0}; }
+
+        if (context == nullptr || data == nullptr)
+        {
+            DDWAF_WARN("Illegal WAF call: context or data was null");
+            return DDWAF_ERR_INVALID_ARGUMENT;
+        }
         try
         {
-            if (context == nullptr || data == nullptr)
-            {
-                DDWAF_WARN("Illegal WAF call: context or data was null");
-                return DDWAF_ERR_INVALID_ARGUMENT;
-            }
-
             PWAdditive* additive = reinterpret_cast<PWAdditive*>(context);
-
             return result ? additive->run(*data, *result, timeout) :
                             additive->run(*data, timeout);
         }

--- a/src/PowerWAFInterface.cpp
+++ b/src/PowerWAFInterface.cpp
@@ -131,6 +131,8 @@ extern "C"
 
     DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object* data, ddwaf_result* result, uint64_t timeout)
     {
+        if (result != nullptr) { *result = {0}; }
+
         if (context == nullptr || data == nullptr)
         {
             DDWAF_WARN("Illegal WAF call: context or data was null");
@@ -139,7 +141,7 @@ extern "C"
         try
         {
             PWAdditive* additive = reinterpret_cast<PWAdditive*>(context);
-            return result ? additive->run(*data, *result = {0}, timeout) :
+            return result ? additive->run(*data, *result, timeout) :
                             additive->run(*data, timeout);
         }
         catch (const std::exception& e)

--- a/tests/TestAdditive.cpp
+++ b/tests/TestAdditive.cpp
@@ -33,13 +33,13 @@ TEST(TestAdditive, TestMultiCall)
     // Run with just arg1
     auto code = ddwaf_run(context, &param1, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_GOOD);
-    EXPECT_EQ(ret.action, DDWAF_GOOD);
+    EXPECT_FALSE(ret.timeout);
     ddwaf_result_free(&ret);
 
     // Run with both arg1 and arg2
     code = ddwaf_run(context, &param2, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MONITOR);
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":".*","parameters":[{"address":"arg1","key_path":[],"value":"string 1","highlight":["string 1"]}]},{"operator":"match_regex","operator_value":".*","parameters":[{"address":"arg2","key_path":[],"value":"string 2","highlight":["string 2"]}]}]}])");
     ddwaf_result_free(&ret);
 
@@ -49,6 +49,7 @@ TEST(TestAdditive, TestMultiCall)
 
 TEST(TestAdditive, TestBad)
 {
+    ddwaf_result ret;
     EXPECT_EQ(ddwaf_context_init(nullptr, nullptr), nullptr);
 
     ddwaf_object object, tmp;
@@ -56,7 +57,8 @@ TEST(TestAdditive, TestBad)
 
     // Since the call was performed with a null context, the parameters will not
     // be freed.
-    EXPECT_EQ(ddwaf_run(nullptr, &object, nullptr, 0), DDWAF_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(ddwaf_run(nullptr, &object, &ret, 0), DDWAF_ERR_INVALID_ARGUMENT);
+    EXPECT_FALSE(ret.timeout);
     ddwaf_object_free(&object);
 
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2}], regex: .*}}]}]})");
@@ -71,13 +73,15 @@ TEST(TestAdditive, TestBad)
 
     // In case of an invalid object, the parameters will be freed on the spot
     ddwaf_object_string(&object, "stringvalue");
-    EXPECT_EQ(ddwaf_run(context, &object, nullptr, 0), DDWAF_ERR_INVALID_OBJECT);
+    EXPECT_EQ(ddwaf_run(context, &object, &ret, 0), DDWAF_ERR_INVALID_OBJECT);
+    EXPECT_FALSE(ret.timeout);
 
     // In case of timeout, the parameters will be owned by the context and freed
     // during destruction
     object = DDWAF_OBJECT_MAP;
     ddwaf_object_map_add(&object, "arg1", ddwaf_object_string(&tmp, "value"));
-    EXPECT_EQ(ddwaf_run(context, &object, nullptr, 0), DDWAF_ERR_TIMEOUT);
+    EXPECT_EQ(ddwaf_run(context, &object, &ret, 0), DDWAF_GOOD);
+    EXPECT_TRUE(ret.timeout);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 
@@ -108,20 +112,19 @@ TEST(TestAdditive, TestParameterOverride)
     ddwaf_result ret;
     auto code = ddwaf_run(context, &param1, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_GOOD);
-    EXPECT_EQ(ret.action, DDWAF_GOOD);
+    EXPECT_FALSE(ret.timeout);
     ddwaf_result_free(&ret);
 
     // Override `arg1`
     code = ddwaf_run(context, &param2, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MONITOR);
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"^string.*","parameters":[{"address":"arg1","key_path":[],"value":"string 1","highlight":["string 1"]}]},{"operator":"match_regex","operator_value":".*","parameters":[{"address":"arg2","key_path":[],"value":"string 2","highlight":["string 2"]}]}]}])");
     ddwaf_result_free(&ret);
 
     // Run again without change
     code = ddwaf_run(context, ddwaf_object_map(&tmp), &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_GOOD);
-    EXPECT_EQ(ret.action, DDWAF_GOOD);
+    EXPECT_FALSE(ret.timeout);
     ddwaf_result_free(&ret);
 
     ddwaf_context_destroy(context);

--- a/tests/TestAdditive.cpp
+++ b/tests/TestAdditive.cpp
@@ -57,7 +57,7 @@ TEST(TestAdditive, TestBad)
 
     // Since the call was performed with a null context, the parameters will not
     // be freed.
-    EXPECT_EQ(ddwaf_run(nullptr, &object, &ret, 0), DDWAF_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(ddwaf_run(nullptr, &object, &ret, LONG_TIME), DDWAF_ERR_INVALID_ARGUMENT);
     EXPECT_FALSE(ret.timeout);
     ddwaf_object_free(&object);
 
@@ -73,7 +73,7 @@ TEST(TestAdditive, TestBad)
 
     // In case of an invalid object, the parameters will be freed on the spot
     ddwaf_object_string(&object, "stringvalue");
-    EXPECT_EQ(ddwaf_run(context, &object, &ret, 0), DDWAF_ERR_INVALID_OBJECT);
+    EXPECT_EQ(ddwaf_run(context, &object, &ret, LONG_TIME), DDWAF_ERR_INVALID_OBJECT);
     EXPECT_FALSE(ret.timeout);
 
     // In case of timeout, the parameters will be owned by the context and freed

--- a/tests/TestParser.cpp
+++ b/tests/TestParser.cpp
@@ -25,7 +25,7 @@ void run_test(ddwaf_handle handle)
     // Run with just arg1
     auto code = ddwaf_run(context, &param, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MONITOR);
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":".*","parameters":[{"address":"arg1","key_path":[],"value":"string 1","highlight":["string 1"]}]},{"operator":"match_regex","operator_value":".*","parameters":[{"address":"arg2","key_path":["x"],"value":"string 2","highlight":["string 2"]}]},{"operator":"match_regex","operator_value":".*","parameters":[{"address":"arg2","key_path":["y"],"value":"string 3","highlight":["string 3"]}]}]}])");
     ddwaf_result_free(&ret);
 

--- a/tests/TestProcessor.cpp
+++ b/tests/TestProcessor.cpp
@@ -28,7 +28,7 @@ TEST(TestPWProcessor, TestOutput)
     ddwaf_result ret;
     EXPECT_EQ(ddwaf_run(context, &parameter, &ret, LONG_TIME), DDWAF_MONITOR);
 
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule2","parameters":[{"address":"value","key_path":[],"value":"rule2","highlight":["rule2"]}]},{"operator":"match_regex","operator_value":"rule3","parameters":[{"address":"value2","key_path":["key"],"value":"rule3","highlight":["rule3"]}]}]}])");
 
     ddwaf_result_free(&ret);
@@ -56,7 +56,7 @@ TEST(TestPWProcessor, TestKeyPaths)
     ddwaf_result ret;
     EXPECT_EQ(ddwaf_run(context, &root, &ret, LONG_TIME), DDWAF_MONITOR);
 
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param","key_path":["x"],"value":"Sqreen","highlight":["Sqreen"]}]}]}])");
 
     ddwaf_result_free(&ret);
@@ -68,7 +68,7 @@ TEST(TestPWProcessor, TestKeyPaths)
 
     EXPECT_EQ(ddwaf_run(context, &root, &ret, LONG_TIME), DDWAF_MONITOR);
 
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"2","name":"rule2","tags":{"type":"flow2","category":"category2"}},"rule_matches":[{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param","key_path":["z"],"value":"Sqreen","highlight":["Sqreen"]}]}]}])");
 
     ddwaf_result_free(&ret);
@@ -85,7 +85,7 @@ TEST(TestPWProcessor, TestKeyPaths)
 
     EXPECT_EQ(ddwaf_run(context, &root, &ret, LONG_TIME), DDWAF_MONITOR);
 
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param","key_path":["y"],"value":"Sqreen","highlight":["Sqreen"]}]}]}])");
 
     ddwaf_result_free(&ret);
@@ -114,7 +114,7 @@ TEST(TestPWProcessor, TestMissingParameter)
     ddwaf_result ret;
     EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_GOOD);
 
-    EXPECT_EQ(ret.action, DDWAF_GOOD);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_EQ(ret.data, nullptr);
 
     ddwaf_result_free(&ret);
@@ -148,7 +148,7 @@ TEST(TestPWProcessor, TestInvalidUTF8Input)
     ddwaf_result ret;
     EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_MONITOR);
 
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     auto pos = std::string { ret.data }.find(mapItem.stringValue);
     EXPECT_TRUE(pos != string::npos);
 
@@ -178,7 +178,7 @@ TEST(TestPWProcessor, TestCache)
         ddwaf_object_map_add(&param, "param", ddwaf_object_string(&tmp, "not valid"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_GOOD);
-        EXPECT_EQ(ret.action, DDWAF_GOOD);
+        EXPECT_FALSE(ret.timeout);
         ddwaf_result_free(&ret);
 
         EXPECT_GE(add->processor.ranCache.size(), 1);
@@ -191,7 +191,7 @@ TEST(TestPWProcessor, TestCache)
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_GOOD);
-        EXPECT_EQ(ret.action, DDWAF_GOOD);
+        EXPECT_FALSE(ret.timeout);
         ddwaf_result_free(&ret);
 
         EXPECT_FALSE(add->processor.ranCache.at("1").first);
@@ -203,7 +203,7 @@ TEST(TestPWProcessor, TestCache)
         ddwaf_object_map_add(&param, "param", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param","key_path":[],"value":"Sqreen","highlight":["Sqreen"]}]},{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param2","key_path":[],"value":"Sqreen","highlight":["Sqreen"]}]}]}])");
 
         EXPECT_TRUE(add->processor.ranCache.at("1").first);
@@ -236,7 +236,7 @@ TEST(TestPWProcessor, TestCacheReport)
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param1, &ret, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param1","key_path":[],"value":"Sqreen","highlight":["Sqreen"]}]}]}])");
 
         ddwaf_result_free(&ret);
@@ -247,7 +247,7 @@ TEST(TestPWProcessor, TestCacheReport)
         ddwaf_object_map_add(&param, "param", ddwaf_object_string(&tmp, "Pony"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_GOOD);
-        EXPECT_EQ(ret.action, DDWAF_GOOD);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_EQ(ret.data, nullptr);
 
         ddwaf_result_free(&ret);
@@ -258,7 +258,7 @@ TEST(TestPWProcessor, TestCacheReport)
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_STREQ(ret.data, R"([{"rule":{"id":"2","name":"rule2","tags":{"type":"flow1","category":"category2"}},"rule_matches":[{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param2","key_path":[],"value":"Sqreen","highlight":["Sqreen"]}]}]}])");
 
         ddwaf_result_free(&ret);
@@ -287,7 +287,7 @@ TEST(TestPWProcessor, TestMultiFlowCacheReport)
         ddwaf_object_map_add(&param, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param1","key_path":[],"value":"Sqreen","highlight":["Sqreen"]}]}]}])");
 
         ddwaf_result_free(&ret);
@@ -298,7 +298,7 @@ TEST(TestPWProcessor, TestMultiFlowCacheReport)
         ddwaf_object_map_add(&param, "param", ddwaf_object_string(&tmp, "Pony"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_GOOD);
-        EXPECT_EQ(ret.action, DDWAF_GOOD);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_EQ(ret.data, nullptr);
 
         ddwaf_result_free(&ret);
@@ -309,7 +309,7 @@ TEST(TestPWProcessor, TestMultiFlowCacheReport)
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_STREQ(ret.data, R"([{"rule":{"id":"2","name":"rule2","tags":{"type":"flow2","category":"category2"}},"rule_matches":[{"operator":"match_regex","operator_value":"Sqreen","parameters":[{"address":"param2","key_path":[],"value":"Sqreen","highlight":["Sqreen"]}]}]}])");
 
         ddwaf_result_free(&ret);
@@ -355,7 +355,8 @@ TEST(TestPWProcessor, TestBudget)
     processor.startNewRun(SQPowerWAF::monotonic_clock::now() + chrono::microseconds(50));
 
     processor.runFlow("flow1", flows["flow1"], rManager);
-    ddwaf_result ret = rManager.synthetize();
+    ddwaf_result ret;
+    rManager.synthetize(ret);
     EXPECT_EQ(ret.data, nullptr);
 
     mapItem.parameterName = NULL;
@@ -383,7 +384,7 @@ TEST(TestPWProcessor, TestBudgetRules)
     ddwaf_object_map_add(&param, "param", ddwaf_object_string(&tmp, "aaaabbbbbaaa"));
 
     EXPECT_EQ(ddwaf_run(context, &param, &ret, 50), DDWAF_GOOD);
-    EXPECT_EQ(ret.action, DDWAF_GOOD);
+    EXPECT_FALSE(ret.timeout);
 
     ddwaf_result_free(&ret);
     ddwaf_context_destroy(context);
@@ -413,7 +414,7 @@ TEST(TestPWProcessor, TestPerfReporting)
         ddwaf_object_map_add(&param, "pm_param", ddwaf_object_string(&tmp, "something"));
 
         EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_GOOD);
-        EXPECT_EQ(ret.action, DDWAF_GOOD);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_EQ(ret.data, nullptr);
         ASSERT_NE(ret.perfData, nullptr);
 
@@ -473,7 +474,7 @@ TEST(TestPWProcessor, TestPerfReportingIncomplete)
     ddwaf_object_map_add(&param, "bla", ddwaf_object_string(&tmp, "pouet bla"));
 
     EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_MONITOR);
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     ASSERT_NE(ret.perfData, nullptr);
 
     {
@@ -524,7 +525,7 @@ TEST(TestPWProcessor, TestDisablePerfReporting)
     ddwaf_object_map_add(&param, "bla", ddwaf_object_string(&tmp, "aaaabbbbbaaa"));
 
     EXPECT_EQ(ddwaf_run(context, &param, &ret, LONG_TIME), DDWAF_GOOD);
-    EXPECT_EQ(ret.action, DDWAF_GOOD);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_EQ(ret.perfData, nullptr);
 
     ddwaf_result_free(&ret);

--- a/tests/TestRegressions.cpp
+++ b/tests/TestRegressions.cpp
@@ -28,9 +28,7 @@ TEST(TestRegressions, TruncatedUTF8)
 
     ddwaf_result out;
     ASSERT_EQ(ddwaf_run(context, &map, &out, 2000), DDWAF_MONITOR);
-
-    //We should have matched something
-    ASSERT_EQ(out.action, DDWAF_MONITOR);
+    EXPECT_FALSE(out.timeout);
 
     //The emoji should be trimmed out of the result
     EXPECT_TRUE(memchr(out.data, emoji[0], strlen(out.data)) == NULL);
@@ -38,24 +36,4 @@ TEST(TestRegressions, TruncatedUTF8)
     ddwaf_result_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
-}
-
-TEST(TestRegression, DISABLED_segfault)
-{
-    /* const char * jsonFile = readFile("processor_libinj_xss.json");*/
-    //ASSERT_TRUE(jsonFile != nullptr);
-    //ASSERT_TRUE(pw_init("rule", jsonFile, NULL, NULL));
-    //free((void*) jsonFile);
-
-    //ddwaf_object map = DDWAF_OBJECT_MAP, string = pw_createString("style=e");
-    //pw_addMap(&map, "value", 0, string);
-
-    //ddwaf_result out = pw_run("rule", map, 2000);
-
-    ////We should have matched something
-    //EXPECT_EQ(out.action, DDWAF_MONITOR);
-
-    //ddwaf_object_free(&map);
-    //ddwaf_result_free(&out);
-    /*pw_clearRule("rule");*/
 }

--- a/tests/TestRetriever.cpp
+++ b/tests/TestRetriever.cpp
@@ -125,7 +125,7 @@ TEST(TestPWRetriever, TestAccessSimplePath)
         ASSERT_NE(context, nullptr);
 
         ASSERT_EQ(ddwaf_run(context, &paramHolder, &ret, LONG_TIME), DDWAF_MONITOR);
-        ASSERT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"target","parameters":[{"address":"blob1","key_path":["a"],"value":"real_target","highlight":["target"]}]}]}])");
         ddwaf_result_free(&ret);
         ddwaf_context_destroy(context);
@@ -138,7 +138,7 @@ TEST(TestPWRetriever, TestAccessSimplePath)
         ASSERT_NE(context, nullptr);
 
         ASSERT_EQ(ddwaf_run(context, &paramHolder, &ret, LONG_TIME), DDWAF_MONITOR);
-        ASSERT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"target","parameters":[{"address":"blob2","key_path":["-1"],"value":"target_bait2","highlight":["target"]}]}]}])");
         ddwaf_result_free(&ret);
         ddwaf_context_destroy(context);
@@ -151,7 +151,7 @@ TEST(TestPWRetriever, TestAccessSimplePath)
         ASSERT_NE(context, nullptr);
 
         ASSERT_EQ(ddwaf_run(context, &paramHolder, &ret, LONG_TIME), DDWAF_MONITOR);
-        ASSERT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_FALSE(ret.timeout);
         EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"target","parameters":[{"address":"blob3","key_path":["alpha"],"value":"targeto","highlight":["target"]}]}]}])");
         ddwaf_result_free(&ret);
         ddwaf_context_destroy(context);
@@ -267,7 +267,7 @@ TEST(PWRetriever, KeyWithComplexStructure)
 
     ddwaf_object_map_add(&parameter, "arg", &list);
 
-    EXPECT_EQ(ddwaf_run(context, &parameter, NULL, LONG_TIME), DDWAF_MONITOR);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MONITOR);
 
     ddwaf_object_free(&rule);
     ddwaf_context_destroy(context);

--- a/tests/TestSchema.cpp
+++ b/tests/TestSchema.cpp
@@ -75,11 +75,12 @@ public:
         return sb.GetString();
     }
 
-    void Validate(ddwaf_result ret)
+    void Validate(ddwaf_result ret, DDWAF_RET_CODE code)
     {
         Document d;
-        EXPECT_EQ(ret.action, DDWAF_MONITOR);
+        EXPECT_EQ(code, DDWAF_MONITOR);
         EXPECT_NE(ret.data, nullptr);
+        EXPECT_FALSE(ret.timeout);
         if (!HasFailure())
         {
             EXPECT_FALSE(d.Parse(ret.data).HasParseError());
@@ -105,8 +106,8 @@ TEST_F(TestSchemaFixture, SimpleResult)
     ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "rule1"));
 
     ddwaf_result ret;
-    ddwaf_run(context, &param, &ret, LONG_TIME);
-    Validate(ret);
+    auto code = ddwaf_run(context, &param, &ret, LONG_TIME);
+    Validate(ret, code);
     ddwaf_result_free(&ret);
 }
 
@@ -119,8 +120,8 @@ TEST_F(TestSchemaFixture, SimpleResultWithKeyPath)
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
     ddwaf_result ret;
-    ddwaf_run(context, &param, &ret, LONG_TIME);
-    Validate(ret);
+    auto code = ddwaf_run(context, &param, &ret, LONG_TIME);
+    Validate(ret, code);
     ddwaf_result_free(&ret);
 }
 
@@ -136,8 +137,8 @@ TEST_F(TestSchemaFixture, SimpleResultWithMultiKeyPath)
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
     ddwaf_result ret;
-    ddwaf_run(context, &param, &ret, LONG_TIME);
-    Validate(ret);
+    auto code = ddwaf_run(context, &param, &ret, LONG_TIME);
+    Validate(ret, code);
     ddwaf_result_free(&ret);
 }
 
@@ -153,8 +154,8 @@ TEST_F(TestSchemaFixture, ResultWithMultiCondition)
     ddwaf_object_map_add(&param, "arg4", &arg4);
 
     ddwaf_result ret;
-    ddwaf_run(context, &param, &ret, LONG_TIME);
-    Validate(ret);
+    auto code = ddwaf_run(context, &param, &ret, LONG_TIME);
+    Validate(ret, code);
     ddwaf_result_free(&ret);
 }
 
@@ -178,7 +179,7 @@ TEST_F(TestSchemaFixture, MultiResultWithMultiCondition)
     ddwaf_object_map_add(&param, "arg4", &arg4);
 
     ddwaf_result ret;
-    ddwaf_run(context, &param, &ret, LONG_TIME);
-    Validate(ret);
+    auto code = ddwaf_run(context, &param, &ret, LONG_TIME);
+    Validate(ret, code);
     ddwaf_result_free(&ret);
 }

--- a/tests/TestTransform.cpp
+++ b/tests/TestTransform.cpp
@@ -592,7 +592,7 @@ TEST(TestTransforms, TestCoverage)
 
     ddwaf_result ret;
     EXPECT_EQ(ddwaf_run(context, &map, &ret, LONG_TIME), DDWAF_MONITOR);
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"test_coverage","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":".*","parameters":[{"address":"arg","key_path":[],"value":"","highlight":[]}]}]}])");
 
     ddwaf_result_free(&ret);

--- a/tests/rule_processor/TestLibInjectionSQL.cpp
+++ b/tests/rule_processor/TestLibInjectionSQL.cpp
@@ -45,7 +45,7 @@ TEST(TestLibInjectionSQL, TestRuleset)
 
     auto code = ddwaf_run(context, &param, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MONITOR);
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"is_sqli","operator_value":"","parameters":[{"address":"arg1","key_path":[],"value":"'OR 1=1/*","highlight":["s&1c"]}]}]}])");
     ddwaf_result_free(&ret);
 

--- a/tests/rule_processor/TestLibInjectionXSS.cpp
+++ b/tests/rule_processor/TestLibInjectionXSS.cpp
@@ -45,7 +45,7 @@ TEST(TestLibInjectionXSS, TestRuleset)
 
     auto code = ddwaf_run(context, &param, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MONITOR);
-    EXPECT_EQ(ret.action, DDWAF_MONITOR);
+    EXPECT_FALSE(ret.timeout);
     EXPECT_STREQ(ret.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"flow1","category":"category1"}},"rule_matches":[{"operator":"is_xss","operator_value":"","parameters":[{"address":"arg1","key_path":[],"value":"<script>alert(1);</script>","highlight":[]}]}]}])");
     ddwaf_result_free(&ret);
 

--- a/tests/test.h
+++ b/tests/test.h
@@ -46,7 +46,6 @@ using namespace ddwaf;
 extern ddwaf_object readFile(const char* filename);
 extern ddwaf_object readRule(const char* rule);
 extern void compareData(const char* rulename, ddwaf_object input, size_t time, const char* expectedOutput);
-extern DDWAF_RET_CODE getCodeForRun(ddwaf_result input);
 extern std::unordered_map<std::string, std::shared_ptr<PowerWAF>>& exportInternalRuleCollection();
 
 namespace YAML


### PR DESCRIPTION
- Removal of `ddwaf_result.action` due to being equivalent to the return value of `ddwaf_run`.
- Removal of `DDWAF_ERR_TIMEOUT`.
- Addition of `ddwaf_result.timeout` to signal when there has been a timeout at any point during the run.
- Rearranged items in `ddwaf_result` to reduce struct size.

In case of timeout, the WAF will return a verdict (`DDWAF_GOOD`, `DDWAF_BLOCK`, `DDWAF_MONITOR`) and set the flag if there has been a timeout during the operation regardless of when it happens.