### PR TITLE
Handle lifetime extension

### DIFF
--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -4,10 +4,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
-#ifndef pw_h
-#define pw_h
+#ifndef DDWAF_H
+#define DDWAF_H
 
 #ifdef __cplusplus
+namespace std {
+template <typename T>
+class shared_ptr;
+} // namespace std
+namespace ddwaf{
+class waf;
+class context;
+} // namespace ddwaf
+using ddwaf_handle = std::shared_ptr<ddwaf::waf> *;
+using ddwaf_context = ddwaf::context *;
+
 extern "C"
 {
 #endif
@@ -72,14 +83,7 @@ typedef enum
     DDWAF_LOG_OFF,
 } DDWAF_LOG_LEVEL;
 
-#ifdef __cplusplus
-namespace ddwaf{
-class waf;
-class context;
-}
-using ddwaf_handle = ddwaf::waf *;
-using ddwaf_context = ddwaf::context *;
-#else
+#ifndef __cplusplus
 typedef struct _ddwaf_handle* ddwaf_handle;
 typedef struct _ddwaf_context* ddwaf_context;
 #endif
@@ -679,4 +683,4 @@ bool ddwaf_set_log_cb(ddwaf_log_cb cb, DDWAF_LOG_LEVEL min_level);
 }
 #endif /* __cplusplus */
 
-#endif /* pw_h */
+#endif /*DDWAF_H */

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -8,10 +8,7 @@
 #define DDWAF_H
 
 #ifdef __cplusplus
