### PR TITLE
Support for glob component and arrays on object filter

### DIFF
--- a/src/exclusion/object_filter.cpp
+++ b/src/exclusion/object_filter.cpp
@@ -41,7 +41,7 @@ void iterate_object(const path_trie::traverser &filter, const ddwaf_object *obje
     while (!path_stack.empty()) {
         auto &[current_object, current_index, current_trie] = path_stack.top();
         if (!object::is_container(current_object)) {
-            DDWAF_DEBUG("This is a bug, the object in the stack is not a map");
+            DDWAF_DEBUG("This is a bug, the object in the stack is not a container");
             path_stack.pop();
             continue;
         }
@@ -56,7 +56,7 @@ void iterate_object(const path_trie::traverser &filter, const ddwaf_object *obje
             path_trie::traverser child_traverser{nullptr};
             // Only consider children with keys
             if (child->parameterName == nullptr || child->parameterNameLength == 0) {
-                child_traverser = current_trie.descend();
+                child_traverser = current_trie.descend_wildcard();
             } else {
                 std::string_view key{
                     child->parameterName, static_cast<std::size_t>(child->parameterNameLength)};

--- a/src/exclusion/object_filter.cpp
+++ b/src/exclusion/object_filter.cpp
@@ -12,7 +12,7 @@
 namespace ddwaf::exclusion {
 
 namespace {
-void iterate_object(const path_trie::multitraverser &filter, const ddwaf_object *object,
+void iterate_object(const path_trie::traverser &filter, const ddwaf_object *object,
     std::unordered_set<const ddwaf_object *> &objects_to_exclude, const object_limits &limits)
 {
     using state = path_trie::traverser::state;
@@ -31,15 +31,16 @@ void iterate_object(const path_trie::multitraverser &filter, const ddwaf_object 
         }
     }
 
-    if (object->type != DDWAF_OBJ_MAP) {
+    if (!object::is_container(object)) {
         return;
     }
-    std::stack<std::tuple<const ddwaf_object *, unsigned, path_trie::multitraverser>> path_stack;
+
+    std::stack<std::tuple<const ddwaf_object *, unsigned, path_trie::traverser>> path_stack;
     path_stack.push({object, 0, filter});
 
     while (!path_stack.empty()) {
         auto &[current_object, current_index, current_trie] = path_stack.top();
-        if (!object::is_map(current_object)) {
+        if (!object::is_container(current_object)) {
             DDWAF_DEBUG("This is a bug, the object in the stack is not a map");
             path_stack.pop();
             continue;
@@ -52,14 +53,15 @@ void iterate_object(const path_trie::multitraverser &filter, const ddwaf_object 
         for (; current_index < size; ++current_index) {
             ddwaf_object *child = &current_object->array[current_index];
 
+            path_trie::traverser child_traverser{nullptr};
             // Only consider children with keys
             if (child->parameterName == nullptr || child->parameterNameLength == 0) {
-                continue;
+                child_traverser = current_trie.descend();
+            } else {
+                std::string_view key{
+                    child->parameterName, static_cast<std::size_t>(child->parameterNameLength)};
+                child_traverser = current_trie.descend(key);
             }
-
-            std::string_view key{
-                child->parameterName, static_cast<std::size_t>(child->parameterNameLength)};
-            auto child_traverser = current_trie.descend(key);
             const auto filter_state = child_traverser.get_state();
 
             if (filter_state == state::found) {
@@ -70,7 +72,7 @@ void iterate_object(const path_trie::multitraverser &filter, const ddwaf_object 
                 continue;
             }
 
-            if (child->type == DDWAF_OBJ_MAP && path_stack.size() < limits.max_container_depth) {
+            if (object::is_container(child) && path_stack.size() < limits.max_container_depth) {
                 ++current_index;
                 found_node = true;
                 path_stack.push({child, 0, child_traverser});
@@ -106,7 +108,7 @@ std::unordered_set<const ddwaf_object *> object_filter::match(
         if (object == nullptr) {
             continue;
         }
-        iterate_object(filter.get_multitraverser(), object, objects_to_exclude, limits_);
+        iterate_object(filter.get_traverser(), object, objects_to_exclude, limits_);
 
         cache.emplace(target);
     }

--- a/src/exclusion/object_filter.hpp
+++ b/src/exclusion/object_filter.hpp
@@ -85,8 +85,11 @@ public:
     public:
         enum class state { not_found, found, intermediate_node };
 
-        explicit traverser(trie_node const *root) {
-            if (root != nullptr) { cur_nodes_.emplace_back(root); }
+        explicit traverser(trie_node const *root)
+        {
+            if (root != nullptr) {
+                cur_nodes_.emplace_back(root);
+            }
         }
 
         [[nodiscard]] traverser descend(std::string_view next_key) const
@@ -158,7 +161,7 @@ public:
         }
 
     private:
-        explicit traverser(std::vector<const trie_node*> && nodes): cur_nodes_(std::move(nodes)) {}
+        explicit traverser(std::vector<const trie_node *> &&nodes) : cur_nodes_(std::move(nodes)) {}
         std::vector<const trie_node *> cur_nodes_;
     };
 

--- a/src/exclusion/object_filter.hpp
+++ b/src/exclusion/object_filter.hpp
@@ -37,8 +37,8 @@ class path_trie {
 
         [[nodiscard]] trie_node const *get_child(std::string_view key) const
         {
-            auto it = children.find(key);
-            if (it == children.end()) {
+            auto it = children_.find(key);
+            if (it == children_.end()) {
                 return nullptr;
             }
             return &it->second;
@@ -49,20 +49,23 @@ class path_trie {
             std::string_view key, InternString &&intern_str_fun)
         {
             {
-                auto it = children.find(key);
-                if (it != children.end()) {
+                auto it = children_.find(key);
+                if (it != children_.end()) {
                     return {it->second, false};
                 }
             }
 
             auto interned_str = std::forward<InternString>(intern_str_fun)(key);
-            auto [it, is_new] = children.emplace(std::piecewise_construct,
+            auto [it, is_new] = children_.emplace(std::piecewise_construct,
                 std::forward_as_tuple(interned_str), std::forward_as_tuple());
             return {std::reference_wrapper{it->second}, true};
         }
 
-        [[nodiscard]] bool is_terminal() const { return children.empty(); }
+        [[nodiscard]] bool is_terminal() const { return children_.empty(); }
 
+        void clear() { children_.clear(); }
+
+    protected:
 #ifdef HAS_NONRECURSIVE_UNORDERED_MAP
         // unordered_map doesn't allow trie_node as the value of the map
         // because trie_node is an incomplete type at this point
@@ -70,7 +73,7 @@ class path_trie {
 #else
         template <typename K, typename V> using MapType = std::unordered_map<K, V>;
 #endif
-        MapType<std::string_view, trie_node> children{};
+        MapType<std::string_view, trie_node> children_{};
     };
     static_assert(std::is_move_assignable_v<trie_node>);
     static_assert(std::is_move_constructible_v<trie_node>);
@@ -82,82 +85,81 @@ public:
     public:
         enum class state { not_found, found, intermediate_node };
 
-        explicit traverser(trie_node const *root) : cur_node{root} {}
+        explicit traverser(trie_node const *root) {
+            if (root != nullptr) { cur_nodes_.emplace_back(root); }
+        }
+
         [[nodiscard]] traverser descend(std::string_view next_key) const
         {
             if (get_state() != state::intermediate_node) {
-                // once found/not_found, as we descend we keep the state
                 return *this;
             }
-            return traverser{cur_node->get_child(next_key)};
+
+            std::vector<const trie_node *> next_nodes;
+            next_nodes.reserve(cur_nodes_.size());
+
+            for (const auto *cur_node : cur_nodes_) {
+                const auto *next_node = cur_node->get_child(next_key);
+                if (next_node != nullptr) {
+                    if (next_node->is_terminal()) {
+                        return traverser{next_node};
+                    }
+
+                    next_nodes.emplace_back(next_node);
+                }
+
+                const auto *glob_node = cur_node->get_child("*");
+                if (glob_node != nullptr) {
+                    if (glob_node->is_terminal()) {
+                        return traverser{glob_node};
+                    }
+
+                    next_nodes.emplace_back(glob_node);
+                }
+            }
+
+            return traverser{std::move(next_nodes)};
         }
+
+        [[nodiscard]] traverser descend() const
+        {
+            if (get_state() != state::intermediate_node) {
+                return *this;
+            }
+
+            std::vector<const trie_node *> next_nodes;
+            next_nodes.reserve(cur_nodes_.size());
+
+            for (const auto *cur_node : cur_nodes_) {
+                const auto *glob_node = cur_node->get_child("*");
+                if (glob_node != nullptr) {
+                    if (glob_node->is_terminal()) {
+                        return traverser{glob_node};
+                    }
+
+                    next_nodes.emplace_back(glob_node);
+                }
+            }
+
+            return traverser{std::move(next_nodes)};
+        }
+
         [[nodiscard]] state get_state() const
         {
-            if (cur_node == nullptr) {
+            if (cur_nodes_.empty()) {
                 return state::not_found;
             }
-            return cur_node->is_terminal() ? state::found : state::intermediate_node;
+
+            if (cur_nodes_.size() == 1 && cur_nodes_.back()->is_terminal()) {
+                return state::found;
+            }
+
+            return state::intermediate_node;
         }
 
     private:
-        trie_node const *const cur_node{};
-    };
-
-    class multitraverser {
-    public:
-        explicit multitraverser(trie_node const *root) : traversers_({traverser{root}}) {}
-        [[nodiscard]] multitraverser descend(std::string_view next_key) const
-        {
-            std::vector<traverser> new_traversers;
-            new_traversers.reserve(traversers_.size());
-
-            for (const auto &traverser : traversers_) {
-                {
-                    auto new_traverser = traverser.descend(next_key);
-                    auto new_state = new_traverser.get_state();
-
-                    if (new_state == traverser::state::found) {
-                        return multitraverser({new_traverser});
-                    }
-
-                    if (new_state != traverser::state::not_found) {
-                        new_traversers.emplace_back(new_traverser);
-                    }
-                }
-
-                {
-                    auto new_traverser = traverser.descend("*");
-                    auto new_state = new_traverser.get_state();
-
-                    if (new_state == traverser::state::found) {
-                        return multitraverser({new_traverser});
-                    }
-
-                    if (new_state != traverser::state::not_found) {
-                        new_traversers.emplace_back(new_traverser);
-                    }
-                }
-            }
-
-            return multitraverser(std::move(new_traversers));
-        }
-
-        [[nodiscard]] traverser::state get_state() const
-        {
-            if (traversers_.empty()) {
-                return traverser::state::not_found;
-            }
-            if (traversers_.size() == 1) {
-                return traversers_.back().get_state();
-            }
-
-            return traverser::state::intermediate_node;
-        }
-
-    protected:
-        explicit multitraverser(std::vector<traverser> &&traversers) : traversers_(traversers) {}
-
-        std::vector<traverser> traversers_;
+        explicit traverser(std::vector<const trie_node*> && nodes): cur_nodes_(std::move(nodes)) {}
+        std::vector<const trie_node *> cur_nodes_;
     };
 
     template <typename StringType,
@@ -184,7 +186,7 @@ public:
         }
         if (!last_is_new) {
             // already existed. If it had children, make it a terminal node
-            cur->children.clear();
+            cur->clear();
         }
     }
 
@@ -194,14 +196,6 @@ public:
             return traverser{nullptr};
         }
         return traverser{&root.value()};
-    }
-
-    [[nodiscard]] multitraverser get_multitraverser() const
-    {
-        if (!root) {
-            return multitraverser{nullptr};
-        }
-        return multitraverser{&root.value()};
     }
 
 private:

--- a/src/exclusion/object_filter.hpp
+++ b/src/exclusion/object_filter.hpp
@@ -95,6 +95,7 @@ public:
         [[nodiscard]] traverser descend(std::string_view next_key) const
         {
             if (get_state() != state::intermediate_node) {
+                // once found/not_found, as we descend we keep the state
                 return *this;
             }
 
@@ -124,7 +125,7 @@ public:
             return traverser{std::move(next_nodes)};
         }
 
-        [[nodiscard]] traverser descend() const
+        [[nodiscard]] traverser descend_wildcard() const
         {
             if (get_state() != state::intermediate_node) {
                 return *this;

--- a/src/exclusion/object_filter.hpp
+++ b/src/exclusion/object_filter.hpp
@@ -111,30 +111,30 @@ public:
             std::vector<traverser> new_traversers;
             new_traversers.reserve(traversers_.size());
 
-            for (const auto &t : traversers_) {
+            for (const auto &traverser : traversers_) {
                 {
-                    auto new_t = t.descend(next_key);
-                    auto new_state = new_t.get_state();
+                    auto new_traverser = traverser.descend(next_key);
+                    auto new_state = new_traverser.get_state();
 
                     if (new_state == traverser::state::found) {
-                        return multitraverser({new_t});
+                        return multitraverser({new_traverser});
                     }
 
                     if (new_state != traverser::state::not_found) {
-                        new_traversers.emplace_back(new_t);
+                        new_traversers.emplace_back(new_traverser);
                     }
                 }
 
                 {
-                    auto new_t = t.descend("*");
-                    auto new_state = new_t.get_state();
+                    auto new_traverser = traverser.descend("*");
+                    auto new_state = new_traverser.get_state();
 
                     if (new_state == traverser::state::found) {
-                        return multitraverser({new_t});
+                        return multitraverser({new_traverser});
                     }
 
                     if (new_state != traverser::state::not_found) {
-                        new_traversers.emplace_back(new_t);
+                        new_traversers.emplace_back(new_traverser);
                     }
                 }
             }
@@ -144,13 +144,18 @@ public:
 
         [[nodiscard]] traverser::state get_state() const
         {
-            if (traversers_.empty()) { return traverser::state::not_found; }
-            if (traversers_.size() == 1) { return traversers_.back().get_state(); }
+            if (traversers_.empty()) {
+                return traverser::state::not_found;
+            }
+            if (traversers_.size() == 1) {
+                return traversers_.back().get_state();
+            }
 
             return traverser::state::intermediate_node;
         }
+
     protected:
-        explicit multitraverser(std::vector<traverser> &&traversers): traversers_(traversers) {}
+        explicit multitraverser(std::vector<traverser> &&traversers) : traversers_(traversers) {}
 
         std::vector<traverser> traversers_;
     };
@@ -198,7 +203,6 @@ public:
         }
         return multitraverser{&root.value()};
     }
-
 
 private:
     std::string_view intern_string(std::string_view orig_sv)

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -12,24 +12,6 @@
 
 namespace ddwaf::object {
 
-namespace {
-bool is_container(const ddwaf_object *obj)
-{
-    return obj != nullptr && (obj->type & PWI_CONTAINER_TYPES) != 0 && obj->array != nullptr;
-}
-
-bool is_map(const ddwaf_object *obj)
-{
-    return obj != nullptr && obj->type == DDWAF_OBJ_MAP && obj->array != nullptr;
-}
-
-bool is_scalar(const ddwaf_object *obj)
-{
-    return obj != nullptr && (obj->type & PWI_DATA_TYPES) != 0;
-}
-
-} // namespace
-
 template <typename T>
 iterator_base<T>::iterator_base(
     const std::unordered_set<const ddwaf_object *> &exclude, const object_limits &limits)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -324,7 +324,7 @@ DDWAF_OBJ_TYPE ddwaf_object_type(ddwaf_object *object)
 
 size_t ddwaf_object_size(ddwaf_object *object)
 {
-    if (object == nullptr || !IS_CONTAINER(object)) {
+    if (object == nullptr || !ddwaf::object::is_container(object)) {
         return 0;
     }
 
@@ -386,7 +386,7 @@ int64_t ddwaf_object_get_signed(ddwaf_object *object)
 
 ddwaf_object *ddwaf_object_get_index(ddwaf_object *object, size_t index)
 {
-    if (object == nullptr || !IS_CONTAINER(object) || index >= object->nbEntries) {
+    if (object == nullptr || !ddwaf::object::is_container(object) || index >= object->nbEntries) {
         return nullptr;
     }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,7 +18,22 @@ size_t find_string_cutoff(
     const char *str, size_t length, uint32_t max_string_length = DDWAF_MAX_STRING_LENGTH);
 
 // Internals
-#define IS_CONTAINER(obj) ((obj)->type & (DDWAF_OBJ_ARRAY | DDWAF_OBJ_MAP))
-
 #define PWI_DATA_TYPES (DDWAF_OBJ_SIGNED | DDWAF_OBJ_UNSIGNED | DDWAF_OBJ_STRING)
 #define PWI_CONTAINER_TYPES (DDWAF_OBJ_ARRAY | DDWAF_OBJ_MAP)
+
+namespace ddwaf::object {
+inline bool is_container(const ddwaf_object *obj)
+{
+    return obj != nullptr && (obj->type & PWI_CONTAINER_TYPES) != 0 && obj->array != nullptr;
+}
+
+inline bool is_map(const ddwaf_object *obj)
+{
+    return obj != nullptr && obj->type == DDWAF_OBJ_MAP && obj->array != nullptr;
+}
+
+inline bool is_scalar(const ddwaf_object *obj)
+{
+    return obj != nullptr && (obj->type & PWI_DATA_TYPES) != 0;
+}
+} // namespace ddwaf::object

--- a/tests/object_filter_test.cpp
+++ b/tests/object_filter_test.cpp
@@ -5,6 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 
 #include "test.h"
+#include "test_utils.hpp"
 
 using namespace ddwaf;
 using namespace ddwaf::exclusion;
@@ -239,5 +240,416 @@ TEST(TestObjectFilter, MultipleTargetsCache)
     {
         auto objects_filtered = filter.match(store, cache, deadline);
         EXPECT_TRUE(objects_filtered.empty());
+    }
+}
+
+TEST(TestObjectFilter, SingleGlobTarget)
+{
+    ddwaf::manifest_builder mb;
+    auto query = mb.insert("query", {});
+    auto manifest = mb.build_manifest();
+
+    object_filter filter;
+    filter.insert(query, {"*"});
+
+    ddwaf::timer deadline{2s};
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, tmp;
+        // Query
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 2);
+        EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, grandchild, tmp;
+        // Query
+        ddwaf_object_map(&grandchild);
+        ddwaf_object_map_add(&grandchild, "value", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", &grandchild);
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 2);
+        EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, tmp;
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", ddwaf_object_invalid(&tmp));
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 0);
+    }
+}
+
+TEST(TestObjectFilter, GlobAndKeyTarget)
+{
+    ddwaf::manifest_builder mb;
+    auto query = mb.insert("query", {});
+    auto manifest = mb.build_manifest();
+
+    object_filter filter;
+    filter.insert(query, {"*"});
+    filter.insert(query, {"uri"});
+
+    ddwaf::timer deadline{2s};
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, tmp;
+        // Query
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 2);
+        EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, grandchild, tmp;
+        // Query
+        ddwaf_object_map(&grandchild);
+        ddwaf_object_map_add(&grandchild, "value", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", &grandchild);
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 2);
+        EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, tmp;
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", ddwaf_object_invalid(&tmp));
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 0);
+    }
+}
+
+TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
+{
+    ddwaf::manifest_builder mb;
+    auto query = mb.insert("query", {});
+    auto manifest = mb.build_manifest();
+
+    object_filter filter;
+    filter.insert(query, {"*", "value"});
+    filter.insert(query, {"uri", "other"});
+
+    ddwaf::timer deadline{2s};
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, grandchild, grandnephew, tmp;
+        // Query
+        ddwaf_object_map(&grandchild);
+        ddwaf_object_map_add(&grandchild, "other", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&grandnephew);
+        ddwaf_object_map_add(&grandnephew, "other", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", &grandchild);
+        ddwaf_object_map_add(&child, "uri", &grandnephew);
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 1);
+        EXPECT_NE(objects_filtered.find(&grandnephew.array[0]), objects_filtered.end());
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, grandchild, grandnephew, tmp;
+        // Query
+        ddwaf_object_map(&grandchild);
+        ddwaf_object_map_add(&grandchild, "value", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&grandnephew);
+        ddwaf_object_map_add(&grandnephew, "value", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", &grandchild);
+        ddwaf_object_map_add(&child, "uri", &grandnephew);
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 2);
+        EXPECT_NE(objects_filtered.find(&grandnephew.array[0]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&grandchild.array[0]), objects_filtered.end());
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, grandchild, grandnephew, tmp;
+        // Query
+        ddwaf_object_map(&grandchild);
+        ddwaf_object_map_add(&grandchild, "whatever", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&grandnephew);
+        ddwaf_object_map_add(&grandnephew, "random", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "value", &grandchild);
+        ddwaf_object_map_add(&child, "other", &grandnephew);
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 0);
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, tmp;
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "value", ddwaf_object_string(&tmp, "value"));
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 0);
+    }
+}
+
+TEST(TestObjectFilter, MultipleGlobsTargets)
+{
+    ddwaf::manifest_builder mb;
+    auto query = mb.insert("query", {});
+    auto manifest = mb.build_manifest();
+
+    object_filter filter;
+    filter.insert(query, {"*", "*", "*"});
+
+    ddwaf::timer deadline{2s};
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, grandchild, grandnephew, greatgrandchild, greatgrandnephew, tmp;
+
+        ddwaf_object_map(&greatgrandchild);
+        ddwaf_object_map_add(&greatgrandchild, "other", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(
+            &greatgrandchild, "somethingelse", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&grandchild);
+        ddwaf_object_map_add(&grandchild, "something", &greatgrandchild);
+
+        ddwaf_object_map(&greatgrandnephew);
+        ddwaf_object_map_add(&greatgrandnephew, "other", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(
+            &greatgrandnephew, "somethingelse", ddwaf_object_string(&tmp, "paramsvalue"));
+
+        ddwaf_object_map(&grandnephew);
+        ddwaf_object_map_add(&grandnephew, "random", &greatgrandnephew);
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", &grandchild);
+        ddwaf_object_map_add(&child, "uri", &grandnephew);
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 4);
+        EXPECT_NE(objects_filtered.find(&greatgrandchild.array[0]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&greatgrandchild.array[1]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&greatgrandnephew.array[0]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&greatgrandnephew.array[1]), objects_filtered.end());
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, grandchild, grandnephew, tmp;
+
+        ddwaf_object_map(&grandchild);
+        ddwaf_object_map_add(&grandchild, "something", ddwaf_object_string(&tmp, "value"));
+
+        ddwaf_object_map(&grandnephew);
+        ddwaf_object_map_add(&grandnephew, "random", ddwaf_object_string(&tmp, "value"));
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", &grandchild);
+        ddwaf_object_map_add(&child, "uri", &grandnephew);
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 0);
+    }
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, child, tmp;
+
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "value"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "value"));
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        EXPECT_EQ(objects_filtered.size(), 0);
+    }
+}
+
+TEST(TestObjectFilter, MultipleComponentsMultipleGlobAndKeyTargets)
+{
+    ddwaf::manifest_builder mb;
+    auto query = mb.insert("query", {});
+    auto manifest = mb.build_manifest();
+
+    object_filter filter;
+    filter.insert(query, {"a", "b", "c"});
+    filter.insert(query, {"a", "*", "d", "e"});
+    filter.insert(query, {"a", "*", "e", "*"});
+    filter.insert(query, {"a", "*", "f", "*", "g"});
+
+    // Successful tests
+    {
+        std::vector<std::pair<std::string, std::string>> tests{
+            {"{query: {a: {b: {c: hello}}}}", "c"},
+            {"{query: {a: {b: {c: {e: hello}}}}}", "c"},
+            {"{query: {a: {b: {d: {e: hello}}}}}", "e"},
+            {"{query: {a: {h: {d: {e: hello}}}}}", "e"},
+            {"{query: {a: {g: {d: {e: {f: [hello, bye]}}}}}}", "e"},
+            {"{query: {a: {n: {e: {f: [hello, bye]}}}}}", "f"},
+            {"{query: {a: {n: {e: {x: [hello, bye]}}}}}", "x"},
+            {"{query: {a: {n: {e: {x: {f: [hello, bye]}}}}}}", "x"},
+            {"{query: {a: {p: {f: {x: {g: [hello, bye]}}}}}}", "g"},
+            {"{query: {a: {a: {f: {e: {g: {k: [hello, bye]}}}}}}}", "g"},
+        };
+
+        for (auto &[object, result] : tests) {
+            object_store store(manifest);
+            object_filter::cache_type cache;
+            ddwaf_object root = json_to_object(object);
+            store.insert(root);
+
+            ddwaf::timer deadline{2s};
+            auto objects_filtered = filter.match(store, cache, deadline);
+            EXPECT_EQ(objects_filtered.size(), 1);
+            EXPECT_STREQ((*objects_filtered.begin())->parameterName, result.c_str());
+        }
+    }
+
+    // Failure tests
+    {
+        std::vector<std::string> tests{
+            "{query: [a, b, c, d]}",
+            "{query: hello}",
+            "{query: {a: hello}}",
+            "{query: {a: {b: hello}}}",
+            "{query: {a: {b: {e: hello}}}}",
+            "{query: {a: {b: [c]}}}",
+            "{query: {a: {b: {g: {e: hello}}}}}",
+            "{query: {a: {b: {f: {e: {h: hello}}}}}}",
+        };
+
+        for (auto &object : tests) {
+            object_store store(manifest);
+            object_filter::cache_type cache;
+            ddwaf_object root = json_to_object(object);
+            store.insert(root);
+
+            ddwaf::timer deadline{2s};
+            auto objects_filtered = filter.match(store, cache, deadline);
+            EXPECT_EQ(objects_filtered.size(), 0);
+        }
     }
 }

--- a/tests/object_filter_test.cpp
+++ b/tests/object_filter_test.cpp
@@ -33,7 +33,7 @@ TEST(TestObjectFilter, RootTarget)
     object_filter::cache_type cache;
     auto objects_filtered = filter.match(store, cache, deadline);
 
-    EXPECT_EQ(objects_filtered.size(), 1);
+    ASSERT_EQ(objects_filtered.size(), 1);
     EXPECT_NE(objects_filtered.find(&root.array[0]), objects_filtered.end());
 }
 
@@ -60,7 +60,7 @@ TEST(TestObjectFilter, SingleTarget)
     object_filter::cache_type cache;
     auto objects_filtered = filter.match(store, cache, deadline);
 
-    EXPECT_EQ(objects_filtered.size(), 1);
+    ASSERT_EQ(objects_filtered.size(), 1);
     EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
 }
 
@@ -103,7 +103,7 @@ TEST(TestObjectFilter, MultipleTargets)
     object_filter::cache_type cache;
     auto objects_filtered = filter.match(store, cache, deadline);
 
-    EXPECT_EQ(objects_filtered.size(), 2);
+    ASSERT_EQ(objects_filtered.size(), 2);
     EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
     EXPECT_NE(objects_filtered.find(&object.array[0]), objects_filtered.end());
 }
@@ -146,7 +146,7 @@ TEST(TestObjectFilter, MissingTarget)
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
     auto objects_filtered = filter.match(store, cache, deadline);
-    EXPECT_EQ(objects_filtered.size(), 0);
+    ASSERT_EQ(objects_filtered.size(), 0);
 }
 
 TEST(TestObjectFilter, SingleTargetCache)
@@ -172,7 +172,7 @@ TEST(TestObjectFilter, SingleTargetCache)
     object_filter::cache_type cache;
     {
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 1);
+        ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
     }
 
@@ -210,7 +210,7 @@ TEST(TestObjectFilter, MultipleTargetsCache)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 1);
+        ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
     }
 
