### PR TITLE
Fix coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,12 +114,10 @@ jobs:
           flags: waf_test
           verbose: true
           files: coverage.xml
-        working-directory: Debug
       - uses: actions/upload-artifact@v3
         with:
           name: Upload coverage
-          path: coverage.xml
-        working-directory: Debug
+          path: ${{ github.workspace }}/Debug/coverage.xml
 
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
         env:
           CC: gcc-12
           CXX: g++-12
+          GCOV: gcov-12
         run: |
           cmake .. -DLIBDDWAF_TEST_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug
         working-directory: Debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,6 @@ jobs:
         env:
           CC: gcc-12
           CXX: g++-12
-          GCOV: gcov-12
         run: |
           cmake .. -DLIBDDWAF_TEST_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug
         working-directory: Debug
@@ -105,7 +104,10 @@ jobs:
         working-directory: Debug
 
       - name: Generate coverage
-        run: gcovr --exclude-throw-branches -v -f '.*src.*' -x -d -o coverage.xml
+        run: |
+          gcovr --gcov-executable gcov-12 --exclude-throw-branches -v -f '.*src.*' -x  -o coverage.xml
+          mkdir -p coverage
+          gcovr --gcov-executable gcov-12 --html-details coverage/coverage.html --exclude-throw-branches -f ".*src.*" -d
         working-directory: Debug
 
       - name: Submit coverage
@@ -117,8 +119,8 @@ jobs:
           files: coverage.xml
       - uses: actions/upload-artifact@v3
         with:
-          name: Upload coverage
-          path: ${{ github.workspace }}/Debug/coverage.xml
+          name: coverage
+          path: ${{ github.workspace }}/Debug/coverage/
 
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         working-directory: Debug
 
       - name: Generate coverage
-        run: gcovr --exclude-throw-branches -f '.*src.*' -x -d -o coverage.xml
+        run: gcovr --exclude-throw-branches -v -f '.*src.*' -x -d -o coverage.xml
         working-directory: Debug
 
       - name: Submit coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,10 @@ jobs:
           flags: waf_test
           verbose: true
           files: coverage.xml
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Upload coverage
+          path: coverage.xml
 
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           submodules: recursive
 
       - name: Install dependencies
-        run: sudo apt update ; sudo apt install -y gcovr
+        run: sudo apt update ; sudo apt install -y gcovr gcc-12
 
       - name: Create directories
         run: mkdir Debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,10 +114,12 @@ jobs:
           flags: waf_test
           verbose: true
           files: coverage.xml
+        working-directory: Debug
       - uses: actions/upload-artifact@v3
         with:
           name: Upload coverage
           path: coverage.xml
+        working-directory: Debug
 
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Coverage was broken after moving to gcc-12, this PR fixes it and also introduces the generation of HTML coverage since codecov is often hitting github rate limits.