### PR TITLE
Longest rule data expiration takes precedence for `ip_match` and `exact_match` operators

### DIFF
--- a/src/rule_processor/exact_match.cpp
+++ b/src/rule_processor/exact_match.cpp
@@ -21,7 +21,13 @@ exact_match::exact_match(const std::vector<std::pair<std::string_view, uint64_t>
     values_.reserve(data.size());
     for (auto [str, expiration] : data) {
         const auto &ref = data_.emplace_back(str);
-        values_.emplace(ref, expiration);
+        auto res = values_.emplace(ref, expiration);
+        if (!res.second) {
+            uint64_t prev_expiration = res.first->second;
+            if (prev_expiration != 0 && (expiration == 0 || expiration > prev_expiration)) {
+                res.first->second = expiration;
+            }
+        }
     }
 }
 

--- a/src/rule_processor/ip_match.cpp
+++ b/src/rule_processor/ip_match.cpp
@@ -27,8 +27,7 @@ ip_match::ip_match(const std::vector<std::string_view> &ip_list)
             prefix_t prefix;
             // NOLINTNEXTLINE(hicpp-no-array-decay,cppcoreguidelines-pro-bounds-array-to-pointer-decay)
             radix_prefix_init(FAMILY_IPv6, ip.data, ip.mask, &prefix);
-            auto *node = radix_put_if_absent(rtree_.get(), &prefix);
-            node->expiration = 0;
+            radix_put_if_absent(rtree_.get(), &prefix, 0);
         }
     }
 }
@@ -47,8 +46,7 @@ ip_match::ip_match(const std::vector<std::pair<std::string_view, uint64_t>> &ip_
             prefix_t prefix;
             // NOLINTNEXTLINE(hicpp-no-array-decay,cppcoreguidelines-pro-bounds-array-to-pointer-decay)
             radix_prefix_init(FAMILY_IPv6, ip.data, ip.mask, &prefix);
-            auto *node = radix_put_if_absent(rtree_.get(), &prefix);
-            node->expiration = expiration;
+            radix_put_if_absent(rtree_.get(), &prefix, expiration);
         }
     }
 }

--- a/tests/rule_processor/exact_match.cpp
+++ b/tests/rule_processor/exact_match.cpp
@@ -65,8 +65,9 @@ TEST(TestExactMatch, Expiration)
         std::chrono::system_clock::now().time_since_epoch())
                        .count();
 
-    exact_match processor(std::vector<std::pair<std::string_view, uint64_t>>{
-        {"aaaa", now - 1}, {"bbbb", now + 100}, {"cccc", now - 1}});
+    exact_match processor(std::vector<std::pair<std::string_view, uint64_t>>{{"aaaa", now - 1},
+        {"bbbb", now + 100}, {"cccc", now - 1}, {"dddd", 0}, {"dddd", now - 1}, {"eeee", now - 1},
+        {"eeee", 0}, {"ffff", now + 100}, {"ffff", now}});
 
     EXPECT_STREQ(processor.name().data(), "exact_match");
     EXPECT_STREQ(processor.to_string().data(), "");
@@ -79,6 +80,10 @@ TEST(TestExactMatch, Expiration)
     EXPECT_TRUE(match);
     EXPECT_STREQ(match->resolved.c_str(), input.data());
     EXPECT_STREQ(match->matched.c_str(), input.data());
+
+    EXPECT_TRUE(processor.match("dddd"));
+    EXPECT_TRUE(processor.match("eeee"));
+    EXPECT_TRUE(processor.match("ffff"));
 }
 
 TEST(TestExactMatch, InvalidMatchInput)

--- a/tests/rule_processor/ip_match_test.cpp
+++ b/tests/rule_processor/ip_match_test.cpp
@@ -64,6 +64,28 @@ TEST(TestIPMatch, CIDR)
     EXPECT_FALSE(match(processor, "1234:abdc::1:0"));
 }
 
