### PR TITLE
Relax rule override restrictions

### DIFF
--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -96,16 +96,9 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, ruleset_in
             rules_by_tags_.insert(rule_ptr->tags, rule_ptr);
         }
 
-        // Old or new overrides are applied on the new rules
-        std::unordered_set<rule *> overridden_rules;
-        for (const auto &ovrd : overrides_.by_ids) {
-            // Overrides by ID
+        for (const auto &ovrd : overrides_.by_tags) {
             auto rule_targets = target_to_rules(ovrd.targets, final_rules_, rules_by_tags_);
             for (const auto &rule_ptr : rule_targets) {
-                if (overridden_rules.find(rule_ptr.get()) != overridden_rules.end()) {
-                    continue;
-                }
-
                 if (ovrd.enabled.has_value()) {
                     rule_ptr->toggle(*ovrd.enabled);
                 }
@@ -113,21 +106,12 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, ruleset_in
                 if (ovrd.actions.has_value()) {
                     rule_ptr->actions = *ovrd.actions;
                 }
-
-                overridden_rules.emplace(rule_ptr.get());
             }
         }
 
-        // Apply overrides by tag
-        for (const auto &ovrd : overrides_.by_tags) {
+        for (const auto &ovrd : overrides_.by_ids) {
             auto rule_targets = target_to_rules(ovrd.targets, final_rules_, rules_by_tags_);
             for (const auto &rule_ptr : rule_targets) {
-                // If a rule has been overridden by ID, it shouldn't be overridden
-                // by tag.
-                if (overridden_rules.find(rule_ptr.get()) != overridden_rules.end()) {
-                    continue;
-                }
-
                 if (ovrd.enabled.has_value()) {
                     rule_ptr->toggle(*ovrd.enabled);
                 }

--- a/tests/interface_test.cpp
+++ b/tests/interface_test.cpp
@@ -703,6 +703,127 @@ TEST(TestInterface, UpdateActionsByTags)
     ddwaf_destroy(handle2);
 }
 
+TEST(TestInterface, UpdateOverrideByIDAndTag)
+{
+    auto rule = readFile("interface.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+
+    ddwaf_handle handle1 = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle1, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_handle handle2;
+    {
+        auto overrides = readRule(
+            R"({rules_override: [{rules_target: [{tags: {type: flow1}}], on_match: ["block"], enabled: false}, {rules_target: [{rule_id: 1}], enabled: true}]})");
+        handle2 = ddwaf_update(handle1, &overrides, nullptr);
+        ddwaf_object_free(&overrides);
+    }
+
+    {
+        ddwaf_context context1 = ddwaf_context_init(handle1);
+        ASSERT_NE(context1, nullptr);
+
+        ddwaf_context context2 = ddwaf_context_init(handle2);
+        ASSERT_NE(context2, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+
+        ddwaf_result result1;
+        ddwaf_result result2;
+
+        EXPECT_EQ(ddwaf_run(context1, &parameter, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, &result2, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EQ(result1.actions.size, 0);
+        EXPECT_EQ(result2.actions.size, 1);
+        EXPECT_STREQ(result2.actions.array[0], "block");
+
+        ddwaf_result_free(&result1);
+        ddwaf_result_free(&result2);
+
+        ddwaf_object_free(&parameter);
+
+        ddwaf_context_destroy(context1);
+        ddwaf_context_destroy(context2);
+    }
+
+    ddwaf_handle handle3;
+    {
+        auto overrides = readRule(
+            R"({rules_override: [{rules_target: [{tags: {type: flow1}}], on_match: ["block"]}, {rules_target: [{rule_id: 1}], on_match: []}]})");
+        handle3 = ddwaf_update(handle2, &overrides, nullptr);
+        ddwaf_object_free(&overrides);
+    }
+
+    {
+        ddwaf_context context2 = ddwaf_context_init(handle2);
+        ASSERT_NE(context2, nullptr);
+
+        ddwaf_context context3 = ddwaf_context_init(handle3);
+        ASSERT_NE(context3, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+
+        ddwaf_result result2;
+        ddwaf_result result3;
+
+        EXPECT_EQ(ddwaf_run(context2, &parameter, &result2, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, &result3, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EQ(result2.actions.size, 1);
+        EXPECT_STREQ(result2.actions.array[0], "block");
+        EXPECT_EQ(result3.actions.size, 0);
+
+        ddwaf_result_free(&result2);
+        ddwaf_result_free(&result3);
+
+        ddwaf_object_free(&parameter);
+
+        ddwaf_context_destroy(context2);
+        ddwaf_context_destroy(context3);
+    }
+
+    ddwaf_handle handle4;
+    {
+        auto overrides = readRule(
+            R"({rules_override: [{rules_target: [{tags: {type: flow1}}], enabled: true}, {rules_target: [{rule_id: 1}], enabled: false}]})");
+        handle4 = ddwaf_update(handle3, &overrides, nullptr);
+        ddwaf_object_free(&overrides);
+    }
+
+    {
+        ddwaf_context context3 = ddwaf_context_init(handle3);
+        ASSERT_NE(context3, nullptr);
+
+        ddwaf_context context4 = ddwaf_context_init(handle4);
+        ASSERT_NE(context4, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_object_free(&parameter);
+
+        ddwaf_context_destroy(context3);
+        ddwaf_context_destroy(context4);
+    }
+
+    ddwaf_destroy(handle1);
+    ddwaf_destroy(handle2);
+    ddwaf_destroy(handle3);
+    ddwaf_destroy(handle4);
+}
+
 TEST(TestInterface, UpdateInvalidOverrides)
 {
     auto rule = readFile("interface.yaml");


### PR DESCRIPTION
Allow rule overrides by tag to operate on rules already overridden by ID, while still maintaining the priority of the override by ID.