@@ -233,7 +233,7 @@ TEST(TestObjectFilter, MultipleTargetsCache)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 1);
+        ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_NE(objects_filtered.find(&object.array[0]), objects_filtered.end());
     }
 
@@ -269,7 +269,7 @@ TEST(TestObjectFilter, SingleGlobTarget)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 2);
+        ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
         EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
     }
@@ -293,7 +293,7 @@ TEST(TestObjectFilter, SingleGlobTarget)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 2);
+        ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
         EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
     }
@@ -309,7 +309,7 @@ TEST(TestObjectFilter, SingleGlobTarget)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 0);
+        ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
 
@@ -340,7 +340,7 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 2);
+        ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
         EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
     }
@@ -364,7 +364,7 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 2);
+        ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
         EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
     }
@@ -380,7 +380,7 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 0);
+        ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
 
@@ -418,7 +418,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 1);
+        ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_NE(objects_filtered.find(&grandnephew.array[0]), objects_filtered.end());
     }
 
@@ -444,7 +444,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 2);
+        ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_NE(objects_filtered.find(&grandnephew.array[0]), objects_filtered.end());
         EXPECT_NE(objects_filtered.find(&grandchild.array[0]), objects_filtered.end());
     }
@@ -471,7 +471,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 0);
+        ASSERT_EQ(objects_filtered.size(), 0);
     }
 
     {
@@ -489,7 +489,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 0);
+        ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
 
