### PR TITLE
Float and null type support

### DIFF
--- a/fuzzing/src/object_builder.cpp
+++ b/fuzzing/src/object_builder.cpp
@@ -88,6 +88,15 @@ uint64_t popUnsignedInteger(Data *data)
     return result;
 }
 
+double popDouble(Data *data)
+{
+    double result = 0;
+
+    popBytes(data, &result, 8);
+
+    return result;
+}
+
 int64_t popInteger(Data *data)
 {
     int64_t result = 0;
@@ -159,9 +168,18 @@ void build_array(Data *data, ddwaf_object *object, size_t deep)
 ddwaf_object create_object(Data *data, size_t deep)
 {
     ddwaf_object result;
-    uint8_t selector = popSelector(data, 6);
+    uint8_t selector = popSelector(data, 9);
 
     switch (selector) {
+    case 8:
+        ddwaf_object_invalid(&result);
+        break;
+    case 7:
+        ddwaf_object_null(&result);
+        break;
+    case 6:
+        ddwaf_object_float(&result, popDouble(data));
+        break;
     case 5:
         ddwaf_object_bool(&result, popBoolean(data));
         break;

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -36,18 +36,22 @@ extern "C"
 typedef enum
 {
     DDWAF_OBJ_INVALID     = 0,
-    /** Value shall be decoded as a int64_t (or int32_t on 32bits platforms). **/
+    // 64-bit signed integer type
     DDWAF_OBJ_SIGNED   = 1 << 0,
-    /** Value shall be decoded as a uint64_t (or uint32_t on 32bits platforms). **/
+    // 64-bit unsigned integer type
     DDWAF_OBJ_UNSIGNED = 1 << 1,
-    /** Value shall be decoded as a UTF-8 string of length nbEntries. **/
+    // UTF-8 string of length nbEntries
     DDWAF_OBJ_STRING   = 1 << 2,
-    /** Value shall be decoded as an array of ddwaf_object of length nbEntries, each item having no parameterName. **/
+    // Array of ddwaf_object of length nbEntries, each item having no parameterName
     DDWAF_OBJ_ARRAY    = 1 << 3,
-    /** Value shall be decoded as an array of ddwaf_object of length nbEntries, each item having a parameterName. **/
+    // Array of ddwaf_object of length nbEntries, each item having a parameterName
     DDWAF_OBJ_MAP      = 1 << 4,
-
+    // Boolean type
     DDWAF_OBJ_BOOL     = 1 << 5,
+    // 64-bit float (or double) type
+    DDWAF_OBJ_FLOAT    = 1 << 6,
+    // Null type, only used for its semantical value
+    DDWAF_OBJ_NULL    = 1 << 7,
 } DDWAF_OBJ_TYPE;
 
 /**
@@ -104,6 +108,7 @@ struct _ddwaf_object
         int64_t intValue;
         ddwaf_object* array;
         bool boolean;
+        double f64;
     };
     uint64_t nbEntries;
     DDWAF_OBJ_TYPE type;
@@ -316,6 +321,19 @@ void ddwaf_result_free(ddwaf_result *result);
 ddwaf_object* ddwaf_object_invalid(ddwaf_object *object);
 
 /**
+ * ddwaf_object_null
+ *
+ * Creates an null object. Provides a different semantical value to invalid as
+ * it can be used to signify that a value is null rather than of an unknown type.
+ *
+ * @param object Object to perform the operation on. (nonnull)
+ *
+ * @return A pointer to the passed object or NULL if the operation failed.
+ **/
+ddwaf_object* ddwaf_object_null(ddwaf_object *object);
+
+
+/**
  * ddwaf_object_string
  *
  * Creates an object from a string.
@@ -356,32 +374,30 @@ ddwaf_object* ddwaf_object_stringl(ddwaf_object *object, const char *string, siz
 ddwaf_object* ddwaf_object_stringl_nc(ddwaf_object *object, const char *string, size_t length);
 
 /**
- * ddwaf_object_unsigned
+ * ddwaf_object_string_from_unsigned
  *
  * Creates an object using an unsigned integer (64-bit). The resulting object
- * will contain a string created using the integer provided. This is the
- * preferred method for passing an unsigned integer to the WAF.
+ * will contain a string created using the integer provided.
  *
  * @param object Object to perform the operation on. (nonnull)
  * @param value Integer to initialise the object with.
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_unsigned(ddwaf_object *object, uint64_t value);
+ddwaf_object* ddwaf_object_string_from_unsigned(ddwaf_object *object, uint64_t value);
 
 /**
- * ddwaf_object_signed
+ * ddwaf_object_string_from_signed
  *
  * Creates an object using a signed integer (64-bit). The resulting object
- * will contain a string created using the integer provided. This is the
- * preferred method for passing a signed integer to the WAF.
+ * will contain a string created using the integer provided.
  *
  * @param object Object to perform the operation on. (nonnull)
  * @param value Integer to initialise the object with.
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_signed(ddwaf_object *object, int64_t value);
+ddwaf_object* ddwaf_object_string_from_signed(ddwaf_object *object, int64_t value);
 
 /**
  * ddwaf_object_unsigned_force
@@ -394,7 +410,7 @@ ddwaf_object* ddwaf_object_signed(ddwaf_object *object, int64_t value);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_unsigned_force(ddwaf_object *object, uint64_t value);
+ddwaf_object* ddwaf_object_unsigned(ddwaf_object *object, uint64_t value);
 
 /**
  * ddwaf_object_signed_force
@@ -407,7 +423,7 @@ ddwaf_object* ddwaf_object_unsigned_force(ddwaf_object *object, uint64_t value);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_signed_force(ddwaf_object *object, int64_t value);
+ddwaf_object* ddwaf_object_signed(ddwaf_object *object, int64_t value);
 
 /**
  * ddwaf_object_bool
@@ -421,6 +437,19 @@ ddwaf_object* ddwaf_object_signed_force(ddwaf_object *object, int64_t value);
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
 ddwaf_object* ddwaf_object_bool(ddwaf_object *object, bool value);
+
+/**
+ * ddwaf_object_float
+ *
+ * Creates an object using a double, the resulting object will contain a
+ * double as opposed to a string.
+ *
+ * @param object Object to perform the operation on. (nonnull)
+ * @param value Double to initialise the object with.
+ *
+ * @return A pointer to the passed object or NULL if the operation failed.
+ **/
+ddwaf_object* ddwaf_object_float(ddwaf_object *object, double value);
 
 /**
  * ddwaf_object_array

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -610,6 +610,17 @@ uint64_t ddwaf_object_get_unsigned(const ddwaf_object *object);
 int64_t ddwaf_object_get_signed(const ddwaf_object *object);
 
 /**
+ * ddwaf_object_get_float
+ *
+ * Returns the float64 (double) contained within the object.
+ *
+ * @param object The object from which to get the float.
+ *
+ * @return The float or 0.0 if the object is not a float.
+ **/
+double ddwaf_object_get_float(const ddwaf_object *object);
+
+/**
  * ddwaf_object_get_bool
  *
  * Returns the boolean contained within the object.

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -32,6 +32,7 @@ EXPORTS
   ddwaf_object_get_string
   ddwaf_object_get_unsigned
   ddwaf_object_get_signed
+  ddwaf_object_get_float
   ddwaf_object_get_index
   ddwaf_object_get_bool
   ddwaf_object_free

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -9,14 +9,16 @@ EXPORTS
   ddwaf_context_destroy
   ddwaf_result_free
   ddwaf_object_invalid
+  ddwaf_object_null
   ddwaf_object_string
   ddwaf_object_stringl
   ddwaf_object_stringl_nc
+  ddwaf_object_string_from_unsigned
+  ddwaf_object_string_from_signed
   ddwaf_object_unsigned
   ddwaf_object_signed
-  ddwaf_object_unsigned_force
-  ddwaf_object_signed_force
   ddwaf_object_bool
+  ddwaf_object_float
   ddwaf_object_array
   ddwaf_object_map
   ddwaf_object_array_add

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -36,6 +36,10 @@ memory::string object_to_string(const ddwaf_object &object)
         return to_string<memory::string>(object.uintValue);
     }
 
+    if (object.type == DDWAF_OBJ_FLOAT) {
+        return to_string<memory::string>(object.f64);
+    }
+
     return {};
 }
 

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -172,6 +172,7 @@ void value_iterator::initialise_cursor_with_path(
             set_cursor_to_next_object();
         }
 
+        // If null or invalid, we ignore it
         break;
     }
 

--- a/src/matcher/base.hpp
+++ b/src/matcher/base.hpp
@@ -97,6 +97,12 @@ public:
             }
         }
 
+        if constexpr (T::supported_type_impl() == DDWAF_OBJ_FLOAT) {
+            if (obj.type == DDWAF_OBJ_FLOAT) {
+                return ptr->match_impl(obj.f64);
+            }
+        }
+
         return {false, {}};
     }
 };

--- a/src/matcher/equals.hpp
+++ b/src/matcher/equals.hpp
@@ -9,6 +9,7 @@
 #include <clock.hpp>
 #include <matcher/base.hpp>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <utils.hpp>
 
@@ -18,7 +19,10 @@ template <typename T> class equals : public base_impl<equals<T>> {
 public:
     using rule_data_type = std::vector<std::pair<std::string_view, uint64_t>>;
 
-    explicit equals(T expected) : expected_(std::move(expected)) {}
+    explicit equals(T expected)
+        requires(!std::is_floating_point_v<T>)
+        : expected_(std::move(expected))
+    {}
     ~equals() override = default;
     equals(const equals &) = default;
     equals(equals &&) noexcept = default;
@@ -62,6 +66,34 @@ protected:
     T expected_;
 
     friend class base_impl<equals<T>>;
+};
+
+template <> class equals<double> : public base_impl<equals<double>> {
+public:
+    using rule_data_type = std::vector<std::pair<std::string_view, uint64_t>>;
+
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    equals(double expected, double precision) : expected_(expected), precision_(precision) {}
+    ~equals() override = default;
+    equals(const equals &) = default;
+    equals(equals &&) noexcept = default;
+    equals &operator=(const equals &) = default;
+    equals &operator=(equals &&) noexcept = default;
+
+protected:
+    static constexpr std::string_view to_string_impl() { return ""; }
+    static constexpr std::string_view name_impl() { return "equals"; }
+    static constexpr DDWAF_OBJ_TYPE supported_type_impl() { return DDWAF_OBJ_FLOAT; }
+
+    [[nodiscard]] std::pair<bool, memory::string> match_impl(double obtained) const
+    {
+        return {std::abs(expected_ - obtained) < precision_, {}};
+    }
+
+    double expected_;
+    double precision_;
+
+    friend class base_impl<equals<double>>;
 };
 
 } // namespace ddwaf::matcher

--- a/src/matcher/equals.hpp
+++ b/src/matcher/equals.hpp
@@ -73,7 +73,7 @@ public:
     using rule_data_type = std::vector<std::pair<std::string_view, uint64_t>>;
 
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-    equals(double expected, double precision) : expected_(expected), precision_(precision) {}
+    equals(double expected, double delta) : expected_(expected), delta_(delta) {}
     ~equals() override = default;
     equals(const equals &) = default;
     equals(equals &&) noexcept = default;
@@ -87,11 +87,11 @@ protected:
 
     [[nodiscard]] std::pair<bool, memory::string> match_impl(double obtained) const
     {
-        return {std::abs(expected_ - obtained) < precision_, {}};
+        return {std::abs(expected_ - obtained) < delta_, {}};
     }
 
     double expected_;
-    double precision_;
+    double delta_;
 
     friend class base_impl<equals<double>>;
 };

--- a/src/matcher/equals.hpp
+++ b/src/matcher/equals.hpp
@@ -17,8 +17,6 @@ namespace ddwaf::matcher {
 
 template <typename T> class equals : public base_impl<equals<T>> {
 public:
-    using rule_data_type = std::vector<std::pair<std::string_view, uint64_t>>;
-
     explicit equals(T expected)
         requires(!std::is_floating_point_v<T>)
         : expected_(std::move(expected))
@@ -70,8 +68,6 @@ protected:
 
 template <> class equals<double> : public base_impl<equals<double>> {
 public:
-    using rule_data_type = std::vector<std::pair<std::string_view, uint64_t>>;
-
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     equals(double expected, double delta) : expected_(expected), delta_(delta) {}
     ~equals() override = default;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -238,8 +238,8 @@ bool ddwaf_object_array_add(ddwaf_object *array, ddwaf_object *object)
         DDWAF_DEBUG("Invalid call, this API can only be called with an array as first parameter");
         return false;
     }
-    if (object == nullptr || object->type == DDWAF_OBJ_INVALID) {
-        DDWAF_DEBUG("Tried to add an invalid entry to an array");
+    if (object == nullptr) {
+        DDWAF_DEBUG("Tried to add a null object to an array");
         return false;
     }
     return ddwaf_object_insert(array, *object);
@@ -283,8 +283,8 @@ static inline bool ddwaf_object_map_add_valid(
         DDWAF_DEBUG("Invalid call, nullptr key");
         return false;
     }
-    if (object == nullptr || object->type == DDWAF_OBJ_INVALID) {
-        DDWAF_DEBUG("Tried to add an invalid entry to a map");
+    if (object == nullptr) {
+        DDWAF_DEBUG("Tried to add a null object to a map");
         return false;
     }
     return true;
@@ -322,8 +322,9 @@ bool ddwaf_object_map_addl_nc(
 // NOLINTNEXTLINE(misc-no-recursion)
 void ddwaf_object_free(ddwaf_object *object)
 {
-    if (object == nullptr || object->type == DDWAF_OBJ_INVALID)
+    if (!ddwaf::object::is_valid(object)) {
         return;
+    }
 
     free((void *)object->parameterName);
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -416,6 +416,15 @@ int64_t ddwaf_object_get_signed(const ddwaf_object *object)
     return object->intValue;
 }
 
+double ddwaf_object_get_float(const ddwaf_object *object)
+{
+    if (object == nullptr || object->type != DDWAF_OBJ_FLOAT) {
+        return 0;
+    }
+
+    return object->f64;
+}
+
 bool ddwaf_object_get_bool(const ddwaf_object *object)
 {
     if (object == nullptr || object->type != DDWAF_OBJ_BOOL) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -322,7 +322,7 @@ bool ddwaf_object_map_addl_nc(
 // NOLINTNEXTLINE(misc-no-recursion)
 void ddwaf_object_free(ddwaf_object *object)
 {
-    if (!ddwaf::object::is_valid(object)) {
+    if (object == nullptr) {
         return;
     }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -31,6 +31,17 @@ ddwaf_object *ddwaf_object_invalid(ddwaf_object *object)
     return object;
 }
 
+ddwaf_object *ddwaf_object_null(ddwaf_object *object)
+{
+    if (object == nullptr) {
+        return nullptr;
+    }
+
+    *object = {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_NULL};
+
+    return object;
+}
+
 static ddwaf_object *ddwaf_object_string_helper(
     ddwaf_object *object, const char *string, size_t length)
 {
@@ -95,7 +106,7 @@ ddwaf_object *ddwaf_object_stringl_nc(ddwaf_object *object, const char *string, 
     return object;
 }
 
-ddwaf_object *ddwaf_object_signed(ddwaf_object *object, int64_t value)
+ddwaf_object *ddwaf_object_string_from_signed(ddwaf_object *object, int64_t value)
 {
     if (object == nullptr) {
         return nullptr;
@@ -108,7 +119,7 @@ ddwaf_object *ddwaf_object_signed(ddwaf_object *object, int64_t value)
     return ddwaf_object_stringl(object, container, length);
 }
 
-ddwaf_object *ddwaf_object_unsigned(ddwaf_object *object, uint64_t value)
+ddwaf_object *ddwaf_object_string_from_unsigned(ddwaf_object *object, uint64_t value)
 {
     if (object == nullptr) {
         return nullptr;
@@ -121,7 +132,7 @@ ddwaf_object *ddwaf_object_unsigned(ddwaf_object *object, uint64_t value)
     return ddwaf_object_stringl(object, container, length);
 }
 
-ddwaf_object *ddwaf_object_unsigned_force(ddwaf_object *object, uint64_t value)
+ddwaf_object *ddwaf_object_unsigned(ddwaf_object *object, uint64_t value)
 {
     if (object == nullptr) {
         return nullptr;
@@ -133,7 +144,7 @@ ddwaf_object *ddwaf_object_unsigned_force(ddwaf_object *object, uint64_t value)
     return object;
 }
 
-ddwaf_object *ddwaf_object_signed_force(ddwaf_object *object, int64_t value)
+ddwaf_object *ddwaf_object_signed(ddwaf_object *object, int64_t value)
 {
     if (object == nullptr) {
         return nullptr;
@@ -153,6 +164,18 @@ ddwaf_object *ddwaf_object_bool(ddwaf_object *object, bool value)
 
     *object = {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_BOOL};
     object->boolean = value;
+
+    return object;
+}
+
+ddwaf_object *ddwaf_object_float(ddwaf_object *object, double value)
+{
+    if (object == nullptr) {
+        return nullptr;
+    }
+
+    *object = {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_FLOAT};
+    object->f64 = value;
 
     return object;
 }

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -61,7 +61,6 @@ static void print_(parameter args, uint64_t depth)
             std::printf("- %" PRId64 "\n", args.intValue);
         break;
     }
-
     case DDWAF_OBJ_UNSIGNED: {
         if (args.parameterName != nullptr)
             std::printf("- %s: %" PRIu64 "\n", args.parameterName, args.uintValue);
@@ -76,7 +75,6 @@ static void print_(parameter args, uint64_t depth)
             std::printf("- %lf\n", args.f64);
         break;
     }
-
     case DDWAF_OBJ_STRING: {
         if (args.parameterName != nullptr)
             std::printf("- %s: %s\n", args.parameterName, args.stringValue);
@@ -84,7 +82,6 @@ static void print_(parameter args, uint64_t depth)
             std::printf("- %s\n", args.stringValue);
         break;
     }
-
     case DDWAF_OBJ_ARRAY: {
         if (args.parameterName != nullptr)
             std::printf("- %s:\n", args.parameterName);
@@ -92,7 +89,6 @@ static void print_(parameter args, uint64_t depth)
         for (uint64_t i = 0; i < args.nbEntries; ++i) print_(args.array[i], depth + 1);
         break;
     }
-
     case DDWAF_OBJ_MAP: {
         if (args.parameterName != nullptr)
             std::printf("- %s:\n", args.parameterName);
@@ -216,6 +212,24 @@ parameter::operator int64_t() const
     }
 
     throw bad_cast("signed", strtype(type));
+}
+
+parameter::operator double() const
+{
+    if (type == DDWAF_OBJ_FLOAT) {
+        return f64;
+    }
+
+    if (type == DDWAF_OBJ_STRING && stringValue != nullptr) {
+        double result;
+        const auto *end{&stringValue[nbEntries]};
+        auto [endConv, err] = std::from_chars(stringValue, end, result);
+        if (err == std::errc{} && endConv == end) {
+            return result;
+        }
+    }
+
+    throw bad_cast("double", strtype(type));
 }
 
 parameter::operator bool() const

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -9,6 +9,7 @@
 #include <cinttypes>
 #include <exception.hpp>
 #include <parameter.hpp>
+#include <sstream>
 
 namespace {
 
@@ -221,10 +222,11 @@ parameter::operator double() const
     }
 
     if (type == DDWAF_OBJ_STRING && stringValue != nullptr) {
-        double result;
-        const auto *end{&stringValue[nbEntries]};
-        auto [endConv, err] = std::from_chars(stringValue, end, result);
-        if (err == std::errc{} && endConv == end) {
+        double result = 0.0;
+        std::istringstream iss({stringValue, static_cast<std::size_t>(nbEntries)});
+        iss >> result;
+
+        if (!iss.fail() && iss.eof()) {
             return result;
         }
     }

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -27,6 +27,10 @@ std::string strtype(int type)
         return "unsigned";
     case DDWAF_OBJ_SIGNED:
         return "signed";
+    case DDWAF_OBJ_FLOAT:
+        return "float";
+    case DDWAF_OBJ_NULL:
+        return "null";
     default:
         break;
     }
@@ -44,6 +48,9 @@ static void print_(parameter args, uint64_t depth)
     case DDWAF_OBJ_INVALID:
         std::printf("- invalid\n");
         break;
+    case DDWAF_OBJ_NULL:
+        std::printf("- null\n");
+        break;
     case DDWAF_OBJ_BOOL:
         std::printf("- %s\n", args.boolean ? "true" : "false");
         break;
@@ -60,6 +67,13 @@ static void print_(parameter args, uint64_t depth)
             std::printf("- %s: %" PRIu64 "\n", args.parameterName, args.uintValue);
         else
             std::printf("- %" PRIu64 "\n", args.uintValue);
+        break;
+    }
+    case DDWAF_OBJ_FLOAT: {
+        if (args.parameterName != nullptr)
+            std::printf("- %s: %lf\n", args.parameterName, args.f64);
+        else
+            std::printf("- %lf\n", args.f64);
         break;
     }
 
@@ -98,7 +112,7 @@ parameter::operator parameter::map() const
     }
 
     if (array == nullptr || nbEntries == 0) {
-        return parameter::map();
+        return {};
     }
 
     std::unordered_map<std::string_view, parameter> map;

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -11,6 +11,8 @@
 #include <parameter.hpp>
 #include <sstream>
 
+#include "utils.hpp"
+
 namespace {
 
 std::string strtype(int type)
@@ -186,10 +188,8 @@ parameter::operator uint64_t() const
     }
 
     if (type == DDWAF_OBJ_STRING && stringValue != nullptr) {
-        uint64_t result;
-        const auto *end{&stringValue[nbEntries]};
-        auto [endConv, err] = std::from_chars(stringValue, end, result);
-        if (err == std::errc{} && endConv == end) {
+        auto [res, result] = from_string<uint64_t>({stringValue, static_cast<size_t>(nbEntries)});
+        if (res) {
             return result;
         }
     }
@@ -204,10 +204,8 @@ parameter::operator int64_t() const
     }
 
     if (type == DDWAF_OBJ_STRING && stringValue != nullptr) {
-        int64_t result;
-        const auto *end{&stringValue[nbEntries]};
-        auto [endConv, err] = std::from_chars(stringValue, end, result);
-        if (err == std::errc{} && endConv == end) {
+        auto [res, result] = from_string<int64_t>({stringValue, static_cast<size_t>(nbEntries)});
+        if (res) {
             return result;
         }
     }
@@ -222,12 +220,8 @@ parameter::operator double() const
     }
 
     if (type == DDWAF_OBJ_STRING && stringValue != nullptr) {
-        double result = 0.0;
-        std::string str{stringValue, static_cast<std::size_t>(nbEntries)};
-        std::istringstream iss(str);
-        iss >> result;
-
-        if (!iss.fail() && iss.eof()) {
+        auto [res, result] = from_string<double>({stringValue, static_cast<size_t>(nbEntries)});
+        if (res) {
             return result;
         }
     }

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -223,7 +223,8 @@ parameter::operator double() const
 
     if (type == DDWAF_OBJ_STRING && stringValue != nullptr) {
         double result = 0.0;
-        std::istringstream iss({stringValue, static_cast<std::size_t>(nbEntries)});
+        std::string str{stringValue, static_cast<std::size_t>(nbEntries)};
+        std::istringstream iss(str);
         iss >> result;
 
         if (!iss.fail() && iss.eof()) {

--- a/src/parameter.hpp
+++ b/src/parameter.hpp
@@ -40,6 +40,7 @@ public:
     explicit operator std::string() const;
     explicit operator uint64_t() const;
     explicit operator int64_t() const;
+    explicit operator double() const;
     explicit operator bool() const;
     explicit operator std::vector<std::string>() const;
     explicit operator std::vector<std::string_view>() const;

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -103,6 +103,10 @@ std::pair<std::string, matcher::base::unique_ptr> parse_matcher(
         } else if (value_type == "signed") {
             auto value = at<int64_t>(params, "value");
             matcher = std::make_unique<matcher::equals<int64_t>>(value);
+        } else if (value_type == "float") {
+            auto value = at<double>(params, "value");
+            auto precision = at<double>(params, "precision", 0.01);
+            matcher = std::make_unique<matcher::equals<double>>(value, precision);
         } else {
             throw ddwaf::parsing_error("invalid type for matcher equals" + value_type);
         }

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -105,8 +105,8 @@ std::pair<std::string, matcher::base::unique_ptr> parse_matcher(
             matcher = std::make_unique<matcher::equals<int64_t>>(value);
         } else if (value_type == "float") {
             auto value = at<double>(params, "value");
-            auto precision = at<double>(params, "precision", 0.01);
-            matcher = std::make_unique<matcher::equals<double>>(value, precision);
+            auto delta = at<double>(params, "delta", 0.01);
+            matcher = std::make_unique<matcher::equals<double>>(value, delta);
         } else {
             throw ddwaf::parsing_error("invalid type for matcher equals" + value_type);
         }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -26,7 +26,7 @@ template <typename T> using optional_ref = std::optional<std::reference_wrapper<
 
 // Internals
 // clang-format off
-#define PWI_DATA_TYPES (DDWAF_OBJ_SIGNED | DDWAF_OBJ_UNSIGNED | DDWAF_OBJ_STRING | DDWAF_OBJ_BOOL)
+#define PWI_DATA_TYPES (DDWAF_OBJ_SIGNED | DDWAF_OBJ_UNSIGNED | DDWAF_OBJ_STRING | DDWAF_OBJ_BOOL | DDWAF_OBJ_FLOAT)
 #define PWI_CONTAINER_TYPES (DDWAF_OBJ_ARRAY | DDWAF_OBJ_MAP)
 #define DDWAF_RESULT_INITIALISER {false,  {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_ARRAY}, {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_ARRAY}, 0}
 // clang-format on

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -6,14 +6,12 @@
 
 #pragma once
 
-#include <alloca.h>
 #include <array>
 #include <charconv>
 #include <cstdint>
 #include <ddwaf.h>
 #include <functional>
 #include <iterator>
-#include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -153,10 +151,10 @@ template <typename StringType, typename T>
 StringType to_string(T value)
     requires std::is_floating_point_v<T>
 {
-    using char_type = typename StringType::char_type;
+    using char_type = typename StringType::value_type;
     using traits_type = typename StringType::traits_type;
     using allocator_type = typename StringType::allocator_type;
-    std::basic_stringstream<char_type, traits_type, allocator_type> ss;
+    std::basic_ostringstream<char_type, traits_type, allocator_type> ss;
     ss << value;
     return std::move(ss).str();
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -90,6 +90,11 @@ inline bool is_scalar(const ddwaf_object *obj)
     return obj != nullptr && (obj->type & PWI_DATA_TYPES) != 0;
 }
 
+inline bool is_valid(const ddwaf_object *obj)
+{
+    return obj != nullptr && obj->type != DDWAF_OBJ_INVALID && obj->type != DDWAF_OBJ_NULL;
+}
+
 } // namespace object
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -6,13 +6,16 @@
 
 #pragma once
 
+#include <alloca.h>
 #include <array>
 #include <charconv>
 #include <cstdint>
 #include <ddwaf.h>
 #include <functional>
 #include <iterator>
+#include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <system_error>
 #include <type_traits>
@@ -150,15 +153,12 @@ template <typename StringType, typename T>
 StringType to_string(T value)
     requires std::is_floating_point_v<T>
 {
-    // Doubles could potentially be quite large so we need a reasonable limit
-    static constexpr size_t max_chars = 32;
-
-    std::array<char, max_chars> str{};
-    auto [ptr, ec] = std::to_chars(str.data(), str.data() + str.size(), value);
-    if (ec == std::errc()) {
-        return {str.data(), ptr};
-    }
-    return {};
+    using char_type = typename StringType::char_type;
+    using traits_type = typename StringType::traits_type;
+    using allocator_type = typename StringType::allocator_type;
+    std::basic_stringstream<char_type, traits_type, allocator_type> ss;
+    ss << value;
+    return std::move(ss).str();
 }
 
 template <typename StringType, typename T>

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -127,13 +127,13 @@ protected:
 
 template <typename StringType, typename T>
 StringType to_string(T value)
-    requires std::is_integral_v<T>
+    requires std::is_integral_v<T> && (!std::is_same_v<T, bool>)
 {
     // Maximum number of characters required to represent a 64 bit integer as a string
     // 20 bytes for UINT64_MAX or INT64_MIN + null byte
-    static constexpr size_t uint64_max_chars = 21;
+    static constexpr size_t max_chars = 21;
 
-    std::array<char, uint64_max_chars> str{};
+    std::array<char, max_chars> str{};
     auto [ptr, ec] = std::to_chars(str.data(), str.data() + str.size(), value);
     if (ec == std::errc()) {
         return {str.data(), ptr};
@@ -141,6 +141,26 @@ StringType to_string(T value)
     return {};
 }
 
-template <typename StringType> StringType to_string(bool value) { return value ? "true" : "false"; }
+template <typename StringType, typename T>
+StringType to_string(T value)
+    requires std::is_floating_point_v<T>
+{
+    // Doubles could potentially be quite large so we need a reasonable limit
+    static constexpr size_t max_chars = 32;
+
+    std::array<char, max_chars> str{};
+    auto [ptr, ec] = std::to_chars(str.data(), str.data() + str.size(), value);
+    if (ec == std::errc()) {
+        return {str.data(), ptr};
+    }
+    return {};
+}
+
+template <typename StringType, typename T>
+StringType to_string(T value)
+    requires std::is_same_v<T, bool>
+{
+    return value ? "true" : "false";
+}
 
 } // namespace ddwaf

--- a/tests/TestInterface.cpp
+++ b/tests/TestInterface.cpp
@@ -35,7 +35,7 @@ TEST(FunctionalTests, ddwaf_run)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object param_key = DDWAF_OBJECT_ARRAY, param_val = DDWAF_OBJECT_ARRAY;
 
-        ddwaf_object_array_add(&param_key, ddwaf_object_unsigned(&tmp, 4242));
+        ddwaf_object_array_add(&param_key, ddwaf_object_string_from_unsigned(&tmp, 4242));
         ddwaf_object_array_add(&param_key, ddwaf_object_string(&tmp, "randomString"));
 
         ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule1"));
@@ -62,7 +62,7 @@ TEST(FunctionalTests, ddwaf_run)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object param_key = DDWAF_OBJECT_ARRAY, param_val = DDWAF_OBJECT_ARRAY;
 
-        ddwaf_object_array_add(&param_key, ddwaf_object_unsigned(&tmp, 4242));
+        ddwaf_object_array_add(&param_key, ddwaf_object_string_from_unsigned(&tmp, 4242));
         ddwaf_object_array_add(&param_key, ddwaf_object_string(&tmp, "randomString"));
 
         ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "randomString"));
@@ -89,7 +89,7 @@ TEST(FunctionalTests, ddwaf_run)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object param_key = DDWAF_OBJECT_ARRAY, param_val = DDWAF_OBJECT_ARRAY;
 
-        ddwaf_object_array_add(&param_key, ddwaf_object_unsigned(&tmp, 4242));
+        ddwaf_object_array_add(&param_key, ddwaf_object_string_from_unsigned(&tmp, 4242));
         ddwaf_object_array_add(&param_key, ddwaf_object_string(&tmp, "randomString"));
 
         ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule2"));
@@ -116,7 +116,7 @@ TEST(FunctionalTests, ddwaf_run)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object param_key = DDWAF_OBJECT_MAP, param_val = DDWAF_OBJECT_ARRAY;
 
-        ddwaf_object_map_add(&param_key, "derp", ddwaf_object_unsigned(&tmp, 4242));
+        ddwaf_object_map_add(&param_key, "derp", ddwaf_object_string_from_unsigned(&tmp, 4242));
         ddwaf_object_map_add(&param_key, "bla", ddwaf_object_string(&tmp, "rule3"));
 
         ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule2"));
@@ -143,7 +143,7 @@ TEST(FunctionalTests, ddwaf_run)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object param_key = DDWAF_OBJECT_MAP, param_val = DDWAF_OBJECT_ARRAY;
 
-        ddwaf_object_map_add(&param_key, "derp", ddwaf_object_unsigned(&tmp, 4242));
+        ddwaf_object_map_add(&param_key, "derp", ddwaf_object_string_from_unsigned(&tmp, 4242));
         ddwaf_object_map_add(&param_key, "bla", ddwaf_object_string(&tmp, "rule3"));
 
         ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "randomString"));
@@ -183,7 +183,7 @@ TEST(FunctionalTests, HandleGood)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object param_key = DDWAF_OBJECT_MAP, param_val = DDWAF_OBJECT_ARRAY;
 
-        ddwaf_object_map_add(&param_key, "derp", ddwaf_object_unsigned(&tmp, 4242));
+        ddwaf_object_map_add(&param_key, "derp", ddwaf_object_string_from_unsigned(&tmp, 4242));
         ddwaf_object_map_add(&param_key, "bla", ddwaf_object_string(&tmp, "rule3"));
 
         ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule2"));
@@ -281,7 +281,7 @@ TEST(FunctionalTests, HandleBad)
 /*ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;*/
 /*ddwaf_object param_key = DDWAF_OBJECT_MAP, param_val = DDWAF_OBJECT_ARRAY;*/
 
-/*ddwaf_object_map_add(&param_key, "derp", ddwaf_object_unsigned(&tmp, 4242));*/
+/*ddwaf_object_map_add(&param_key, "derp", ddwaf_object_string_from_unsigned(&tmp, 4242));*/
 /*ddwaf_object_map_add(&param_key, "bla", ddwaf_object_string(&tmp, "rule3"));*/
 
 /*ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule2"));*/

--- a/tests/integration/matchers/test.cpp
+++ b/tests/integration/matchers/test.cpp
@@ -132,3 +132,33 @@ TEST(TestIntegrationOperation, UnsignedEquals)
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
+
+TEST(TestIntegrationOperation, FloatEquals)
+{
+    auto rule = readFile("equals.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+    ddwaf_object value;
+    ddwaf_object_float(&value, 42.01);
+    ddwaf_object_map_add(&map, "input", &value);
+
+    ddwaf_result out;
+    ASSERT_EQ(ddwaf_run(context, &map, &out, 2000), DDWAF_MATCH);
+    EXPECT_FALSE(out.timeout);
+    EXPECT_EVENTS(out,
+        {.id = "5",
+            .name = "rule5-float-equals",
+            .tags = {{"type", "flow"}, {"category", "category"}},
+            .matches = {{.op = "equals", .address = "input", .value = "42.01", .highlight = ""}}});
+
+    ddwaf_result_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}

--- a/tests/integration/matchers/test.cpp
+++ b/tests/integration/matchers/test.cpp
@@ -86,7 +86,7 @@ TEST(TestIntegrationOperation, SignedEquals)
 
     ddwaf_object map = DDWAF_OBJECT_MAP;
     ddwaf_object value;
-    ddwaf_object_signed_force(&value, -42);
+    ddwaf_object_signed(&value, -42);
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_result out;
@@ -116,7 +116,7 @@ TEST(TestIntegrationOperation, UnsignedEquals)
 
     ddwaf_object map = DDWAF_OBJECT_MAP;
     ddwaf_object value;
-    ddwaf_object_unsigned_force(&value, 42);
+    ddwaf_object_unsigned(&value, 42);
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_result out;

--- a/tests/integration/matchers/yaml/equals.yaml
+++ b/tests/integration/matchers/yaml/equals.yaml
@@ -48,3 +48,16 @@ rules:
             - address: input
           type: unsigned
           value: 42
+  - id: 5
+    name: rule5-float-equals
+    tags:
+      type: flow
+      category: category
+    conditions:
+      - operator: equals
+        parameters:
+          inputs:
+            - address: input
+          type: float
+          value: 42.0
+          precision: 0.1

--- a/tests/integration/matchers/yaml/equals.yaml
+++ b/tests/integration/matchers/yaml/equals.yaml
@@ -60,4 +60,4 @@ rules:
             - address: input
           type: float
           value: 42.0
-          precision: 0.1
+          delta: 0.1

--- a/tests/interface_test.cpp
+++ b/tests/interface_test.cpp
@@ -63,7 +63,7 @@ TEST(TestInterface, HandleLifetime)
     ddwaf_object tmp;
     ddwaf_object param_key = DDWAF_OBJECT_ARRAY, param_val = DDWAF_OBJECT_ARRAY;
 
-    ddwaf_object_array_add(&param_key, ddwaf_object_unsigned(&tmp, 4242));
+    ddwaf_object_array_add(&param_key, ddwaf_object_string_from_unsigned(&tmp, 4242));
     ddwaf_object_array_add(&param_key, ddwaf_object_string(&tmp, "randomString"));
 
     ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule1"));
@@ -102,7 +102,7 @@ TEST(TestInterface, HandleLifetimeMultipleContexts)
     ddwaf_object param_key = DDWAF_OBJECT_ARRAY;
     ddwaf_object param_val = DDWAF_OBJECT_ARRAY;
 
-    ddwaf_object_array_add(&param_key, ddwaf_object_unsigned(&tmp, 4242));
+    ddwaf_object_array_add(&param_key, ddwaf_object_string_from_unsigned(&tmp, 4242));
     ddwaf_object_array_add(&param_key, ddwaf_object_string(&tmp, "randomString"));
 
     ddwaf_object_array_add(&param_val, ddwaf_object_string(&tmp, "rule1"));

--- a/tests/key_iterator_test.cpp
+++ b/tests/key_iterator_test.cpp
@@ -41,7 +41,7 @@ TEST(TestKeyIterator, TestStringScalar)
 TEST(TestKeyIterator, TestUnsignedScalar)
 {
     ddwaf_object object;
-    ddwaf_object_string_from_unsigned(&object, 22);
+    ddwaf_object_unsigned(&object, 22);
 
     std::unordered_set<const ddwaf_object *> exclude;
     ddwaf::object::key_iterator it(&object, {}, exclude);
@@ -56,7 +56,7 @@ TEST(TestKeyIterator, TestUnsignedScalar)
 TEST(TestKeyIterator, TestSignedScalar)
 {
     ddwaf_object object;
-    ddwaf_object_string_from_signed(&object, 22);
+    ddwaf_object_signed(&object, 22);
 
     std::unordered_set<const ddwaf_object *> exclude;
     ddwaf::object::key_iterator it(&object, {}, exclude);

--- a/tests/key_iterator_test.cpp
+++ b/tests/key_iterator_test.cpp
@@ -255,6 +255,81 @@ TEST(TestKeyIterator, TestMapMultipleItems)
     ddwaf_object_free(&object);
 }
 
+TEST(TestKeyIterator, TestMapMultipleNullAndInvalid)
+{
+    ddwaf_object object, tmp;
+    ddwaf_object_map(&object);
+
+    for (unsigned i = 0; i < 25; i++) {
+        {
+            auto index = std::to_string(i * 3);
+            std::string key = "key" + index;
+            std::string value = "value" + index;
+            ddwaf_object_map_add(&object, key.c_str(), ddwaf_object_string(&tmp, value.c_str()));
+        }
+
+        {
+            auto index = std::to_string(i * 3 + 1);
+            std::string key = "key" + index;
+            ddwaf_object_map_add(&object, key.c_str(), ddwaf_object_null(&tmp));
+        }
+
+        {
+            auto index = std::to_string(i * 3 + 2);
+            std::string key = "key" + index;
+            ddwaf_object_map_add(&object, key.c_str(), ddwaf_object_invalid(&tmp));
+        }
+    }
+
+    std::unordered_set<const ddwaf_object *> exclude;
+    ddwaf::object::key_iterator it(&object, {}, exclude);
+
+    for (unsigned i = 0; i < 25; i++) {
+        {
+            auto index = std::to_string(i * 3);
+            std::string key = "key" + index;
+
+            EXPECT_TRUE((bool)it);
+            EXPECT_STREQ((*it)->stringValue, key.c_str());
+
+            auto path = it.get_current_path();
+            EXPECT_EQ(path.size(), 1);
+            EXPECT_STREQ(path[0].c_str(), key.c_str());
+        }
+
+        ++it;
+
+        {
+            auto index = std::to_string(i * 3 + 1);
+            std::string key = "key" + index;
+
+            EXPECT_TRUE((bool)it);
+
+            auto path = it.get_current_path();
+            EXPECT_EQ(path.size(), 1);
+            EXPECT_STREQ(path[0].c_str(), key.c_str());
+        }
+
+        ++it;
+
+        {
+            auto index = std::to_string(i * 3 + 2);
+            std::string key = "key" + index;
+
+            EXPECT_TRUE((bool)it);
+
+            auto path = it.get_current_path();
+            EXPECT_EQ(path.size(), 1);
+            EXPECT_STREQ(path[0].c_str(), key.c_str());
+        }
+        ++it;
+    }
+
+    EXPECT_FALSE(++it);
+
+    ddwaf_object_free(&object);
+}
+
 TEST(TestKeyIterator, TestMapPastSizeLimit)
 {
     ddwaf::object_limits limits;

--- a/tests/key_iterator_test.cpp
+++ b/tests/key_iterator_test.cpp
@@ -41,7 +41,7 @@ TEST(TestKeyIterator, TestStringScalar)
 TEST(TestKeyIterator, TestUnsignedScalar)
 {
     ddwaf_object object;
-    ddwaf_object_unsigned_force(&object, 22);
+    ddwaf_object_string_from_unsigned(&object, 22);
 
     std::unordered_set<const ddwaf_object *> exclude;
     ddwaf::object::key_iterator it(&object, {}, exclude);
@@ -56,7 +56,7 @@ TEST(TestKeyIterator, TestUnsignedScalar)
 TEST(TestKeyIterator, TestSignedScalar)
 {
     ddwaf_object object;
-    ddwaf_object_signed_force(&object, 22);
+    ddwaf_object_string_from_signed(&object, 22);
 
     std::unordered_set<const ddwaf_object *> exclude;
     ddwaf::object::key_iterator it(&object, {}, exclude);

--- a/tests/matcher/equals_test.cpp
+++ b/tests/matcher/equals_test.cpp
@@ -43,6 +43,15 @@ TEST(TestEqualsUint, Basic)
     EXPECT_FALSE(matcher.match(1).first);
 }
 
+TEST(TestEqualsDouble, Basic)
+{
+    matcher::equals<double> matcher(5.1, 0.0001);
+
+    EXPECT_TRUE(matcher.match(5.1).first);
+    EXPECT_FALSE(matcher.match(5.11).first);
+    EXPECT_FALSE(matcher.match(-5.1).first);
+}
+
 TEST(TestEqualsString, Basic)
 {
     matcher::equals<std::string> matcher("aaaa");

--- a/tests/object_test.cpp
+++ b/tests/object_test.cpp
@@ -70,7 +70,7 @@ TEST(TestObject, TestCreateInt)
 {
     {
         ddwaf_object object;
-        ddwaf_object_signed(&object, INT64_MIN);
+        ddwaf_object_string_from_signed(&object, INT64_MIN);
 
         EXPECT_EQ(object.type, DDWAF_OBJ_STRING);
         EXPECT_EQ(object.nbEntries, 20);
@@ -90,7 +90,7 @@ TEST(TestObject, TestCreateInt)
 
     {
         ddwaf_object object;
-        ddwaf_object_signed(&object, INT64_MAX);
+        ddwaf_object_string_from_signed(&object, INT64_MAX);
 
         EXPECT_EQ(object.type, DDWAF_OBJ_STRING);
         EXPECT_EQ(object.nbEntries, 19);
@@ -112,7 +112,7 @@ TEST(TestObject, TestCreateInt)
 TEST(TestObject, TestCreateIntForce)
 {
     ddwaf_object object;
-    ddwaf_object_signed_force(&object, INT64_MIN);
+    ddwaf_object_signed(&object, INT64_MIN);
 
     EXPECT_EQ(object.type, DDWAF_OBJ_SIGNED);
     EXPECT_EQ(object.intValue, INT64_MIN);
@@ -129,7 +129,7 @@ TEST(TestObject, TestCreateIntForce)
 TEST(TestObject, TestCreateUint)
 {
     ddwaf_object object;
-    ddwaf_object_unsigned(&object, UINT64_MAX);
+    ddwaf_object_string_from_unsigned(&object, UINT64_MAX);
 
     EXPECT_EQ(object.type, DDWAF_OBJ_STRING);
     EXPECT_EQ(object.nbEntries, 20);
@@ -150,7 +150,7 @@ TEST(TestObject, TestCreateUint)
 TEST(TestObject, TestCreateUintForce)
 {
     ddwaf_object object;
-    ddwaf_object_unsigned_force(&object, UINT64_MAX);
+    ddwaf_object_unsigned(&object, UINT64_MAX);
 
     EXPECT_EQ(object.type, DDWAF_OBJ_UNSIGNED);
     EXPECT_EQ(object.uintValue, UINT64_MAX);
@@ -249,8 +249,8 @@ TEST(TestObject, TestAddArray)
     EXPECT_FALSE(ddwaf_object_array_add(&object, &container));
     EXPECT_FALSE(ddwaf_object_array_add(&container, &object));
 
-    EXPECT_TRUE(ddwaf_object_array_add(&container, ddwaf_object_signed(&object, 42)));
-    EXPECT_TRUE(ddwaf_object_array_add(&container, ddwaf_object_unsigned(&object, 43)));
+    EXPECT_TRUE(ddwaf_object_array_add(&container, ddwaf_object_string_from_signed(&object, 42)));
+    EXPECT_TRUE(ddwaf_object_array_add(&container, ddwaf_object_string_from_unsigned(&object, 43)));
 
     EXPECT_EQ(container.type, DDWAF_OBJ_ARRAY);
     EXPECT_EQ(container.nbEntries, 2);
@@ -287,24 +287,24 @@ TEST(TestObject, TestAddMap)
     ddwaf_object_map(&map);
     ddwaf_object_array(&array);
 
-    EXPECT_FALSE(ddwaf_object_map_add(nullptr, "key", ddwaf_object_signed(&tmp, 42)));
+    EXPECT_FALSE(ddwaf_object_map_add(nullptr, "key", ddwaf_object_string_from_signed(&tmp, 42)));
     ddwaf_object_free(&tmp);
-    EXPECT_FALSE(ddwaf_object_map_add(&array, "key", ddwaf_object_signed(&tmp, 42)));
+    EXPECT_FALSE(ddwaf_object_map_add(&array, "key", ddwaf_object_string_from_signed(&tmp, 42)));
     ddwaf_object_free(&tmp);
-    EXPECT_FALSE(ddwaf_object_map_add(&map, nullptr, ddwaf_object_signed(&tmp, 42)));
+    EXPECT_FALSE(ddwaf_object_map_add(&map, nullptr, ddwaf_object_string_from_signed(&tmp, 42)));
     ddwaf_object_free(&tmp);
 
     EXPECT_FALSE(ddwaf_object_map_add(&map, "key", ddwaf_object_invalid(&tmp)));
     EXPECT_FALSE(ddwaf_object_map_add(&map, "key", nullptr));
 
-    ASSERT_TRUE(ddwaf_object_map_add(&map, "key", ddwaf_object_signed(&tmp, 42)));
+    ASSERT_TRUE(ddwaf_object_map_add(&map, "key", ddwaf_object_string_from_signed(&tmp, 42)));
     EXPECT_STREQ(map.array[0].parameterName, "key");
 
-    ASSERT_TRUE(ddwaf_object_map_addl(&map, "key2", 4, ddwaf_object_signed(&tmp, 43)));
+    ASSERT_TRUE(ddwaf_object_map_addl(&map, "key2", 4, ddwaf_object_string_from_signed(&tmp, 43)));
     EXPECT_STREQ(map.array[1].parameterName, "key2");
 
     char *str = strdup("key3");
-    ASSERT_TRUE(ddwaf_object_map_addl_nc(&map, str, 4, ddwaf_object_signed(&tmp, 44)));
+    ASSERT_TRUE(ddwaf_object_map_addl_nc(&map, str, 4, ddwaf_object_string_from_signed(&tmp, 44)));
     EXPECT_EQ(map.array[2].parameterName, str);
 
     // Getters

--- a/tests/object_test.cpp
+++ b/tests/object_test.cpp
@@ -247,35 +247,38 @@ TEST(TestObject, TestAddArray)
 
     EXPECT_FALSE(ddwaf_object_array_add(nullptr, &object));
     EXPECT_FALSE(ddwaf_object_array_add(&object, &container));
-    EXPECT_FALSE(ddwaf_object_array_add(&container, &object));
 
+    EXPECT_TRUE(ddwaf_object_array_add(&container, &object));
     EXPECT_TRUE(ddwaf_object_array_add(&container, ddwaf_object_string_from_signed(&object, 42)));
     EXPECT_TRUE(ddwaf_object_array_add(&container, ddwaf_object_string_from_unsigned(&object, 43)));
 
     EXPECT_EQ(container.type, DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(container.nbEntries, 2);
+    EXPECT_EQ(container.nbEntries, 3);
     EXPECT_EQ(container.parameterName, nullptr);
 
-    EXPECT_EQ(container.array[0].type, DDWAF_OBJ_STRING);
-    EXPECT_STREQ(container.array[0].stringValue, "42");
-
     EXPECT_EQ(container.array[1].type, DDWAF_OBJ_STRING);
-    EXPECT_STREQ(container.array[1].stringValue, "43");
+    EXPECT_STREQ(container.array[1].stringValue, "42");
+
+    EXPECT_EQ(container.array[2].type, DDWAF_OBJ_STRING);
+    EXPECT_STREQ(container.array[2].stringValue, "43");
 
     // Getters
     EXPECT_EQ(ddwaf_object_type(&container), DDWAF_OBJ_ARRAY);
     EXPECT_EQ(ddwaf_object_length(&container), 0);
-    EXPECT_EQ(ddwaf_object_size(&container), 2);
+    EXPECT_EQ(ddwaf_object_size(&container), 3);
 
     const auto *internal = ddwaf_object_get_index(&container, 0);
-    EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_STRING);
-    EXPECT_STREQ(ddwaf_object_get_string(internal, nullptr), "42");
+    EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_INVALID);
 
     internal = ddwaf_object_get_index(&container, 1);
     EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_STRING);
+    EXPECT_STREQ(ddwaf_object_get_string(internal, nullptr), "42");
+
+    internal = ddwaf_object_get_index(&container, 2);
+    EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_STRING);
     EXPECT_STREQ(ddwaf_object_get_string(internal, nullptr), "43");
 
-    EXPECT_EQ(ddwaf_object_get_index(&container, 2), nullptr);
+    EXPECT_EQ(ddwaf_object_get_index(&container, 3), nullptr);
 
     ddwaf_object_free(&container);
 }
@@ -293,45 +296,50 @@ TEST(TestObject, TestAddMap)
     ddwaf_object_free(&tmp);
     EXPECT_FALSE(ddwaf_object_map_add(&map, nullptr, ddwaf_object_string_from_signed(&tmp, 42)));
     ddwaf_object_free(&tmp);
-
-    EXPECT_FALSE(ddwaf_object_map_add(&map, "key", ddwaf_object_invalid(&tmp)));
     EXPECT_FALSE(ddwaf_object_map_add(&map, "key", nullptr));
 
-    ASSERT_TRUE(ddwaf_object_map_add(&map, "key", ddwaf_object_string_from_signed(&tmp, 42)));
+    EXPECT_TRUE(ddwaf_object_map_add(&map, "key", ddwaf_object_invalid(&tmp)));
     EXPECT_STREQ(map.array[0].parameterName, "key");
 
+    ASSERT_TRUE(ddwaf_object_map_add(&map, "key", ddwaf_object_string_from_signed(&tmp, 42)));
+    EXPECT_STREQ(map.array[1].parameterName, "key");
+
     ASSERT_TRUE(ddwaf_object_map_addl(&map, "key2", 4, ddwaf_object_string_from_signed(&tmp, 43)));
-    EXPECT_STREQ(map.array[1].parameterName, "key2");
+    EXPECT_STREQ(map.array[2].parameterName, "key2");
 
     char *str = strdup("key3");
     ASSERT_TRUE(ddwaf_object_map_addl_nc(&map, str, 4, ddwaf_object_string_from_signed(&tmp, 44)));
-    EXPECT_EQ(map.array[2].parameterName, str);
+    EXPECT_EQ(map.array[3].parameterName, str);
 
     // Getters
     EXPECT_EQ(ddwaf_object_type(&map), DDWAF_OBJ_MAP);
     EXPECT_EQ(ddwaf_object_length(&map), 0);
-    EXPECT_EQ(ddwaf_object_size(&map), 3);
+    EXPECT_EQ(ddwaf_object_size(&map), 4);
 
     size_t length;
     const auto *internal = ddwaf_object_get_index(&map, 0);
+    EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_INVALID);
+    EXPECT_STREQ(ddwaf_object_get_key(internal, &length), "key");
+
+    internal = ddwaf_object_get_index(&map, 1);
     EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_STRING);
     EXPECT_STREQ(ddwaf_object_get_string(internal, nullptr), "42");
     EXPECT_STREQ(ddwaf_object_get_key(internal, &length), "key");
     EXPECT_EQ(length, 3);
 
-    internal = ddwaf_object_get_index(&map, 1);
+    internal = ddwaf_object_get_index(&map, 2);
     EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_STRING);
     EXPECT_STREQ(ddwaf_object_get_string(internal, nullptr), "43");
     EXPECT_STREQ(ddwaf_object_get_key(internal, &length), "key2");
     EXPECT_EQ(length, 4);
 
-    internal = ddwaf_object_get_index(&map, 2);
+    internal = ddwaf_object_get_index(&map, 3);
     EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_STRING);
     EXPECT_STREQ(ddwaf_object_get_string(internal, nullptr), "44");
     EXPECT_STREQ(ddwaf_object_get_key(internal, &length), "key3");
     EXPECT_EQ(length, 4);
 
-    EXPECT_EQ(ddwaf_object_get_index(&map, 3), nullptr);
+    EXPECT_EQ(ddwaf_object_get_index(&map, 4), nullptr);
 
     ddwaf_object_free(&map);
     ddwaf_object_free(&array);

--- a/tests/parameter_test.cpp
+++ b/tests/parameter_test.cpp
@@ -148,6 +148,34 @@ TEST(TestParameter, ToInt64)
     }
 }
 
+TEST(TestParameter, ToFloat)
+{
+    {
+        ddwaf_object root;
+        ddwaf_object_float(&root, 21.23);
+
+        double value = static_cast<double>(parameter(root));
+        EXPECT_EQ(value, 21.23);
+    }
+
+    {
+        ddwaf_object root;
+        ddwaf_object_string(&root, "21.23");
+
+        double value = static_cast<double>(parameter(root));
+        EXPECT_EQ(value, 21.23);
+
+        ddwaf_object_free(&root);
+    }
+
+    {
+        ddwaf_object root;
+        ddwaf_object_map(&root);
+
+        EXPECT_THROW(static_cast<double>(ddwaf::parameter(root)), ddwaf::bad_cast);
+    }
+}
+
 TEST(TestParameter, ToString)
 {
     {

--- a/tests/parameter_test.cpp
+++ b/tests/parameter_test.cpp
@@ -76,7 +76,7 @@ TEST(TestParameter, ToUint64)
 {
     {
         ddwaf_object root;
-        ddwaf_object_string_from_unsigned(&root, 2123);
+        ddwaf_object_unsigned(&root, 2123);
 
         uint64_t value = static_cast<uint64_t>(parameter(root));
         EXPECT_EQ(value, 2123);
@@ -114,7 +114,7 @@ TEST(TestParameter, ToInt64)
 {
     {
         ddwaf_object root;
-        ddwaf_object_string_from_signed(&root, -2123);
+        ddwaf_object_signed(&root, -2123);
 
         int64_t value = static_cast<int64_t>(parameter(root));
         EXPECT_EQ(value, -2123);

--- a/tests/parameter_test.cpp
+++ b/tests/parameter_test.cpp
@@ -76,7 +76,7 @@ TEST(TestParameter, ToUint64)
 {
     {
         ddwaf_object root;
-        ddwaf_object_unsigned_force(&root, 2123);
+        ddwaf_object_string_from_unsigned(&root, 2123);
 
         uint64_t value = static_cast<uint64_t>(parameter(root));
         EXPECT_EQ(value, 2123);
@@ -84,7 +84,7 @@ TEST(TestParameter, ToUint64)
 
     {
         ddwaf_object root;
-        ddwaf_object_unsigned(&root, 2123);
+        ddwaf_object_string_from_unsigned(&root, 2123);
 
         uint64_t value = static_cast<uint64_t>(parameter(root));
         EXPECT_EQ(value, 2123);
@@ -114,7 +114,7 @@ TEST(TestParameter, ToInt64)
 {
     {
         ddwaf_object root;
-        ddwaf_object_signed_force(&root, -2123);
+        ddwaf_object_string_from_signed(&root, -2123);
 
         int64_t value = static_cast<int64_t>(parameter(root));
         EXPECT_EQ(value, -2123);
@@ -122,7 +122,7 @@ TEST(TestParameter, ToInt64)
 
     {
         ddwaf_object root;
-        ddwaf_object_signed(&root, -2123);
+        ddwaf_object_string_from_signed(&root, -2123);
 
         int64_t value = static_cast<int64_t>(parameter(root));
         EXPECT_EQ(value, -2123);
@@ -272,7 +272,7 @@ TEST(TestParameter, ToStringVector)
         ddwaf_object root, tmp;
         ddwaf_object_array(&root);
 
-        ddwaf_object_array_add(&root, ddwaf_object_unsigned_force(&tmp, 50));
+        ddwaf_object_array_add(&root, ddwaf_object_unsigned(&tmp, 50));
 
         ddwaf::parameter param = root;
         EXPECT_THROW(param.operator std::vector<std::string>(), ddwaf::malformed_object);
@@ -311,7 +311,7 @@ TEST(TestParameter, ToStringViewVector)
         ddwaf_object root, tmp;
         ddwaf_object_array(&root);
 
-        ddwaf_object_array_add(&root, ddwaf_object_unsigned_force(&tmp, 50));
+        ddwaf_object_array_add(&root, ddwaf_object_unsigned(&tmp, 50));
 
         ddwaf::parameter param = root;
         EXPECT_THROW(param.operator std::vector<std::string_view>(), ddwaf::malformed_object);
@@ -351,7 +351,7 @@ TEST(TestParameter, ToStringViewSet)
         ddwaf_object root, tmp;
         ddwaf_object_array(&root);
 
-        ddwaf_object_array_add(&root, ddwaf_object_unsigned_force(&tmp, 50));
+        ddwaf_object_array_add(&root, ddwaf_object_unsigned(&tmp, 50));
 
         ddwaf::parameter param = root;
         EXPECT_THROW(param.operator ddwaf::parameter::string_set(), ddwaf::malformed_object);

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -172,6 +172,9 @@ void object_to_json_helper(
     case DDWAF_OBJ_UNSIGNED:
         output.SetUint64(obj.uintValue);
         break;
+    case DDWAF_OBJ_FLOAT:
+        output.SetDouble(obj.f64);
+        break;
     case DDWAF_OBJ_STRING: {
         auto sv = std::string_view(obj.stringValue, obj.nbEntries);
         output.SetString(sv.data(), sv.size(), alloc);
@@ -199,7 +202,8 @@ void object_to_json_helper(
         }
         break;
     case DDWAF_OBJ_INVALID:
-        throw std::runtime_error("invalid parameter in structure");
+    case DDWAF_OBJ_NULL:
+        break;
     };
 }
 

--- a/tests/transformer/manager_test.cpp
+++ b/tests/transformer/manager_test.cpp
@@ -51,7 +51,7 @@ TEST(TestTransformerManager, InvalidTypes)
 {
     ddwaf_object src;
     ddwaf_object dst;
-    ddwaf_object_unsigned_force(&src, 29);
+    ddwaf_object_unsigned(&src, 29);
 
     EXPECT_FALSE(transformer::manager::transform(src, dst, {transformer_id::compress_whitespace}));
     EXPECT_FALSE(transformer::manager::transform(src, dst, {transformer_id::lowercase}));

--- a/tests/value_iterator_test.cpp
+++ b/tests/value_iterator_test.cpp
@@ -119,6 +119,39 @@ TEST(TestValueIterator, TestArrayMultipleItems)
     ddwaf_object_free(&object);
 }
 
+TEST(TestValueIterator, TestArrayMultipleNullAndInvalid)
+{
+    ddwaf_object object;
+    ddwaf_object tmp;
+    ddwaf_object_array(&object);
+    for (unsigned i = 0; i < 25; i++) {
+        ddwaf_object_array_add(&object, ddwaf_object_string(&tmp, std::to_string(i).c_str()));
+        ddwaf_object_array_add(&object, ddwaf_object_invalid(&tmp));
+        ddwaf_object_array_add(&object, ddwaf_object_null(&tmp));
+    }
+
+    EXPECT_EQ(ddwaf_object_size(&object), 75);
+
+    std::unordered_set<const ddwaf_object *> exclude;
+    ddwaf::object::value_iterator it(&object, {}, exclude);
+
+    // Null and invalid objects should be skipped
+    unsigned index = 0;
+    do {
+        EXPECT_TRUE(it);
+        EXPECT_STREQ((*it)->stringValue, std::to_string(index).c_str());
+
+        auto path = it.get_current_path();
+        EXPECT_EQ(path.size(), 1);
+        EXPECT_STREQ(path[0].c_str(), std::to_string(index * 3).c_str());
+        ++index;
+    } while (++it);
+
+    EXPECT_FALSE(++it);
+
+    ddwaf_object_free(&object);
+}
+
 TEST(TestValueIterator, TestArrayPastSizeLimit)
 {
     ddwaf::object_limits limits;
@@ -280,6 +313,56 @@ TEST(TestValueIterator, TestMapMultipleItems)
 
     for (unsigned i = 0; i < 50; i++) {
         auto index = std::to_string(i);
+        std::string key = "key" + index;
+        std::string value = "value" + index;
+
+        EXPECT_TRUE(it);
+        EXPECT_STREQ((*it)->stringValue, value.c_str());
+        EXPECT_STREQ((*it)->parameterName, key.c_str());
+
+        auto path = it.get_current_path();
+        EXPECT_EQ(path.size(), 1);
+        EXPECT_STREQ(path[0].c_str(), key.c_str());
+        ++it;
+    }
+
+    EXPECT_FALSE(it);
+
+    ddwaf_object_free(&object);
+}
+
+TEST(TestValueIterator, TestMapMultipleMultipleNullAndInvalid)
+{
+    ddwaf_object object;
+    ddwaf_object tmp;
+    ddwaf_object_map(&object);
+
+    for (unsigned i = 0; i < 25; i++) {
+        {
+            auto index = std::to_string(i * 3);
+            std::string key = "key" + index;
+            std::string value = "value" + index;
+            ddwaf_object_map_add(&object, key.c_str(), ddwaf_object_string(&tmp, value.c_str()));
+        }
+
+        {
+            auto index = std::to_string(i * 3 + 1);
+            std::string key = "key" + index;
+            ddwaf_object_map_add(&object, key.c_str(), ddwaf_object_invalid(&tmp));
+        }
+
+        {
+            auto index = std::to_string(i * 3 + 2);
+            std::string key = "key" + index;
+            ddwaf_object_map_add(&object, key.c_str(), ddwaf_object_null(&tmp));
+        }
+    }
+
+    std::unordered_set<const ddwaf_object *> exclude;
+    ddwaf::object::value_iterator it(&object, {}, exclude);
+
+    for (unsigned i = 0; i < 25; i++) {
+        auto index = std::to_string(i * 3);
         std::string key = "key" + index;
         std::string value = "value" + index;
 

--- a/tests/value_iterator_test.cpp
+++ b/tests/value_iterator_test.cpp
@@ -42,7 +42,7 @@ TEST(TestValueIterator, TestStringScalar)
 TEST(TestValueIterator, TestUnsignedScalar)
 {
     ddwaf_object object;
-    ddwaf_object_string_from_unsigned(&object, 22);
+    ddwaf_object_unsigned(&object, 22);
 
     std::unordered_set<const ddwaf_object *> exclude;
     ddwaf::object::value_iterator it(&object, {}, exclude);
@@ -58,7 +58,7 @@ TEST(TestValueIterator, TestUnsignedScalar)
 TEST(TestValueIterator, TestSignedScalar)
 {
     ddwaf_object object;
-    ddwaf_object_string_from_signed(&object, 22);
+    ddwaf_object_signed(&object, 22);
 
     std::unordered_set<const ddwaf_object *> exclude;
     ddwaf::object::value_iterator it(&object, {}, exclude);

--- a/tests/value_iterator_test.cpp
+++ b/tests/value_iterator_test.cpp
@@ -42,7 +42,7 @@ TEST(TestValueIterator, TestStringScalar)
 TEST(TestValueIterator, TestUnsignedScalar)
 {
     ddwaf_object object;
-    ddwaf_object_unsigned_force(&object, 22);
+    ddwaf_object_string_from_unsigned(&object, 22);
 
     std::unordered_set<const ddwaf_object *> exclude;
     ddwaf::object::value_iterator it(&object, {}, exclude);
@@ -58,7 +58,7 @@ TEST(TestValueIterator, TestUnsignedScalar)
 TEST(TestValueIterator, TestSignedScalar)
 {
     ddwaf_object object;
-    ddwaf_object_signed_force(&object, 22);
+    ddwaf_object_string_from_signed(&object, 22);
 
     std::unordered_set<const ddwaf_object *> exclude;
     ddwaf::object::value_iterator it(&object, {}, exclude);

--- a/validator/utils.cpp
+++ b/validator/utils.cpp
@@ -128,6 +128,9 @@ void object_to_yaml_helper(const ddwaf_object &obj, YAML::Node &output)
     case DDWAF_OBJ_UNSIGNED:
         output = obj.uintValue;
         break;
+    case DDWAF_OBJ_FLOAT:
+        output = obj.f64;
+        break;
     case DDWAF_OBJ_STRING:
         output = std::string{obj.stringValue, obj.nbEntries};
         break;
@@ -153,7 +156,8 @@ void object_to_yaml_helper(const ddwaf_object &obj, YAML::Node &output)
         }
         break;
     case DDWAF_OBJ_INVALID:
-        throw std::runtime_error("invalid parameter in structure");
+    case DDWAF_OBJ_NULL:
+        output = YAML::Null;
     };
 }
 


### PR DESCRIPTION
Add support for `float` and `null` types, while also allowing `invalid` within containers.

Breaking changes:

- `ddwaf_object` now has one more field in the union for doubles called `f64`
- `ddwaf_object_*_force` are now the standard, so the `_force` suffix has been removed.
- `ddwaf_object_signed` and `ddwaf_object_unsigned` have now been renamed to `ddwaf_object_string_from_*`
- Not breaking but two new types have been introduced, `DDWAF_OBJ_FLOAT` and `DDWAF_OBJ_NULL`