### PR TITLE
WAF Obfuscator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/utils.cpp
     ${libddwaf_SOURCE_DIR}/src/log.cpp
     ${libddwaf_SOURCE_DIR}/src/validator.cpp
+    ${libddwaf_SOURCE_DIR}/src/obfuscator.cpp
     ${libddwaf_SOURCE_DIR}/src/parser/parser.cpp
     ${libddwaf_SOURCE_DIR}/src/parser/parser_v1.cpp
     ${libddwaf_SOURCE_DIR}/src/parser/parser_v2.cpp

--- a/fuzzing/src/ddwaf_interface.cpp
+++ b/fuzzing/src/ddwaf_interface.cpp
@@ -119,8 +119,11 @@ ddwaf_object file_to_object(const char* filename)
 
 ddwaf_handle init_waf()
 {
+    ddwaf_config config{{0, 0, 0},
+        {R"((p(ass)?w(or)?d|pass(_?phrase)?|secret|(api_?|private_?|public_?)key)|token|consumer_?(id|key|secret)|sign(ed|ature)|bearer|authorization)",
+         R"(^(?:\d[ -]*?){13,16}$)"}};
     ddwaf_object rule   = file_to_object("sample_rules.yml");
-    ddwaf_handle handle = ddwaf_init(&rule, NULL, NULL);
+    ddwaf_handle handle = ddwaf_init(&rule, &config, NULL);
     ddwaf_object_free(&rule);
     return handle;
 }

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -17,8 +17,8 @@ extern "C"
 #include <stddef.h>
 
 #define DDWAF_MAX_STRING_LENGTH 4096
-#define DDWAF_MAX_MAP_DEPTH 20
-#define DDWAF_MAX_ARRAY_SIZE 256
+#define DDWAF_MAX_CONTAINER_DEPTH 20
+#define DDWAF_MAX_CONTAINER_SIZE 256
 #define DDWAF_RUN_TIMEOUT 5000
 
 /**
@@ -115,14 +115,15 @@ struct _ddwaf_object
 struct _ddwaf_config
 {
     struct {
-        /** Maximum size of ddwaf::object arrays and maps. */
-        uint32_t max_array_size;
-        /** Maximum depth of ddwaf::object maps. */
-        uint32_t max_map_depth;
+        /** Maximum size of ddwaf::object containers. */
+        uint32_t max_container_size;
+        /** Maximum depth of ddwaf::object containers. */
+        uint32_t max_container_depth;
         /** Maximum length of ddwaf::object strings. */
         uint32_t max_string_length;
     } limits;
 