@@ -536,7 +536,7 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 4);
+        ASSERT_EQ(objects_filtered.size(), 4);
         EXPECT_NE(objects_filtered.find(&greatgrandchild.array[0]), objects_filtered.end());
         EXPECT_NE(objects_filtered.find(&greatgrandchild.array[1]), objects_filtered.end());
         EXPECT_NE(objects_filtered.find(&greatgrandnephew.array[0]), objects_filtered.end());
@@ -565,7 +565,7 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 0);
+        ASSERT_EQ(objects_filtered.size(), 0);
     }
 
     {
@@ -584,7 +584,7 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
-        EXPECT_EQ(objects_filtered.size(), 0);
+        ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
 
@@ -623,7 +623,7 @@ TEST(TestObjectFilter, MultipleComponentsMultipleGlobAndKeyTargets)
 
             ddwaf::timer deadline{2s};
             auto objects_filtered = filter.match(store, cache, deadline);
-            EXPECT_EQ(objects_filtered.size(), 1);
+            ASSERT_EQ(objects_filtered.size(), 1);
             EXPECT_STREQ((*objects_filtered.begin())->parameterName, result.c_str());
         }
     }
@@ -649,7 +649,45 @@ TEST(TestObjectFilter, MultipleComponentsMultipleGlobAndKeyTargets)
 
             ddwaf::timer deadline{2s};
             auto objects_filtered = filter.match(store, cache, deadline);