-namespace std {
-template <typename T>
-class shared_ptr;
-} // namespace std
+#include <memory>
 namespace ddwaf{
 class waf;
 class context;

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -39,6 +39,7 @@ public:
     context &operator=(context &&) = delete;
     ~context() = default;
 
+    void set_waf(std::shared_ptr<waf> &waf) { waf_reference_ = waf; }
     DDWAF_RET_CODE run(const ddwaf_object &, optional_ref<ddwaf_result> res, uint64_t);
 
     // These two functions below return references to internal objects,
@@ -71,6 +72,8 @@ protected:
     // Cache of collections to avoid processing once a result has been obtained
     std::unordered_map<std::string_view, collection::cache_type> collection_cache_;
     std::unordered_set<std::string_view> seen_actions_;
+    
+    std::shared_ptr<waf> waf_reference_;
 };
 
 } // namespace ddwaf

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -25,8 +25,10 @@ class context {
 public:
     using object_set = std::unordered_set<const ddwaf_object *>;
 
-    context(ddwaf::ruleset &ruleset, const ddwaf::config &config)
-        : ruleset_(ruleset), config_(config), store_(ruleset_.manifest, config_.free_fn)
+    context(
+        ddwaf::ruleset &ruleset, const ddwaf::config &config, std::shared_ptr<waf> handle = nullptr)
+        : ruleset_(ruleset), config_(config), store_(ruleset_.manifest, config_.free_fn),
+          handle_(std::move(handle))
     {
         rule_filter_cache_.reserve(ruleset_.rule_filters.size());
         input_filter_cache_.reserve(ruleset_.input_filters.size());
@@ -39,7 +41,6 @@ public:
     context &operator=(context &&) = delete;
     ~context() = default;
 
-    void set_waf(std::shared_ptr<waf> &waf) { waf_reference_ = waf; }
     DDWAF_RET_CODE run(const ddwaf_object &, optional_ref<ddwaf_result> res, uint64_t);
 
     // These two functions below return references to internal objects,
@@ -72,8 +73,8 @@ protected:
     // Cache of collections to avoid processing once a result has been obtained
     std::unordered_map<std::string_view, collection::cache_type> collection_cache_;
     std::unordered_set<std::string_view> seen_actions_;
-    
-    std::shared_ptr<waf> waf_reference_;
+
+    std::shared_ptr<waf> handle_;
 };
 
 } // namespace ddwaf

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -47,7 +47,7 @@ ddwaf_handle ddwaf_init(
     try {
         if (rule != nullptr) {
             ddwaf::ruleset_info ri(info);
-            return ddwaf::waf::from_config(*rule, config, ri);
+            return new std::shared_ptr<ddwaf::waf>(ddwaf::waf::from_config(*rule, config, ri));
         }
     } catch (const std::exception &e) {
         DDWAF_ERROR("%s", e.what());
@@ -75,13 +75,13 @@ void ddwaf_destroy(ddwaf_handle handle)
 
 DDWAF_RET_CODE ddwaf_update_rule_data(ddwaf_handle handle, ddwaf_object *data)
 {
-    if (handle == nullptr || data == nullptr) {
+    if (handle == nullptr || *handle == nullptr || data == nullptr) {
         return DDWAF_ERR_INVALID_ARGUMENT;
     }
 
     try {
         ddwaf::parameter param = *data;
-        handle->update_rule_data(param);
+        (*handle)->update_rule_data(param);
     } catch (const ddwaf::bad_cast &e) {
         DDWAF_ERROR("%s", e.what());
         return DDWAF_ERR_INVALID_OBJECT;
@@ -98,13 +98,13 @@ DDWAF_RET_CODE ddwaf_update_rule_data(ddwaf_handle handle, ddwaf_object *data)
 
 DDWAF_RET_CODE ddwaf_toggle_rules(ddwaf_handle handle, ddwaf_object *rule_map)
 {
-    if (handle == nullptr || rule_map == nullptr) {
+    if (handle == nullptr || *handle == nullptr || rule_map == nullptr) {
         return DDWAF_ERR_INVALID_ARGUMENT;
     }
 
     try {
         ddwaf::parameter param = *rule_map;
-        handle->toggle_rules(param);
+        (*handle)->toggle_rules(param);
     } catch (const ddwaf::bad_cast &e) {
         DDWAF_ERROR("%s", e.what());
         return DDWAF_ERR_INVALID_OBJECT;
@@ -119,14 +119,14 @@ DDWAF_RET_CODE ddwaf_toggle_rules(ddwaf_handle handle, ddwaf_object *rule_map)
     return DDWAF_OK;
 }
 
-const char *const *ddwaf_required_addresses(ddwaf::waf *const handle, uint32_t *size)
+const char *const *ddwaf_required_addresses(ddwaf::waf::ptr *handle, uint32_t *size)
 {
-    if (handle == nullptr) {
+    if (handle == nullptr || *handle == nullptr) {
         *size = 0;
         return nullptr;
     }
 
-    const auto &addresses = handle->get_root_addresses();
+    const auto &addresses = (*handle)->get_root_addresses();
     if (addresses.empty() || addresses.size() > std::numeric_limits<uint32_t>::max()) {
         *size = 0;
         return nullptr;
@@ -136,14 +136,14 @@ const char *const *ddwaf_required_addresses(ddwaf::waf *const handle, uint32_t *
     return addresses.data();
 }
 
-const char *const *ddwaf_required_rule_data_ids(ddwaf::waf *const handle, uint32_t *size)
+const char *const *ddwaf_required_rule_data_ids(ddwaf::waf::ptr * handle, uint32_t *size)
 {
-    if (handle == nullptr) {
+    if (handle == nullptr || *handle == nullptr) {
         *size = 0;
         return nullptr;
     }
 
-    const auto &ids = handle->get_rule_data_ids();
+    const auto &ids = (*handle)->get_rule_data_ids();
     if (ids.empty() || ids.size() > std::numeric_limits<uint32_t>::max()) {
         *size = 0;
         return nullptr;
@@ -153,13 +153,13 @@ const char *const *ddwaf_required_rule_data_ids(ddwaf::waf *const handle, uint32
     return ids.data();
 }
 
-ddwaf_context ddwaf_context_init(ddwaf::waf *const handle)
+ddwaf_context ddwaf_context_init(ddwaf::waf::ptr *handle)
 {
     ddwaf_context output = nullptr;
 
     try {
-        if (handle != nullptr) {
-            output = new ddwaf::context(handle->create_context());
+        if (handle != nullptr && *handle != nullptr) {
+            output = new ddwaf::context((*handle)->create_context());
         }
     } catch (const std::exception &e) {
         DDWAF_ERROR("%s", e.what());

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -47,7 +47,10 @@ ddwaf_handle ddwaf_init(
     try {
         if (rule != nullptr) {
             ddwaf::ruleset_info ri(info);
-            return new std::shared_ptr<ddwaf::waf>(ddwaf::waf::from_config(*rule, config, ri));
+            auto waf_ptr = ddwaf::waf::from_config(*rule, config, ri);
+            if (waf_ptr) {
+                return new std::shared_ptr<ddwaf::waf>(std::move(waf_ptr));
+            }
         }
     } catch (const std::exception &e) {
         DDWAF_ERROR("%s", e.what());
@@ -136,7 +139,7 @@ const char *const *ddwaf_required_addresses(ddwaf::waf::ptr *handle, uint32_t *s
     return addresses.data();
 }
 
-const char *const *ddwaf_required_rule_data_ids(ddwaf::waf::ptr * handle, uint32_t *size)
+const char *const *ddwaf_required_rule_data_ids(ddwaf::waf::ptr *handle, uint32_t *size)
 {
     if (handle == nullptr || *handle == nullptr) {
         *size = 0;
@@ -155,18 +158,16 @@ const char *const *ddwaf_required_rule_data_ids(ddwaf::waf::ptr * handle, uint32
 
 ddwaf_context ddwaf_context_init(ddwaf::waf::ptr *handle)
 {
-    ddwaf_context output = nullptr;
-
     try {
         if (handle != nullptr && *handle != nullptr) {
-            output = new ddwaf::context((*handle)->create_context());
+            return new ddwaf::context((*handle)->create_context());
         }
     } catch (const std::exception &e) {
         DDWAF_ERROR("%s", e.what());
     } catch (...) {
         DDWAF_ERROR("unknown exception");
     }
-    return output;
+    return nullptr;
 }
 
 DDWAF_RET_CODE ddwaf_run(

--- a/src/waf.cpp
+++ b/src/waf.cpp
@@ -63,7 +63,7 @@ ddwaf::object_limits limits_from_config(const ddwaf_config *config)
 
 } // namespace
 
-waf *waf::from_config(
+waf::ptr waf::from_config(
     const ddwaf_object &ruleset, const ddwaf_config *config, ddwaf::ruleset_info &info)
 {
     try {
@@ -75,7 +75,7 @@ waf *waf::from_config(
 
         ddwaf::ruleset rs;
         parser::parse(ruleset, info, rs, cfg);
-        return new waf(std::move(rs), std::move(cfg));
+        return std::shared_ptr<waf>(new waf(std::move(rs), std::move(cfg)));
     } catch (const std::exception &e) {
         DDWAF_ERROR("%s", e.what());
     }

--- a/src/waf.hpp
+++ b/src/waf.hpp
@@ -15,18 +15,14 @@
 
 namespace ddwaf {
 
-class waf {
+class waf : public std::enable_shared_from_this<waf> {
 public:
     using ptr = std::shared_ptr<waf>;
 
-    waf(ddwaf::ruleset &&ruleset, ddwaf::config &&config)
-        : ruleset_(std::move(ruleset)), config_(std::move(config))
-    {}
-
-    static waf *from_config(
+    static waf::ptr from_config(
         const ddwaf_object &rules, const ddwaf_config *config, ddwaf::ruleset_info &info);
 
-    ddwaf::context create_context() { return {ruleset_, config_}; }
+    ddwaf::context create_context() { return {ruleset_, config_, shared_from_this()}; }
 
     void update_rule_data(ddwaf::parameter::vector &&input) { ruleset_.dispatcher.dispatch(input); }
 
@@ -42,6 +38,10 @@ public:
     }
 
 protected:
+    waf(ddwaf::ruleset &&ruleset, ddwaf::config &&config)
+        : ruleset_(std::move(ruleset)), config_(std::move(config))
+    {}
+
     ddwaf::ruleset ruleset_;
     ddwaf::config config_;
 };

--- a/src/waf.hpp
+++ b/src/waf.hpp
@@ -7,6 +7,7 @@
 
 #include <config.hpp>
 #include <context.hpp>
+#include <memory>
 #include <ruleset.hpp>
 #include <ruleset_info.hpp>
 #include <utils.hpp>
@@ -16,6 +17,8 @@ namespace ddwaf {
 
 class waf {
 public:
+    using ptr = std::shared_ptr<waf>;
+
     waf(ddwaf::ruleset &&ruleset, ddwaf::config &&config)
         : ruleset_(std::move(ruleset)), config_(std::move(config))
     {}

--- a/tests/interface_test.cpp
+++ b/tests/interface_test.cpp
@@ -71,3 +71,77 @@ TEST(TestInterface, EmptyRuleDatIDs)
 
     ddwaf_destroy(handle);
 }
+
+TEST(TestInterface, HandleLifetime)
+{
+    auto rule = readFile("interface.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
+    ddwaf_object param_key = DDWAF_OBJECT_ARRAY, param_val = DDWAF_OBJECT_ARRAY;
+
+    ddwaf_object_array_add(&param_key, ddwaf_object_unsigned(&tmp, 4242));
+    ddwaf_object_array_add(&param_key, ddwaf_object_string(&tmp, "randomString"));
+
+    ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule1"));
+
+    ddwaf_object_map_add(&parameter, "value1", &param_key);
+    ddwaf_object_map_add(&parameter, "value2", &param_val);
+
+    EXPECT_EQ(ddwaf_run(context, &parameter, NULL, LONG_TIME), DDWAF_MATCH);
+
+    ddwaf_object_free(&parameter);
+    ddwaf_context_destroy(context);
+}
+
+TEST(TestInterface, HandleLifetimeMultipleContexts)
+{
+    auto rule = readFile("interface.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context1 = ddwaf_context_init(handle);
+    ASSERT_NE(context1, nullptr);
+
+    ddwaf_context context2 = ddwaf_context_init(handle);
+    ASSERT_NE(context2, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
+    ddwaf_object param_key = DDWAF_OBJECT_ARRAY, param_val = DDWAF_OBJECT_ARRAY;
+
+    ddwaf_object_array_add(&param_key, ddwaf_object_unsigned(&tmp, 4242));
+    ddwaf_object_array_add(&param_key, ddwaf_object_string(&tmp, "randomString"));
+
+    ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule1"));
+
+    ddwaf_object_map_add(&parameter, "value1", &param_key);
+    ddwaf_object_map_add(&parameter, "value2", &param_val);
+
+    EXPECT_EQ(ddwaf_run(context1, &parameter, NULL, LONG_TIME), DDWAF_MATCH);
+    ddwaf_context_destroy(context1);
+
+    EXPECT_EQ(ddwaf_run(context2, &parameter, NULL, LONG_TIME), DDWAF_MATCH);
+    ddwaf_context_destroy(context2);
+
+    ddwaf_object_free(&parameter);
+}

--- a/tests/waf_test.cpp
+++ b/tests/waf_test.cpp
@@ -14,7 +14,7 @@ TEST(TestWaf, RootAddresses)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::ruleset_info info;
-    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    auto instance = waf::from_config(rule, nullptr, info);
     ddwaf_object_free(&rule);
 
     std::set<std::string_view> available_addresses{"value1", "value2"};
@@ -29,7 +29,7 @@ TEST(TestWaf, RuleDatIDs)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::ruleset_info info;
-    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    auto instance = waf::from_config(rule, nullptr, info);
     ddwaf_object_free(&rule);
 
     std::set<std::string_view> available_ids{"usr_data", "ip_data"};
@@ -44,7 +44,7 @@ TEST(TestWaf, EmptyRuleDatIDs)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::ruleset_info info;
-    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    auto instance = waf::from_config(rule, nullptr, info);
     ddwaf_object_free(&rule);
 
     EXPECT_TRUE(instance->get_rule_data_ids().empty());
@@ -56,7 +56,7 @@ TEST(TestWaf, BasicContextRun)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::ruleset_info info;
-    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    auto instance = waf::from_config(rule, nullptr, info);
     ddwaf_object_free(&rule);
 
     ddwaf_object root, tmp;
@@ -73,7 +73,7 @@ TEST(TestWaf, ToggleRule)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::ruleset_info info;
-    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    auto instance = waf::from_config(rule, nullptr, info);
     ddwaf_object_free(&rule);
 
     {
@@ -111,7 +111,7 @@ TEST(TestWaf, ToggleNonExistentRules)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::ruleset_info info;
-    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    auto instance = waf::from_config(rule, nullptr, info);
     ddwaf_object_free(&rule);
 
     ddwaf_object root, tmp;
@@ -129,7 +129,7 @@ TEST(TestWaf, ToggleWithInvalidObject)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::ruleset_info info;
-    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    auto instance = waf::from_config(rule, nullptr, info);
     ASSERT_NE(instance.get(), nullptr);
     ddwaf_object_free(&rule);
 
@@ -160,7 +160,7 @@ TEST(TestWaf, RuleDisabledInRuleset)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::ruleset_info info;
-    std::unique_ptr<ddwaf::waf> instance(waf::from_config(rule, nullptr, info));
+    auto instance = waf::from_config(rule, nullptr, info);
     ddwaf_object_free(&rule);
 
     {


### PR DESCRIPTION
Ensure contexts share ownership of the handle and extend its lifetime when the user calls `ddwaf_destroy` while contexts are still in use.