### PR TITLE
Experiment building libddwaf on the oldest available macos target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           path: ${{ github.workspace }}/packages/*.tar.gz
 
   macos-build:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
         with:
@@ -71,7 +71,7 @@ jobs:
           path: ${{ github.workspace }}/packages/*.tar.gz
 
   macos-cross-build:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           path: ${{ github.workspace }}/packages/*.tar.gz
 
   macos-cross-build:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
         with:

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -9,7 +9,7 @@ set(INSTALL_DIR  ${CMAKE_BINARY_DIR}/third_party)
 # workaround for using it in target_include_directories
 file(MAKE_DIRECTORY ${INSTALL_DIR}/include)
 
-set(RAPIDJSON_COMMIT d87b698d0fcc10a5f632ecbc80a9cb2a8fa094a5)
+set(RAPIDJSON_COMMIT 22a62fcc2c2fa2418f5d358cdf65c1df73b418ae)
 ExternalProject_Add(proj_rapidjson
     URL               https://github.com/Tencent/rapidjson/archive/${RAPIDJSON_COMMIT}.tar.gz
     INSTALL_DIR       ${INSTALL_DIR}


### PR DESCRIPTION
We are currently compiling libddwaf on `macos-latest` where it appears some new symbols have been introduced in the libstdc++ which are absent for macos 10.15's libstdc++. 

Related to https://github.com/DataDog/dd-trace-go/issues/1478