-            EXPECT_EQ(objects_filtered.size(), 0);
+            ASSERT_EQ(objects_filtered.size(), 0);
         }
+    }
+}
+
+TEST(TestObjectFilter, ArrayWithGlobTargets)
+{
+    ddwaf::manifest_builder mb;
+    auto query = mb.insert("query", {});
+    auto manifest = mb.build_manifest();
+
+    object_filter filter;
+    filter.insert(query, {"a", "*", "c", "d"});
+
+    {
+        object_store store(manifest);
+        object_filter::cache_type cache;
+        ddwaf_object root, a, b, c, d, tmp;
+
+        ddwaf_object_map(&d);
+        ddwaf_object_map_add(&d, "d", ddwaf_object_string(&tmp, "value"));
+
+        ddwaf_object_map(&c);
+        ddwaf_object_map_add(&c, "c", &d);
+
+        ddwaf_object_array(&b);
+        ddwaf_object_array_add(&b, &c);
+
+        ddwaf_object_map(&a);
+        ddwaf_object_map_add(&a, "a", &b);
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &a);
+
+        store.insert(root);
+
+        ddwaf::timer deadline{2s};
+        auto objects_filtered = filter.match(store, cache, deadline);
+        ASSERT_EQ(objects_filtered.size(), 1);
     }
 }

