### PR TITLE
Fix benchmark, test output and update ruleset to 1.7.0

### DIFF
--- a/perf/main.cpp
+++ b/perf/main.cpp
@@ -190,18 +190,17 @@ benchmark::settings generate_settings(int argc, char *argv[])
 
         std::size_t delimiter = 0;
 
-        std::vector<std::string_view> test_list;
         std::string_view remaining = test_str;
         while ((delimiter = remaining.find(',')) != std::string::npos) {
             auto substr = remaining.substr(0, delimiter);
             if (!substr.empty()) {
-                test_list.push_back(substr);
+                s.test_list.emplace(substr);
             }
             remaining = remaining.substr(delimiter + 1);
         }
 
         if (!remaining.empty()) {
-            test_list.push_back(remaining);
+            s.test_list.emplace(remaining);
         }
     }
 

--- a/perf/yaml_helpers.cpp
+++ b/perf/yaml_helpers.cpp
@@ -61,6 +61,9 @@ YAML::Emitter &operator<<(YAML::Emitter &out, const ddwaf_object &o)
     out.SetStringFormat(YAML::DoubleQuoted);
 
     switch (o.type) {
+    case DDWAF_OBJ_BOOL:
+        out << o.boolean;
+        break;
     case DDWAF_OBJ_SIGNED:
         out << o.intValue;
         break;

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -396,12 +396,9 @@ void PrintTo(const ddwaf_object &actions, ::std::ostream *os)
     *os << "]";
 }
 
-void PrintTo(const ddwaf_result &result, ::std::ostream *os)
+void PrintTo(const std::list<ddwaf::test::event> &events, ::std::ostream *os)
 {
-    auto data = ddwaf::test::object_to_json(result.events);
-    YAML::Node doc = YAML::Load(data.c_str());
-    auto events = doc.as<std::vector<ddwaf::test::event>>();
-    for (auto e : events) { *os << e; }
+    for (const auto &e : events) { *os << e; }
 }
 
 WafResultActionMatcher::WafResultActionMatcher(std::vector<std::string_view> &&values)
@@ -442,11 +439,8 @@ bool WafResultActionMatcher::MatchAndExplain(
 }
 
 bool WafResultDataMatcher::MatchAndExplain(
-    const std::string &result, ::testing::MatchResultListener * /*unused*/) const
+    std::list<ddwaf::test::event> events, ::testing::MatchResultListener * /*unused*/) const
 {
-    YAML::Node doc = YAML::Load(result.c_str());
-    auto events = doc.as<std::list<ddwaf::test::event>>();
-
     if (events.size() != expected_events_.size()) {
         return false;
     }

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -87,7 +87,7 @@ protected:
 
 // Required by gtest to pretty print relevant types
 void PrintTo(const ddwaf_object &actions, ::std::ostream *os);
-void PrintTo(const ddwaf_result &result, ::std::ostream *os);
+void PrintTo(const std::list<ddwaf::test::event> &events, ::std::ostream *os);
 
 class WafResultActionMatcher {
 public:
@@ -109,7 +109,7 @@ public:
         : expected_events_(std::move(expected_events))
     {}
 
-    bool MatchAndExplain(const std::string &result, ::testing::MatchResultListener *) const;
+    bool MatchAndExplain(std::list<ddwaf::test::event>, ::testing::MatchResultListener *) const;
 
     void DescribeTo(::std::ostream *os) const
     {
@@ -142,7 +142,9 @@ inline ::testing::PolymorphicMatcher<WafResultDataMatcher> WithEvents(
   {                                                                                                \
     auto data = ddwaf::test::object_to_json(result.events);                                        \
     EXPECT_TRUE(ValidateSchema(data));                                                             \
-    EXPECT_THAT(data, WithEvents({__VA_ARGS__}));                                                  \
+    YAML::Node doc = YAML::Load(data.c_str());                                                     \
+    auto events = doc.as<std::list<ddwaf::test::event>>();                                         \
+    EXPECT_THAT(events, WithEvents({__VA_ARGS__}));                                                \
   }
 
 ddwaf_object readFile(std::string_view filename, std::string_view base = "./");

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -187,7 +187,7 @@ set_target_properties(lib_yamlcpp proj_yamlcpp PROPERTIES EXCLUDE_FROM_ALL TRUE)
 # Appsec event rules
 ExternalProject_Add(proj_event_rules
     GIT_REPOSITORY https://github.com/DataDog/appsec-event-rules.git
-    GIT_TAG 1.6.0
+    GIT_TAG 1.7.0
     GIT_SHALLOW ON
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""


### PR DESCRIPTION
- Fix benchmark `--test` option
- Add boolean support to YAML emitter in benchmark
- Fix test output to show formatted events rather than JSON string
- Update reference ruleset to 1.7.0