### PR TITLE
Fix an integer overflow in the log macro

### DIFF
--- a/src/PWRetriever.cpp
+++ b/src/PWRetriever.cpp
@@ -78,7 +78,7 @@ bool PWRetriever::PWArgsWrapper::_validate_object(const ddwaf_object& input, uin
                 }
                 else
                 {
-                    DDWAF_TRACE("Performing recursive validation of item #%zu", i);
+                    DDWAF_TRACE("Performing recursive validation of item #%llu", i);
                 }
 
                 if (!_validate_object(array[i], depth + 1))

--- a/src/PWRetriever.cpp
+++ b/src/PWRetriever.cpp
@@ -78,7 +78,7 @@ bool PWRetriever::PWArgsWrapper::_validate_object(const ddwaf_object& input, uin
                 }
                 else
                 {
-                    DDWAF_TRACE("Performing recursive validation of item #%llu", i);
+                    DDWAF_TRACE("Performing recursive validation of item #" PRIu64, i);
                 }
 
                 if (!_validate_object(array[i], depth + 1))

--- a/src/PWTransformer.cpp
+++ b/src/PWTransformer.cpp
@@ -844,10 +844,10 @@ bool PWTransformer::transformEncodeBase64(ddwaf_object* parameter, bool readOnly
     for (; read + 2 < originalLength; read += 3)
     {
         const uint8_t quartet[4] = {
-            oldString[read] >> 2,
-            (oldString[read] & 0x3) << 4 | (oldString[read + 1] >> 4),
-            (oldString[read + 1] & 0xf) << 2 | oldString[read + 2] >> 6,
-            oldString[read + 2] & 0x3f
+			static_cast<uint8_t>(oldString[read] >> 2),
+			static_cast<uint8_t>((oldString[read] & 0x3) << 4 | (oldString[read + 1] >> 4)),
+			static_cast<uint8_t>((oldString[read + 1] & 0xf) << 2 | oldString[read + 2] >> 6),
+			static_cast<uint8_t>(oldString[read + 2] & 0x3f)
         };
 
         newString[write++] = b64Encoding[quartet[0]];
@@ -862,14 +862,14 @@ bool PWTransformer::transformEncodeBase64(ddwaf_object* parameter, bool readOnly
         // We know that must have either one, or two bytes to process (otherwise the loop above would have run one more time)
         const uint8_t originalBytes[2] = {
             oldString[read],
-            read + 1 == originalLength ? (char) 0 : oldString[read + 1]
+            read + 1 == originalLength ? (uint8_t) 0 : oldString[read + 1]
         };
 
         // Compute the codes, only three as the forth is only set by the third, missing input byte
         const uint8_t convertedBytes[3] = {
-            originalBytes[0] >> 2,
-            (originalBytes[0] & 0x3) << 4 | (originalBytes[1] >> 4),
-            (originalBytes[1] & 0xf) << 2
+			static_cast<uint8_t>(originalBytes[0] >> 2),
+			static_cast<uint8_t>((originalBytes[0] & 0x3) << 4 | (originalBytes[1] >> 4)),
+			static_cast<uint8_t>((originalBytes[1] & 0xf) << 2)
         };
 
         // The first byte is always set in this branch, so no matter what we must set the first two bytes in the output

--- a/src/PowerWAF.cpp
+++ b/src/PowerWAF.cpp
@@ -44,7 +44,7 @@ PowerWAF::PowerWAF(PWManifest&& manifest_, rule_map&& rules_,
 
         if (config->maxTimeStore >= 0)
         {
-            maxTimeStore = config->maxTimeStore;
+            maxTimeStore = (uint32_t) config->maxTimeStore;
         }
     }
 }

--- a/src/PowerWAFInterface.cpp
+++ b/src/PowerWAFInterface.cpp
@@ -99,11 +99,12 @@ extern "C"
 
         PowerWAF* waf   = reinterpret_cast<PowerWAF*>(handle);
         auto& addresses = waf->manifest.get_root_addresses();
-        *size           = addresses.size();
-        if (addresses.empty())
+        if (addresses.empty() || addresses.size() > UINT32_MAX)
         {
             return nullptr;
         }
+
+		*size           = (uint32_t) addresses.size();
         return addresses.data();
     }
 

--- a/src/PowerWAFInterface.cpp
+++ b/src/PowerWAFInterface.cpp
@@ -99,8 +99,9 @@ extern "C"
 
         PowerWAF* waf   = reinterpret_cast<PowerWAF*>(handle);
         auto& addresses = waf->manifest.get_root_addresses();
-        if (addresses.empty() || addresses.size() > UINT32_MAX)
+        if (addresses.empty() || addresses.size() > std::numeric_limits<uint32_t>::max())
         {
+            *size = 0;
             return nullptr;
         }
 

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -56,11 +56,12 @@ constexpr const char* base_name(const char* path)
         if (ddwaf::logger::valid(level))                                                 \
         {                                                                                \
             constexpr const char* filename = base_name(file);                            \
-            int bytes                      = snprintf(NULL, 0, fmt, ##__VA_ARGS__);      \
-            if (bytes > 0)                                                               \
+            int _bytes                     = snprintf(NULL, 0, fmt, ##__VA_ARGS__);      \
+            if (_bytes > 0)                                                              \
             {                                                                            \
-                char* message = (char*) malloc(bytes + 1);                               \
-                if (message != NULL)                                                     \
+				size_t bytes = (size_t) _bytes; 			                             \
+				char* message = (char*) malloc(bytes + 1); 			                     \
+				if (message != NULL)                                                     \
                 {                                                                        \
                     snprintf(message, bytes + 1, fmt, ##__VA_ARGS__);                    \
                     ddwaf::logger::log(level, function, filename, line, message, bytes); \

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -111,7 +111,7 @@ extern "C"
 
         // INT64_MIN is 20 char long
         char container[sizeof(STR(INT64_MIN))] = { 0 };
-        int length                             = snprintf(container, sizeof(container), "%" PRId64, value);
+        size_t length                          = (size_t) snprintf(container, sizeof(container), "%" PRId64, value);
 
         return ddwaf_object_stringl(object, container, length);
     }
@@ -125,7 +125,7 @@ extern "C"
 
         // UINT64_MAX is 20 char long
         char container[sizeof(STR(UINT64_MAX))] = { 0 };
-        int length                              = snprintf(container, sizeof(container), "%" PRIu64, value);
+        size_t length                           = (size_t) snprintf(container, sizeof(container), "%" PRIu64, value);
 
         return ddwaf_object_stringl(object, container, length);
     }

--- a/src/parser/parser_v1.cpp
+++ b/src/parser/parser_v1.cpp
@@ -47,7 +47,7 @@ ddwaf::condition parseCondition(parameter::map& rule, PWManifest& manifest,
             }
 
             patterns.push_back(pattern.stringValue);
-            lengths.push_back(pattern.nbEntries);
+            lengths.push_back((uint32_t) pattern.nbEntries);
         }
 
         processor = std::make_unique<PerfMatch>(patterns, lengths);

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -47,7 +47,7 @@ ddwaf::condition parseCondition(parameter::map& rule, PWManifest& manifest,
             }
 
             patterns.push_back(pattern.stringValue);
-            lengths.push_back(pattern.nbEntries);
+            lengths.push_back((uint32_t) pattern.nbEntries);
         }
 
         processor = std::make_unique<PerfMatch>(patterns, lengths);


### PR DESCRIPTION
Fix an integer overflow in `DDWAF_LOG_HELPER`. This is likely unexploitable since `malloc(INT32_MIN)` should return `NULL` which causes an early abort.
Also solves a bunch of implicit casts warnings.