--- a/tests/path_trie_test.cpp
+++ b/tests/path_trie_test.cpp
@@ -21,7 +21,7 @@ TEST(TestPathTrie, Basic)
         EXPECT_EQ(path.get_state(), state::intermediate_node);
 
         auto to = path.descend("to");
-        EXPECT_EQ(path.get_state(), state::intermediate_node);
+        EXPECT_EQ(to.get_state(), state::intermediate_node);
 
         auto object = to.descend("object");
         EXPECT_EQ(object.get_state(), state::found);
@@ -48,6 +48,131 @@ TEST(TestPathTrie, Basic)
     }
 }
 
+TEST(TestPathTrie, Glob)
+{
+    ddwaf::exclusion::path_trie trie;
+    trie.insert<std::string>({"path", "*", "object"});
+
+    auto it = trie.get_traverser();
+    {
+        auto path = it.descend("path");
+        EXPECT_EQ(path.get_state(), state::intermediate_node);
+
+        auto to = path.descend("to");
+        EXPECT_EQ(to.get_state(), state::intermediate_node);
+
+        auto object = to.descend("object");
+        EXPECT_EQ(object.get_state(), state::found);
+    }
+
+    {
+        auto path = it.descend("path");
+        EXPECT_EQ(path.get_state(), state::intermediate_node);
+
+        auto to = path.descend();
+        EXPECT_EQ(to.get_state(), state::intermediate_node);
+
+        auto object = to.descend("object");
+        EXPECT_EQ(object.get_state(), state::found);
+    }
+
+    {
+        auto path = it.descend();
+        EXPECT_EQ(path.get_state(), state::not_found);
+    }
+}
+
+
+TEST(TestPathTrie, MultipleGlobsAndPaths)
+{
+    ddwaf::exclusion::path_trie trie;
+    trie.insert<std::string>({"path", "*", "object", "*", "box"});
+    trie.insert<std::string>({"path", "was", "closed"});
+    trie.insert<std::string>({"path", "*", "object", "but", "empty"});
+
+    auto it = trie.get_traverser();
+    {
+        auto path = it.descend("path");
+        EXPECT_EQ(path.get_state(), state::intermediate_node);
+
+        auto to = path.descend("to");
+        EXPECT_EQ(to.get_state(), state::intermediate_node);
+
+        auto object = to.descend("object");
+        EXPECT_EQ(object.get_state(), state::intermediate_node);
+
+        auto in = object.descend("in");
+        EXPECT_EQ(in.get_state(), state::intermediate_node);
+
+        auto box = in.descend("box");
+        EXPECT_EQ(box.get_state(), state::found);
+    }
+
+    {
+        auto path = it.descend("path");
+        EXPECT_EQ(path.get_state(), state::intermediate_node);
+
+        auto was = path.descend("was");
+        EXPECT_EQ(was.get_state(), state::intermediate_node);
+
+        {
+            auto object = was.descend("object");
+            EXPECT_EQ(object.get_state(), state::intermediate_node);
+
+            auto in = object.descend("in");
+            EXPECT_EQ(in.get_state(), state::intermediate_node);
+
+            auto box = in.descend("box");
+            EXPECT_EQ(box.get_state(), state::found);
+        }
+
+        {
+            auto closed = was.descend("closed");
+            EXPECT_EQ(closed.get_state(), state::found);
+        }
+    }
+
+    {
+        auto path = it.descend("path");
+        EXPECT_EQ(path.get_state(), state::intermediate_node);
+
+        auto was = path.descend("was");
+        EXPECT_EQ(was.get_state(), state::intermediate_node);
+
+        auto object = was.descend("object");
+        EXPECT_EQ(object.get_state(), state::intermediate_node);
+
+        auto but = object.descend("but");
+        EXPECT_EQ(but.get_state(), state::intermediate_node);
+
+        {
+            auto box = but.descend("box");
+            EXPECT_EQ(box.get_state(), state::found);
+        }
+
+        {
+            auto empty = but.descend("empty");
+            EXPECT_EQ(empty.get_state(), state::found);
+        }
+    }
+
+    {
+        auto path = it.descend("path");
+        EXPECT_EQ(path.get_state(), state::intermediate_node);
+
+        auto to = path.descend();
+        EXPECT_EQ(to.get_state(), state::intermediate_node);
+
+        auto object = to.descend("object");
+        EXPECT_EQ(object.get_state(), state::intermediate_node);
+
+        auto in = object.descend();
+        EXPECT_EQ(in.get_state(), state::intermediate_node);
+
+        auto box = in.descend("box");
+        EXPECT_EQ(box.get_state(), state::found);
+    }
+}
 TEST(TestPathTrie, Empty)
 {
     ddwaf::exclusion::path_trie trie;

--- a/tests/path_trie_test.cpp
+++ b/tests/path_trie_test.cpp
@@ -82,7 +82,6 @@ TEST(TestPathTrie, Glob)
     }
 }
 
