### PR TITLE
Strip libddwaf.a for darwin/linux release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ if (LIBDDWAF_BUILD_STATIC)
               endif()
               add_custom_command(TARGET libddwaf_static POST_BUILD
                   COMMAND ${STRIP} -x -S $<TARGET_FILE:libddwaf_static> -o $<TARGET_FILE:libddwaf_static>.stripped)
-              install(FILES $<TARGET_FILE:libddwaf_static>.stripped DESTINATION${CMAKE_INSTALL_LIBDIR})
+              install(FILES $<TARGET_FILE:libddwaf_static>.stripped DESTINATION ${CMAKE_INSTALL_LIBDIR})
           endif()
       endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,8 +198,18 @@ if (LIBDDWAF_BUILD_STATIC)
               COMMAND ${CMAKE_COMMAND} -E copy ar_comb/combined${CMAKE_STATIC_LIBRARY_SUFFIX} $<TARGET_FILE:libddwaf_static>
               COMMAND rm -rf ar_comb
               WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-        endif()
-    endif()
+      endif()
+      if(NOT (CMAKE_BUILD_TYPE MATCHES Debug))
+          if (CMAKE_SYSTEM_NAME STREQUAL Darwin OR CMAKE_SYSTEM_NAME STREQUAL Linux)
+              find_program(STRIP strip)
+              if (STRIP STREQUAL "STRIP-NOTFOUND")
+                  message(FATAL_ERROR "strip not found")
+              endif()
+              add_custom_command(TARGET libddwaf_static POST_BUILD
+                  COMMAND ${STRIP} -x -S $<TARGET_FILE:libddwaf_static> -o $<TARGET_FILE:libddwaf_static>.stripped)
+          endif()
+      endif()
+  endif()
 endif()
 
 # Shared library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(LIBDDWAF_SHARED_LINKER_FLAGS "-static-libstdc++" CACHE STRING "Shared library extra linker flags")
 set(LIBDDWAF_EXE_LINKER_FLAGS "" CACHE STRING "Executable extra linker flags")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON
 
 set(LIBDDWAF_SHARED_LINKER_FLAGS "-static-libstdc++" CACHE STRING "Shared library extra linker flags")
 set(LIBDDWAF_EXE_LINKER_FLAGS "" CACHE STRING "Executable extra linker flags")
@@ -208,7 +208,7 @@ if (LIBDDWAF_BUILD_STATIC)
               endif()
               add_custom_command(TARGET libddwaf_static POST_BUILD
                   COMMAND ${STRIP} -x -S $<TARGET_FILE:libddwaf_static> -o $<TARGET_FILE:libddwaf_static>.stripped)
-              install(ARCHIVE $<TARGET_FILE:libddwaf_static>.stripped DESTINATION${CMAKE_INSTALL_LIBDIR})
+              install(FILES $<TARGET_FILE:libddwaf_static>.stripped DESTINATION${CMAKE_INSTALL_LIBDIR})
           endif()
       endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ if (LIBDDWAF_BUILD_STATIC)
               endif()
               add_custom_command(TARGET libddwaf_static POST_BUILD
                   COMMAND ${STRIP} -x -S $<TARGET_FILE:libddwaf_static> -o $<TARGET_FILE:libddwaf_static>.stripped)
+              install(ARCHIVE $<TARGET_FILE:libddwaf_static>.stripped DESTINATION${CMAKE_INSTALL_LIBDIR})
           endif()
       endif()
   endif()


### PR DESCRIPTION
Add strip invocation on libddwaf.a for linux and darwin in release builds.
libddwaf.a is used by the Go tracer to link with the WAF and stripping makes for a better user experience.
This emerged from https://github.com/DataDog/dd-trace-go/issues/1478.