### PR TITLE
linux/aarch64: add missing libunwind.a artefact

### DIFF
--- a/docker/libddwaf/aarch64/Dockerfile
+++ b/docker/libddwaf/aarch64/Dockerfile
@@ -15,7 +15,7 @@ RUN make -C /build libddwaf && \
 	cp /build/build/libddwaf/*.tar.gz /opt && \
 	cp /build/build/libddwaf/tests/testPowerWAF /build && \
 	rm -rf /build/build
-RUN tar -C /muslsysroot/lib -czf /opt/libc++-static-${TARGET_ARCH}-linux.tar.gz libc++.a libc++abi.a
+RUN tar -C /muslsysroot/lib -czf /opt/libc++-static-${TARGET_ARCH}-linux.tar.gz libc++.a libc++abi.a libunwind.a
 
 # PowerWAF tetsts
 RUN apt-get update && apt-get install -y qemu-user-static


### PR DESCRIPTION
Add the missing libunwind.a file to the aarch64 archive of the libc++.