-
 TEST(TestPathTrie, MultipleGlobsAndPaths)
 {
     ddwaf::exclusion::path_trie trie;

--- a/tests/path_trie_test.cpp
+++ b/tests/path_trie_test.cpp
@@ -69,7 +69,7 @@ TEST(TestPathTrie, Glob)
         auto path = it.descend("path");
         EXPECT_EQ(path.get_state(), state::intermediate_node);
 
-        auto to = path.descend();
+        auto to = path.descend_wildcard();
         EXPECT_EQ(to.get_state(), state::intermediate_node);
 
         auto object = to.descend("object");
@@ -77,7 +77,7 @@ TEST(TestPathTrie, Glob)
     }
 
     {
-        auto path = it.descend();
+        auto path = it.descend_wildcard();
         EXPECT_EQ(path.get_state(), state::not_found);
     }
 }
@@ -159,13 +159,13 @@ TEST(TestPathTrie, MultipleGlobsAndPaths)
         auto path = it.descend("path");
         EXPECT_EQ(path.get_state(), state::intermediate_node);
 
-        auto to = path.descend();
+        auto to = path.descend_wildcard();
         EXPECT_EQ(to.get_state(), state::intermediate_node);
 
         auto object = to.descend("object");
         EXPECT_EQ(object.get_state(), state::intermediate_node);
 