+TEST(TestIPMatch, OverlappingCIDR)
+{
+    ip_match processor(std::vector<std::string_view>{
+        "1.2.0.0/16",
+        "1.2.3.4",
+        "1234:abdc::0/112",
+        "1234:abdc::1",
+    });
+
+    EXPECT_FALSE(match(processor, "1.1.0.0"));
+    EXPECT_TRUE(match(processor, "1.2.0.0"));
+    EXPECT_TRUE(match(processor, "1.2.3.4"));
+    EXPECT_TRUE(match(processor, "1.2.255.255"));
+    EXPECT_FALSE(match(processor, "1.3.0.0"));
+
+    EXPECT_FALSE(match(processor, "1234:abdb::0"));
+    EXPECT_TRUE(match(processor, "1234:abdc::0"));
+    EXPECT_TRUE(match(processor, "1234:abdc::1"));
+    EXPECT_TRUE(match(processor, "1234:abdc::ffff"));
+    EXPECT_FALSE(match(processor, "1234:abdc::1:0"));
+}
+
 TEST(TestIPMatch, InvalidInput)
 {
     ip_match processor(std::vector<std::string_view>{
@@ -101,4 +123,34 @@ TEST(TestIPMatch, Expiration)
     EXPECT_TRUE(match(processor, "abcd::1234:5678:1234:5678"));
     EXPECT_FALSE(match(processor, "abcd::1234:0:0:0"));
     EXPECT_TRUE(match(processor, "abcd::1234:ffff:ffff:ffff"));
+}
+
+TEST(TestIPMatch, OverlappingExpiration)
+{
+    uint64_t now = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now().time_since_epoch())
+                       .count();
+
+    ip_match processor(std::vector<std::pair<std::string_view, uint64_t>>{{"4.4.4.4", 0},
+        {"4.4.4.4", now - 1}, {"5.5.5.5", now - 1}, {"5.5.5.5", 0}, {"1.0.0.0/8", now - 1},
+        {"1.2.3.4", now + 100}, {"2.2.0.0/16", now + 100}, {"2.2.7.8", now - 100},
+        {"2.3.0.0/16", 0}, {"2.3.9.1", now - 100}, {"2.4.0.0/16", now - 1}, {"2.4.3.4", 0}});
+
+    EXPECT_STREQ(processor.to_string().data(), "");
+    EXPECT_STREQ(processor.name().data(), "ip_match");
+
+    EXPECT_TRUE(match(processor, "4.4.4.4"));
+    EXPECT_TRUE(match(processor, "5.5.5.5"));
+
+    EXPECT_FALSE(match(processor, "1.1.1.1"));
+    EXPECT_TRUE(match(processor, "1.2.3.4"));
+
+    EXPECT_TRUE(match(processor, "2.2.0.1"));
+    EXPECT_TRUE(match(processor, "2.2.7.8"));
+
+    EXPECT_TRUE(match(processor, "2.3.0.1"));
+    EXPECT_TRUE(match(processor, "2.3.9.1"));
+
+    EXPECT_FALSE(match(processor, "2.4.0.1"));
+    EXPECT_TRUE(match(processor, "2.4.3.4"));
 }

--- a/third_party/radixlib/radixlib.c
+++ b/third_party/radixlib/radixlib.c
@@ -238,12 +238,18 @@ radix_node_t* radix_matching_do(radix_tree_t* radix, prefix_t* prefix)
         stack[cnt++] = node;
 
     node = NULL;
-    while (cnt-- > 0) {
-        if (_comp_with_mask(PREFIX_TO_UCHAR(stack[cnt]->prefix), PREFIX_TO_UCHAR(prefix),
-                stack[cnt]->prefix->bitlen)) {
-            if (node == NULL || stack[cnt]->expiration == 0 ||
-                (node->expiration != 0 && stack[cnt]->expiration > node->expiration)) {
-                node = stack[cnt];
+    while (cnt > 0)
+    {
+        radix_node_t *curnode = stack[--cnt];
+
+        if (_comp_with_mask(PREFIX_TO_UCHAR(curnode->prefix), PREFIX_TO_UCHAR(prefix),
+                curnode->prefix->bitlen))
+	{
+            if (node == NULL || curnode->expiration == 0 || curnode->expiration > node->expiration)
+            {
+                node = curnode;
+                if (node->expiration == 0)
+                    break;
             }
         }
     }

--- a/third_party/radixlib/radixlib.h
+++ b/third_party/radixlib/radixlib.h
@@ -87,7 +87,7 @@ extern "C"
     void radix_free(radix_tree_t* radix);
 
     radix_node_t* radix_matching_do(radix_tree_t* radix, prefix_t* prefix);
-    radix_node_t* radix_put_if_absent(radix_tree_t* radix, prefix_t* prefix);
+    radix_node_t* radix_put_if_absent(radix_tree_t* radix, prefix_t* prefix, uint64_t expiration);
     void radix_remove(radix_tree_t* radix, radix_node_t* node);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR enforces the longest expiration for `ip_match` and `exact_match` operators.

Additionally, it adds support for IP network matching with expiration. Basically, if `2.0.0.0/16` is blocked forever but `2.2.2.2` is blocked for 5 minutes, `2.2.2.2` should still be blocked after 5 minutes.

