### PR TITLE
Support for per-input transformers

### DIFF
--- a/src/PWTransformer.cpp
+++ b/src/PWTransformer.cpp
@@ -1403,7 +1403,7 @@ PW_TRANSFORM_ID PWTransformer::getIDForString(std::string_view str)
     else if (str == "keys_only")
         return PWT_KEYS_ONLY;
     else if (str == "values_only")
-        return PWT_KEYS_ONLY;
+        return PWT_VALUES_ONLY;
     else if (str == "unicode_normalize")
         return PWT_UNICODE_NORMALIZE;
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -12,17 +12,18 @@
 
 namespace ddwaf {
 
-std::optional<event::match> condition::match_object(
-    const ddwaf_object *object, const rule_processor::base::ptr &processor) const
+std::optional<event::match> condition::match_object(const ddwaf_object *object,
+    const rule_processor::base::ptr &processor,
+    const std::vector<PW_TRANSFORM_ID> &transformers) const
 {
-    const bool has_transform = !transformers_.empty();
+    const bool has_transform = !transformers.empty();
     bool transform_required = false;
 
     if (has_transform) {
         // This codepath is shared with the mutable path. The structure can't be const :/
         transform_required =
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-            PWTransformer::doesNeedTransform(transformers_, const_cast<ddwaf_object *>(object));
+            PWTransformer::doesNeedTransform(transformers, const_cast<ddwaf_object *>(object));
     }
 
     const size_t length =
@@ -42,7 +43,7 @@ std::optional<event::match> condition::match_object(
 
     // Transform it and pick the pointer to process
     bool transformFailed = false;
-    for (const PW_TRANSFORM_ID &transform : transformers_) {
+    for (const PW_TRANSFORM_ID &transform : transformers) {
         transformFailed = !PWTransformer::transform(transform, &copy);
         if (transformFailed || (copy.type == DDWAF_OBJ_STRING && copy.nbEntries == 0)) {
             break;
@@ -57,8 +58,9 @@ std::optional<event::match> condition::match_object(
 }
 
 template <typename T>
-std::optional<event::match> condition::match_target(
-    T &it, const rule_processor::base::ptr &processor, ddwaf::timer &deadline) const
+std::optional<event::match> condition::match_target(T &it,
+    const rule_processor::base::ptr &processor, const std::vector<PW_TRANSFORM_ID> &transformers,
+    ddwaf::timer &deadline) const
 {
     for (; it; ++it) {
         if (deadline.expired()) {
@@ -69,7 +71,7 @@ std::optional<event::match> condition::match_target(
             continue;
         }
 
-        auto optional_match = match_object(*it, processor);
+        auto optional_match = match_object(*it, processor, transformers);
         if (!optional_match.has_value()) {
             continue;
         }
@@ -108,7 +110,7 @@ std::optional<event::match> condition::match(const object_store &store,
         return std::nullopt;
     }
 
-    for (const auto &[target, name, key_path] : targets_) {
+    for (const auto &[target, name, key_path, transformers] : targets_) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();
         }
@@ -128,10 +130,10 @@ std::optional<event::match> condition::match(const object_store &store,
         std::optional<event::match> optional_match;
         if (source_ == data_source::keys) {
             object::key_iterator it(object, key_path, objects_excluded, limits_);
-            optional_match = match_target(it, processor, deadline);
+            optional_match = match_target(it, processor, transformers, deadline);
         } else {
             object::value_iterator it(object, key_path, objects_excluded, limits_);
-            optional_match = match_target(it, processor, deadline);
+            optional_match = match_target(it, processor, transformers, deadline);
         }
 
         if (optional_match.has_value()) {

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -110,7 +110,7 @@ std::optional<event::match> condition::match(const object_store &store,
         return std::nullopt;
     }
 
-    for (const auto &[target, name, key_path, transformers] : targets_) {
+    for (const auto &[target, name, key_path, transformers, source] : targets_) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();
         }
@@ -128,7 +128,7 @@ std::optional<event::match> condition::match(const object_store &store,
         }
 
         std::optional<event::match> optional_match;
-        if (source_ == data_source::keys) {
+        if (source == data_source::keys) {
             object::key_iterator it(object, key_path, objects_excluded, limits_);
             optional_match = match_target(it, processor, transformers, deadline);
         } else {

--- a/src/condition.hpp
+++ b/src/condition.hpp
@@ -31,17 +31,16 @@ public:
         manifest::target_type root;
         std::string name;
         std::vector<std::string> key_path;
+        std::vector<PW_TRANSFORM_ID> transformers;
     };
 
     enum class data_source : uint8_t { values, keys };
 
-    condition(std::vector<target_type> targets, std::vector<PW_TRANSFORM_ID> transformers,
-        std::shared_ptr<rule_processor::base> processor, std::string data_id = {},
-        ddwaf::object_limits limits = ddwaf::object_limits(),
+    condition(std::vector<target_type> targets, std::shared_ptr<rule_processor::base> processor,
+        std::string data_id = {}, ddwaf::object_limits limits = ddwaf::object_limits(),
         data_source source = data_source::values)
-        : targets_(std::move(targets)), transformers_(std::move(transformers)),
-          processor_(std::move(processor)), data_id_(std::move(data_id)), limits_(limits),
-          source_(source)
+        : targets_(std::move(targets)), processor_(std::move(processor)),
+          data_id_(std::move(data_id)), limits_(limits), source_(source)
     {}
 
     ~condition() = default;
@@ -62,17 +61,17 @@ public:
     }
 
 protected:
-    std::optional<event::match> match_object(
-        const ddwaf_object *object, const rule_processor::base::ptr &processor) const;
+    std::optional<event::match> match_object(const ddwaf_object *object,
+        const rule_processor::base::ptr &processor,
+        const std::vector<PW_TRANSFORM_ID> &transformers) const;
 
     template <typename T>
-    std::optional<event::match> match_target(
-        T &it, const rule_processor::base::ptr &processor, ddwaf::timer &deadline) const;
+    std::optional<event::match> match_target(T &it, const rule_processor::base::ptr &processor,
+        const std::vector<PW_TRANSFORM_ID> &transformers, ddwaf::timer &deadline) const;
 
     [[nodiscard]] const rule_processor::base::ptr &get_processor(
         const std::unordered_map<std::string, rule_processor::base::ptr> &dynamic_processors) const;
     std::vector<condition::target_type> targets_;
-    std::vector<PW_TRANSFORM_ID> transformers_;
     std::shared_ptr<rule_processor::base> processor_;
     std::string data_id_;
     ddwaf::object_limits limits_;

--- a/src/condition.hpp
+++ b/src/condition.hpp
@@ -27,20 +27,21 @@ namespace ddwaf {
 class condition {
 public:
     using ptr = std::shared_ptr<condition>;
-    struct target_type {
-        manifest::target_type root;
-        std::string name;
-        std::vector<std::string> key_path;
-        std::vector<PW_TRANSFORM_ID> transformers;
-    };
 
     enum class data_source : uint8_t { values, keys };
 
+    struct target_type {
+        manifest::target_type root;
+        std::string name;
+        std::vector<std::string> key_path{};
+        std::vector<PW_TRANSFORM_ID> transformers{};
+        data_source source{data_source::values};
+    };
+
     condition(std::vector<target_type> targets, std::shared_ptr<rule_processor::base> processor,
-        std::string data_id = {}, ddwaf::object_limits limits = ddwaf::object_limits(),
-        data_source source = data_source::values)
+        std::string data_id = {}, ddwaf::object_limits limits = ddwaf::object_limits())
         : targets_(std::move(targets)), processor_(std::move(processor)),
-          data_id_(std::move(data_id)), limits_(limits), source_(source)
+          data_id_(std::move(data_id)), limits_(limits)
     {}
 
     ~condition() = default;
@@ -75,7 +76,6 @@ protected:
     std::shared_ptr<rule_processor::base> processor_;
     std::string data_id_;
     ddwaf::object_limits limits_;
-    data_source source_;
 };
 
 } // namespace ddwaf

--- a/src/parser/parser_v1.cpp
+++ b/src/parser/parser_v1.cpp
@@ -100,11 +100,12 @@ condition::ptr parseCondition(parameter::map &rule, manifest &target_manifest,
         if (!key_path.empty()) {
             target.key_path.emplace_back(key_path);
         }
+        target.transformers = transformers;
         targets.emplace_back(std::move(target));
     }
 
     return std::make_shared<condition>(
-        std::move(targets), std::move(transformers), std::move(processor), std::string{}, limits);
+        std::move(targets), std::move(processor), std::string{}, limits);
 }
 
 void parseRule(parameter::map &rule, base_section_info &info, manifest &target_manifest,

--- a/tests/collection_test.cpp
+++ b/tests/collection_test.cpp
@@ -20,9 +20,9 @@ TYPED_TEST(TestCollection, SingleRuleMatch)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -75,11 +75,11 @@ TYPED_TEST(TestCollection, MultipleRuleCachedMatch)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -95,9 +95,9 @@ TYPED_TEST(TestCollection, MultipleRuleCachedMatch)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -153,11 +153,11 @@ TYPED_TEST(TestCollection, MultipleRuleFailAndMatch)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -172,9 +172,9 @@ TYPED_TEST(TestCollection, MultipleRuleFailAndMatch)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -228,21 +228,19 @@ TYPED_TEST(TestCollection, SingleRuleMultipleCalls)
     std::vector<condition::ptr> conditions;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        conditions.emplace_back(
-            std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-                std::make_unique<rule_processor::ip_match>(
-                    std::vector<std::string_view>{"192.168.0.1"})));
+        conditions.emplace_back(std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"})));
     }
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        conditions.emplace_back(
-            std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-                std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"})));
+        conditions.emplace_back(std::make_shared<condition>(std::move(targets),
+            std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"})));
     }
 
     std::unordered_map<std::string, std::string> tags{{"type", "type"}, {"category", "category"}};
@@ -296,11 +294,11 @@ TEST(TestPriorityCollection, NoRegularMatchAfterPriorityMatch)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -315,9 +313,9 @@ TEST(TestPriorityCollection, NoRegularMatchAfterPriorityMatch)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -376,11 +374,11 @@ TEST(TestPriorityCollection, PriorityMatchAfterRegularMatch)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -395,9 +393,9 @@ TEST(TestPriorityCollection, PriorityMatchAfterRegularMatch)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -456,11 +454,11 @@ TEST(TestPriorityCollection, NoPriorityMatchAfterPriorityMatch)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -475,9 +473,9 @@ TEST(TestPriorityCollection, NoPriorityMatchAfterPriorityMatch)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};

--- a/tests/condition_test.cpp
+++ b/tests/condition_test.cpp
@@ -13,10 +13,10 @@ TEST(TestCondition, Match)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("server.request.query"), "server.request.query", {}});
+    targets.push_back({manifest.insert("server.request.query"), "server.request.query", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-        std::make_unique<rule_processor::regex_match>(".*", 0, true));
+    auto cond = std::make_shared<condition>(
+        std::move(targets), std::make_unique<rule_processor::regex_match>(".*", 0, true));
 
     ddwaf_object root;
     ddwaf_object tmp;
@@ -44,9 +44,9 @@ TEST(TestCondition, NoMatch)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{}));
 
     ddwaf_object root;
@@ -68,10 +68,10 @@ TEST(TestCondition, ExcludeInput)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("server.request.query"), "server.request.query", {}});
+    targets.push_back({manifest.insert("server.request.query"), "server.request.query", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-        std::make_unique<rule_processor::regex_match>(".*", 0, true));
+    auto cond = std::make_shared<condition>(
+        std::move(targets), std::make_unique<rule_processor::regex_match>(".*", 0, true));
 
     ddwaf_object root;
     ddwaf_object tmp;
@@ -92,10 +92,10 @@ TEST(TestCondition, ExcludeKeyPath)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("server.request.query"), "server.request.query", {}});
+    targets.push_back({manifest.insert("server.request.query"), "server.request.query", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-        std::make_unique<rule_processor::regex_match>(".*", 0, true));
+    auto cond = std::make_shared<condition>(
+        std::move(targets), std::make_unique<rule_processor::regex_match>(".*", 0, true));
 
     ddwaf_object root;
     ddwaf_object map;

--- a/tests/context_test.cpp
+++ b/tests/context_test.cpp
@@ -25,9 +25,9 @@ TEST(TestContext, MatchTimeout)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -58,9 +58,9 @@ TEST(TestContext, NoMatch)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -92,9 +92,9 @@ TEST(TestContext, Match)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -127,11 +127,11 @@ TEST(TestContext, MatchMultipleRulesInCollectionSingleRun)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -146,9 +146,9 @@ TEST(TestContext, MatchMultipleRulesInCollectionSingleRun)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -201,11 +201,11 @@ TEST(TestContext, MatchMultipleRulesWithPrioritySingleRun)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -220,9 +220,9 @@ TEST(TestContext, MatchMultipleRulesWithPrioritySingleRun)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -286,11 +286,11 @@ TEST(TestContext, MatchMultipleRulesInCollectionDoubleRun)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -305,9 +305,9 @@ TEST(TestContext, MatchMultipleRulesInCollectionDoubleRun)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -372,11 +372,11 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -391,9 +391,9 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -478,11 +478,11 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -497,9 +497,9 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -566,11 +566,11 @@ TEST(TestContext, MatchMultipleRulesWithPriorityUntilAllActionsMet)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -585,9 +585,9 @@ TEST(TestContext, MatchMultipleRulesWithPriorityUntilAllActionsMet)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -670,11 +670,11 @@ TEST(TestContext, MatchMultipleCollectionsSingleRun)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -689,9 +689,9 @@ TEST(TestContext, MatchMultipleCollectionsSingleRun)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -727,11 +727,11 @@ TEST(TestContext, MatchMultiplePriorityCollectionsSingleRun)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -746,9 +746,9 @@ TEST(TestContext, MatchMultiplePriorityCollectionsSingleRun)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -784,11 +784,11 @@ TEST(TestContext, MatchMultipleCollectionsDoubleRun)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -803,9 +803,9 @@ TEST(TestContext, MatchMultipleCollectionsDoubleRun)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -853,11 +853,11 @@ TEST(TestContext, MatchMultiplePriorityCollectionsDoubleRun)
     ddwaf::manifest manifest;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -872,9 +872,9 @@ TEST(TestContext, MatchMultiplePriorityCollectionsDoubleRun)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -925,9 +925,9 @@ TEST(TestContext, RuleFilterWithCondition)
     ddwaf::rule::ptr rule;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -944,11 +944,11 @@ TEST(TestContext, RuleFilterWithCondition)
     // Generate filter
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -986,9 +986,9 @@ TEST(TestContext, RuleFilterTimeout)
     ddwaf::rule::ptr rule;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -1005,11 +1005,11 @@ TEST(TestContext, RuleFilterTimeout)
     // Generate filter
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -1042,9 +1042,9 @@ TEST(TestContext, NoRuleFilterWithCondition)
     ddwaf::rule::ptr rule;
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -1061,11 +1061,11 @@ TEST(TestContext, NoRuleFilterWithCondition)
     // Generate filter
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -1302,11 +1302,11 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRulesWithConditions)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -1318,9 +1318,9 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRulesWithConditions)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -1397,11 +1397,11 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRulesWithConditions)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
 
@@ -1413,9 +1413,9 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRulesWithConditions)
 
     {
         std::vector<ddwaf::condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
 
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
 
         std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -1474,7 +1474,7 @@ TEST(TestContext, InputFilterExclude)
     condition::target_type client_ip{manifest.insert("http.client_ip"), "http.client_ip", {}};
 
     std::vector<ddwaf::condition::target_type> targets{client_ip};
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -1518,7 +1518,7 @@ TEST(TestContext, InputFilterExcludeRule)
     condition::target_type client_ip{manifest.insert("http.client_ip"), "http.client_ip", {}};
 
     std::vector<ddwaf::condition::target_type> targets{client_ip};
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -1569,9 +1569,9 @@ TEST(TestContext, InputFilterWithCondition)
     {
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{client_ip};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.emplace_back(std::move(cond));
 
         std::unordered_map<std::string, std::string> tags{
@@ -1589,7 +1589,7 @@ TEST(TestContext, InputFilterWithCondition)
 
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{usr_id};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.emplace_back(std::move(cond));
 
@@ -1666,9 +1666,9 @@ TEST(TestContext, InputFilterMultipleRules)
     {
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{client_ip};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.emplace_back(std::move(cond));
 
         std::unordered_map<std::string, std::string> tags{
@@ -1683,7 +1683,7 @@ TEST(TestContext, InputFilterMultipleRules)
     {
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{usr_id};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.emplace_back(std::move(cond));
 
@@ -1781,9 +1781,9 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
     {
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{client_ip};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.emplace_back(std::move(cond));
 
         std::unordered_map<std::string, std::string> tags{
@@ -1798,7 +1798,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
     {
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{usr_id};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.emplace_back(std::move(cond));
 
@@ -1909,9 +1909,9 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
     {
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{client_ip};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.emplace_back(std::move(cond));
 
         std::unordered_map<std::string, std::string> tags{
@@ -1926,7 +1926,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
     {
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{usr_id};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.emplace_back(std::move(cond));
 
@@ -1942,7 +1942,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
     {
         std::vector<std::shared_ptr<condition>> conditions;
         std::vector<ddwaf::condition::target_type> targets{cookie_header};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"mycookie"}));
         conditions.emplace_back(std::move(cond));
 

--- a/tests/input_filter_test.cpp
+++ b/tests/input_filter_test.cpp
@@ -75,8 +75,8 @@ TEST(TestInputFilter, InputExclusionWithCondition)
     ddwaf::manifest manifest;
     auto client_ip = manifest.insert("http.client_ip");
 
-    std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -109,8 +109,8 @@ TEST(TestInputFilter, InputExclusionFailedCondition)
     ddwaf::manifest manifest;
     auto client_ip = manifest.insert("http.client_ip");
 
-    std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -141,8 +141,8 @@ TEST(TestInputFilter, ObjectExclusionWithCondition)
     auto client_ip = manifest.insert("http.client_ip");
     auto query = manifest.insert("query");
 
-    std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -182,8 +182,8 @@ TEST(TestInputFilter, ObjectExclusionFailedCondition)
     auto client_ip = manifest.insert("http.client_ip");
     auto query = manifest.insert("query");
 
-    std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -222,16 +222,16 @@ TEST(TestInputFilter, InputValidateCachedMatch)
 
     std::vector<std::shared_ptr<condition>> conditions;
     {
-        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
-        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}, {}}};
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -284,16 +284,16 @@ TEST(TestInputFilter, InputMatchWithoutCache)
 
     std::vector<std::shared_ptr<condition>> conditions;
     {
-        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
-        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}, {}}};
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -342,16 +342,16 @@ TEST(TestInputFilter, InputNoMatchWithoutCache)
 
     std::vector<std::shared_ptr<condition>> conditions;
     {
-        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
-        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}, {}}};
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -407,16 +407,16 @@ TEST(TestInputFilter, InputCachedMatchSecondRun)
 
     std::vector<std::shared_ptr<condition>> conditions;
     {
-        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
-        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}, {}}};
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -471,16 +471,16 @@ TEST(TestInputFilter, ObjectValidateCachedMatch)
 
     std::vector<std::shared_ptr<condition>> conditions;
     {
-        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
-        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}, {}}};
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -543,16 +543,16 @@ TEST(TestInputFilter, ObjectMatchWithoutCache)
 
     std::vector<std::shared_ptr<condition>> conditions;
     {
-        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
-        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}, {}}};
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -612,16 +612,16 @@ TEST(TestInputFilter, ObjectNoMatchWithoutCache)
 
     std::vector<std::shared_ptr<condition>> conditions;
     {
-        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
-        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}, {}}};
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -680,16 +680,16 @@ TEST(TestInputFilter, ObjectCachedMatchSecondRun)
 
     std::vector<std::shared_ptr<condition>> conditions;
     {
-        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        std::vector<condition::target_type> targets{{client_ip, "http.client_ip", {}, {}}};
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
-        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}}};
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        std::vector<condition::target_type> targets{{usr_id, "usr.id", {}, {}}};
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }

