### PR TITLE
Per-input transformers support on exclusion filter conditions

### DIFF
--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -319,6 +319,13 @@ condition::ptr parse_filter_condition(
         target.root = target_manifest.insert(address);
         target.name = address;
         target.key_path = std::move(key_path);
+        target.source = condition::data_source::values;
+
+        auto it = input.find("transformers");
+        if (it != input.end()) {
+            auto input_transformers = static_cast<parameter::vector>(it->second);
+            target.transformers = parse_transformers(input_transformers, target.source);
+        }
 
         targets.emplace_back(target);
     }

--- a/tests/input_filter_test.cpp
+++ b/tests/input_filter_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "PWTransformer.h"
 #include "test.h"
 
 using namespace ddwaf;
@@ -85,6 +86,40 @@ TEST(TestInputFilter, InputExclusionWithCondition)
     ddwaf_object tmp;
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+
+    ddwaf::object_store store(manifest);
+    store.insert(root);
+
+    auto obj_filter = std::make_shared<object_filter>();
+    obj_filter->insert(client_ip, {});
+    auto rule = std::make_shared<ddwaf::rule>(ddwaf::rule("", "", {}, {}));
+    input_filter filter("filter", std::move(conditions), {rule.get()}, std::move(obj_filter));
+
+    ddwaf::timer deadline{2s};
+    input_filter::cache_type cache;
+
+    auto opt_spec = filter.match(store, cache, deadline);
+    ASSERT_TRUE(opt_spec.has_value());
+    EXPECT_EQ(opt_spec->rules.size(), 1);
+    EXPECT_EQ(opt_spec->objects.size(), 1);
+    EXPECT_NE(opt_spec->objects.find(&root.array[0]), opt_spec->objects.end());
+}
+
+TEST(TestInputFilter, InputExclusionWithConditionAndTransformers)
+{
+    ddwaf::manifest manifest;
+    auto client_ip = manifest.insert("usr.id");
+
+    std::vector<condition::target_type> targets{{client_ip, "usr.id", {}, {PWT_LOWERCASE}}};
+    auto cond = std::make_shared<condition>(std::move(targets),
+        std::make_unique<rule_processor::exact_match>(std::vector<std::string>{"admin"}));
+
+    std::vector<std::shared_ptr<condition>> conditions{std::move(cond)};
+
+    ddwaf_object root;
+    ddwaf_object tmp;
+    ddwaf_object_map(&root);
+    ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "ADMIN"));
 
     ddwaf::object_store store(manifest);
     store.insert(root);

--- a/tests/rule_filter_test.cpp
+++ b/tests/rule_filter_test.cpp
@@ -514,7 +514,6 @@ TEST(TestRuleFilter, ExcludeSingleRuleWithCondition)
     ddwaf_destroy(handle);
 }
 
-
 TEST(TestRuleFilter, ExcludeSingleRuleWithConditionAndTransformers)
 {
     auto rule = readFile("exclude_one_rule_with_condition_and_transformers.yaml");

--- a/tests/yaml/exclude_one_rule_with_condition_and_transformers.yaml
+++ b/tests/yaml/exclude_one_rule_with_condition_and_transformers.yaml
@@ -1,0 +1,40 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    conditions:
+      - operator: exact_match
+        parameters:
+          inputs:
+            - address: usr.id
+              transformers:
+                - lowercase
+                - compressWhiteSpace
+          list:
+            - ad min
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1
+  - id: 2
+    name: rule2
+    tags:
+      type: type2
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1


### PR DESCRIPTION
Exclusion filter conditions currently don't support transformers, this change introduces support specifically for per-input transformers.