-        auto in = object.descend();
+        auto in = object.descend_wildcard();
         EXPECT_EQ(in.get_state(), state::intermediate_node);
 
         auto box = in.descend("box");

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -142,3 +142,5 @@ inline ::testing::PolymorphicMatcher<WafResultDataMatcher> WithEvents(
 
 ddwaf_object readFile(const char *filename);
 ddwaf_object readRule(const char *rule);
+
+inline ddwaf_object json_to_object(std::string_view data) { return readRule(data.data()); }

--- a/validator/ruleset.yaml
+++ b/validator/ruleset.yaml
@@ -121,6 +121,12 @@ exclusions:
       - address: rule40-input1
         key_path: [parent]
       - address: rule40-input2
+  - id: 19
+    inputs:
+      - address: rule40-input1
+        key_path: [a, b, c, d]
+      - address: rule40-input1
+        key_path: [a,"*", c, e]
 
 rules:
   - id: 1

--- a/validator/tests/216_rule40_keypath_exclusion_with_glob.yaml
+++ b/validator/tests/216_rule40_keypath_exclusion_with_glob.yaml
@@ -5,7 +5,7 @@
       input: {
         exclusion-filter-4-input: exclusion-filter-4,
         rule40-input1: {
-          a: {d: {c: {d: rule40}}}
+          a: {b: {c: {d: rule40}}}
         }
       },
       code: ok

--- a/validator/tests/216_rule40_keypath_exclusion_with_glob.yaml
+++ b/validator/tests/216_rule40_keypath_exclusion_with_glob.yaml
@@ -1,0 +1,14 @@
+{
+  name: "Keypath exclusion with condition",
+  runs: [
+    {
+      input: {
+        exclusion-filter-4-input: exclusion-filter-4,
+        rule40-input1: {
+          a: {d: {c: {d: rule40}}}
+        }
+      },
+      code: ok
+    },
+  ],
+}


### PR DESCRIPTION
This PR introduces support for the glob key path component (`*`) within object filters. This has been implemented by allowing the trie traverser to keep track and descend through many nodes at the same time.  In addition, the use of the glob also allows for arrays within the key path.