+    /** Obfuscator regexes - the strings are owned by the caller */
     struct {
         /** Regular expression for key-based obfuscation */
         const char *key_regex;

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -18,7 +18,7 @@ extern "C"
 
 #define DDWAF_MAX_STRING_LENGTH 4096
 #define DDWAF_MAX_MAP_DEPTH 20
-#define DDWAF_MAX_ARRAY_LENGTH 256
+#define DDWAF_MAX_ARRAY_SIZE 256
 #define DDWAF_RUN_TIMEOUT 5000
 
 /**
@@ -114,10 +114,21 @@ struct _ddwaf_object
  **/
 struct _ddwaf_config
 {
-    /** Maximum length of ddwaf::object arrays. */
-    uint64_t maxArrayLength;
-    /** Maximum depth of ddwaf::object maps. */
-    uint64_t maxMapDepth;
+    struct {
+        /** Maximum size of ddwaf::object arrays and maps. */
+        uint32_t max_array_size;
+        /** Maximum depth of ddwaf::object maps. */
+        uint32_t max_map_depth;
+        /** Maximum length of ddwaf::object strings. */
+        uint32_t max_string_length;
+    } limits;
+
+    struct {
+        /** Regular expression for key-based obfuscation */
+        const char *key_regex;
+        /** Regular expression for value-based obfuscation */
+        const char *value_regex;
+    } obfuscator;
 };
 
 /**

--- a/src/PWAdditive.hpp
+++ b/src/PWAdditive.hpp
@@ -15,6 +15,7 @@
 #include <optional>
 #include <utils.h>
 #include <validator.hpp>
+#include <obfuscator.hpp>
 
 class PWAdditive
 {
@@ -39,6 +40,7 @@ protected:
     std::vector<ddwaf_object> argCache;
 
     ddwaf::validator object_validator;
+    const ddwaf::obfuscator &event_obfuscator;
     PWRetriever retriever;
     PWProcessor processor;
     ddwaf_object_free_fn obj_free;

--- a/src/PWProcessor.cpp
+++ b/src/PWProcessor.cpp
@@ -15,12 +15,10 @@ PWProcessor::PWProcessor(PWRetriever& input, const ddwaf::rule_vector& rules_)
     : parameters(input), rules(rules_)
 {
     ranCache.reserve(rules.size());
-    document.SetArray();
 }
 
 void PWProcessor::startNewRun(const ddwaf::monotonic_clock::time_point& _deadline)
 {
-    document.GetArray().Clear();
     deadline = _deadline;
 }
 
@@ -155,9 +153,4 @@ bool PWProcessor::runFlow(const std::string& name,
 bool PWProcessor::isFirstRun() const
 {
     return ranCache.empty();
-}
-
-rapidjson::Document::AllocatorType& PWProcessor::getGlobalAllocator()
-{
-    return document.GetAllocator();
 }

--- a/src/PWProcessor.hpp
+++ b/src/PWProcessor.hpp
@@ -21,7 +21,6 @@ struct PWProcessor;
 
 struct PWProcessor
 {
-    rapidjson::Document document;
     PWRetriever& parameters;
     const ddwaf::rule_vector& rules;
 
@@ -40,7 +39,6 @@ public:
                  PWRetManager& manager);
 
     bool isFirstRun() const;
-    rapidjson::Document::AllocatorType& getGlobalAllocator();
 };
 
 #endif /* PWProcessor_hpp */

--- a/src/PWRet.cpp
+++ b/src/PWRet.cpp
@@ -75,7 +75,7 @@ void PWRetManager::recordRuleMatch(const std::unique_ptr<IPWRuleProcessor>& proc
                 continue;
             }
 
-            redact = redact || event_obfuscator.obfuscate_key(
+            redact = redact || event_obfuscator.is_sensitive_key(
                 {key.stringValue, static_cast<size_t>(key.nbEntries)});
 
             jsonKey.SetString(key.stringValue, static_cast<rapidjson::SizeType>(key.nbEntries), allocator);
@@ -92,8 +92,8 @@ void PWRetManager::recordRuleMatch(const std::unique_ptr<IPWRuleProcessor>& proc
     highlight.SetArray();
 
     redact = redact ||
-             event_obfuscator.obfuscate_value(gather.resolvedValue) ||
-             event_obfuscator.obfuscate_value(gather.matchedValue);
+             event_obfuscator.is_sensitive_value(gather.resolvedValue) ||
+             event_obfuscator.is_sensitive_value(gather.matchedValue);
 
     if (redact) {
         param.AddMember("value", redaction_msg, allocator);

--- a/src/PWRet.cpp
+++ b/src/PWRet.cpp
@@ -77,7 +77,8 @@ void PWRetManager::recordRuleMatch(const std::unique_ptr<IPWRuleProcessor>& proc
             }
 
             if (!redact) {
-                redact = event_obfuscator.obfuscate_key({key.stringValue, key.nbEntries});
+                redact = event_obfuscator.obfuscate_key(
+                    {key.stringValue, static_cast<size_t>(key.nbEntries)});
             }
             jsonKey.SetString(key.stringValue, static_cast<rapidjson::SizeType>(key.nbEntries), allocator);
         }

--- a/src/PWRet.hpp
+++ b/src/PWRet.hpp
@@ -23,7 +23,7 @@ class PWRetManager;
 class PWRetManager
 {
 public:
-    PWRetManager(const ddwaf::obfuscator &eo = ddwaf::obfuscator());
+    PWRetManager(const ddwaf::obfuscator &eo);
 
     DDWAF_RET_CODE getResult() const { return worstCode; }
 

--- a/src/PWRet.hpp
+++ b/src/PWRet.hpp
@@ -17,19 +17,13 @@ class PWRetManager;
 #include <clock.hpp>
 #include <ddwaf.h>
 #include <memory>
+#include <obfuscator.hpp>
 #include <utils.h>
 
 class PWRetManager
 {
-    rapidjson::Document outputDocument;
-    rapidjson::Document::AllocatorType& allocator;
-    rapidjson::Value ruleCollector;
-
-    DDWAF_RET_CODE worstCode { DDWAF_GOOD };
-    bool timeout { false };
-
 public:
-    PWRetManager(rapidjson::Document::AllocatorType& allocator);
+    PWRetManager(const ddwaf::obfuscator &eo = ddwaf::obfuscator());
 
     DDWAF_RET_CODE getResult() const { return worstCode; }
 
@@ -63,6 +57,15 @@ public:
     FRIEND_TEST(TestPWProcessor, TestCache);
     FRIEND_TEST(TestPWProcessor, TestBudget);
 #endif
+protected:
+    rapidjson::Document outputDocument;
+    rapidjson::Document::AllocatorType& allocator;
+    rapidjson::Value ruleCollector;
+    
+    const ddwaf::obfuscator &event_obfuscator;
+
+    DDWAF_RET_CODE worstCode { DDWAF_GOOD };
+    bool timeout { false };
 };
 
 #endif /* PWRet_hpp */

--- a/src/PWRet.hpp
+++ b/src/PWRet.hpp
@@ -61,7 +61,7 @@ protected:
     rapidjson::Document outputDocument;
     rapidjson::Document::AllocatorType& allocator;
     rapidjson::Value ruleCollector;
-    
+
     const ddwaf::obfuscator &event_obfuscator;
 
     DDWAF_RET_CODE worstCode { DDWAF_GOOD };

--- a/src/PWRetriever.cpp
+++ b/src/PWRetriever.cpp
@@ -337,7 +337,7 @@ bool PWRetriever::Iterator::State::isOver() const
 }
 
 PWRetriever::Iterator::Iterator(PWRetriever& _retriever) : 
-    retriever(_retriever), argsIterator(nullptr, retriever.max_map_depth) {}
+    retriever(_retriever), argsIterator(nullptr, retriever.max_depth) {}
 
 void PWRetriever::Iterator::reset(const std::vector<PWManifest::ARG_ID>& targets)
 {
@@ -462,7 +462,7 @@ bool PWRetriever::Iterator::matchIterOnPath(const std::set<std::string>& path, b
 
 PWRetriever::PWRetriever(const PWManifest& _manifest, const ddwaf::object_limits &limits):
     manifest(_manifest), wrapper(),
-    max_map_depth(limits.max_map_depth),
+    max_depth(limits.max_container_depth),
     internalIterator(*this) {}
 
 void PWRetriever::addParameter(const ddwaf_object input)

--- a/src/PWRetriever.cpp
+++ b/src/PWRetriever.cpp
@@ -40,9 +40,9 @@ bool PWRetriever::PWArgsWrapper::isValid() const
     return !parameters.empty();
 }
 
-PWRetriever::ArgsIterator::State::State(const ddwaf_object* args, uint64_t maxDepth) : activeItem(args), itemIndex(0)
+PWRetriever::ArgsIterator::State::State(const ddwaf_object* args, uint32_t maxDepth) : activeItem(args), itemIndex(0)
 {
-    stack.reserve((size_t) maxDepth);
+    stack.reserve(static_cast<size_t>(maxDepth));
 }
 
 bool PWRetriever::ArgsIterator::State::isOver() const
@@ -331,14 +331,13 @@ bool PWRetriever::ArgsIterator::matchIterOnPath(const std::set<std::string>& pat
     return true;
 }
 
-PWRetriever::Iterator::State::State(uint64_t _maxDepth) : maxDepth(_maxDepth) {}
-
 bool PWRetriever::Iterator::State::isOver() const
 {
     return targetCursor == targetEnd;
 }
 
-PWRetriever::Iterator::Iterator(PWRetriever& _retriever) : retriever(_retriever), state(retriever.max_map_depth), argsIterator(nullptr, state.maxDepth) {}
+PWRetriever::Iterator::Iterator(PWRetriever& _retriever) : 
+    retriever(_retriever), argsIterator(nullptr, retriever.max_map_depth) {}
 
 void PWRetriever::Iterator::reset(const std::vector<PWManifest::ARG_ID>& targets)
 {
@@ -461,8 +460,10 @@ bool PWRetriever::Iterator::matchIterOnPath(const std::set<std::string>& path, b
     return argsIterator.matchIterOnPath(path, isAllowList, blockDepth);
 }
 
-PWRetriever::PWRetriever(const PWManifest& _manifest, uint64_t _maxMapDepth, uint64_t _maxArrayLength) : manifest(_manifest), wrapper(), max_map_depth(_maxMapDepth),
-                                                                                                         max_array_length(_maxArrayLength), internalIterator(*this) {}
+PWRetriever::PWRetriever(const PWManifest& _manifest, const ddwaf::object_limits &limits):
+    manifest(_manifest), wrapper(),
+    max_map_depth(limits.max_map_depth),
+    internalIterator(*this) {}
 
 void PWRetriever::addParameter(const ddwaf_object input)
 {

--- a/src/PWRetriever.hpp
+++ b/src/PWRetriever.hpp
@@ -111,7 +111,7 @@ public:
 private:
     const PWManifest& manifest;
     PWArgsWrapper wrapper;
-    uint32_t max_map_depth;
+    uint32_t max_depth;
     Iterator internalIterator;
 
     std::unordered_set<PWManifest::ARG_ID> newestBatch;

--- a/src/PWRetriever.hpp
+++ b/src/PWRetriever.hpp
@@ -18,6 +18,7 @@
 #include <IPWRuleProcessor.h>
 #include <PWManifest.h>
 #include <utils.h>
+#include <validator.hpp>
 
 struct RuleMatchTarget;
 
@@ -45,7 +46,7 @@ public:
             const ddwaf_object* activeItem;
             size_t itemIndex;
 
-            State(const ddwaf_object* args, uint64_t maxDepth);
+            State(const ddwaf_object* args, uint32_t maxDepth);
             bool isOver() const;
             void pushStack(const ddwaf_object* newActive);
             bool popStack();
@@ -81,9 +82,7 @@ public:
         {
             std::vector<PWManifest::ARG_ID>::const_iterator targetCursor;
             std::vector<PWManifest::ARG_ID>::const_iterator targetEnd;
-            const uint64_t maxDepth;
 
-            State(uint64_t _maxDepth);
             bool isOver() const;
         };
 
@@ -112,8 +111,7 @@ public:
 private:
     const PWManifest& manifest;
     PWArgsWrapper wrapper;
-    uint64_t max_map_depth;
-    uint64_t max_array_length;
+    uint32_t max_map_depth;
     Iterator internalIterator;
 
     std::unordered_set<PWManifest::ARG_ID> newestBatch;
@@ -124,7 +122,8 @@ private:
     using ruleCallback = bool(const ddwaf_object*, DDWAF_OBJ_TYPE, bool, bool);
 
 public:
-    PWRetriever(const PWManifest& _manifest, uint64_t _maxMapDepth, uint64_t _maxArrayLength);
+    PWRetriever(const PWManifest& _manifest,
+        const ddwaf::object_limits &limits = ddwaf::object_limits());
     void addParameter(const ddwaf_object input);
     bool hasNewArgs() const;
     bool isKeyInLastBatch(PWManifest::ARG_ID key) const;

--- a/src/PowerWAF.cpp
+++ b/src/PowerWAF.cpp
@@ -24,25 +24,60 @@
 using namespace ddwaf;
 using namespace std::literals;
 
-PowerWAF::PowerWAF(PWManifest&& manifest_, rule_vector&& rules_,
-                   flow_map&& flows_, const ddwaf_config* config)
-    : manifest(std::move(manifest_)),
-      rules(std::move(rules_)),
-      flows(std::move(flows_))
+namespace {
+obfuscator obfuscator_from_config(const ddwaf_config* config)
 {
-    if (config != nullptr)
-    {
-        if (config->maxArrayLength != 0)
-        {
-            maxArrayLength = config->maxArrayLength;
+    std::string_view key_regex, value_regex;
+
+    if (config != nullptr) {
+        if (config->obfuscator.key_regex) {
+            key_regex = config->obfuscator.key_regex;
         }
 
-        if (config->maxMapDepth != 0)
-        {
-            maxMapDepth = config->maxMapDepth;
+        if (config->obfuscator.value_regex) {
+            value_regex = config->obfuscator.value_regex;
         }
     }
+
+    return obfuscator(key_regex, value_regex);
 }
+
+ddwaf::object_limits limits_from_config(const ddwaf_config *config)
+{
+    ddwaf::object_limits limits;
+
+    if (config != nullptr) {
+        if (config->limits.max_array_size != 0)
+        {
+            limits.max_array_size = config->limits.max_array_size;
+        }
+
+        if (config->limits.max_map_depth != 0)
+        {
+            limits.max_map_depth = config->limits.max_map_depth;
+        }
+
+
+        if (config->limits.max_string_length != 0)
+        {
+            limits.max_string_length = config->limits.max_string_length;
+        }
+    }
+
+    return limits;
+}
+
+}
+
+PowerWAF::PowerWAF(PWManifest&& manifest_, rule_vector&& rules_,
+                   flow_map&& flows_, ddwaf::obfuscator &&event_obfuscator_,
+                   object_limits limits_)
+    : manifest(std::move(manifest_)),
+      rules(std::move(rules_)),
+      flows(std::move(flows_)),
+      event_obfuscator(std::move(event_obfuscator_)),
+      limits(limits_)
+{}
 
 PowerWAF* PowerWAF::fromConfig(const ddwaf_object ruleset,
                                const ddwaf_config* config, ddwaf::ruleset_info& info)
@@ -50,12 +85,14 @@ PowerWAF* PowerWAF::fromConfig(const ddwaf_object ruleset,
     PWManifest manifest;
     rule_vector rules;
     flow_map flows;
+    obfuscator obf = obfuscator_from_config(config);
+    object_limits limits = limits_from_config(config);
 
     try
     {
         parser::parse(ruleset, info, rules, manifest, flows);
         return new PowerWAF(std::move(manifest), std::move(rules),
-                            std::move(flows), config);
+                            std::move(flows), std::move(obf), limits);
     }
     catch (const std::exception& e)
     {

--- a/src/PowerWAF.cpp
+++ b/src/PowerWAF.cpp
@@ -47,14 +47,14 @@ ddwaf::object_limits limits_from_config(const ddwaf_config *config)
     ddwaf::object_limits limits;
 
     if (config != nullptr) {
-        if (config->limits.max_array_size != 0)
+        if (config->limits.max_container_size != 0)
         {
-            limits.max_array_size = config->limits.max_array_size;
+            limits.max_container_size = config->limits.max_container_size;
         }
 
-        if (config->limits.max_map_depth != 0)
+        if (config->limits.max_container_depth != 0)
         {
-            limits.max_map_depth = config->limits.max_map_depth;
+            limits.max_container_depth = config->limits.max_container_depth;
         }
 
 

--- a/src/PowerWAF.hpp
+++ b/src/PowerWAF.hpp
@@ -24,9 +24,6 @@ public:
 
     static constexpr ddwaf_version waf_version { 1, 2, 1 };
 
-    uint64_t maxMapDepth { DDWAF_MAX_MAP_DEPTH };
-    uint64_t maxArrayLength { DDWAF_MAX_ARRAY_SIZE };
-
     PWManifest manifest;
     ddwaf::rule_vector rules;
     ddwaf::flow_map flows;

--- a/src/PowerWAF.hpp
+++ b/src/PowerWAF.hpp
@@ -3,31 +3,34 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
+#pragma once
 
-#ifndef pw_hpp
-#define pw_hpp
-
+#include <obfuscator.hpp>
 #include <PWManifest.h>
 #include <rule.hpp>
 #include <ruleset_info.hpp>
 #include <utils.h>
+#include <validator.hpp>
 
-struct PowerWAF
+class PowerWAF
 {
-    uint64_t maxMapDepth { DDWAF_MAX_MAP_DEPTH };
-    uint64_t maxArrayLength { DDWAF_MAX_ARRAY_LENGTH };
-
-    PWManifest manifest;
-    ddwaf::rule_vector rules;
-    ddwaf::flow_map flows;
-
+public:
     PowerWAF(PWManifest&& manifest_, ddwaf::rule_vector&& rules_,
-             ddwaf::flow_map&& flows_, const ddwaf_config* config);
+             ddwaf::flow_map&& flows_, ddwaf::obfuscator &&event_obfuscator_,
+             ddwaf::object_limits limits_ = ddwaf::object_limits());
 
     static PowerWAF* fromConfig(const ddwaf_object rules,
                                 const ddwaf_config* config, ddwaf::ruleset_info& info);
 
     static constexpr ddwaf_version waf_version { 1, 2, 1 };
-};
 
-#endif /* pw_hpp */
+    uint64_t maxMapDepth { DDWAF_MAX_MAP_DEPTH };
+    uint64_t maxArrayLength { DDWAF_MAX_ARRAY_SIZE };
+
+    PWManifest manifest;
+    ddwaf::rule_vector rules;
+    ddwaf::flow_map flows;
+
+    ddwaf::obfuscator event_obfuscator;
+    ddwaf::object_limits limits;
+};

--- a/src/obfuscator.cpp
+++ b/src/obfuscator.cpp
@@ -33,13 +33,24 @@ obfuscator::obfuscator(std::string_view key_regex_str,
     options.set_case_sensitive(false);
 
     if (!key_regex_str.empty()) {
-        const re2::StringPiece sp(key_regex_str.data(), key_regex_str.size());
+        re2::StringPiece sp(key_regex_str.data(), key_regex_str.size());
         key_regex = std::make_unique<re2::RE2>(sp, options);
 
         if (!key_regex->ok())
         {
-            DDWAF_ERROR("invalid obfuscator key regex: %s",
-                value_regex->error_arg().c_str());
+            DDWAF_ERROR("invalid obfuscator key regex: %s - using default",
+                key_regex->error_arg().c_str());
+
+            sp = re2::StringPiece(default_key_regex_str.data(),
+                default_key_regex_str.size());
+            key_regex = std::make_unique<re2::RE2>(sp, options);
+
+            if (!key_regex->ok())
+            {
+                throw std::runtime_error(
+                    "invalid default obfuscator key regex: " +
+                    key_regex->error_arg());
+            }
         }
     }
 

--- a/src/obfuscator.cpp
+++ b/src/obfuscator.cpp
@@ -32,11 +32,13 @@ obfuscator::obfuscator(std::string_view key_regex_str,
     options.set_case_sensitive(false);
 
     if (!key_regex_str.empty()) {
-        key_regex = std::make_unique<re2::RE2>(key_regex_str, options);
+        const re2::StringPiece sp(key_regex_str.data(), key_regex_str.size());
+        key_regex = std::make_unique<re2::RE2>(sp, options);
     }
 
     if (!value_regex_str.empty()) {
-        value_regex = std::make_unique<re2::RE2>(value_regex_str, options);
+        const re2::StringPiece sp(value_regex_str.data(), value_regex_str.size());
+        value_regex = std::make_unique<re2::RE2>(sp, options);
     }
 }
 

--- a/src/obfuscator.cpp
+++ b/src/obfuscator.cpp
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include <obfuscator.hpp>
+#include <utils.h>
+
+namespace ddwaf
+{
+
+namespace
+{
+
+bool match(re2::RE2 &regex, std::string_view value)
+{
+    size_t length = findStringCutoff(value.data(), value.size());
+    const re2::StringPiece key_ref(value.data(), length);
+
+    return regex.Match(key_ref, 0, length, re2::RE2::UNANCHORED, nullptr, 0);
+}
+
+}
+
+obfuscator::obfuscator(std::string_view key_regex_str,
+    std::string_view value_regex_str)
+{
+    re2::RE2::Options options;
+    options.set_max_mem(512 * 1024);
+    options.set_log_errors(false);
+    options.set_case_sensitive(false);
+
+    if (!key_regex_str.empty()) {
+        key_regex = std::make_unique<re2::RE2>(key_regex_str, options);
+    }
+
+    if (!value_regex_str.empty()) {
+        value_regex = std::make_unique<re2::RE2>(value_regex_str, options);
+    }
+}
+
+bool obfuscator::obfuscate_key(std::string_view key) const
+{
+    if (key_regex && match(*key_regex, key)) {
+        return true;
+    }
+
+    return false;
+}
+
+
+bool obfuscator::obfuscate_value(std::string_view value) const
+{
+    if (value_regex && match(*value_regex, value)) {
+        return true;
+    }
+
+    return false;
+}
+
+}

--- a/src/obfuscator.hpp
+++ b/src/obfuscator.hpp
@@ -27,7 +27,7 @@ public:
     bool is_sensitive_key(std::string_view key) const;
     bool is_sensitive_value(std::string_view value) const;
 
-    static constexpr std::string_view redaction_msg{"<redacted by datadog>"};
+    static constexpr std::string_view redaction_msg{"<Redacted>"};
 
 protected:
     static constexpr std::string_view default_key_regex_str{R"((p(ass)?w(or)?d|pass(_?phrase)?|secret|(api_?|private_?|public_?)key)|token|consumer_?(id|key|secret)|sign(ed|ature)|bearer|authorization)"};

--- a/src/obfuscator.hpp
+++ b/src/obfuscator.hpp
@@ -27,6 +27,8 @@ public:
     bool obfuscate_key(std::string_view key) const;
     bool obfuscate_value(std::string_view value) const;
 
+    static constexpr std::string_view redaction_msg{"<redacted by datadog>"};
+
 protected:
     std::unique_ptr<re2::RE2> key_regex { nullptr };
     std::unique_ptr<re2::RE2> value_regex { nullptr };

--- a/src/obfuscator.hpp
+++ b/src/obfuscator.hpp
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#pragma once
+
+#include <re2/re2.h>
+#include <string_view>
+#include <memory>
+#include <ddwaf.h>
+
+namespace ddwaf
+{
+
+// For now this class only services as an inmutable instance of an obfuscator
+// which provides a verdict regarding whether to obfuscate or not. Eventually
+// the objective would be to directly pass events to the obfuscator and have it
+// obfuscate as required.
+
+class obfuscator
+{
+public:
+    explicit obfuscator(std::string_view key_regex_str = std::string_view(),
+        std::string_view value_regex_str = std::string_view());
+    bool obfuscate_key(std::string_view key) const;
+    bool obfuscate_value(std::string_view value) const;
+
+protected:
+    std::unique_ptr<re2::RE2> key_regex { nullptr };
+    std::unique_ptr<re2::RE2> value_regex { nullptr };
+};
+
+}

--- a/src/obfuscator.hpp
+++ b/src/obfuscator.hpp
@@ -30,6 +30,8 @@ public:
     static constexpr std::string_view redaction_msg{"<redacted by datadog>"};
 
 protected:
+    static constexpr std::string_view default_key_regex_str{R"((p(ass)?w(or)?d|pass(_?phrase)?|secret|(api_?|private_?|public_?)key)|token|consumer_?(id|key|secret)|sign(ed|ature)|bearer|authorization)"};
+
     std::unique_ptr<re2::RE2> key_regex { nullptr };
     std::unique_ptr<re2::RE2> value_regex { nullptr };
 };

--- a/src/obfuscator.hpp
+++ b/src/obfuscator.hpp
@@ -24,8 +24,8 @@ class obfuscator
 public:
     explicit obfuscator(std::string_view key_regex_str = std::string_view(),
         std::string_view value_regex_str = std::string_view());
-    bool obfuscate_key(std::string_view key) const;
-    bool obfuscate_value(std::string_view value) const;
+    bool is_sensitive_key(std::string_view key) const;
+    bool is_sensitive_value(std::string_view value) const;
 
     static constexpr std::string_view redaction_msg{"<redacted by datadog>"};
 

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -13,21 +13,27 @@
 namespace ddwaf
 {
 
-validator::validator(uint64_t max_map_depth, uint64_t max_array_length)
-    : max_map_depth_(max_map_depth), max_array_length_(max_array_length)
+validator::validator(const object_limits &limits): limits_(limits)
 {
     //Do the limits make sense?
-    if (max_map_depth_ == 0)
+    if (limits_.max_map_depth == 0)
     {
         DDWAF_DEBUG("Illegal WAF call: sanitization constant 'max_map_depth' should be a positive value");
         throw std::invalid_argument("max_map_depth should be a positive value");
     }
 
-    if (max_array_length_ == 0)
+    if (limits_.max_array_size == 0)
     {
-        DDWAF_DEBUG("Illegal WAF call: sanitization constant 'max_array_length' should be a positive value");
-        throw std::invalid_argument("max_array_length should be a positive value");
+        DDWAF_DEBUG("Illegal WAF call: sanitization constant 'max_array_size' should be a positive value");
+        throw std::invalid_argument("max_array_size should be a positive value");
     }
+
+    if (limits_.max_string_length == 0)
+    {
+        DDWAF_DEBUG("Illegal WAF call: sanitization constant 'max_string_length' should be a positive value");
+        throw std::invalid_argument("max_string_length should be a positive value");
+    }
+
 }
 
 bool validator::validate(ddwaf_object input) const
@@ -75,7 +81,7 @@ bool validator::validate(ddwaf_object input) const
 
 bool validator::validate_helper(ddwaf_object input, uint64_t depth) const
 {
-    if (depth > max_map_depth_)
+    if (depth > limits_.max_map_depth)
     {
         DDWAF_DEBUG("Validation error: Structure depth exceed the allowed limit!");
         return false;
@@ -113,7 +119,7 @@ bool validator::validate_helper(ddwaf_object input, uint64_t depth) const
                 return false;
             }
 
-            else if (input.nbEntries > max_array_length_)
+            else if (input.nbEntries > limits_.max_array_size)
             {
                 DDWAF_DEBUG("Validation error: Array is unacceptably long");
                 return false;

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -16,16 +16,16 @@ namespace ddwaf
 validator::validator(const object_limits &limits): limits_(limits)
 {
     //Do the limits make sense?
-    if (limits_.max_map_depth == 0)
+    if (limits_.max_container_depth == 0)
     {
-        DDWAF_DEBUG("Illegal WAF call: sanitization constant 'max_map_depth' should be a positive value");
-        throw std::invalid_argument("max_map_depth should be a positive value");
+        DDWAF_DEBUG("Illegal WAF call: sanitization constant 'max_container_depth' should be a positive value");
+        throw std::invalid_argument("max_container_depth should be a positive value");
     }
 
-    if (limits_.max_array_size == 0)
+    if (limits_.max_container_size == 0)
     {
-        DDWAF_DEBUG("Illegal WAF call: sanitization constant 'max_array_size' should be a positive value");
-        throw std::invalid_argument("max_array_size should be a positive value");
+        DDWAF_DEBUG("Illegal WAF call: sanitization constant 'max_container_size' should be a positive value");
+        throw std::invalid_argument("max_container_size should be a positive value");
     }
 
     if (limits_.max_string_length == 0)
@@ -81,7 +81,7 @@ bool validator::validate(ddwaf_object input) const
 
 bool validator::validate_helper(ddwaf_object input, uint64_t depth) const
 {
-    if (depth > limits_.max_map_depth)
+    if (depth > limits_.max_container_depth)
     {
         DDWAF_DEBUG("Validation error: Structure depth exceed the allowed limit!");
         return false;
@@ -119,7 +119,7 @@ bool validator::validate_helper(ddwaf_object input, uint64_t depth) const
                 return false;
             }
 
-            else if (input.nbEntries > limits_.max_array_size)
+            else if (input.nbEntries > limits_.max_container_size)
             {
                 DDWAF_DEBUG("Validation error: Array is unacceptably long");
                 return false;

--- a/src/validator.hpp
+++ b/src/validator.hpp
@@ -12,11 +12,17 @@
 namespace ddwaf
 {
 
+struct object_limits {
+    uint32_t max_map_depth { DDWAF_MAX_MAP_DEPTH };
+    uint32_t max_array_size { DDWAF_MAX_ARRAY_SIZE };
+    uint32_t max_string_length { DDWAF_MAX_STRING_LENGTH };
+};
+
 class validator
 {
 public:
     validator() = default;
-    validator(uint64_t max_map_depth, uint64_t max_array_length);
+    validator(const object_limits &limits);
 
     bool validate(ddwaf_object input) const;
 
@@ -34,8 +40,7 @@ public:
 protected:
     bool validate_helper(ddwaf_object input, uint64_t depth = 0) const;
 
-    uint64_t max_map_depth_ { DDWAF_MAX_MAP_DEPTH };
-    uint64_t max_array_length_ { DDWAF_MAX_ARRAY_LENGTH };
+    object_limits limits_;
 };
 
 }

--- a/src/validator.hpp
+++ b/src/validator.hpp
@@ -13,8 +13,8 @@ namespace ddwaf
 {
 
 struct object_limits {
-    uint32_t max_map_depth { DDWAF_MAX_MAP_DEPTH };
-    uint32_t max_array_size { DDWAF_MAX_ARRAY_SIZE };
+    uint32_t max_container_depth { DDWAF_MAX_CONTAINER_DEPTH };
+    uint32_t max_container_size { DDWAF_MAX_CONTAINER_SIZE };
     uint32_t max_string_length { DDWAF_MAX_STRING_LENGTH };
 };
 

--- a/tests/TestAdditive.cpp
+++ b/tests/TestAdditive.cpp
@@ -142,7 +142,7 @@ TEST(TestAdditive, SelectiveRerun)
     PWManifest manifest;
     populateManifest(manifest);
 
-    PWRetriever retriever(manifest, DDWAF_MAX_MAP_DEPTH, DDWAF_MAX_ARRAY_LENGTH);
+    PWRetriever retriever(manifest);
 
     // Manufacture parameters
     ddwaf_object map = DDWAF_OBJECT_MAP, tmp;

--- a/tests/TestObfuscator.cpp
+++ b/tests/TestObfuscator.cpp
@@ -73,6 +73,7 @@ TEST(TestObfuscator, TestConfigKeyValue)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"rule1","highlight":["rule1"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -87,6 +88,7 @@ TEST(TestObfuscator, TestConfigKeyValue)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -100,6 +102,7 @@ TEST(TestObfuscator, TestConfigKeyValue)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -114,6 +117,7 @@ TEST(TestObfuscator, TestConfigKeyValue)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -142,6 +146,7 @@ TEST(TestObfuscator, TestConfigKey)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"rule1","highlight":["rule1"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -156,6 +161,7 @@ TEST(TestObfuscator, TestConfigKey)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -169,6 +175,7 @@ TEST(TestObfuscator, TestConfigKey)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"rule1_obf","highlight":["rule1"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -197,6 +204,7 @@ TEST(TestObfuscator, TestConfigValue)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"rule1","highlight":["rule1"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -211,6 +219,7 @@ TEST(TestObfuscator, TestConfigValue)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"rule1","highlight":["rule1"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -224,6 +233,7 @@ TEST(TestObfuscator, TestConfigValue)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -251,6 +261,7 @@ TEST(TestObfuscator, TestConfigEmpty)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"rule1","highlight":["rule1"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -265,6 +276,7 @@ TEST(TestObfuscator, TestConfigEmpty)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"rule1","highlight":["rule1"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -278,11 +290,11 @@ TEST(TestObfuscator, TestConfigEmpty)
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
         EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"rule1_obf","highlight":["rule1"]}]}]}])");
+        ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
 
     ddwaf_destroy(handle);
 }
-
 
 }

--- a/tests/TestObfuscator.cpp
+++ b/tests/TestObfuscator.cpp
@@ -87,7 +87,7 @@ TEST(TestObfuscator, TestConfigKeyValue)
 
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<Redacted>","highlight":["<Redacted>"]}]}]}])");
         ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
@@ -101,7 +101,7 @@ TEST(TestObfuscator, TestConfigKeyValue)
 
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"<Redacted>","highlight":["<Redacted>"]}]}]}])");
         ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
@@ -116,7 +116,7 @@ TEST(TestObfuscator, TestConfigKeyValue)
 
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<Redacted>","highlight":["<Redacted>"]}]}]}])");
         ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
@@ -160,7 +160,7 @@ TEST(TestObfuscator, TestConfigKey)
 
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<Redacted>","highlight":["<Redacted>"]}]}]}])");
         ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
@@ -232,7 +232,7 @@ TEST(TestObfuscator, TestConfigValue)
 
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":[],"value":"<Redacted>","highlight":["<Redacted>"]}]}]}])");
         ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
@@ -260,7 +260,7 @@ TEST(TestObfuscator, TestConfigHighlight)
 
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_STREQ(out.data, R"([{"rule":{"id":"2","name":"rule2","tags":{"type":"security_scanner","category":"category2"}},"rule_matches":[{"operator":"phrase_match","operator_value":"","parameters":[{"address":"value","key_path":[],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        EXPECT_STREQ(out.data, R"([{"rule":{"id":"2","name":"rule2","tags":{"type":"security_scanner","category":"category2"}},"rule_matches":[{"operator":"phrase_match","operator_value":"","parameters":[{"address":"value","key_path":[],"value":"<Redacted>","highlight":["<Redacted>"]}]}]}])");
         ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }
@@ -375,7 +375,7 @@ TEST(TestObfuscator, TestInvalidConfigKey)
 
         ddwaf_result out;
         EXPECT_EQ(ddwaf_run(context, &parameter, &out, LONG_TIME), DDWAF_MONITOR);
-        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<redacted by datadog>","highlight":["<redacted by datadog>"]}]}]}])");
+        EXPECT_STREQ(out.data, R"([{"rule":{"id":"1","name":"rule1","tags":{"type":"security_scanner","category":"category1"}},"rule_matches":[{"operator":"match_regex","operator_value":"rule1","parameters":[{"address":"value","key_path":["passwordle"],"value":"<Redacted>","highlight":["<Redacted>"]}]}]}])");
         ddwaf_result_free(&out);
         ddwaf_context_destroy(context);
     }

--- a/tests/TestObfuscator.cpp
+++ b/tests/TestObfuscator.cpp
@@ -13,43 +13,43 @@ TEST(TestObfuscator, TestKeyValueObfuscator)
 {
     ddwaf::obfuscator event_obfuscator("^password$"sv, "value"sv);
 
-    EXPECT_TRUE(event_obfuscator.obfuscate_key("password"sv));
-    EXPECT_FALSE(event_obfuscator.obfuscate_key("passworde"sv));
-    EXPECT_FALSE(event_obfuscator.obfuscate_key("random"sv));
+    EXPECT_TRUE(event_obfuscator.is_sensitive_key("password"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_key("passworde"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_key("random"sv));
 
-    EXPECT_TRUE(event_obfuscator.obfuscate_value("random value"sv));
-    EXPECT_TRUE(event_obfuscator.obfuscate_value("value"sv));
-    EXPECT_FALSE(event_obfuscator.obfuscate_value("random"sv));
+    EXPECT_TRUE(event_obfuscator.is_sensitive_value("random value"sv));
+    EXPECT_TRUE(event_obfuscator.is_sensitive_value("value"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_value("random"sv));
 }
 
 TEST(TestObfuscator, TestKeyObfuscator)
 {
     ddwaf::obfuscator event_obfuscator("^password$"sv);
 
-    EXPECT_TRUE(event_obfuscator.obfuscate_key("password"sv));
-    EXPECT_FALSE(event_obfuscator.obfuscate_key("passworde"sv));
-    EXPECT_FALSE(event_obfuscator.obfuscate_key("random"sv));
+    EXPECT_TRUE(event_obfuscator.is_sensitive_key("password"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_key("passworde"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_key("random"sv));
 
-    EXPECT_FALSE(event_obfuscator.obfuscate_value("random value"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_value("random value"sv));
 }
 
 TEST(TestObfuscator, TestValueObfuscator)
 {
     ddwaf::obfuscator event_obfuscator({}, "value"sv);
 
-    EXPECT_FALSE(event_obfuscator.obfuscate_key("password"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_key("password"sv));
 
-    EXPECT_TRUE(event_obfuscator.obfuscate_value("random value"sv));
-    EXPECT_TRUE(event_obfuscator.obfuscate_value("value"sv));
-    EXPECT_FALSE(event_obfuscator.obfuscate_value("random"sv));
+    EXPECT_TRUE(event_obfuscator.is_sensitive_value("random value"sv));
+    EXPECT_TRUE(event_obfuscator.is_sensitive_value("value"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_value("random"sv));
 }
 
 TEST(TestObfuscator, TestEmptyObfuscator)
 {
     ddwaf::obfuscator event_obfuscator;
 
-    EXPECT_FALSE(event_obfuscator.obfuscate_key("password"sv));
-    EXPECT_FALSE(event_obfuscator.obfuscate_value("value"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_key("password"sv));
+    EXPECT_FALSE(event_obfuscator.is_sensitive_value("value"sv));
 }
 
 TEST(TestObfuscator, TestConfigKeyValue)

--- a/tests/TestProcessor.cpp
+++ b/tests/TestProcessor.cpp
@@ -349,7 +349,8 @@ TEST(TestPWProcessor, TestBudget)
     auto& rules = waf->rules;
 
     rapidjson::Document document;
-    PWRetManager rManager;
+    ddwaf::obfuscator eo;
+    PWRetManager rManager(eo);
     PWProcessor processor(wrapper, rules);
     processor.startNewRun(ddwaf::monotonic_clock::now() + chrono::microseconds(50));
 

--- a/tests/TestProcessor.cpp
+++ b/tests/TestProcessor.cpp
@@ -340,7 +340,7 @@ TEST(TestPWProcessor, TestBudget)
     ddwaf_object_map_add(&param, "rx_param", &mapItem);
 
     PowerWAF* waf = reinterpret_cast<PowerWAF*>(handle);
-    PWRetriever wrapper(waf->manifest, DDWAF_MAX_MAP_DEPTH, 500);
+    PWRetriever wrapper(waf->manifest);
     wrapper.addParameter(param);
     ASSERT_TRUE(wrapper.isValid());
 
@@ -349,7 +349,7 @@ TEST(TestPWProcessor, TestBudget)
     auto& rules = waf->rules;
 
     rapidjson::Document document;
-    PWRetManager rManager(document.GetAllocator());
+    PWRetManager rManager;
     PWProcessor processor(wrapper, rules);
     processor.startNewRun(ddwaf::monotonic_clock::now() + chrono::microseconds(50));
 

--- a/tests/TestRetriever.cpp
+++ b/tests/TestRetriever.cpp
@@ -179,7 +179,8 @@ TEST(PWRetriever, NullErrorManagement)
     retriever.addParameter(map);
 
     rapidjson::Document document;
-    PWRetManager rManager;
+    ddwaf::obfuscator eo;
+    PWRetManager rManager(eo);
 
     const condition& cond = ((PowerWAF*) handle)->rules[0].conditions.front();
 

--- a/tests/TestRetriever.cpp
+++ b/tests/TestRetriever.cpp
@@ -11,7 +11,7 @@ using namespace ddwaf;
 TEST(TestPWRetriever, TestCreateNoTarget)
 {
     PWManifest manifest;
-    PWRetriever retriever(manifest, 5, 5);
+    PWRetriever retriever(manifest, ddwaf::object_limits{5, 5, 4096});
 
     PWRetriever::Iterator& iterator = retriever.getIterator({});
 
@@ -29,7 +29,7 @@ TEST(TestPWRetriever, TestCreateNoTarget)
 TEST(TestPWRetriever, TestIterateInvalidItem)
 {
     PWManifest manifest;
-    PWRetriever retriever(manifest, 5, 5);
+    PWRetriever retriever(manifest, ddwaf::object_limits{5, 5, 4096});
     vector<PWManifest::ARG_ID> targets = { 0 };
 
     PWRetriever::Iterator& iterator = retriever.getIterator({});
@@ -69,7 +69,7 @@ TEST(TestPWRetriever, TestInvalidArgConstructor)
 TEST(TestPWRetriever, TestIterateEmptyArray)
 {
     PWManifest manifest;
-    PWRetriever retriever(manifest, 5, 5);
+    PWRetriever retriever(manifest, ddwaf::object_limits{5, 5, 4096});
     vector<PWManifest::ARG_ID> targets = { 0 };
 
     PWRetriever::Iterator& iterator = retriever.getIterator({});
@@ -175,11 +175,11 @@ TEST(PWRetriever, NullErrorManagement)
     ddwaf_object_map_add(&subMap, "lol", ddwaf_object_string(&tmp, "bla"));
     ddwaf_object_map_add(&map, "blob", &subMap);
 
-    PWRetriever retriever(((PowerWAF*) handle)->manifest, 64, 1024);
+    PWRetriever retriever(((PowerWAF*) handle)->manifest);
     retriever.addParameter(map);
 
     rapidjson::Document document;
-    PWRetManager rManager(document.GetAllocator());
+    PWRetManager rManager;
 
     const condition& cond = ((PowerWAF*) handle)->rules[0].conditions.front();
 
@@ -203,7 +203,7 @@ TEST(PWRetriever, IteratorAccessNull)
     ddwaf_object_map_add(&subMap, "lol", ddwaf_object_string(&tmp, "bla"));
     ddwaf_object_map_add(&map, "blob", &subMap);
 
-    PWRetriever retriever(((PowerWAF*) handle)->manifest, 64, 1024);
+    PWRetriever retriever(((PowerWAF*) handle)->manifest);
     retriever.addParameter(map);
 
     PWRetriever::Iterator& iterator = retriever.getIterator({});
@@ -231,7 +231,7 @@ TEST(PWRetriever, IteratorBlockList)
     ddwaf_object_map_add(&subMap, "a", ddwaf_object_string(&tmp, "bla3"));
     ddwaf_object_map_add(&map, "blob1", &subMap);
 
-    PWRetriever retriever(((PowerWAF*) handle)->manifest, 64, 1024);
+    PWRetriever retriever(((PowerWAF*) handle)->manifest);
     retriever.addParameter(map);
 
     const vector<PWManifest::ARG_ID> target = { 0 };

--- a/tests/TestRule.cpp
+++ b/tests/TestRule.cpp
@@ -39,7 +39,7 @@ TEST(TestRule, TestRuleDoMatchInvalidParameters)
     const condition& cond = waf->rules[0].conditions[0];
 
     //Send garbage input
-    PWRetriever retriever(waf->manifest, 256, 256);
+    PWRetriever retriever(waf->manifest);
     PWRetriever::Iterator iterator(retriever);
 
     //Try to trigger a null pointer deref

--- a/tests/TestValidator.cpp
+++ b/tests/TestValidator.cpp
@@ -205,9 +205,9 @@ TEST(TestValidator, TestLimits)
     param.array           = &mapItem;
     mapItem.parameterName = string;
 
-    EXPECT_THROW(validator(0, 42), std::invalid_argument);
-    EXPECT_THROW(validator(42, 0), std::invalid_argument);
-    EXPECT_TRUE(validator(1, 1).validate(param));
+    EXPECT_THROW(validator(ddwaf::object_limits{0, 42, 4096}), std::invalid_argument);
+    EXPECT_THROW(validator(ddwaf::object_limits{42, 0, 4096}), std::invalid_argument);
+    EXPECT_TRUE(validator(ddwaf::object_limits{1, 1, 4096}).validate(param));
 
     ddwaf_object array = DDWAF_OBJECT_ARRAY, tmp;
 
@@ -218,17 +218,17 @@ TEST(TestValidator, TestLimits)
 
     array.parameterName = string;
     param.array         = &array;
-    EXPECT_FALSE(validator(1, 450).validate(param));
-    EXPECT_TRUE(validator(1, 500).validate(param));
+    EXPECT_FALSE(validator(ddwaf::object_limits{1, 450, 4096}).validate(param));
+    EXPECT_TRUE(validator(ddwaf::object_limits{1, 500, 4096}).validate(param));
 
     ddwaf_object subArray = DDWAF_OBJECT_ARRAY;
     ddwaf_object_array_add(&subArray, ddwaf_object_unsigned_force(&tmp, 42));
 
     ddwaf_object_array_add(&array, &subArray);
 
-    EXPECT_FALSE(validator(10, 500).validate(param));
-    EXPECT_TRUE(validator(10, 501).validate(param));
-    EXPECT_FALSE(validator(1, 501).validate(param));
+    EXPECT_FALSE(validator(ddwaf::object_limits{10, 500, 4096}).validate(param));
+    EXPECT_TRUE(validator(ddwaf::object_limits{10, 501, 4096}).validate(param));
+    EXPECT_FALSE(validator(ddwaf::object_limits{1, 501, 4096}).validate(param));
 
     array.parameterName = 0;
     ddwaf_object_free(&array);

--- a/tests/test.h
+++ b/tests/test.h
@@ -12,6 +12,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -32,12 +33,15 @@ struct PowerWAF;
 #include <ddwaf.h>
 #include <exception.hpp>
 #include <log.hpp>
+#include <obfuscator.hpp>
 #include <parameter.hpp>
 #include <parser/common.hpp>
 #include <ruleset_info.hpp>
 #include <utils.h>
 #include <validator.hpp>
 #include <yaml-cpp/yaml.h>
+
+using namespace std::literals;
 
 using namespace ddwaf;
 // 1s and 1us

--- a/tests/yaml/obfuscator.yaml
+++ b/tests/yaml/obfuscator.yaml
@@ -1,0 +1,26 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: security_scanner
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value
+          regex: rule1
+  - id: 2
+    name: rule2
+    tags:
+      type: security_scanner
+      category: category2
+    conditions:
+      - operator: phrase_match
+        parameters:
+          inputs:
+            - address: value
+          list:
+            - badvalue
+            - othervalue


### PR DESCRIPTION
WAF Obfuscator provided as a separate class, for now this simply provides a verdict on whether obfuscation should be done, but the objective would be to have an intermediate event structure which can then be directly obfuscated instead. As of now this introduces an inefficiency in that matches can be discarded after they have been created, if other conditions do not match, so the obfuscation would've been unnecessary (the same applies to generating JSON at that stage). This inefficiency will be addressed with the intermediate event structure.

This also introduces a slight refactoring of the object limits, for now the `max_string_length` limit is not being used but it will be in the near future.