### PR TITLE
Disable the 1)c libinjection fingerprint

### DIFF
--- a/third_party/libinjection/src/libinjection_sqli_data.h
+++ b/third_party/libinjection/src/libinjection_sqli_data.h
@@ -844,7 +844,8 @@ static const keyword_t sql_keywords[] = {
     {"01)BVK", 'F'},
     {"01)BVO", 'F'},
     {"01)BVU", 'F'},
-    {"01)C", 'F'},
+    // Mostly catches passwords
+    {"01)C", '~'},
     {"01)E(1", 'F'},
     {"01)E(F", 'F'},
     {"01)E(N", 'F'},


### PR DESCRIPTION
libinjection work by computing a fingerprint from an input and matching it in a deny list database.
We disable the `1)c` fingerprint because it only triggered false positives from our analysis.