### PR TITLE
Fix duplicate matches accumulated per flow

### DIFF
--- a/src/PWProcessor.cpp
+++ b/src/PWProcessor.cpp
@@ -83,12 +83,12 @@ void PWProcessor::runFlow(const std::string& name, const std::vector<std::string
 
     ddwaf::rule_map::const_iterator ruleMatched;
 
-    retManager.startRule();
-
     //Process each rule we have to run for this step of the flow
     for (const std::string& ruleID : flow)
     {
         DDWAF_DEBUG("Running the WAF on rule %s", ruleID.c_str());
+
+        retManager.startRule();
 
         //Have we already ran this rule?
         bool cachedNegativeMatch = false, hitFromThisRun = false;

--- a/tests/yaml/regressions2.yaml
+++ b/tests/yaml/regressions2.yaml
@@ -1,0 +1,50 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: param1
+          regex: Sqreen
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: param2
+          regex: fail_value
+  - id: 2
+    name: rule2
+    tags:
+      type: flow1
+      category: category2
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: param1
+          regex: Sqreen
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: param2
+          regex: Duplicate
+  - id: 3
+    name: rule3
+    tags:
+      type: flow1
+      category: category3
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: param1
+          regex: Sqreen
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: param2
+          regex: another_fail_value


### PR DESCRIPTION
Multiple matches accumulate while processing a flow, causing the reported match to contain duplicate matches.