### PR TITLE
Rule filter bypass / monitor mode support

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "exclusion/rule_filter.hpp"
 #include <collection.hpp>
 #include <exception.hpp>
 #include <log.hpp>
@@ -12,7 +13,7 @@ namespace ddwaf {
 
 std::optional<event> match_rule(rule *rule, const object_store &store,
     memory::unordered_map<ddwaf::rule *, rule::cache_type> &cache,
-    const memory::unordered_set<ddwaf::rule *> &rules_to_exclude,
+    const memory::unordered_map<ddwaf::rule *, exclusion::filter_mode> &rules_to_exclude,
     const memory::unordered_map<ddwaf::rule *, collection::object_set> &objects_to_exclude,
     const std::unordered_map<std::string, rule_processor::base::ptr> &dynamic_processors,
     ddwaf::timer &deadline)
@@ -29,9 +30,15 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
         return std::nullopt;
     }
 
-    if (rules_to_exclude.find(rule) != rules_to_exclude.end()) {
-        DDWAF_DEBUG("Excluding Rule %s", id.c_str());
-        return std::nullopt;
+    bool skip_actions = false;
+    auto exclude_it = rules_to_exclude.find(rule);
+    if (exclude_it != rules_to_exclude.end()) {
+        if (exclude_it->second == exclusion::filter_mode::bypass) {
+            DDWAF_DEBUG("Excluding Rule %s", id.c_str());
+            return std::nullopt;
+        }
+
+        skip_actions = true;
     }
 
     DDWAF_DEBUG("Running the WAF on rule %s", id.c_str());
@@ -53,6 +60,10 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
             event = rule->match(store, rule_cache, {}, dynamic_processors, deadline);
         }
 
