### PR TITLE
Ruleset parsing diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/PWRet.cpp
     ${libddwaf_SOURCE_DIR}/src/PWRetriever.cpp
     ${libddwaf_SOURCE_DIR}/src/rule.cpp
+    ${libddwaf_SOURCE_DIR}/src/ruleset_info.cpp
     ${libddwaf_SOURCE_DIR}/src/PWTransformer.cpp
     ${libddwaf_SOURCE_DIR}/src/utils.cpp
     ${libddwaf_SOURCE_DIR}/src/log.cpp

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ int main(void)
     YAML::Node doc = YAML::Load(R"({version: '0.1', events: [{id: 1, tags: {type: flow1}, conditions: [{operation: match_regex, parameters: {inputs: [arg1], regex: .*}},{operation: match_regex, parameters: {inputs: [arg2], regex: .*}}], action: record}]})");
 
     ddwaf_object rule = doc.as<ddwaf_object>();//= convert_yaml_to_args(doc);
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ddwaf_object_free(&rule);
     if (handle == nullptr) {
         exit(EXIT_FAILURE);

--- a/examples/verify_rule.cpp
+++ b/examples/verify_rule.cpp
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
 #endif
 		YAML::Node rule = YAML::Load(read_rule_file(argv[fileIndex]));
 		ddwaf_object convertedRule = convertRuleToRuleset(rule);
-		ddwaf_handle handle = ddwaf_init(&convertedRule, nullptr);
+		ddwaf_handle handle = ddwaf_init(&convertedRule, nullptr, nullptr);
 		ddwaf_object_free(&convertedRule);
 		
 		if (handle == nullptr)

--- a/examples/verify_ruleset.cpp
+++ b/examples/verify_ruleset.cpp
@@ -140,7 +140,7 @@ int main(int argc, char* argv[])
     YAML::Node doc       = YAML::Load(rule_str);
 
     ddwaf_object rule   = doc.as<ddwaf_object>();
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ddwaf_object_free(&rule);
 
     if (handle == nullptr)

--- a/fuzzing/src/ddwaf_interface.cpp
+++ b/fuzzing/src/ddwaf_interface.cpp
@@ -120,7 +120,7 @@ ddwaf_object file_to_object(const char* filename)
 ddwaf_handle init_waf()
 {
     ddwaf_object rule   = file_to_object("sample_rules.yml");
-    ddwaf_handle handle = ddwaf_init(&rule, NULL);
+    ddwaf_handle handle = ddwaf_init(&rule, NULL, NULL);
     ddwaf_object_free(&rule);
     return handle;
 }

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -77,7 +77,7 @@ typedef struct _ddwaf_object ddwaf_object;
 typedef struct _ddwaf_config ddwaf_config;
 typedef struct _ddwaf_result ddwaf_result;
 typedef struct _ddwaf_version ddwaf_version;
-
+typedef struct _ddwaf_ruleset_info ddwaf_ruleset_info;
 /**
  * @struct ddwaf_object
  *
@@ -93,7 +93,7 @@ struct _ddwaf_object
         const char* stringValue;
         uint64_t uintValue;
         int64_t intValue;
-        const ddwaf_object* array;
+        ddwaf_object* array;
     };
     uint64_t nbEntries;
     DDWAF_OBJ_TYPE type;
@@ -144,6 +144,21 @@ struct _ddwaf_version
 };
 
 /**
+ * @ddwaf_ruleset_info
+ *
+ * Structure containing diagnostics on the provided ruleset.
+ * */
+struct _ddwaf_ruleset_info
+{
+    /** Number of rules successfully loaded **/
+    uint16_t loaded;
+    /** Number of rules which failed to parse **/
+    uint64_t failed;
+    /** Map of rule parsing errors {error: [rules]} **/
+    ddwaf_object errors;
+};
+
+/**
  * @typedef ddwaf_object_free_fn
  *
  * Type of the function to free ddwaf::objects.
@@ -173,10 +188,12 @@ typedef void (*ddwaf_log_cb)(
  *
  * @param rule ddwaf::object containing the patterns to be used by the WAF. (nonnull)
  * @param config Optional configuration of the WAF. (nullable)
+ * @param info Optional ruleset parsing diagnostics. (nullable)
  *
  * @return Handle to the WAF instance.
  **/
-ddwaf_handle ddwaf_init(const ddwaf_object *rule, const ddwaf_config* config);
+ddwaf_handle ddwaf_init(const ddwaf_object *rule,
+    const ddwaf_config* config, ddwaf_ruleset_info *info);
 
 /**
  * ddwaf_destroy
@@ -186,7 +203,14 @@ ddwaf_handle ddwaf_init(const ddwaf_object *rule, const ddwaf_config* config);
  * @param Handle to the WAF instance.
  */
 void ddwaf_destroy(ddwaf_handle handle);
-
+/**
+ * ddwaf_ruleset_info_free
+ *
+ * Free the memory associated with the ruleset info structure.
+ *
+ * @param info Ruleset info to free.
+ * */
+void ddwaf_ruleset_info_free(ddwaf_ruleset_info *info);
 /**
  * ddwaf_required_addresses
  *

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -154,7 +154,8 @@ struct _ddwaf_ruleset_info
     uint16_t loaded;
     /** Number of rules which failed to parse **/
     uint16_t failed;
-    /** Map of rule parsing errors {error: [rules]} **/
+    /** Map from an error string to an array of all the rule ids for which
+     *  that error was raised. {error: [rule_ids]} **/
     ddwaf_object errors;
     /** Ruleset version **/
     const char *version;

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -153,9 +153,11 @@ struct _ddwaf_ruleset_info
     /** Number of rules successfully loaded **/
     uint16_t loaded;
     /** Number of rules which failed to parse **/
-    uint64_t failed;
+    uint16_t failed;
     /** Map of rule parsing errors {error: [rules]} **/
     ddwaf_object errors;
+    /** Ruleset version **/
+    const char *version;
 };
 
 /**

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -2,6 +2,7 @@ LIBRARY ddwaf
 EXPORTS
   ddwaf_init
   ddwaf_destroy
+  ddwaf_ruleset_info_free
   ddwaf_context_init
   ddwaf_run
   ddwaf_context_destroy

--- a/smoketest/smoke.c
+++ b/smoketest/smoke.c
@@ -222,7 +222,7 @@ int main() {
     ddwaf_object *rule = prepare_rule();
     dump(rule);
 
-    ddwaf_handle handle = ddwaf_init(rule, NULL);
+    ddwaf_handle handle = ddwaf_init(rule, NULL, NULL);
     if (!handle) {
         puts("handle is null");
         return 1;

--- a/src/PowerWAF.cpp
+++ b/src/PowerWAF.cpp
@@ -49,7 +49,8 @@ PowerWAF::PowerWAF(PWManifest&& manifest_, rule_map&& rules_,
     }
 }
 
-PowerWAF* PowerWAF::fromConfig(const ddwaf_object ruleset, const ddwaf_config* config)
+PowerWAF* PowerWAF::fromConfig(const ddwaf_object ruleset,
+                               const ddwaf_config* config, ddwaf::ruleset_info& info)
 {
     PWManifest manifest;
     rule_map rules;
@@ -57,7 +58,7 @@ PowerWAF* PowerWAF::fromConfig(const ddwaf_object ruleset, const ddwaf_config* c
 
     try
     {
-        parser::parse(ruleset, rules, manifest, flows);
+        parser::parse(ruleset, info, rules, manifest, flows);
         return new PowerWAF(std::move(manifest), std::move(rules),
                             std::move(flows), config);
     }

--- a/src/PowerWAF.hpp
+++ b/src/PowerWAF.hpp
@@ -9,6 +9,7 @@
 
 #include <PWManifest.h>
 #include <rule.hpp>
+#include <ruleset_info.hpp>
 #include <utils.h>
 
 struct PowerWAF
@@ -26,7 +27,8 @@ struct PowerWAF
     PowerWAF(PWManifest&& manifest_, ddwaf::rule_map&& rules_,
              ddwaf::flow_map&& flows_, const ddwaf_config* config);
 
-    static PowerWAF* fromConfig(const ddwaf_object rules, const ddwaf_config* config);
+    static PowerWAF* fromConfig(const ddwaf_object rules,
+                                const ddwaf_config* config, ddwaf::ruleset_info& info);
 
     static constexpr ddwaf_version waf_version { 1, 0, 18 };
 };

--- a/src/PowerWAFInterface.cpp
+++ b/src/PowerWAFInterface.cpp
@@ -13,6 +13,7 @@
 #include <PWAdditive.hpp>
 #include <PWRet.hpp>
 #include <exception.hpp>
+#include <ruleset_info.hpp>
 
 #include <log.hpp>
 
@@ -46,13 +47,15 @@ const char* log_level_to_str(DDWAF_LOG_LEVEL level)
 // explicit instantiation declaration to suppress warning
 extern "C"
 {
-    ddwaf_handle ddwaf_init(const ddwaf_object* rule, const ddwaf_config* config)
+    ddwaf_handle ddwaf_init(const ddwaf_object* rule,
+                            const ddwaf_config* config, ddwaf_ruleset_info* info)
     {
         try
         {
             if (rule != nullptr)
             {
-                PowerWAF* waf = PowerWAF::fromConfig(*rule, config);
+                ddwaf::ruleset_info ri(info);
+                PowerWAF* waf = PowerWAF::fromConfig(*rule, config, ri);
                 return reinterpret_cast<ddwaf_handle>(waf);
             }
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -185,7 +185,7 @@ extern "C"
         //We preallocate 8 entries
         if (array->nbEntries == 0)
         {
-            array->array = (const ddwaf_object*) malloc(8 * sizeof(ddwaf_object));
+            array->array = (ddwaf_object*) malloc(8 * sizeof(ddwaf_object));
             if (array->array == NULL)
             {
                 DDWAF_DEBUG("Allocation failure when trying to initialize a map or an array");

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -7,6 +7,7 @@
 #include <cinttypes>
 #include <exception.hpp>
 #include <parameter.hpp>
+
 namespace
 {
 
@@ -131,6 +132,33 @@ parameter::operator parameter::vector()
         return parameter::vector();
     }
     return std::vector<parameter>(array, array + nbEntries);
+}
+
+parameter::operator parameter::string_set()
+{
+    if (type != DDWAF_OBJ_ARRAY)
+    {
+        throw bad_cast("array", strtype(type));
+    }
+
+    if (array == nullptr || nbEntries == 0)
+    {
+        return parameter::string_set();
+    }
+
+    parameter::string_set set;
+    set.reserve(nbEntries);
+    for (unsigned i = 0; i < nbEntries; i++)
+    {
+        if (array[i].type != DDWAF_OBJ_STRING)
+        {
+            throw malformed_object("item in array not a string, can't cast to string set");
+        }
+
+        set.emplace(array[i].stringValue, array[i].nbEntries);
+    }
+
+    return set;
 }
 
 parameter::operator std::string_view()

--- a/src/parameter.hpp
+++ b/src/parameter.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace ddwaf
@@ -22,6 +23,7 @@ class parameter : public ddwaf_object
 public:
     typedef std::unordered_map<std::string_view, parameter> map;
     typedef std::vector<parameter> vector;
+    typedef std::unordered_set<std::string_view> string_set;
 
     parameter() = default;
     parameter(const ddwaf_object& arg) { *((ddwaf_object*) this) = arg; }
@@ -36,6 +38,7 @@ public:
 
     operator map();
     operator vector();
+    operator string_set();
     operator std::string_view();
     operator std::string();
 
@@ -70,6 +73,12 @@ template <>
 struct parameter_traits<parameter::vector>
 {
     static const char* name() { return "parameter::vector"; }
+};
+
+template <>
+struct parameter_traits<parameter::string_set>
+{
+    static const char* name() { return "parameter::string_set"; }
 };
 
 }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -16,18 +16,18 @@ namespace ddwaf::parser
 
 namespace v1
 {
-    void parse(parameter::map& ruleset, ddwaf::rule_map& ruleManager,
-               PWManifest& manifest, ddwaf::flow_map& flows);
+    void parse(parameter::map& ruleset, ruleset_info& info,
+               rule_map& ruleManager, PWManifest& manifest, flow_map& flows);
 }
 
 namespace v2
 {
-    void parse(parameter::map& ruleset, ddwaf::rule_map& ruleManager,
-               PWManifest& manifest, ddwaf::flow_map& flows);
+    void parse(parameter::map& ruleset, ruleset_info& info,
+               rule_map& ruleManager, PWManifest& manifest, flow_map& flows);
 }
 
-void parse(parameter object, ddwaf::rule_map& ruleManager,
-           PWManifest& manifest, ddwaf::flow_map& flows)
+void parse(parameter object, ruleset_info& info, rule_map& ruleManager,
+           PWManifest& manifest, flow_map& flows)
 {
     parameter::map ruleset   = parameter::map(object);
     std::string_view version = at<std::string_view>(ruleset, "version");
@@ -41,9 +41,9 @@ void parse(parameter object, ddwaf::rule_map& ruleManager,
     switch (major)
     {
         case 1:
-            return v1::parse(ruleset, ruleManager, manifest, flows);
+            return v1::parse(ruleset, info, ruleManager, manifest, flows);
         case 2:
-            return v2::parse(ruleset, ruleManager, manifest, flows);
+            return v2::parse(ruleset, info, ruleManager, manifest, flows);
         default:
             DDWAF_ERROR("incompatible ruleset version %u.%u", major, minor);
             throw unsupported_version();

--- a/src/parser/parser.hpp
+++ b/src/parser/parser.hpp
@@ -11,6 +11,7 @@
 #include <PWRetriever.hpp>
 #include <parameter.hpp>
 #include <rule.hpp>
+#include <ruleset_info.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -18,7 +19,7 @@
 namespace ddwaf::parser
 {
 
-void parse(parameter ruleset, rule_map& rules,
+void parse(parameter ruleset, ruleset_info& info, rule_map& rules,
            PWManifest& manifest, flow_map& flows);
 
 }

--- a/src/parser/parser_v1.cpp
+++ b/src/parser/parser_v1.cpp
@@ -11,6 +11,7 @@
 #include <parameter.hpp>
 #include <parser/common.hpp>
 #include <rule.hpp>
+#include <ruleset_info.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -142,13 +143,14 @@ ddwaf::condition parseCondition(parameter::map& rule, PWManifest& manifest,
     return ddwaf::condition(std::move(targets), std::move(transformers), std::move(processor));
 }
 
-void parseRule(parameter::map& rule, ddwaf::rule_map& rules,
-               PWManifest& manifest, ddwaf::flow_map& flows)
+void parseRule(parameter::map& rule, ddwaf::ruleset_info& info,
+               ddwaf::rule_map& rules, PWManifest& manifest, ddwaf::flow_map& flows)
 {
     auto id = at<std::string>(rule, "id");
     if (rules.find(id) != rules.end())
     {
         DDWAF_WARN("duplicate rule %s", id.c_str());
+        info.insert_error(id, "duplicate rule");
         return;
     }
 
@@ -186,10 +188,13 @@ void parseRule(parameter::map& rule, ddwaf::rule_map& rules,
 
         auto& flow = flows[type];
         flow.push_back(id);
+
+        info.add_loaded();
     }
     catch (const std::exception& e)
     {
         DDWAF_WARN("failed to parse rule '%s': %s", id.c_str(), e.what());
+        info.insert_error(id, e.what());
     }
 }
 
@@ -198,7 +203,7 @@ void parseRule(parameter::map& rule, ddwaf::rule_map& rules,
 namespace ddwaf::parser::v1
 {
 
-void parse(parameter::map& ruleset, ddwaf::rule_map& rules,
+void parse(parameter::map& ruleset, ruleset_info& info, ddwaf::rule_map& rules,
            PWManifest& manifest, ddwaf::flow_map& flows)
 {
     auto rules_array = at<parameter::vector>(ruleset, "events");
@@ -206,11 +211,12 @@ void parse(parameter::map& ruleset, ddwaf::rule_map& rules,
     {
         try
         {
-            parseRule(rule, rules, manifest, flows);
+            parseRule(rule, info, rules, manifest, flows);
         }
         catch (const std::exception& e)
         {
             DDWAF_WARN("%s", e.what());
+            info.add_failed();
         }
     }
 

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -235,6 +235,13 @@ namespace ddwaf::parser::v2
 void parse(parameter::map& ruleset, ruleset_info& info, ddwaf::rule_map& rules,
            PWManifest& manifest, ddwaf::flow_map& flows)
 {
+    auto metadata      = at<parameter::map>(ruleset, "metadata", parameter::map());
+    auto rules_version = metadata.find("rules_version");
+    if (rules_version != metadata.end())
+    {
+        info.set_version(rules_version->second);
+    }
+
     auto rules_array = at<parameter::vector>(ruleset, "rules");
     for (parameter::map rule : rules_array)
     {

--- a/src/ruleset_info.cpp
+++ b/src/ruleset_info.cpp
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "ddwaf.h"
+
+extern "C"
+{
+
+    void ddwaf_ruleset_info_free(ddwaf_ruleset_info* info)
+    {
+        ddwaf_object_free(&info->errors);
+    }
+}

--- a/src/ruleset_info.cpp
+++ b/src/ruleset_info.cpp
@@ -11,7 +11,11 @@ extern "C"
 
     void ddwaf_ruleset_info_free(ddwaf_ruleset_info* info)
     {
-        ddwaf_object_free(&info->errors);
+        if (info != nullptr)
+        {
+            ddwaf_object_free(&info->errors);
+            delete[] info->version;
+        }
     }
 }
 

--- a/src/ruleset_info.cpp
+++ b/src/ruleset_info.cpp
@@ -4,7 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
-#include "ddwaf.h"
+#include <ruleset_info.hpp>
 
 extern "C"
 {
@@ -13,4 +13,45 @@ extern "C"
     {
         ddwaf_object_free(&info->errors);
     }
+}
+
+namespace ddwaf
+{
+
+void ruleset_info::insert_error(std::string_view rule_id, std::string_view error)
+{
+    if (info == nullptr)
+    {
+        return;
+    }
+
+    ddwaf_object *rules, id, tmp;
+
+    auto it = errors.find(error);
+    if (it == errors.end())
+    {
+        ddwaf_object_array(&tmp);
+        bool res = ddwaf_object_map_addl(&info->errors,
+                                         error.data(), error.size(), &tmp);
+        if (!res)
+        {
+            return;
+        }
+
+        // Get the map element we just added
+        rules = &info->errors.array[info->errors.nbEntries - 1];
+        std::string_view key(rules->parameterName, rules->parameterNameLength);
+        errors[key] = rules;
+    }
+    else
+    {
+        rules = it->second;
+    }
+
+    ddwaf_object_stringl(&id, rule_id.data(), rule_id.size());
+    ddwaf_object_array_add(rules, &id);
+
+    add_failed();
+}
+
 }

--- a/src/ruleset_info.cpp
+++ b/src/ruleset_info.cpp
@@ -29,31 +29,33 @@ void ruleset_info::insert_error(std::string_view rule_id, std::string_view error
         return;
     }
 
-    ddwaf_object *rules, id, tmp;
+    ddwaf_object *rule_array, id_str;
 
-    auto it = errors.find(error);
-    if (it == errors.end())
+    auto it = error_obj_cache.find(error);
+    if (it == error_obj_cache.end())
     {
-        ddwaf_object_array(&tmp);
+        ddwaf_object tmp_array;
+        ddwaf_object_array(&tmp_array);
         bool res = ddwaf_object_map_addl(&info->errors,
-                                         error.data(), error.size(), &tmp);
+                                         error.data(), error.size(), &tmp_array);
         if (!res)
         {
             return;
         }
 
         // Get the map element we just added
-        rules = &info->errors.array[info->errors.nbEntries - 1];
-        std::string_view key(rules->parameterName, rules->parameterNameLength);
-        errors[key] = rules;
+        rule_array = &info->errors.array[info->errors.nbEntries - 1];
+        std::string_view key(rule_array->parameterName,
+                             rule_array->parameterNameLength);
+        error_obj_cache[key] = rule_array;
     }
     else
     {
-        rules = it->second;
+        rule_array = it->second;
     }
 
-    ddwaf_object_stringl(&id, rule_id.data(), rule_id.size());
-    ddwaf_object_array_add(rules, &id);
+    ddwaf_object_stringl(&id_str, rule_id.data(), rule_id.size());
+    ddwaf_object_array_add(rule_array, &id_str);
 
     add_failed();
 }

--- a/src/ruleset_info.hpp
+++ b/src/ruleset_info.hpp
@@ -60,7 +60,7 @@ public:
     void insert_error(std::string_view rule_id, std::string_view error);
 
 protected:
-    std::map<std::string_view, ddwaf_object*> errors;
+    std::map<std::string_view, ddwaf_object*> error_obj_cache;
     ddwaf_ruleset_info* info;
 };
 

--- a/src/ruleset_info.hpp
+++ b/src/ruleset_info.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstring>
 #include <ddwaf.h>
 #include <map>
 #include <string_view>
@@ -22,8 +23,9 @@ public:
         {
             return;
         }
-        info->loaded = 0;
-        info->failed = 0;
+        info->loaded  = 0;
+        info->failed  = 0;
+        info->version = nullptr;
         ddwaf_object_map(&info->errors);
     }
 
@@ -40,6 +42,19 @@ public:
         {
             info->loaded++;
         }
+    }
+
+    void set_version(std::string_view version)
+    {
+        if (info == nullptr || version.size() == 0 || version == "")
+        {
+            return;
+        }
+
+        char* str = new char[version.size() + 1];
+        std::memcpy(str, version.data(), version.size());
+        str[version.size()] = '\0';
+        info->version       = str;
     }
 
     void insert_error(std::string_view rule_id, std::string_view error);

--- a/src/ruleset_info.hpp
+++ b/src/ruleset_info.hpp
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#pragma once
+
+#include <ddwaf.h>
+#include <string_view>
+
+namespace ddwaf
+{
+
+class ruleset_info
+{
+public:
+    explicit ruleset_info(ddwaf_ruleset_info* info_) : info(info_)
+    {
+        if (info == nullptr)
+        {
+            return;
+        }
+        info->loaded = 0;
+        info->failed = 0;
+        ddwaf_object_map(&info->errors);
+    }
+
+    void add_failed()
+    {
+        if (info != nullptr)
+        {
+            info->failed++;
+        }
+    }
+    void add_loaded()
+    {
+        if (info != nullptr)
+        {
+            info->loaded++;
+        }
+    }
+
+    void insert_error(std::string_view rule_id, std::string_view error)
+    {
+        if (info == nullptr)
+        {
+            return;
+        }
+
+        ddwaf_object *rules, id, tmp;
+
+        auto it = errors.find(error);
+        if (it == errors.end())
+        {
+            ddwaf_object_array(&tmp);
+            bool res = ddwaf_object_map_addl(&info->errors,
+                                             error.data(), error.size(), &tmp);
+            if (!res)
+            {
+                return;
+            }
+
+            // Get the map element we just added
+            rules = &info->errors.array[info->errors.nbEntries - 1];
+            std::string_view key(rules->parameterName, rules->parameterNameLength);
+            errors[key] = rules;
+        }
+        else
+        {
+            rules = it->second;
+        }
+
+        ddwaf_object_stringl(&id, rule_id.data(), rule_id.size());
+        ddwaf_object_array_add(rules, &id);
+
+        add_failed();
+    }
+
+protected:
+    std::map<std::string_view, ddwaf_object*> errors;
+    ddwaf_ruleset_info* info;
+};
+
+}

--- a/src/ruleset_info.hpp
+++ b/src/ruleset_info.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <ddwaf.h>
+#include <map>
 #include <string_view>
 
 namespace ddwaf
@@ -41,41 +42,7 @@ public:
         }
     }
 
-    void insert_error(std::string_view rule_id, std::string_view error)
-    {
-        if (info == nullptr)
-        {
-            return;
-        }
-
-        ddwaf_object *rules, id, tmp;
-
-        auto it = errors.find(error);
-        if (it == errors.end())
-        {
-            ddwaf_object_array(&tmp);
-            bool res = ddwaf_object_map_addl(&info->errors,
-                                             error.data(), error.size(), &tmp);
-            if (!res)
-            {
-                return;
-            }
-
-            // Get the map element we just added
-            rules = &info->errors.array[info->errors.nbEntries - 1];
-            std::string_view key(rules->parameterName, rules->parameterNameLength);
-            errors[key] = rules;
-        }
-        else
-        {
-            rules = it->second;
-        }
-
-        ddwaf_object_stringl(&id, rule_id.data(), rule_id.size());
-        ddwaf_object_array_add(rules, &id);
-
-        add_failed();
-    }
+    void insert_error(std::string_view rule_id, std::string_view error);
 
 protected:
     std::map<std::string_view, ddwaf_object*> errors;

--- a/tests/TestAdditive.cpp
+++ b/tests/TestAdditive.cpp
@@ -20,7 +20,7 @@ TEST(TestAdditive, TestMultiCall)
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2}], regex: .*}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -70,7 +70,7 @@ TEST(TestAdditive, TestBad)
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2}], regex: .*}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -100,7 +100,7 @@ TEST(TestAdditive, TestParameterOverride)
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: ^string.*}}, {operator: match_regex, parameters: {inputs: [{address: arg2}], regex: .*}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 

--- a/tests/TestInterface.cpp
+++ b/tests/TestInterface.cpp
@@ -11,14 +11,14 @@ TEST(FunctionalTests, ddwaf_run)
     auto rule = readFile("interface.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle1 = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle1 = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle1, nullptr);
     ddwaf_object_free(&rule);
 
     rule = readFile("interface2.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle2 = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle2 = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle2, nullptr);
     ddwaf_object_free(&rule);
 
@@ -166,7 +166,7 @@ TEST(FunctionalTests, HandleGood)
     auto rule = readFile("interface2.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    const ddwaf_handle handle = ddwaf_init(&rule, NULL);
+    const ddwaf_handle handle = ddwaf_init(&rule, NULL, nullptr);
     ddwaf_object_free(&rule);
 
     ASSERT_NE(handle, nullptr);
@@ -203,7 +203,7 @@ TEST(FunctionalTests, HandleGood)
 TEST(FunctionalTests, HandleBad)
 {
     ddwaf_object tmp, object = DDWAF_OBJECT_INVALID;
-    EXPECT_EQ(ddwaf_init(&object, nullptr), nullptr);
+    EXPECT_EQ(ddwaf_init(&object, nullptr, nullptr), nullptr);
 
     EXPECT_NO_FATAL_FAILURE(ddwaf_destroy(nullptr));
 
@@ -214,7 +214,7 @@ TEST(FunctionalTests, HandleBad)
     auto rule = readFile("interface.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -239,14 +239,14 @@ TEST(FunctionalTests, Budget)
     auto rule = readFile("interface.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle1 = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle1 = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle1, nullptr);
     ddwaf_object_free(&rule);
 
     rule = readFile("interface2.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle2 = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle2 = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle2, nullptr);
     ddwaf_object_free(&rule);
 
@@ -303,7 +303,7 @@ TEST(FunctionalTests, ddwaf_runNull)
 {
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: arachni_detection, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: bla}], regex: Arachni}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -325,7 +325,7 @@ TEST(FunctionalTests, ddwaf_runNull)
     ////Add a removeNull transformer
     rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: arachni_detection, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: bla}], regex: Arachni}}], transformers: [removeNulls]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
-    handle = ddwaf_init(&rule, nullptr);
+    handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 

--- a/tests/TestPowerWAF.cpp
+++ b/tests/TestPowerWAF.cpp
@@ -11,7 +11,7 @@ TEST(TestPowerWAF, TestEmptyParameters)
     auto rule = readFile("powerwaf.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ddwaf_object_free(&rule);
     ASSERT_NE(handle, nullptr);
 
@@ -163,7 +163,7 @@ TEST(TestPowerWAF, TestConfig)
     auto rule = readFile("powerwaf.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ddwaf_object_free(&rule);
     ASSERT_NE(handle, nullptr);
 

--- a/tests/TestProcessor.cpp
+++ b/tests/TestProcessor.cpp
@@ -14,7 +14,7 @@ TEST(TestPWProcessor, TestOutput)
     auto rule = readFile("processor.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -44,7 +44,7 @@ TEST(TestPWProcessor, TestKeyPaths)
     auto rule = readFile("processor5.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -101,7 +101,7 @@ TEST(TestPWProcessor, TestMissingParameter)
     auto rule = readFile("processor.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -130,7 +130,7 @@ TEST(TestPWProcessor, TestInvalidUTF8Input)
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: values}, {address: keys}], regex: bla}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -165,7 +165,7 @@ TEST(TestPWProcessor, TestCache)
     auto rule = readFile("processor2.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -222,7 +222,7 @@ TEST(TestPWProcessor, TestCacheReport)
     auto rule = readFile("processor3.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -273,7 +273,7 @@ TEST(TestPWProcessor, TestMultiFlowCacheReport)
     auto rule = readFile("processor4.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -324,7 +324,7 @@ TEST(TestPWProcessor, TestBudget)
     auto rule = readFile("slow.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -371,7 +371,7 @@ TEST(TestPWProcessor, TestBudgetRules)
     auto rule = readFile("slow.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -400,7 +400,7 @@ TEST(TestPWProcessor, TestPerfReporting)
         auto rule = readFile("slow.yaml");
         ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-        ddwaf_handle handle = ddwaf_init(&rule, &config);
+        ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
         ASSERT_NE(handle, nullptr);
         ddwaf_object_free(&rule);
 
@@ -461,7 +461,7 @@ TEST(TestPWProcessor, TestPerfReportingIncomplete)
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: bla, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: bla}], regex: pouet}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -512,7 +512,7 @@ TEST(TestPWProcessor, TestDisablePerfReporting)
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: bla, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: bla}], regex: pouet}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, &config);
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 

--- a/tests/TestRegressions.cpp
+++ b/tests/TestRegressions.cpp
@@ -10,7 +10,7 @@ TEST(TestRegressions, TruncatedUTF8)
 {
     auto rule = readFile("regressions.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -44,7 +44,7 @@ TEST(TestRegressions, DuplicateFlowMatches)
     auto rule = readFile("regressions2.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 

--- a/tests/TestRetriever.cpp
+++ b/tests/TestRetriever.cpp
@@ -106,7 +106,7 @@ TEST(TestPWRetriever, TestAccessSimplePath)
     auto rule = readFile("retriever.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
 
     // Whitelist
@@ -167,7 +167,7 @@ TEST(PWRetriever, NullErrorManagement)
     auto rule = readFile("retriever.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
 
     ddwaf_object map = DDWAF_OBJECT_MAP, subMap = DDWAF_OBJECT_MAP, tmp;
@@ -195,7 +195,7 @@ TEST(PWRetriever, IteratorAccessNull)
     auto rule = readFile("retriever.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
 
     ddwaf_object map = DDWAF_OBJECT_MAP, subMap = DDWAF_OBJECT_MAP, tmp;
@@ -220,7 +220,7 @@ TEST(PWRetriever, IteratorBlockList)
     auto rule = readFile("retriever.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
 
     ddwaf_object map = DDWAF_OBJECT_MAP, subMap = DDWAF_OBJECT_MAP, subSubMap = DDWAF_OBJECT_MAP, tmp;
@@ -250,7 +250,7 @@ TEST(PWRetriever, KeyWithComplexStructure)
     auto rule = readFile("retriever.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
 
     ddwaf_context context = ddwaf_context_init(handle, ddwaf_object_free);

--- a/tests/TestRule.cpp
+++ b/tests/TestRule.cpp
@@ -27,7 +27,7 @@ TEST(TestRule, TestRuleDoMatchInvalidParameters)
     auto rule_ = readFile("powerwaf.yaml");
     ASSERT_TRUE(rule_.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule_, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule_, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule_);
 

--- a/tests/TestSchema.cpp
+++ b/tests/TestSchema.cpp
@@ -39,7 +39,7 @@ public:
             throw std::runtime_error("failed to load schema.yaml");
         }
 
-        handle = ddwaf_init(&rule, nullptr);
+        handle = ddwaf_init(&rule, nullptr, nullptr);
         if (handle == nullptr)
         {
             throw std::runtime_error("failed to obtain waf handle");

--- a/tests/TestTransform.cpp
+++ b/tests/TestTransform.cpp
@@ -580,7 +580,7 @@ TEST(TestTransforms, TestCoverage)
     auto rule = readFile("transform.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
@@ -606,7 +606,7 @@ TEST(TestTransforms, TestRuleRunOnKey)
     auto rule = readFile("runOnKey.yaml");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -82,7 +82,7 @@ class parsing_error : public std::exception
 {
 public:
     parsing_error(const std::string& what) : what_(what) {}
-    const char* what() { return what_.c_str(); }
+    const char* what() const noexcept { return what_.c_str(); }
 
 protected:
     const std::string what_;

--- a/tests/rule_processor/TestLibInjectionSQL.cpp
+++ b/tests/rule_processor/TestLibInjectionSQL.cpp
@@ -29,7 +29,7 @@ TEST(TestLibInjectionSQL, TestRuleset)
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: is_sqli, parameters: {inputs: [{address: arg1}]}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 

--- a/tests/rule_processor/TestLibInjectionXSS.cpp
+++ b/tests/rule_processor/TestLibInjectionXSS.cpp
@@ -29,7 +29,7 @@ TEST(TestLibInjectionXSS, TestRuleset)
     auto rule = readRule(R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: is_xss, parameters: {inputs: [{address: arg1}]}}]}]})");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 

--- a/tests/test.h
+++ b/tests/test.h
@@ -32,6 +32,8 @@ struct PowerWAF;
 #include <ddwaf.h>
 #include <exception.hpp>
 #include <log.hpp>
+#include <parameter.hpp>
+#include <ruleset_info.hpp>
 #include <utils.h>
 #include <validator.hpp>
 #include <yaml-cpp/yaml.h>

--- a/tests/yaml/invalid_multiple_diff.yaml
+++ b/tests/yaml/invalid_multiple_diff.yaml
@@ -1,0 +1,35 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+              key_path:
+                - x
+          regex: .*
+  - id: 2
+    name: rule2
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: squash
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+          regex: .*

--- a/tests/yaml/invalid_multiple_diff_v1.yaml
+++ b/tests/yaml/invalid_multiple_diff_v1.yaml
@@ -1,0 +1,33 @@
+version: '1.1'
+events:
+  - id: 1
+    name: rule1
+    tags:
+      category: category1
+    conditions:
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2:x
+          regex: .*
+  - id: 2
+    name: rule2
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operation: squash
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2
+          regex: .*

--- a/tests/yaml/invalid_multiple_mix.yaml
+++ b/tests/yaml/invalid_multiple_mix.yaml
@@ -1,0 +1,89 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+              key_path:
+                - x
+          regex: .*
+  - id: 2
+    name: rule2
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: squash
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+          regex: .*
+  - id: 3
+    name: rule3
+    tags:
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+              key_path:
+                - y
+          regex: .*
+  - id: 4
+    name: rule4
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+              key_path:
+                - x
+          regex: .*
+      - operator: match_regex
+        parameters:
+          regex: .*
+  - id: 5
+    name: rule5
+    tags:
+      type: type1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+          regex: .*

--- a/tests/yaml/invalid_multiple_mix_v1.yaml
+++ b/tests/yaml/invalid_multiple_mix_v1.yaml
@@ -1,0 +1,83 @@
+version: '1.1'
+events:
+  - id: 1
+    name: rule1
+    tags:
+      category: category1
+    conditions:
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2:x
+          regex: .*
+  - id: 2
+    name: rule2
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operation: squash
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2
+          regex: .*
+  - id: 3
+    name: rule3
+    tags:
+      category: category1
+    conditions:
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2:y
+          regex: .*
+  - id: 4
+    name: rule4
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2:x
+          regex: .*
+      - operation: match_regex
+        parameters:
+          regex: .*
+  - id: 5
+    name: rule5
+    tags:
+      type: type1
+      category: category1
+    conditions:
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2
+          regex: .*

--- a/tests/yaml/invalid_multiple_same.yaml
+++ b/tests/yaml/invalid_multiple_same.yaml
@@ -1,0 +1,50 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+              key_path:
+                - x
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+              key_path:
+                - y
+          regex: .*
+  - id: 2
+    name: rule2
+    tags:
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+              key_path:
+                - x
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+              key_path:
+                - y
+          regex: .*

--- a/tests/yaml/invalid_multiple_same_v1.yaml
+++ b/tests/yaml/invalid_multiple_same_v1.yaml
@@ -1,0 +1,42 @@
+version: '1.1'
+events:
+  - id: 1
+    name: rule1
+    tags:
+      category: category1
+    conditions:
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2:x
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2:y
+          regex: .*
+  - id: 2
+    name: rule2
+    tags:
+      category: category1
+    conditions:
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2:x
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2:y
+          regex: .*

--- a/tests/yaml/invalid_single.yaml
+++ b/tests/yaml/invalid_single.yaml
@@ -1,0 +1,17 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg1
+          regex: .*
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: arg2
+          regex: .*

--- a/tests/yaml/invalid_single_v1.yaml
+++ b/tests/yaml/invalid_single_v1.yaml
@@ -1,0 +1,17 @@
+version: '1.1'
+events:
+  - id: 1
+    name: rule1
+    tags:
+      category: category1
+    conditions:
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg1
+          regex: .*
+      - operation: match_regex
+        parameters:
+          inputs:
+            - arg2
+          regex: .*


### PR DESCRIPTION
This PR introduces `ddwaf_ruleset_info`, parsing diagnostics provided through `ddwaf_init`. These include:
- Failed rules
- Loaded rules
- Errors for failed rules when possible, i.e. the ID was available
- Version of the ruleset