### PR TITLE
Make libinjection look for backticks

### DIFF
--- a/examples/verify_rule.cpp
+++ b/examples/verify_rule.cpp
@@ -138,7 +138,7 @@ bool runVectors(YAML::Node rule, ddwaf_handle handle, bool runPositiveMatches)
 	bool success = true;
 	std::string ruleID = rule["id"].as<std::string>();
 	YAML::Node matches = rule["test_vectors"][runPositiveMatches ? "matches" : "no_matches"];
-	if (matches != nullptr)
+	if (matches)
 	{
 		size_t counter = 0;
 		for (YAML::const_iterator vector = matches.begin(); vector != matches.end(); ++vector, ++counter) {
@@ -198,7 +198,7 @@ int main(int argc, char* argv[])
 			continue;
 		}
 		
-		if(rule["test_vectors"] != nullptr)
+		if(rule["test_vectors"])
 		{
 			// Run positive test vectors (patterns the rule should match)
 			success &= runVectors(rule, handle, true);

--- a/third_party/libinjection/src/libinjection_sqli.h
+++ b/third_party/libinjection/src/libinjection_sqli.h
@@ -24,9 +24,10 @@ enum sqli_flags {
     , FLAG_QUOTE_NONE    = 1   /* 1 << 0 */
     , FLAG_QUOTE_SINGLE  = 2   /* 1 << 1 */
     , FLAG_QUOTE_DOUBLE  = 4   /* 1 << 2 */
+    , FLAG_QUOTE_TICK    = 8   /* 1 << 3 */
 
-    , FLAG_SQL_ANSI      = 8   /* 1 << 3 */
-    , FLAG_SQL_MYSQL     = 16  /* 1 << 4 */
+    , FLAG_SQL_ANSI      = 16  /* 1 << 4 */
+    , FLAG_SQL_MYSQL     = 32  /* 1 << 5 */
 };
 
 enum lookup_type {


### PR DESCRIPTION
Make libinjection more tolerant of backticks, since they're often used in SQL injections.
For instance, introduce detection for 
```
1` or "1" = "1"
```