+        if (event.has_value() && skip_actions) {
+            event->skip_actions = true;
+        }
+
         return event;
     } catch (const ddwaf::timeout_exception &) {
         DDWAF_INFO("Ran out of time while processing %s", id.c_str());
@@ -64,7 +75,8 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
 
 template <typename Derived>
 void base_collection<Derived>::match(memory::vector<event> &events, const object_store &store,
-    collection_cache &cache, const memory::unordered_set<rule *> &rules_to_exclude,
+    collection_cache &cache,
+    const memory::unordered_map<ddwaf::rule *, exclusion::filter_mode> &rules_to_exclude,
     const memory::unordered_map<rule *, object_set> &objects_to_exclude,
     const std::unordered_map<std::string, rule_processor::base::ptr> &dynamic_processors,
     ddwaf::timer &deadline) const

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -34,10 +34,11 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
     auto exclude_it = rules_to_exclude.find(rule);
     if (exclude_it != rules_to_exclude.end()) {
         if (exclude_it->second == exclusion::filter_mode::bypass) {
-            DDWAF_DEBUG("Excluding Rule %s", id.c_str());
+            DDWAF_DEBUG("Bypassing Rule %s", id.c_str());
             return std::nullopt;
         }
 
+        DDWAF_DEBUG("Monitoring Rule %s", id.c_str());
         skip_actions = true;
     }
 

--- a/src/collection.hpp
+++ b/src/collection.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "exclusion/rule_filter.hpp"
 #include <context_allocator.hpp>
 #include <event.hpp>
 #include <rule.hpp>
@@ -48,7 +49,8 @@ public:
     void insert(const rule::ptr &rule) { rules_.emplace_back(rule.get()); }
 
     void match(memory::vector<event> &events /* output */, const object_store &store,
-        collection_cache &cache, const memory::unordered_set<ddwaf::rule *> &rules_to_exclude,
+        collection_cache &cache,
+        const memory::unordered_map<ddwaf::rule *, exclusion::filter_mode> &rules_to_exclude,
         const memory::unordered_map<ddwaf::rule *, object_set> &objects_to_exclude,
         const std::unordered_map<std::string, rule_processor::base::ptr> &dynamic_processors,
         ddwaf::timer &deadline) const;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -66,7 +66,7 @@ DDWAF_RET_CODE context::run(
     return code;
 }
 
-const memory::unordered_set<rule *> &context::filter_rules(ddwaf::timer &deadline)
+const memory::unordered_map<rule *, filter_mode> &context::filter_rules(ddwaf::timer &deadline)
 {
     for (const auto &[id, filter] : ruleset_->rule_filters) {
         if (deadline.expired()) {
@@ -84,14 +84,20 @@ const memory::unordered_set<rule *> &context::filter_rules(ddwaf::timer &deadlin
         rule_filter::cache_type &cache = it->second;
         auto exclusion = filter->match(store_, cache, deadline);
         if (exclusion.has_value()) {
-            for (auto &&rule : exclusion->get()) { rules_to_exclude_.insert(rule); }
+            for (auto &&rule : exclusion->get()) {
+                auto [it, res] = rules_to_exclude_.emplace(rule, filter->get_mode());
+                // Bypass has precedence over monitor
+                if (!res && it != rules_to_exclude_.end() && it->second != filter_mode::bypass) {
+                    it->second = filter->get_mode();
+                }
+            }
         }
     }
     return rules_to_exclude_;
 }
 
 const memory::unordered_map<rule *, context::object_set> &context::filter_inputs(
-    const memory::unordered_set<rule *> &rules_to_exclude, ddwaf::timer &deadline)
+    const memory::unordered_map<rule *, filter_mode> &rules_to_exclude, ddwaf::timer &deadline)
 {
     for (const auto &[id, filter] : ruleset_->input_filters) {
         if (deadline.expired()) {
@@ -110,7 +116,9 @@ const memory::unordered_map<rule *, context::object_set> &context::filter_inputs
         auto exclusion = filter->match(store_, cache, deadline);
         if (exclusion.has_value()) {
             for (const auto &rule : exclusion->rules) {
-                if (rules_to_exclude.find(rule) != rules_to_exclude.end()) {
+                auto exclude_it = rules_to_exclude.find(rule);
+                if (exclude_it != rules_to_exclude.end() &&
+                    exclude_it->second == filter_mode::bypass) {
                     continue;
                 }
 
@@ -123,7 +131,8 @@ const memory::unordered_map<rule *, context::object_set> &context::filter_inputs
     return objects_to_exclude_;
 }
 
-memory::vector<event> context::match(const memory::unordered_set<rule *> &rules_to_exclude,
+memory::vector<event> context::match(
+    const memory::unordered_map<rule *, filter_mode> &rules_to_exclude,
     const memory::unordered_map<rule *, object_set> &objects_to_exclude, ddwaf::timer &deadline)
 {
     memory::vector<ddwaf::event> events;

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -23,6 +23,8 @@
 
 namespace ddwaf {
 
+using filter_mode = exclusion::filter_mode;
+
 class context {
 public:
     using object_set = std::unordered_set<const ddwaf_object *>;
@@ -44,11 +46,11 @@ public:
 
     // These two functions below return references to internal objects,
     // however using them this way helps with testing
-    const memory::unordered_set<rule *> &filter_rules(ddwaf::timer &deadline);
+    const memory::unordered_map<rule *, filter_mode> &filter_rules(ddwaf::timer &deadline);
     const memory::unordered_map<rule *, object_set> &filter_inputs(
-        const memory::unordered_set<rule *> &rules_to_exclude, ddwaf::timer &deadline);
+        const memory::unordered_map<rule *, filter_mode> &rules_to_exclude, ddwaf::timer &deadline);
 
-    memory::vector<event> match(const memory::unordered_set<rule *> &rules_to_exclude,
+    memory::vector<event> match(const memory::unordered_map<rule *, filter_mode> &rules_to_exclude,
         const memory::unordered_map<rule *, object_set> &objects_to_exclude,
         ddwaf::timer &deadline);
 
@@ -65,7 +67,7 @@ protected:
     memory::unordered_map<rule_filter *, rule_filter::cache_type> rule_filter_cache_;
     memory::unordered_map<input_filter *, input_filter::cache_type> input_filter_cache_;
 
-    memory::unordered_set<rule *> rules_to_exclude_;
+    memory::unordered_map<rule *, filter_mode> rules_to_exclude_;
     memory::unordered_map<rule *, object_set> objects_to_exclude_;
 
     // Cache of collections to avoid processing once a result has been obtained

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -102,7 +102,9 @@ void event_serializer::serialize(const memory::vector<event> &events, ddwaf_resu
                 ddwaf_object actions_array;
                 ddwaf_object_array(&actions_array);
                 for (const auto &action : actions) {
-                    all_actions.emplace(action);
+                    if (!event.skip_actions) {
+                        all_actions.emplace(action);
+                    }
                     ddwaf_object_array_add(&actions_array, to_object(tmp, action));
                 }
                 ddwaf_object_map_add(&rule_map, "on_match", &actions_array);

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -31,6 +31,7 @@ struct event {
 
     const ddwaf::rule *rule{nullptr};
     memory::vector<match> matches;
+    bool skip_actions{false};
 };
 
 using optional_event = std::optional<event>;

--- a/src/exclusion/rule_filter.cpp
+++ b/src/exclusion/rule_filter.cpp
@@ -9,9 +9,9 @@
 
 namespace ddwaf::exclusion {
 
-rule_filter::rule_filter(
-    std::string id, std::vector<condition::ptr> conditions, std::set<rule *> rule_targets)
-    : id_(std::move(id)), conditions_(std::move(conditions))
+rule_filter::rule_filter(std::string id, std::vector<condition::ptr> conditions,
+    std::set<rule *> rule_targets, filter_mode mode)
+    : id_(std::move(id)), conditions_(std::move(conditions)), mode_(mode)
 {
     rule_targets_.reserve(rule_targets.size());
     for (auto it = rule_targets.begin(); it != rule_targets.end();) {

--- a/src/exclusion/rule_filter.hpp
+++ b/src/exclusion/rule_filter.hpp
@@ -15,6 +15,9 @@
 #include <rule.hpp>
 
 namespace ddwaf::exclusion {
+
+enum class filter_mode { bypass, monitor };
+
 class rule_filter {
 public:
     using ptr = std::shared_ptr<rule_filter>;
@@ -24,13 +27,14 @@ public:
         std::optional<std::vector<condition::ptr>::const_iterator> last_cond{};
     };
 
-    rule_filter(
-        std::string id, std::vector<condition::ptr> conditions, std::set<rule *> rule_targets);
+    rule_filter(std::string id, std::vector<condition::ptr> conditions,
+        std::set<rule *> rule_targets, filter_mode mode = filter_mode::bypass);
 
     optional_ref<const std::unordered_set<rule *>> match(
         const object_store &store, cache_type &cache, ddwaf::timer &deadline) const;
 
-    std::string_view get_id() { return id_; }
+    std::string_view get_id() const { return id_; }
+    filter_mode get_mode() const { return mode_; }
 
     void get_addresses(std::unordered_set<std::string> &addresses) const
     {
@@ -43,6 +47,7 @@ protected:
     std::string id_;
     std::vector<condition::ptr> conditions_;
     std::unordered_set<rule *> rule_targets_;
+    filter_mode mode_{filter_mode::bypass};
 };
 
 } // namespace ddwaf::exclusion

--- a/src/exclusion/rule_filter.hpp
+++ b/src/exclusion/rule_filter.hpp
@@ -47,7 +47,7 @@ protected:
     std::string id_;
     std::vector<condition::ptr> conditions_;
     std::unordered_set<rule *> rule_targets_;
-    filter_mode mode_{filter_mode::bypass};
+    filter_mode mode_;
 };
 
 } // namespace ddwaf::exclusion

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -400,11 +400,21 @@ rule_filter_spec parse_rule_filter(const parameter::map &filter, const object_li
         }
     }
 
+    exclusion::filter_mode on_match;
+    auto on_match_str = at<std::string_view>(filter, "on_match", "bypass");
+    if (on_match_str == "bypass") {
+        on_match = exclusion::filter_mode::bypass;
+    } else if (on_match_str == "monitor") {
+        on_match = exclusion::filter_mode::monitor;
+    } else {
+        throw ddwaf::parsing_error("usupported on_match value" + std::string(on_match_str));
+    }
+
     if (conditions.empty() && rules_target.empty()) {
         throw ddwaf::parsing_error("empty exclusion filter");
     }
 
-    return {std::move(conditions), std::move(rules_target)};
+    return {std::move(conditions), std::move(rules_target), on_match};
 }
 
 std::string index_to_id(unsigned idx) { return "index:" + std::to_string(idx); }

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -407,7 +407,7 @@ rule_filter_spec parse_rule_filter(const parameter::map &filter, const object_li
     } else if (on_match_str == "monitor") {
         on_match = exclusion::filter_mode::monitor;
     } else {
-        throw ddwaf::parsing_error("usupported on_match value" + std::string(on_match_str));
+        throw ddwaf::parsing_error("unsupported on_match value: " + std::string(on_match_str));
     }
 
     if (conditions.empty() && rules_target.empty()) {

--- a/src/parser/specification.hpp
+++ b/src/parser/specification.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "exclusion/rule_filter.hpp"
 #include <condition.hpp>
 #include <exception.hpp>
 #include <exclusion/object_filter.hpp>
@@ -44,6 +45,7 @@ struct override_spec {
 struct rule_filter_spec {
     std::vector<condition::ptr> conditions;
     std::vector<rule_target_spec> targets;
+    exclusion::filter_mode on_match;
 };
 
 struct input_filter_spec {

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -146,7 +146,7 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
                 target_to_rules(filter.targets, final_user_rules_, user_rules_by_tags_));
 
             auto filter_ptr = std::make_shared<exclusion::rule_filter>(
-                id, filter.conditions, std::move(rule_targets));
+                id, filter.conditions, std::move(rule_targets), filter.on_match);
             rule_filters_.emplace(filter_ptr->get_id(), filter_ptr);
         }
 

--- a/tests/context_test.cpp
+++ b/tests/context_test.cpp
@@ -1498,7 +1498,7 @@ TEST(TestContext, InputFilterExcludeRule)
     // The rule is added to the filter stage so that it's excluded from the
     // final result, since we're not actually excluding the rule from the match
     // stage we still get an event.
-    auto objects_to_exclude = ctx.filter_inputs({rule.get()}, deadline);
+    auto objects_to_exclude = ctx.filter_inputs({{rule.get(), filter_mode::bypass}}, deadline);
     EXPECT_EQ(objects_to_exclude.size(), 0);
     auto events = ctx.match({}, objects_to_exclude, deadline);
     EXPECT_EQ(events.size(), 1);

--- a/tests/parser_v2_rule_filters.cpp
+++ b/tests/parser_v2_rule_filters.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "exclusion/rule_filter.hpp"
 #include "ruleset_info.hpp"
 #include "test.h"
 
@@ -497,6 +498,7 @@ TEST(TestParserV2RuleFilters, ParseConditionalGlobal)
     const auto &filter = filter_it->second;
     EXPECT_EQ(filter.conditions.size(), 1);
     EXPECT_EQ(filter.targets.size(), 0);
+    EXPECT_EQ(filter.on_match, exclusion::filter_mode::bypass);
 }
 
 TEST(TestParserV2RuleFilters, ParseConditionalMultipleConditions)
@@ -539,9 +541,130 @@ TEST(TestParserV2RuleFilters, ParseConditionalMultipleConditions)
     const auto &filter = filter_it->second;
     EXPECT_EQ(filter.conditions.size(), 3);
     EXPECT_EQ(filter.targets.size(), 1);
+    EXPECT_EQ(filter.on_match, exclusion::filter_mode::bypass);
 
     const auto &target = filter.targets[0];
     EXPECT_EQ(target.type, parser::target_type::id);
     EXPECT_STR(target.rule_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
+}
+
+TEST(TestParserV2RuleFilters, ParseOnMatchMonitor)
+{
+    ddwaf::object_limits limits;
+
+    auto object = readRule(R"([{id: 1, rules_target: [{rule_id: 2939}], on_match: monitor}])");
+
+    ddwaf::ruleset_info::section_info section;
+    auto filters_array = static_cast<parameter::vector>(parameter(object));
+    auto filters = parser::v2::parse_filters(filters_array, section, limits);
+    ddwaf_object_free(&object);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("1"), loaded.end());
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(filters.rule_filters.size(), 1);
+    EXPECT_EQ(filters.input_filters.size(), 0);
+
+    const auto &filter_it = filters.rule_filters.begin();
+    EXPECT_STR(filter_it->first, "1");
+
+    const auto &filter = filter_it->second;
+    EXPECT_EQ(filter.on_match, exclusion::filter_mode::monitor);
+}
+
+TEST(TestParserV2RuleFilters, ParseOnMatchBypass)
+{
+    ddwaf::object_limits limits;
+
+    auto object = readRule(R"([{id: 1, rules_target: [{rule_id: 2939}], on_match: bypass}])");
+
+    ddwaf::ruleset_info::section_info section;
+    auto filters_array = static_cast<parameter::vector>(parameter(object));
+    auto filters = parser::v2::parse_filters(filters_array, section, limits);
+    ddwaf_object_free(&object);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("1"), loaded.end());
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(filters.rule_filters.size(), 1);
+    EXPECT_EQ(filters.input_filters.size(), 0);
+
+    const auto &filter_it = filters.rule_filters.begin();
+    EXPECT_STR(filter_it->first, "1");
+
+    const auto &filter = filter_it->second;
+    EXPECT_EQ(filter.on_match, exclusion::filter_mode::bypass);
+}
+
+TEST(TestParserV2RuleFilters, ParseInvalidOnMatch)
+{
+    ddwaf::object_limits limits;
+
+    auto object = readRule(R"([{id: 1, rules_target: [{rule_id: 2939}], on_match: obliterate}])");
+
+    ddwaf::ruleset_info::section_info section;
+    auto filters_array = static_cast<parameter::vector>(parameter(object));
+    auto filters = parser::v2::parse_filters(filters_array, section, limits);
+    ddwaf_object_free(&object);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("1"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("unsupported on_match value: obliterate");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("1"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(filters.rule_filters.size(), 0);
+    EXPECT_EQ(filters.input_filters.size(), 0);
 }

--- a/tests/rule_filter_test.cpp
+++ b/tests/rule_filter_test.cpp
@@ -22,7 +22,8 @@ TEST(TestRuleFilter, Match)
     auto rule = std::make_shared<ddwaf::rule>(ddwaf::rule("", "", {}, {}));
     ddwaf::exclusion::rule_filter filter{"filter", std::move(conditions), {rule.get()}};
 
-    ddwaf_object root, tmp;
+    ddwaf_object root;
+    ddwaf_object tmp;
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -48,7 +49,8 @@ TEST(TestRuleFilter, NoMatch)
 
     ddwaf::exclusion::rule_filter filter{"filter", std::move(conditions), {}};
 
-    ddwaf_object root, tmp;
+    ddwaf_object root;
+    ddwaf_object tmp;
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -91,7 +93,8 @@ TEST(TestRuleFilter, ValidateCachedMatch)
     // only the latest address. This ensures that the IP condition can't be
     // matched on the second run.
     {
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -103,7 +106,8 @@ TEST(TestRuleFilter, ValidateCachedMatch)
     }
 
     {
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
@@ -145,7 +149,8 @@ TEST(TestRuleFilter, MatchWithoutCache)
     ddwaf::object_store store;
     {
         ddwaf::exclusion::rule_filter::cache_type cache;
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -157,7 +162,8 @@ TEST(TestRuleFilter, MatchWithoutCache)
 
     {
         ddwaf::exclusion::rule_filter::cache_type cache;
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
@@ -196,7 +202,8 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
     // address is passed, the filter doesn't match (as it should be).
     {
         ddwaf::exclusion::rule_filter::cache_type cache;
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -209,7 +216,8 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
 
     {
         ddwaf::exclusion::rule_filter::cache_type cache;
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
@@ -251,7 +259,8 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
     // In this test we validate that when a match has already occurred, the
     // second run for the same filter returns nothing.
     {
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
@@ -264,7 +273,8 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
     }
 
     {
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "random", ddwaf_object_string(&tmp, "random"));
 
@@ -287,7 +297,8 @@ TEST(TestRuleFilter, ExcludeSingleRule)
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object root, tmp;
+    ddwaf_object root;
+    ddwaf_object tmp;
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -317,7 +328,8 @@ TEST(TestRuleFilter, ExcludeByType)
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object root, tmp;
+    ddwaf_object root;
+    ddwaf_object tmp;
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -347,7 +359,8 @@ TEST(TestRuleFilter, ExcludeByCategory)
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object root, tmp;
+    ddwaf_object root;
+    ddwaf_object tmp;
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -371,7 +384,8 @@ TEST(TestRuleFilter, ExcludeByTags)
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object root, tmp;
+    ddwaf_object root;
+    ddwaf_object tmp;
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -402,7 +416,8 @@ TEST(TestRuleFilter, ExcludeAllWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
@@ -418,7 +433,8 @@ TEST(TestRuleFilter, ExcludeAllWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -458,7 +474,8 @@ TEST(TestRuleFilter, ExcludeSingleRuleWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
@@ -481,7 +498,8 @@ TEST(TestRuleFilter, ExcludeSingleRuleWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -521,7 +539,8 @@ TEST(TestRuleFilter, ExcludeSingleRuleWithConditionAndTransformers)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "AD      MIN"));
@@ -544,7 +563,8 @@ TEST(TestRuleFilter, ExcludeSingleRuleWithConditionAndTransformers)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -583,7 +603,8 @@ TEST(TestRuleFilter, ExcludeByTypeWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
@@ -606,7 +627,8 @@ TEST(TestRuleFilter, ExcludeByTypeWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -646,7 +668,8 @@ TEST(TestRuleFilter, ExcludeByCategoryWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
@@ -662,7 +685,8 @@ TEST(TestRuleFilter, ExcludeByCategoryWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
@@ -702,7 +726,8 @@ TEST(TestRuleFilter, ExcludeByTagsWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
@@ -725,7 +750,8 @@ TEST(TestRuleFilter, ExcludeByTagsWithCondition)
         ddwaf_context context = ddwaf_context_init(handle);
         ASSERT_NE(context, nullptr);
 
-        ddwaf_object root, tmp;
+        ddwaf_object root;
+        ddwaf_object tmp;
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 

--- a/tests/rule_filter_test.cpp
+++ b/tests/rule_filter_test.cpp
@@ -777,3 +777,36 @@ TEST(TestRuleFilter, ExcludeByTagsWithCondition)
     }
     ddwaf_destroy(handle);
 }
+
+TEST(TestRuleFilter, MonitorSingleRule)
+{
+    auto rule = readFile("monitor_one_rule.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object tmp;
+    ddwaf_object_map(&root);
+    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+
+    ddwaf_result out;
+    EXPECT_EQ(ddwaf_run(context, &root, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EVENTS(out, {.id = "1",
+                           .name = "rule1",
+                           .tags = {{"type", "type1"}, {"category", "category"}},
+                           .actions = {"block"},
+                           .matches = {{.op = "ip_match",
+                               .address = "http.client_ip",
+                               .value = "192.168.0.1",
+                               .highlight = "192.168.0.1"}}});
+    EXPECT_THAT(out.actions, WithActions({}));
+    ddwaf_result_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}

--- a/tests/rule_filter_test.cpp
+++ b/tests/rule_filter_test.cpp
@@ -810,3 +810,25 @@ TEST(TestRuleFilter, MonitorSingleRule)
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
+
+TEST(TestRuleFilter, FilterModePrecedence)
+{
+    auto rule = readFile("monitor_bypass_precedence.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object tmp;
+    ddwaf_object_map(&root);
+    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, LONG_TIME), DDWAF_OK);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}

--- a/tests/yaml/monitor_bypass_precedence.yaml
+++ b/tests/yaml/monitor_bypass_precedence.yaml
@@ -1,0 +1,24 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    on_match: monitor
+  - id: 2
+    rules_target:
+      - rule_id: 1
+    on_match: bypass
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1
+    on_match: [ block ]

--- a/tests/yaml/monitor_one_rule.yaml
+++ b/tests/yaml/monitor_one_rule.yaml
@@ -1,0 +1,20 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    on_match: monitor
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1
+    on_match: [ block ]

--- a/validator/main.cpp
+++ b/validator/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char *argv[])
                         continue;
                     }
 
-                    auto it = add_dir(sample_path.root_directory(), files);
+                    auto it = add_dir(sample_path.parent_path(), files);
                     if (it == files.end()) {
                         continue;
                     }

--- a/validator/runner.cpp
+++ b/validator/runner.cpp
@@ -93,6 +93,7 @@ bool test_runner::run_test(const YAML::Node &runs)
         out.SetMapFormat(YAML::Block);
         out.SetSeqFormat(YAML::Block);
         out << object_to_yaml(res->events);
+        out << object_to_yaml(res->actions);
     }
 
     return passed;

--- a/validator/tests/exclusions/rule_filter/conditional/009_rule1_monitored_through_condition.yaml
+++ b/validator/tests/exclusions/rule_filter/conditional/009_rule1_monitored_through_condition.yaml
@@ -1,0 +1,33 @@
+{
+  name: "Monitor all rules through condition-based exclusion filter",
+  runs: [
+    {
+      input: {
+        exclusion-filter-4-input: "exclusion-filter-4",
+        rule1-input: "rule1",
+        rule2-input: "rule2"
+      },
+      rules: [
+        {
+          1: [
+            {
+              address: rule1-input,
+              value: rule1
+            }
+          ]
+        },
+        {
+
+          2: [
+            {
+              address: rule2-input,
+              value: rule2
+            }
+          ]
+        }
+      ],
+      code: match,
+      actions: []
+    }
+  ]
+}

--- a/validator/tests/exclusions/rule_filter/conditional/010_rule_no_exclusions.yaml
+++ b/validator/tests/exclusions/rule_filter/conditional/010_rule_no_exclusions.yaml
@@ -1,0 +1,22 @@
+{
+  name: "Monitor all rules through condition-based exclusion filter",
+  runs: [
+    {
+      input: {
+        rule1-input: "rule1"
+      },
+      rules: [
+        {
+          1: [
+            {
+              address: rule1-input,
+              value: rule1
+            }
+          ]
+        }
+      ],
+      code: match,
+      actions: [ block ]
+    }
+  ]
+}

--- a/validator/tests/exclusions/rule_filter/conditional/ruleset.yaml
+++ b/validator/tests/exclusions/rule_filter/conditional/ruleset.yaml
@@ -7,6 +7,7 @@ exclusions:
           inputs:
             - address: exclusion-filter-1-input
           regex: exclusion-filter-1
+    on_match: bypass
   - id: 2
     conditions:
       - operator: match_regex
@@ -31,6 +32,16 @@ exclusions:
           type: flow2
           category: category2
       - rule_id: 3
+    on_match: bypass
+  - id: 4
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: exclusion-filter-4-input
+          regex: exclusion-filter-4
+    on_match: monitor
+
 rules:
   - id: 1
     name: rule1-basic-single-input
@@ -43,6 +54,7 @@ rules:
           inputs:
             - address: rule1-input
           regex: rule1
+    on_match: [ block ]
   - id: 2
     name: rule2-target-excluded-through-conditions
     tags:

--- a/validator/tests/exclusions/rule_filter/unconditional/009_rule9_rule_monitored_by_id.yaml
+++ b/validator/tests/exclusions/rule_filter/unconditional/009_rule9_rule_monitored_by_id.yaml
@@ -1,0 +1,22 @@
+{
+  name: "Rule monitored by ID",
+  runs: [
+    {
+      input: {
+        rule9-input: "rule9"
+      },
+      rules: [
+        {
+          9: [
+            {
+              address: rule9-input,
+              value: rule9
+            }
+          ]
+        }
+      ],
+      code: match,
+      actions: []
+    }
+  ]
+}

--- a/validator/tests/exclusions/rule_filter/unconditional/010_rule10_rule_monitored_by_tags.yaml
+++ b/validator/tests/exclusions/rule_filter/unconditional/010_rule10_rule_monitored_by_tags.yaml
@@ -1,0 +1,22 @@
+{
+  name: "Rule monitored by rags",
+  runs: [
+    {
+      input: {
+        rule10-input: "rule10"
+      },
+      rules: [
+        {
+          10: [
+            {
+              address: rule10-input,
+              value: rule10
+            }
+          ]
+        }
+      ],
+      code: match,
+      actions: []
+    }
+  ]
+}

--- a/validator/tests/exclusions/rule_filter/unconditional/ruleset.yaml
+++ b/validator/tests/exclusions/rule_filter/unconditional/ruleset.yaml
@@ -22,6 +22,12 @@ exclusions:
           type: flow7
           category: category7
       - rule_id: 8
+    on_match: bypass
+  - id: 6
+    rules_target:
+      - rule_id: 9
+    on_match: monitor
+
 rules:
   - id: 1
     name: rule1-exclude-by-id
@@ -111,3 +117,15 @@ rules:
           inputs:
             - address: rule8-input
           regex: rule8
+  - id: 9
+    name: rule9-monitor-by-id
+    tags:
+      type: flow9
+      category: category9
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: rule9-input
+          regex: rule9
+    on_match: [ block ]

--- a/validator/tests/exclusions/rule_filter/unconditional/ruleset.yaml
+++ b/validator/tests/exclusions/rule_filter/unconditional/ruleset.yaml
@@ -3,10 +3,12 @@ exclusions:
   - id: 1
     rules_target:
       - rule_id: 1
+    on_match: bypass
   - id: 2
     rules_target:
       - tags:
           type: flow2
+    on_match: bypass
   - id: 3
     rules_target:
       - tags:
@@ -26,6 +28,17 @@ exclusions:
   - id: 6
     rules_target:
       - rule_id: 9
+    on_match: monitor
+  - id: 7
+    rules_target:
+      - tags:
+          type: flow10
+          category: category10
+    on_match: monitor
+  # Test precedence of bypass over monitor
+  - id: 8
+    rules_target:
+      - rule_id: 1
     on_match: monitor
 
 rules:
@@ -128,4 +141,16 @@ rules:
           inputs:
             - address: rule9-input
           regex: rule9
+    on_match: [ block ]
+  - id: 10
+    name: rule10-monitor-by-tags
+    tags:
+      type: flow10
+      category: category10
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: rule10-input
+          regex: rule10
     on_match: [ block ]


### PR DESCRIPTION
This PR adds support for rule filter monitor and bypass (default) modes:
- In monitor mode, rules are still evaluated but actions (`on_match`) are not provided as part of the result.
- Bypass mode  is the current (and default) behaviour in which a rule is simply skipped from evaluation.