### PR TITLE
Add function to obtain required rule data IDs

### DIFF
--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -268,6 +268,19 @@ void ddwaf_ruleset_info_free(ddwaf_ruleset_info *info);
  **/
 const char* const* ddwaf_required_addresses(const ddwaf_handle handle, uint32_t *size);
 /**
+ * ddwaf_required_rule_data_ids
+ *
+ * Get a list of required rule data IDs (if any). The memory is owned by the
+ * WAF and should not be freed.
+ *
+ * @param Handle to the WAF instance.
+ * @param size Output parameter in which the size will be returned. The value of
+ *             size will be 0 if the return value is nullptr.
+ * @return NULL if error, otherwise a pointer to an array with size elements.
+ **/
+const char* const* ddwaf_required_rule_data_ids(const ddwaf_handle handle, uint32_t *size);
+
+/**
  * ddwaf_context_init
  *
  * Context object to perform matching using the provided WAF instance.

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -263,8 +263,8 @@ void ddwaf_ruleset_info_free(ddwaf_ruleset_info *info);
  *
  * @param Handle to the WAF instance.
  * @param size Output parameter in which the size will be returned. The value of
- *             size will be 0 if the return value is nullptr.
- * @return NULL if error, otherwise a pointer to an array with size elements.
+ *             size will be 0 if the return value is NULL.
+ * @return NULL if empty, otherwise a pointer to an array with size elements.
  **/
 const char* const* ddwaf_required_addresses(const ddwaf_handle handle, uint32_t *size);
 /**
@@ -275,8 +275,8 @@ const char* const* ddwaf_required_addresses(const ddwaf_handle handle, uint32_t 
  *
  * @param Handle to the WAF instance.
  * @param size Output parameter in which the size will be returned. The value of
- *             size will be 0 if the return value is nullptr.
- * @return NULL if error, otherwise a pointer to an array with size elements.
+ *             size will be 0 if the return value is NULL.
+ * @return NULL if empty, otherwise a pointer to an array with size elements.
  **/
 const char* const* ddwaf_required_rule_data_ids(const ddwaf_handle handle, uint32_t *size);
 

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -155,6 +155,26 @@ extern "C"
         return addresses.data();
     }
 
+
+    const char* const* ddwaf_required_rule_data_ids(const ddwaf_handle handle, uint32_t *size)
+    {
+        if (handle == nullptr)
+        {
+            *size = 0;
+            return nullptr;
+        }
+
+        const auto& ids = handle->get_rule_data_ids();
+        if (ids.empty() || ids.size() > std::numeric_limits<uint32_t>::max())
+        {
+            *size = 0;
+            return nullptr;
+        }
+
+        *size = (uint32_t) ids.size();
+        return ids.data();
+    }
+
     ddwaf_context ddwaf_context_init(const ddwaf_handle handle)
     {
         ddwaf_context output = nullptr;

--- a/src/rule_data_dispatcher.hpp
+++ b/src/rule_data_dispatcher.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <type_traits>
 #include <parameter.hpp>
+#include <vector>
 #include <rule.hpp>
 #include <parser/rule_data_parser.hpp>
 
@@ -88,7 +89,7 @@ public:
     void dispatch(const std::string &id, std::string_view type, parameter &data) {
         auto it = type_dispatchers_.find(id);
         if (it == type_dispatchers_.end()) {
-            DDWAF_ERROR("Dispatcher not found for id '%s'", id.c_str());
+            DDWAF_WARN("Rule data id '%s' has no associated dispatcher", id.c_str());
             return;
         }
 
@@ -115,9 +116,22 @@ public:
             }
         }
     }
+
+    const std::vector<const char*>& get_rule_data_ids() {
+        if (!type_dispatchers_.empty() && rule_data_ids_.empty()) {
+            rule_data_ids_.reserve(type_dispatchers_.size());
+            for (auto &[key, value] : type_dispatchers_) {
+                rule_data_ids_.emplace_back(key.c_str());
+            }
+        }
+
+        return rule_data_ids_;
+    }
+        
 protected:
     std::unordered_map<std::string,
         std::unique_ptr<type_dispatcher_base>> type_dispatchers_;
+    std::vector<const char *> rule_data_ids_;
 };
 
 class dispatcher_builder {

--- a/src/waf.hpp
+++ b/src/waf.hpp
@@ -37,6 +37,10 @@ public:
     const std::vector<const char*>& get_root_addresses() const {
         return ruleset_.manifest.get_root_addresses();
     }
+    const std::vector<const char*>& get_rule_data_ids() {
+        return ruleset_.dispatcher.get_rule_data_ids();
+    }
+
 protected:
     ddwaf::ruleset ruleset_;
     ddwaf::config config_;

--- a/tests/interface_test.cpp
+++ b/tests/interface_test.cpp
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "ddwaf.h"
+#include "test.h"
+
+using namespace ddwaf;
+
+TEST(TestInterface, RootAddresses)
+{
+    auto rule = readFile("interface.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    uint32_t size;
+    const char * const * addresses = ddwaf_required_addresses(handle, &size);
+    EXPECT_EQ(size, 2);
+
+    std::set<std::string_view> available_addresses{"value1", "value2"};
+    while ((size--) != 0U) {
+        EXPECT_NE(available_addresses.find(addresses[size]), available_addresses.end());
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestInterface, RuleDatIDs)
+{
+    auto rule = readFile("rule_data.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    uint32_t size;
+    const char * const * ids = ddwaf_required_rule_data_ids(handle, &size);
+    EXPECT_EQ(size, 2);
+
+    std::set<std::string_view> available_ids{"usr_data", "ip_data"};
+    while ((size--) != 0U) {
+        EXPECT_NE(available_ids.find(ids[size]), available_ids.end());
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestInterface, EmptyRuleDatIDs)
+{
+    auto rule = readFile("interface.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    uint32_t size;
+    const char * const * ids = ddwaf_required_rule_data_ids(handle, &size);
+    EXPECT_EQ(ids, nullptr);
+    EXPECT_EQ(size, 0);
+
+    ddwaf_destroy(handle);
+}
+
+

--- a/tests/waf_test.cpp
+++ b/tests/waf_test.cpp
@@ -23,6 +23,33 @@ TEST(TestWaf, RootAddresses)
     }
 }
 
+TEST(TestWaf, RuleDatIDs)
+{
+    auto rule = readFile("rule_data.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf::ruleset_info info;
+    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    ddwaf_object_free(&rule);
+
+    std::set<std::string_view> available_ids{"usr_data", "ip_data"};
+    for (auto id: instance->get_rule_data_ids()) {
+        EXPECT_NE(available_ids.find(id), available_ids.end());
+    }
+}
+
+TEST(TestWaf, EmptyRuleDatIDs)
+{
+    auto rule = readFile("interface.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf::ruleset_info info;
+    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(instance->get_rule_data_ids().empty());
+}
+
 TEST(TestWaf, BasicContextRun)
 {
     auto rule = readFile("interface.yaml");


### PR DESCRIPTION
Add a function to obtain the require rule data IDs. This provides the WAF user with the ability to filter and discard unnecessary rule IDs before passing them to the WAF.