### PR TITLE
Fix MacOS compilation errors for 10.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Create Build Directory
         run: cmake -E make_directory ${{ github.workspace }}/build ${{ github.workspace }}/packages
       - name: Generating Build Scripts
-        run: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=${{ github.workspace }} -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/packages ${{ github.workspace }}
+        run: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMACOSX_DEPLOYMENT_TARGET=10.9 -DCMAKE_INSTALL_PREFIX=${{ github.workspace }} -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/packages ${{ github.workspace }}
         working-directory: ${{ github.workspace }}/build
       - name: Build Binaries
         run: cmake --build . --config RelWithDebInfo --verbose --target all --target testPowerWAF -j
@@ -78,7 +78,7 @@ jobs:
       - name: Create Build Directory
         run: cmake -E make_directory ${{ github.workspace }}/build ${{ github.workspace }}/packages
       - name: Generating Build Scripts
-        run: cmake -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=${{ github.workspace }} -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/packages ${{ github.workspace }}
+        run: cmake -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMACOSX_DEPLOYMENT_TARGET=10.9 -DCMAKE_INSTALL_PREFIX=${{ github.workspace }} -DCPACK_PACKAGE_DIRECTORY=${{ github.workspace }}/packages ${{ github.workspace }}
         working-directory: ${{ github.workspace }}/build
       - name: Build Binaries
         run: cmake --build . --config RelWithDebInfo --verbose --target all -j

--- a/src/PWAdditive.cpp
+++ b/src/PWAdditive.cpp
@@ -55,8 +55,8 @@ DDWAF_RET_CODE PWAdditive::run(ddwaf_object newParameters,
     // consistent across all possible timeout scenarios.
     if (timeLeft == 0)
     {
-        if (res) {
-            ddwaf_result &output = res.value();
+        if (res.has_value()) {
+            ddwaf_result &output = *res;
             output.timeout = true;
         }
         return DDWAF_GOOD;
@@ -80,8 +80,8 @@ DDWAF_RET_CODE PWAdditive::run(ddwaf_object newParameters,
     }
 
     DDWAF_RET_CODE code = retManager.getResult();
-    if (res) {
-        ddwaf_result &output = res.value();
+    if (res.has_value()) {
+        ddwaf_result &output = *res;
         retManager.synthetize(output);
 
         const SQPowerWAF::monotonic_clock::duration runTime = SQPowerWAF::monotonic_clock::now() - now;

--- a/src/rule.hpp
+++ b/src/rule.hpp
@@ -29,8 +29,9 @@ class condition;
 using rule_map = std::unordered_map<std::string, rule>;
 using flow_map = std::unordered_map<std::string, std::vector<std::string>>;
 
-struct rule
+class rule
 {
+public:
     std::string name;
     std::string category;
     std::vector<condition> conditions;


### PR DESCRIPTION
The MacOS toolchain has incomplete support for C++17 on 10.9 (which is the minimum version required for distributing Python binaries on MacOS). This PR builds the MacOS libraries for this target and workarounds the unsupported method.