--- a/tests/integration/conditions/test.cpp
+++ b/tests/integration/conditions/test.cpp
@@ -76,6 +76,77 @@ TEST(TestConditionsIntegration, GlobalTransformer)
     ddwaf_destroy(handle);
 }
 
+TEST(TestConditionsIntegration, GlobalTransformerKeysOnly)
+{
+    auto rule = readFile("global_transformer.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, ddwaf_object_free};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object tmp;
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
+        ddwaf_object_map_add(&parameter, "value3_0", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
+        ddwaf_object_map_add(&parameter, "value3_0", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
+        ddwaf_object_map_add(&parameter, "value3_1", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
+        ddwaf_object_map_add(&parameter, "value3_1", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
 TEST(TestConditionsIntegration, InputTransformer)
 {
     auto rule = readFile("input_transformer.yaml", base_dir);
@@ -130,6 +201,317 @@ TEST(TestConditionsIntegration, InputTransformer)
 
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_1", ddwaf_object_string(&tmp, "      RULE2   "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestConditionsIntegration, InputTransformerKeysOnly)
+{
+    auto rule = readFile("input_transformer.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, ddwaf_object_free};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object tmp;
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
+        ddwaf_object_map_add(&parameter, "value3_0", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
+        ddwaf_object_map_add(&parameter, "value3_0", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
+        ddwaf_object_map_add(&parameter, "value3_1", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
+        ddwaf_object_map_add(&parameter, "value3_1", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestConditionsIntegration, OverlappingTransformer)
+{
+    auto rule = readFile("overlapping_transformers.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, ddwaf_object_free};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object tmp;
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, " RULE1 "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "    rule1 "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, " rule1 "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, " RULE1 "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_2", ddwaf_object_string(&tmp, "   rule1   "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_2", ddwaf_object_string(&tmp, "  RULE1   "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_3", ddwaf_object_string(&tmp, "    RULE1   "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestConditionsIntegration, OverlappingTransformerKeysOnly)
+{
+    auto rule = readFile("overlapping_transformers.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, ddwaf_object_free};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object tmp;
+    /*    {*/
+    /*ddwaf_context context = ddwaf_context_init(handle);*/
+    /*ASSERT_NE(context, nullptr);*/
+
+    /*ddwaf_object parameter = DDWAF_OBJECT_MAP;*/
+    /*ddwaf_object map = DDWAF_OBJECT_MAP;*/
+    /*ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));*/
+    /*ddwaf_object_map_add(&parameter, "value2_0", &map);*/
+
+    /*EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);*/
+
+    /*ddwaf_context_destroy(context);*/
+    /*}*/
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
+        ddwaf_object_map_add(&parameter, "value2_1", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "rule2"));
+        ddwaf_object_map_add(&parameter, "value2_1", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
+        ddwaf_object_map_add(&parameter, "value2_1", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
+        ddwaf_object_map_add(&parameter, "value2_2", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
+        ddwaf_object_map_add(&parameter, "value2_2", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
+        ddwaf_object_map_add(&parameter, "value2_3", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "rule2"));
+        ddwaf_object_map_add(&parameter, "value2_3", &map);
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
+        ddwaf_object_map_add(&parameter, "value2_3", &map);
 
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
 

--- a/tests/integration/conditions/test.cpp
+++ b/tests/integration/conditions/test.cpp
@@ -1,0 +1,140 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "../../test.h"
+#include "ddwaf.h"
+
+using namespace ddwaf;
+
+namespace {
+constexpr std::string_view base_dir = "integration/conditions/";
+} // namespace
+
+TEST(TestConditionsIntegration, GlobalTransformer)
+{
+    auto rule = readFile("global_transformer.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, ddwaf_object_free};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object tmp;
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "RULE1"));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, "RULE1"));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value2_0", ddwaf_object_string(&tmp, "  RULE2    "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value2_1", ddwaf_object_string(&tmp, "      RULE2   "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestConditionsIntegration, InputTransformer)
+{
+    auto rule = readFile("input_transformer.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, ddwaf_object_free};
+
+    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object tmp;
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "RULE1"));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, "RULE1"));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value2_0", ddwaf_object_string(&tmp, "  RULE2    "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_MATCH);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value2_1", ddwaf_object_string(&tmp, "      RULE2   "));
+
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, LONG_TIME), DDWAF_OK);
+
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}

--- a/tests/integration/conditions/yaml/global_transformer.yaml
+++ b/tests/integration/conditions/yaml/global_transformer.yaml
@@ -1,0 +1,39 @@
+version: '2.1'
+rules:
+  - id: rule1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+      confidence: 1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1_0
+            - address: value1_1
+          regex: rule1
+          options:
+            case_sensitive: true
+    transformers:
+      - lowercase
+
+  - id: rule2
+    name: rule2
+    tags:
+      type: flow2
+      category: category2
+      confidence: 1000
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value2_0
+            - address: value2_1
+          regex: ^ rule2 $
+          options:
+            case_sensitive: true
+    transformers:
+      - lowercase
+      - compressWhiteSpace
+

--- a/tests/integration/conditions/yaml/input_transformer.yaml
+++ b/tests/integration/conditions/yaml/input_transformer.yaml
@@ -35,3 +35,23 @@ rules:
           regex: ^ rule2 $
           options:
             case_sensitive: true
+  - id: rule3
+    name: rule3
+    tags:
+      type: flow3
+      category: category3
+      confidence: 1000
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value3_0
+              transformers:
+                - keys_only
+                - lowercase
+            - address: value3_1
+              transformers:
+                - lowercase
+          regex: rule3
+          options:
+            case_sensitive: true

--- a/tests/integration/conditions/yaml/input_transformer.yaml
+++ b/tests/integration/conditions/yaml/input_transformer.yaml
@@ -1,0 +1,37 @@
+version: '2.1'
+rules:
+  - id: rule1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+      confidence: 1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1_0
+              transformers:
+                - lowercase
+            - address: value1_1
+          regex: rule1
+          options:
+            case_sensitive: true
+  - id: rule2
+    name: rule2
+    tags:
+      type: flow2
+      category: category2
+      confidence: 1000
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value2_0
+              transformers:
+                - lowercase
+                - compressWhiteSpace
+            - address: value2_1
+          regex: ^ rule2 $
+          options:
+            case_sensitive: true

--- a/tests/integration/conditions/yaml/overlapping_transformers.yaml
+++ b/tests/integration/conditions/yaml/overlapping_transformers.yaml
@@ -12,7 +12,15 @@ rules:
           inputs:
             - address: value1_0
             - address: value1_1
-          regex: rule1
+              transformers: []
+            - address: value1_2
+              transformers:
+                - compressWhiteSpace
+            - address: value1_3
+              transformers:
+                - lowercase
+                - compressWhiteSpace
+          regex: ^ rule1 $
           options:
             case_sensitive: true
     transformers:
@@ -30,29 +38,15 @@ rules:
           inputs:
             - address: value2_0
             - address: value2_1
-          regex: ^ rule2 $
-          options:
-            case_sensitive: true
-    transformers:
-      - lowercase
-      - compressWhiteSpace
-
-  - id: rule3
-    name: rule3
-    tags:
-      type: flow3
-      category: category3
-      confidence: 1000
-    conditions:
-      - operator: match_regex
-        parameters:
-          inputs:
-            - address: value3_0
-            - address: value3_1
-          regex: rule3
+              transformers:
+                - values_only
+            - address: value2_2
+              transformers:
+                - lowercase
+            - address: value2_3
+              transformers: []
+          regex: rule2
           options:
             case_sensitive: true
     transformers:
       - keys_only
-      - lowercase
-

--- a/tests/rule_filter_test.cpp
+++ b/tests/rule_filter_test.cpp
@@ -13,9 +13,9 @@ TEST(TestRuleFilter, Match)
     std::vector<ddwaf::condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -41,9 +41,9 @@ TEST(TestRuleFilter, NoMatch)
     std::vector<condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -70,17 +70,17 @@ TEST(TestRuleFilter, ValidateCachedMatch)
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -125,17 +125,17 @@ TEST(TestRuleFilter, MatchWithoutCache)
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -179,17 +179,17 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -233,17 +233,17 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }

--- a/tests/rule_test.cpp
+++ b/tests/rule_test.cpp
@@ -13,9 +13,9 @@ TEST(TestRule, Match)
     std::vector<condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -59,9 +59,9 @@ TEST(TestRule, NoMatch)
     std::vector<condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
@@ -89,17 +89,17 @@ TEST(TestRule, ValidateCachedMatch)
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -171,17 +171,17 @@ TEST(TestRule, MatchWithoutCache)
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -247,17 +247,17 @@ TEST(TestRule, NoMatchWithoutCache)
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -304,17 +304,17 @@ TEST(TestRule, FullCachedMatchSecondRun)
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
-            std::make_unique<rule_processor::ip_match>(
-                std::vector<std::string_view>{"192.168.0.1"}));
+        targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
+        auto cond = std::make_shared<condition>(
+            std::move(targets), std::make_unique<rule_processor::ip_match>(
+                                    std::vector<std::string_view>{"192.168.0.1"}));
         conditions.push_back(std::move(cond));
     }
 
     {
         std::vector<condition::target_type> targets;
-        targets.push_back({manifest.insert("usr.id"), "usr.id", {}});
-        auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+        targets.push_back({manifest.insert("usr.id"), "usr.id", {}, {}});
+        auto cond = std::make_shared<condition>(std::move(targets),
             std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
         conditions.push_back(std::move(cond));
     }
@@ -361,9 +361,9 @@ TEST(TestRule, ExcludeObject)
     std::vector<condition::target_type> targets;
 
     ddwaf::manifest manifest;
-    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}});
+    targets.push_back({manifest.insert("http.client_ip"), "http.client_ip", {}, {}});
 
-    auto cond = std::make_shared<condition>(std::move(targets), std::vector<PW_TRANSFORM_ID>{},
+    auto cond = std::make_shared<condition>(std::move(targets),
         std::make_unique<rule_processor::ip_match>(std::vector<std::string_view>{"192.168.0.1"}));
 
     std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};


### PR DESCRIPTION
Support per-input transformers with the schema of the following example:

```
"inputs": [
  {
    "address": "http.client_ip",
    "key_path": [],
    "transformers": []
  }
],