### PR TITLE
Scanners for schema scalar classification

### DIFF
--- a/src/generator/base.hpp
+++ b/src/generator/base.hpp
@@ -29,12 +29,8 @@ public:
     base &operator=(const base &) = default;
     base &operator=(base &&) = default;
 
-    virtual ddwaf_object generate(const ddwaf_object *input, ddwaf::timer &deadline) = 0;
     virtual ddwaf_object generate(
-        const ddwaf_object *input, const std::set<scanner *> & /*scanners*/, ddwaf::timer &deadline)
-    {
-        return generate(input, deadline);
-    };
+        const ddwaf_object *input, const std::set<scanner *> &scanners, ddwaf::timer &deadline) = 0;
 };
 
 } // namespace ddwaf::generator

--- a/src/generator/base.hpp
+++ b/src/generator/base.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
 #include <string_view>
-#include <unordered_set>
 #include <vector>
 
 #include "clock.hpp"
@@ -30,7 +30,9 @@ public:
     base &operator=(base &&) = default;
 
     virtual ddwaf_object generate(const ddwaf_object *input, ddwaf::timer &deadline) = 0;
-    virtual ddwaf_object generate(const ddwaf_object *input, const std::unordered_map<std::string_view, scanner::ptr> & /*scanners*/, ddwaf::timer &deadline) {
+    virtual ddwaf_object generate(
+        const ddwaf_object *input, const std::set<scanner *> & /*scanners*/, ddwaf::timer &deadline)
+    {
         return generate(input, deadline);
     };
 };

--- a/src/generator/base.hpp
+++ b/src/generator/base.hpp
@@ -9,9 +9,11 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 #include "clock.hpp"
+#include "scanner.hpp"
 #include "utils.hpp"
 
 namespace ddwaf::generator {
@@ -28,6 +30,9 @@ public:
     base &operator=(base &&) = default;
 
     virtual ddwaf_object generate(const ddwaf_object *input, ddwaf::timer &deadline) = 0;
+    virtual ddwaf_object generate(const ddwaf_object *input, const std::unordered_map<std::string_view, scanner::ptr> & /*scanners*/, ddwaf::timer &deadline) {
+        return generate(input, deadline);
+    };
 };
 
 } // namespace ddwaf::generator

--- a/src/generator/extract_schema.cpp
+++ b/src/generator/extract_schema.cpp
@@ -15,6 +15,7 @@
 
 #include "exception.hpp"
 #include "generator/extract_schema.hpp"
+#include "log.hpp"
 
 namespace ddwaf::generator {
 namespace schema {

--- a/src/generator/extract_schema.cpp
+++ b/src/generator/extract_schema.cpp
@@ -329,7 +329,7 @@ ddwaf_object generate(const ddwaf_object *object, ddwaf::timer &deadline)
 
 } // namespace schema
 
-ddwaf_object extract_schema::generate(const ddwaf_object *input, ddwaf::timer &deadline)
+ddwaf_object extract_schema::generate(const ddwaf_object *input, const std::unordered_map<std::string_view, scanner::ptr> & /*scanners*/, ddwaf::timer &deadline)
 {
     if (input == nullptr) {
         return {};

--- a/src/generator/extract_schema.hpp
+++ b/src/generator/extract_schema.hpp
@@ -30,10 +30,6 @@ public:
     extract_schema &operator=(const extract_schema &) = delete;
     extract_schema &operator=(extract_schema &&) = default;
 
-    ddwaf_object generate(const ddwaf_object *input, ddwaf::timer &deadline) override
-    {
-        return generate(input, {}, deadline);
-    }
     ddwaf_object generate(const ddwaf_object *input, const std::set<scanner *> &scanners,
         ddwaf::timer &deadline) override;
 };

--- a/src/generator/extract_schema.hpp
+++ b/src/generator/extract_schema.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -29,10 +30,12 @@ public:
     extract_schema &operator=(const extract_schema &) = delete;
     extract_schema &operator=(extract_schema &&) = default;
 
-    ddwaf_object generate(const ddwaf_object *input, ddwaf::timer &deadline) override {
+    ddwaf_object generate(const ddwaf_object *input, ddwaf::timer &deadline) override
+    {
         return generate(input, {}, deadline);
     }
-    ddwaf_object generate(const ddwaf_object *input, const std::unordered_map<std::string_view, scanner::ptr> &scanners, ddwaf::timer &deadline) override;
+    ddwaf_object generate(const ddwaf_object *input, const std::set<scanner *> &scanners,
+        ddwaf::timer &deadline) override;
 };
 
 } // namespace ddwaf::generator

--- a/src/generator/extract_schema.hpp
+++ b/src/generator/extract_schema.hpp
@@ -29,7 +29,10 @@ public:
     extract_schema &operator=(const extract_schema &) = delete;
     extract_schema &operator=(extract_schema &&) = default;
 
-    ddwaf_object generate(const ddwaf_object *input, ddwaf::timer &deadline) override;
+    ddwaf_object generate(const ddwaf_object *input, ddwaf::timer &deadline) override {
+        return generate(input, {}, deadline);
+    }
+    ddwaf_object generate(const ddwaf_object *input, const std::unordered_map<std::string_view, scanner::ptr> &scanners, ddwaf::timer &deadline) override;
 };
 
 } // namespace ddwaf::generator

--- a/src/parser/parser.hpp
+++ b/src/parser/parser.hpp
@@ -41,5 +41,8 @@ filter_spec_container parse_filters(
 
 processor_container parse_processors(
     parameter::vector &processor_array, base_section_info &info, const object_limits &limits);
+
+scanner_container parse_scanners(parameter::vector &scanner_array, base_section_info &info);
+
 } // namespace v2
 } // namespace ddwaf::parser

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -319,7 +319,7 @@ expression::ptr parse_simplified_expression(
 
         auto [rule_data_id, matcher] = parse_matcher(matcher_name, params);
         if (!rule_data_id.empty()) {
-            throw ddwaf::parsing_error("filter conditions don't support dynamic data");
+            throw ddwaf::parsing_error("dynamic data on filter condition");
         }
 
         builder.set_matcher(std::move(matcher));
@@ -464,7 +464,7 @@ matcher::base::unique_ptr parse_scanner_matcher(const parameter::map &root)
 
     auto [rule_data_id, matcher] = parse_matcher(matcher_name, matcher_params);
     if (!rule_data_id.empty()) {
-        throw ddwaf::parsing_error("scanners don't support dynamic data");
+        throw ddwaf::parsing_error("dynamic data on scanner condition");
     }
 
     return std::move(matcher);

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -702,7 +702,7 @@ processor_container parse_processors(
     return processors;
 }
 
-scanner_container parse_scanner(parameter::vector &scanner_array, base_section_info &info)
+scanner_container parse_scanners(parameter::vector &scanner_array, base_section_info &info)
 {
     scanner_container scanners;
     for (unsigned i = 0; i < scanner_array.size(); i++) {
@@ -716,8 +716,6 @@ scanner_container parse_scanner(parameter::vector &scanner_array, base_section_i
                 info.add_failed(id, "duplicate scanner");
                 continue;
             }
-
-            auto name = at<std::string>(node, "name");
 
             std::unordered_map<std::string, std::string> tags;
             for (auto &[key, value] : at<parameter::map>(node, "tags")) {
@@ -750,8 +748,8 @@ scanner_container parse_scanner(parameter::vector &scanner_array, base_section_i
             }
 
             DDWAF_DEBUG("Parsed scanner %s", id.c_str());
-            auto scnr = std::make_shared<scanner>(scanner{std::move(id), std::move(name),
-                std::move(tags), std::move(key_matcher), std::move(value_matcher)});
+            auto scnr = std::make_shared<scanner>(scanner{std::move(id), std::move(tags),
+                std::move(key_matcher), std::move(value_matcher)});
             scanners.emplace(scnr->get_id(), scnr);
             info.add_loaded(scnr->get_id());
         } catch (const std::exception &e) {

--- a/src/parser/specification.hpp
+++ b/src/parser/specification.hpp
@@ -13,6 +13,7 @@
 #include <parameter.hpp>
 #include <processor.hpp>
 #include <rule.hpp>
+#include <scanner.hpp>
 
 #include <string>
 
@@ -29,7 +30,7 @@ struct rule_spec {
 
 enum class target_type { none, id, tags };
 
-struct rule_target_spec {
+struct reference_target_spec {
     target_type type;
     std::string rule_id;
     std::unordered_map<std::string, std::string> tags;
@@ -38,24 +39,25 @@ struct rule_target_spec {
 struct override_spec {
     std::optional<bool> enabled;
     std::optional<std::vector<std::string>> actions;
-    std::vector<rule_target_spec> targets;
+    std::vector<reference_target_spec> targets;
 };
 
 struct rule_filter_spec {
     expression::ptr expr;
-    std::vector<rule_target_spec> targets;
+    std::vector<reference_target_spec> targets;
     exclusion::filter_mode on_match;
 };
 
 struct input_filter_spec {
     expression::ptr expr;
     std::shared_ptr<exclusion::object_filter> filter;
-    std::vector<rule_target_spec> targets;
+    std::vector<reference_target_spec> targets;
 };
 
 // Containers
 using rule_spec_container = std::unordered_map<std::string, rule_spec>;
 using rule_data_container = std::unordered_map<std::string, matcher::base::shared_ptr>;
+using scanner_container = std::unordered_map<std::string_view, scanner::ptr>;
 
 struct processor_container {
     [[nodiscard]] bool empty() const { return pre.empty() && post.empty(); }

--- a/src/parser/specification.hpp
+++ b/src/parser/specification.hpp
@@ -28,30 +28,39 @@ struct rule_spec {
     std::vector<std::string> actions;
 };
 
-enum class target_type { none, id, tags };
+enum class reference_type { none, id, tags };
 
-struct reference_target_spec {
-    target_type type;
-    std::string rule_id;
+struct reference_spec {
+    reference_type type;
+    std::string ref_id;
     std::unordered_map<std::string, std::string> tags;
 };
 
 struct override_spec {
     std::optional<bool> enabled;
     std::optional<std::vector<std::string>> actions;
-    std::vector<reference_target_spec> targets;
+    std::vector<reference_spec> targets;
 };
 
 struct rule_filter_spec {
     expression::ptr expr;
-    std::vector<reference_target_spec> targets;
+    std::vector<reference_spec> targets;
     exclusion::filter_mode on_match;
 };
 
 struct input_filter_spec {
     expression::ptr expr;
     std::shared_ptr<exclusion::object_filter> filter;
-    std::vector<reference_target_spec> targets;
+    std::vector<reference_spec> targets;
+};
+
+struct processor_spec {
+    std::shared_ptr<generator::base> generator;
+    expression::ptr expr;
+    std::vector<processor::target_mapping> mappings;
+    std::vector<reference_spec> scanners;
+    bool evaluate{false};
+    bool output{true};
 };
 
 // Containers
@@ -68,8 +77,8 @@ struct processor_container {
         post.clear();
     }
 
-    std::unordered_map<std::string_view, processor::ptr> pre;
-    std::unordered_map<std::string_view, processor::ptr> post;
+    std::unordered_map<std::string, processor_spec> pre;
+    std::unordered_map<std::string, processor_spec> post;
 };
 
 struct override_spec_container {

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -41,7 +41,7 @@ void processor::eval(object_store &store, optional_ref<ddwaf_object> &derived, c
         // Whatever the outcome, we don't want to try and generate it again
         cache.generated.emplace(mapping.output);
 
-        auto object = generator_->generate(input, deadline);
+        auto object = generator_->generate(input, scanners_, deadline);
         if (object.type == DDWAF_OBJ_INVALID) {
             continue;
         }

--- a/src/processor.hpp
+++ b/src/processor.hpp
@@ -32,10 +32,12 @@ public:
         std::unordered_set<target_index> generated;
     };
 
-    processor(std::string id, std::unique_ptr<generator::base> generator, expression::ptr expr,
-        std::vector<target_mapping> mappings, bool evaluate, bool output)
+    processor(std::string id, std::shared_ptr<generator::base> generator, expression::ptr expr,
+        std::vector<target_mapping> mappings, std::set<scanner *> scanners, bool evaluate,
+        bool output)
         : id_(std::move(id)), generator_(std::move(generator)), expr_(std::move(expr)),
-          mappings_(std::move(mappings)), evaluate_(evaluate), output_(output)
+          mappings_(std::move(mappings)), scanners_(std::move(scanners)), evaluate_(evaluate),
+          output_(output)
     {}
 
     processor(const processor &) = delete;
@@ -52,9 +54,10 @@ public:
 
 protected:
     std::string id_;
-    std::unique_ptr<generator::base> generator_;
+    std::shared_ptr<generator::base> generator_;
     expression::ptr expr_;
     std::vector<target_mapping> mappings_;
+    std::set<scanner *> scanners_;
     bool evaluate_{false};
     bool output_{true};
 };

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -19,10 +19,12 @@
 #include <obfuscator.hpp>
 #include <processor.hpp>
 #include <rule.hpp>
+#include <scanner.hpp>
 
 namespace ddwaf {
 
 using rule_tag_map = ddwaf::multi_key_map<std::string_view, rule *>;
+using scanner_tag_map = ddwaf::multi_key_map<std::string_view, scanner *>;
 
 struct ruleset {
     using ptr = std::shared_ptr<ruleset>;
@@ -111,6 +113,8 @@ struct ruleset {
 
     std::vector<rule::ptr> rules;
     std::unordered_map<std::string, matcher::base::shared_ptr> dynamic_matchers;
+
+    std::unordered_map<std::string_view, scanner::ptr> scanners;
 
     // The key used to organise collections is rule.type
     std::unordered_set<std::string_view> collection_types;

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -23,9 +23,6 @@
 
 namespace ddwaf {
 
-using rule_tag_map = ddwaf::multi_key_map<std::string_view, rule *>;
-using scanner_tag_map = ddwaf::multi_key_map<std::string_view, scanner *>;
-
 struct ruleset {
     using ptr = std::shared_ptr<ruleset>;
 

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -326,6 +326,25 @@ ruleset_builder::change_state ruleset_builder::load(parameter::map &root, base_r
         }
     }
 
+    it = root.find("scanners");
+    if (it != root.end()) {
+        DDWAF_DEBUG("Parsing scanners");
+        auto &section = info.add_section("scanners");
+        try {
+            auto scanners = static_cast<parameter::vector>(it->second);
+            if (!scanners.empty()) {
+                scanners_ = parser::v2::parse_scanners(scanners, section);
+            } else {
+                DDWAF_DEBUG("Clearing all scanners");
+                scanners_.clear();
+            }
+            state = state | change_state::scanners;
+        } catch (const std::exception &e) {
+            DDWAF_WARN("Failed to parse scanners: %s", e.what());
+            section.set_error(e.what());
+        }
+    }
+
     return state;
 }
 

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -33,28 +33,47 @@ constexpr ruleset_builder::change_state operator&(
 
 namespace {
 
-std::set<rule *> target_to_rules(const std::vector<parser::reference_target_spec> &targets,
+std::set<rule *> references_to_rules(const std::vector<parser::reference_spec> &references,
     const std::unordered_map<std::string_view, rule::ptr> &rules, const rule_tag_map &rules_by_tags)
 {
-    std::set<rule *> rule_targets;
-    if (!targets.empty()) {
-        for (const auto &target : targets) {
-            if (target.type == parser::target_type::id) {
-                auto rule_it = rules.find(target.rule_id);
+    std::set<rule *> rule_refs;
+    if (!references.empty()) {
+        for (const auto &ref : references) {
+            if (ref.type == parser::reference_type::id) {
+                auto rule_it = rules.find(ref.ref_id);
                 if (rule_it == rules.end()) {
                     continue;
                 }
-                rule_targets.emplace(rule_it->second.get());
-            } else if (target.type == parser::target_type::tags) {
-                auto current_targets = rules_by_tags.multifind(target.tags);
-                rule_targets.merge(current_targets);
+                rule_refs.emplace(rule_it->second.get());
+            } else if (ref.type == parser::reference_type::tags) {
+                auto current_refs = rules_by_tags.multifind(ref.tags);
+                rule_refs.merge(current_refs);
             }
         }
     } else {
-        // An empty rules target applies to all rules
-        for (const auto &[id, rule] : rules) { rule_targets.emplace(rule.get()); }
+        // An empty rules reference applies to all rules
+        for (const auto &[id, rule] : rules) { rule_refs.emplace(rule.get()); }
     }
-    return rule_targets;
+    return rule_refs;
+}
+
+std::set<scanner *> references_to_scanners(const std::vector<parser::reference_spec> &references,
+    const parser::scanner_container &scanners, const scanner_tag_map &scanners_by_tags)
+{
+    std::set<scanner *> scanner_refs;
+    for (const auto &ref : references) {
+        if (ref.type == parser::reference_type::id) {
+            auto it = scanners.find(ref.ref_id);
+            if (it == scanners.end()) {
+                continue;
+            }
+            scanner_refs.emplace(it->second.get());
+        } else if (ref.type == parser::reference_type::tags) {
+            auto current_refs = scanners_by_tags.multifind(ref.tags);
+            scanner_refs.merge(current_refs);
+        }
+    }
+    return scanner_refs;
 }
 
 } // namespace
@@ -71,7 +90,8 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
     constexpr static change_state base_rule_update = change_state::rules | change_state::overrides;
     constexpr static change_state filters_update =
         base_rule_update | change_state::custom_rules | change_state::filters;
-
+    constexpr static change_state processors_update =
+        change_state::processors | change_state::scanners;
     // When a configuration with 'rules' or 'rules_override' is received, we
     // need to regenerate the ruleset from the base rules as we want to ensure
     // that there are no side-effects on running contexts.
@@ -91,7 +111,7 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
 
         for (const auto &ovrd : overrides_.by_tags) {
             auto rule_targets =
-                target_to_rules(ovrd.targets, final_base_rules_, base_rules_by_tags_);
+                references_to_rules(ovrd.targets, final_base_rules_, base_rules_by_tags_);
             for (const auto &rule_ptr : rule_targets) {
                 if (ovrd.enabled.has_value()) {
                     rule_ptr->toggle(*ovrd.enabled);
@@ -105,7 +125,7 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
 
         for (const auto &ovrd : overrides_.by_ids) {
             auto rule_targets =
-                target_to_rules(ovrd.targets, final_base_rules_, base_rules_by_tags_);
+                references_to_rules(ovrd.targets, final_base_rules_, base_rules_by_tags_);
             for (const auto &rule_ptr : rule_targets) {
                 if (ovrd.enabled.has_value()) {
                     rule_ptr->toggle(*ovrd.enabled);
@@ -141,9 +161,9 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
         // First generate rule filters
         for (const auto &[id, filter] : exclusions_.rule_filters) {
             auto rule_targets =
-                target_to_rules(filter.targets, final_base_rules_, base_rules_by_tags_);
+                references_to_rules(filter.targets, final_base_rules_, base_rules_by_tags_);
             rule_targets.merge(
-                target_to_rules(filter.targets, final_user_rules_, user_rules_by_tags_));
+                references_to_rules(filter.targets, final_user_rules_, user_rules_by_tags_));
 
             auto filter_ptr = std::make_shared<exclusion::rule_filter>(
                 id, filter.expr, std::move(rule_targets), filter.on_match);
@@ -153,13 +173,38 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
         // Finally input filters
         for (auto &[id, filter] : exclusions_.input_filters) {
             auto rule_targets =
-                target_to_rules(filter.targets, final_base_rules_, base_rules_by_tags_);
+                references_to_rules(filter.targets, final_base_rules_, base_rules_by_tags_);
             rule_targets.merge(
-                target_to_rules(filter.targets, final_user_rules_, user_rules_by_tags_));
+                references_to_rules(filter.targets, final_user_rules_, user_rules_by_tags_));
 
             auto filter_ptr = std::make_shared<exclusion::input_filter>(
                 id, filter.expr, std::move(rule_targets), filter.filter);
             input_filters_.emplace(filter_ptr->get_id(), filter_ptr);
+        }
+    }
+
+    // Generate new processors
+    if ((state & processors_update) != change_state::none) {
+        if ((state & change_state::scanners) != change_state::none) {
+            scanners_by_tags_.clear();
+
+            for (auto &[id, scanner] : scanners_) {
+                scanners_by_tags_.insert(scanner->get_tags(), scanner.get());
+            }
+        }
+
+        for (auto &[id, spec] : processors_.pre) {
+            auto scanners = references_to_scanners(spec.scanners, scanners_, scanners_by_tags_);
+            auto proc = std::make_shared<processor>(id, spec.generator, spec.expr, spec.mappings,
+                std::move(scanners), spec.evaluate, spec.output);
+            preprocessors_.emplace(proc->get_id(), std::move(proc));
+        }
+
+        for (auto &[id, spec] : processors_.post) {
+            auto scanners = references_to_scanners(spec.scanners, scanners_, scanners_by_tags_);
+            auto proc = std::make_shared<processor>(id, spec.generator, spec.expr, spec.mappings,
+                std::move(scanners), spec.evaluate, spec.output);
+            postprocessors_.emplace(proc->get_id(), std::move(proc));
         }
     }
 
@@ -171,8 +216,8 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
     rs->dynamic_matchers = dynamic_matchers_;
     rs->rule_filters = rule_filters_;
     rs->input_filters = input_filters_;
-    rs->preprocessors = processors_.pre;
-    rs->postprocessors = processors_.post;
+    rs->preprocessors = preprocessors_;
+    rs->postprocessors = postprocessors_;
     rs->free_fn = free_fn_;
     rs->event_obfuscator = event_obfuscator_;
 

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -185,6 +185,9 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
 
     // Generate new processors
     if ((state & processors_update) != change_state::none) {
+        preprocessors_.clear();
+        postprocessors_.clear();
+
         if ((state & change_state::scanners) != change_state::none) {
             scanners_by_tags_.clear();
 
@@ -218,6 +221,7 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
     rs->input_filters = input_filters_;
     rs->preprocessors = preprocessors_;
     rs->postprocessors = postprocessors_;
+    rs->scanners = scanners_;
     rs->free_fn = free_fn_;
     rs->event_obfuscator = event_obfuscator_;
 

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -33,7 +33,7 @@ constexpr ruleset_builder::change_state operator&(
 
 namespace {
 
-std::set<rule *> target_to_rules(const std::vector<parser::rule_target_spec> &targets,
+std::set<rule *> target_to_rules(const std::vector<parser::reference_target_spec> &targets,
     const std::unordered_map<std::string_view, rule::ptr> &rules, const rule_tag_map &rules_by_tags)
 {
     std::set<rule *> rule_targets;

--- a/src/ruleset_builder.hpp
+++ b/src/ruleset_builder.hpp
@@ -50,6 +50,7 @@ protected:
         filters = 8,
         data = 16,
         processors = 32,
+        scanners = 64,
     };
 
     friend constexpr change_state operator|(change_state lhs, change_state rhs);
@@ -86,6 +87,8 @@ protected:
     parser::filter_spec_container exclusions_;
     // Obtained from 'processors'
     parser::processor_container processors_;
+    // Obtained from 'scanners'
+    parser::scanner_container scanners_;
 
     // These are the contents of the latest generated ruleset
 
@@ -100,7 +103,6 @@ protected:
     // Filters
     std::unordered_map<std::string_view, exclusion::rule_filter::ptr> rule_filters_;
     std::unordered_map<std::string_view, exclusion::input_filter::ptr> input_filters_;
-    // The list of targets used by rule_filters_, input_filters_ and their internal
 };
 
 } // namespace ddwaf

--- a/src/ruleset_builder.hpp
+++ b/src/ruleset_builder.hpp
@@ -18,6 +18,9 @@
 
 namespace ddwaf {
 
+using rule_tag_map = ddwaf::multi_key_map<std::string_view, rule *>;
+using scanner_tag_map = ddwaf::multi_key_map<std::string_view, scanner *>;
+
 class ruleset_builder {
 public:
     using ptr = std::shared_ptr<ruleset_builder>;
@@ -103,6 +106,13 @@ protected:
     // Filters
     std::unordered_map<std::string_view, exclusion::rule_filter::ptr> rule_filters_;
     std::unordered_map<std::string_view, exclusion::input_filter::ptr> input_filters_;
+
+    // An mkmap organising scanners by their tags, used for processors
+    scanner_tag_map scanners_by_tags_;
+
+    // Processors
+    std::unordered_map<std::string_view, processor::ptr> preprocessors_;
+    std::unordered_map<std::string_view, processor::ptr> postprocessors_;
 };
 
 } // namespace ddwaf

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -41,9 +41,10 @@ public:
         ddwaf_object key_obj;
         if (key.data() != nullptr && !key.empty()) {
             ddwaf_object_stringl_nc(&key_obj, key.data(), key.size());
-            return eval(key_obj, value);
+        } else {
+            ddwaf_object_invalid(&key_obj);
         }
-        return false;
+        return eval(key_obj, value);
     }
 
     const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }
@@ -52,7 +53,10 @@ public:
 protected:
     static bool eval_matcher(const matcher::base::unique_ptr &matcher, const ddwaf_object &obj)
     {
-        return matcher ? matcher->match(obj).first : true;
+        if (!matcher || obj.type == DDWAF_OBJ_INVALID) {
+            return true;
+        }
+        return matcher->match(obj).first;
     }
 
     std::string id_;

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <matcher/base.hpp>
+
+namespace ddwaf {
+class scanner {
+public:
+    using ptr = std::shared_ptr<scanner>;
+
+    scanner(std::string id, std::string name, std::unordered_map<std::string, std::string> tags,
+        matcher::base::unique_ptr key_matcher, matcher::base::unique_ptr value_matcher)
+        : id_(std::move(id)), name_(std::move(name)), tags_(std::move(tags)),
+          key_matcher_(std::move(key_matcher)), value_matcher_(std::move(value_matcher))
+    {}
+
+    scanner(const scanner &) = delete;
+    scanner &operator=(const scanner &) = delete;
+
+    scanner(scanner &&) = default;
+    scanner &operator=(scanner &&) = default;
+
+    virtual ~scanner() = default;
+
+    bool eval(const ddwaf_object &key, const ddwaf_object &value) const
+    {
+        return eval_matcher(key_matcher_, key) && eval_matcher(value_matcher_, value);
+    }
+
+    constexpr const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }
+    constexpr std::string_view get_id() const { return id_; }
+    constexpr std::string_view get_name() const { return name_; }
+
+protected:
+    static bool eval_matcher(const matcher::base::unique_ptr &matcher, const ddwaf_object &obj)
+    {
+        return matcher ? matcher->match(obj).first : true;
+    }
+
+    std::string id_;
+    std::string name_;
+    std::unordered_map<std::string, std::string> tags_;
+    matcher::base::unique_ptr key_matcher_;
+    matcher::base::unique_ptr value_matcher_;
+};
+
+} // namespace ddwaf

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include <matcher/base.hpp>
@@ -16,9 +17,9 @@ class scanner {
 public:
     using ptr = std::shared_ptr<scanner>;
 
-    scanner(std::string id, std::string name, std::unordered_map<std::string, std::string> tags,
+    scanner(std::string id, std::unordered_map<std::string, std::string> tags,
         matcher::base::unique_ptr key_matcher, matcher::base::unique_ptr value_matcher)
-        : id_(std::move(id)), name_(std::move(name)), tags_(std::move(tags)),
+        : id_(std::move(id)), tags_(std::move(tags)),
           key_matcher_(std::move(key_matcher)), value_matcher_(std::move(value_matcher))
     {}
 
@@ -35,9 +36,8 @@ public:
         return eval_matcher(key_matcher_, key) && eval_matcher(value_matcher_, value);
     }
 
-    constexpr const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }
-    constexpr std::string_view get_id() const { return id_; }
-    constexpr std::string_view get_name() const { return name_; }
+    const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }
+    std::string_view get_id() const { return id_; }
 
 protected:
     static bool eval_matcher(const matcher::base::unique_ptr &matcher, const ddwaf_object &obj)
@@ -46,7 +46,6 @@ protected:
     }
 
     std::string id_;
-    std::string name_;
     std::unordered_map<std::string, std::string> tags_;
     matcher::base::unique_ptr key_matcher_;
     matcher::base::unique_ptr value_matcher_;

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -39,7 +39,9 @@ public:
     bool eval(std::string_view key, const ddwaf_object &value) const
     {
         ddwaf_object key_obj;
-        ddwaf_object_stringl_nc(&key_obj, key.data(), key.size());
+        if (key.data() != nullptr && !key.empty()) {
+            ddwaf_object_stringl_nc(&key_obj, key.data(), key.size());
+        }
         return eval(key_obj, value);
     }
 

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -41,8 +41,9 @@ public:
         ddwaf_object key_obj;
         if (key.data() != nullptr && !key.empty()) {
             ddwaf_object_stringl_nc(&key_obj, key.data(), key.size());
+            return eval(key_obj, value);
         }
-        return eval(key_obj, value);
+        return false;
     }
 
     const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -19,8 +19,8 @@ public:
 
     scanner(std::string id, std::unordered_map<std::string, std::string> tags,
         matcher::base::unique_ptr key_matcher, matcher::base::unique_ptr value_matcher)
-        : id_(std::move(id)), tags_(std::move(tags)),
-          key_matcher_(std::move(key_matcher)), value_matcher_(std::move(value_matcher))
+        : id_(std::move(id)), tags_(std::move(tags)), key_matcher_(std::move(key_matcher)),
+          value_matcher_(std::move(value_matcher))
     {}
 
     scanner(const scanner &) = delete;
@@ -34,6 +34,13 @@ public:
     bool eval(const ddwaf_object &key, const ddwaf_object &value) const
     {
         return eval_matcher(key_matcher_, key) && eval_matcher(value_matcher_, value);
+    }
+
+    bool eval(std::string_view key, const ddwaf_object &value) const
+    {
+        ddwaf_object key_obj;
+        ddwaf_object_stringl_nc(&key_obj, key.data(), key.size());
+        return eval(key_obj, value);
     }
 
     const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }

--- a/tests/context_test.cpp
+++ b/tests/context_test.cpp
@@ -88,7 +88,7 @@ public:
 
 class processor : public ddwaf::processor {
 public:
-    processor() : ddwaf::processor({}, {}, {}, {}, true, true) {}
+    processor() : ddwaf::processor({}, {}, {}, {}, {}, true, true) {}
     ~processor() override = default;
 
     MOCK_METHOD(void, eval,

--- a/tests/generator/extract_schema_test.cpp
+++ b/tests/generator/extract_schema_test.cpp
@@ -21,7 +21,7 @@ TEST(TestExtractSchema, UnknownScalarSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([0])");
 
     ddwaf_object_free(&output);
@@ -35,7 +35,7 @@ TEST(TestExtractSchema, NullScalarSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([1])");
 
     ddwaf_object_free(&output);
@@ -49,7 +49,7 @@ TEST(TestExtractSchema, BoolScalarSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([2])");
 
     ddwaf_object_free(&output);
@@ -64,7 +64,7 @@ TEST(TestExtractSchema, IntScalarSchema)
         generator::extract_schema gen;
 
         ddwaf::timer deadline{2s};
-        auto output = gen.generate(&input, deadline);
+        auto output = gen.generate(&input, {}, deadline);
         EXPECT_SCHEMA_EQ(output, R"([4])");
 
         ddwaf_object_free(&output);
@@ -75,7 +75,7 @@ TEST(TestExtractSchema, IntScalarSchema)
         generator::extract_schema gen;
 
         ddwaf::timer deadline{2s};
-        auto output = gen.generate(&input, deadline);
+        auto output = gen.generate(&input, {}, deadline);
         EXPECT_SCHEMA_EQ(output, R"([4])");
 
         ddwaf_object_free(&output);
@@ -90,7 +90,7 @@ TEST(TestExtractSchema, StringScalarSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([8])");
 
     ddwaf_object_free(&output);
@@ -105,7 +105,7 @@ TEST(TestExtractSchema, FloatScalarSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([16])");
 
     ddwaf_object_free(&output);
@@ -119,7 +119,7 @@ TEST(TestExtractSchema, EmptyArraySchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([[],{"len":0}])");
 
     ddwaf_object_free(&output);
@@ -138,7 +138,7 @@ TEST(TestExtractSchema, ArraySchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([[[1],[0],[8],[4]],{"len":4}])");
 
     ddwaf_object_free(&output);
@@ -158,7 +158,7 @@ TEST(TestExtractSchema, ArrayWithDuplicateScalarSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([[[8]],{"len":4}])");
 
     ddwaf_object_free(&output);
@@ -194,7 +194,7 @@ TEST(TestExtractSchema, ArrayWithDuplicateMapsSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output,
         R"([[[{"unsigned":[4]}],[{"signed":[4]}],[{"string":[8],"unsigned":[4]}]],{"len":4}])");
 
@@ -231,7 +231,7 @@ TEST(TestExtractSchema, ArrayWithDuplicateArraysSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([[[[[4]],{"len":1}],[[[8],[4]],{"len":2}]],{"len":4}])");
 
     ddwaf_object_free(&output);
@@ -267,7 +267,7 @@ TEST(TestExtractSchema, ArrayWithDuplicateContainersSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([[[[[4]],{"len":1}],[{"string":[8],"unsigned":[4]}]],{"len":4}])");
 
     ddwaf_object_free(&output);
@@ -282,7 +282,7 @@ TEST(TestExtractSchema, EmptyMapSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([{}])");
 
     ddwaf_object_free(&output);
@@ -311,7 +311,7 @@ TEST(TestExtractSchema, MapSchema)
     generator::extract_schema gen;
 
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output,
         R"([{"array":[[[4]],{"len":1}],"invalid":[0],"map":[{"unsigned":[4],"string":[8]}],"null":[1],"string":[8],"unsigned":[4]}])");
     ddwaf_object_free(&output);
@@ -333,7 +333,7 @@ TEST(TestExtractSchema, DepthLimit)
 
     generator::extract_schema gen;
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output,
         R"([[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}]],{"len":1}])");
 
@@ -353,7 +353,7 @@ TEST(TestExtractSchema, ArrayNodesLimit)
 
     generator::extract_schema gen;
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([[[[],{"len":0}]],{"len":20,"truncated":true}])");
 
     ddwaf_object_free(&output);
@@ -372,7 +372,7 @@ TEST(TestExtractSchema, RecordNodesLimit)
 
     generator::extract_schema gen;
     ddwaf::timer deadline{2s};
-    auto output = gen.generate(&input, deadline);
+    auto output = gen.generate(&input, {}, deadline);
     EXPECT_SCHEMA_EQ(output, R"([{"child":[[],{"len":0}]},{"truncated":true}])");
 
     ddwaf_object_free(&output);

--- a/tests/generator/extract_schema_test.cpp
+++ b/tests/generator/extract_schema_test.cpp
@@ -11,18 +11,6 @@
 using namespace ddwaf;
 using namespace std::literals;
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage)
-#define EXPECT_SCHEMA_EQ(obtained, expected)                                                       \
-  {                                                                                                \
-    auto obtained_doc = test::object_to_rapidjson(obtained);                                       \
-    EXPECT_TRUE(ValidateSchemaSchema(obtained_doc));                                               \
-    rapidjson::Document expected_doc;                                                              \
-    expected_doc.Parse(expected);                                                                  \
-    EXPECT_FALSE(expected_doc.HasParseError());                                                    \
-    EXPECT_TRUE(json_equals(obtained_doc, expected_doc)) << test::object_to_json(obtained);        \
-  }
-// NOLINTEND(cppcoreguidelines-macro-usage)
-
 namespace {
 
 TEST(TestExtractSchema, UnknownScalarSchema)
@@ -421,7 +409,7 @@ TEST(TestExtractSchema, SchemaWithMultipleScanners)
     scanner scnr1{"1", {{"type", "PII"}, {"category", "second"}}, nullptr,
         std::make_unique<matcher::regex_match>("string", 6, true)};
     scanner scnr2{"2", {{"type", "PII"}, {"category", "third"}}, nullptr,
-        std::make_unique<matcher::regex_match>("string", 6, true)};
+        std::make_unique<matcher::regex_match>("stng", 4, true)};
 
     ddwaf::timer deadline{2s};
     auto output = gen.generate(&input, {&scnr0, &scnr1, &scnr2}, deadline);

--- a/tests/integration/processors/ruleset/processor_with_scanner_by_id.json
+++ b/tests/integration/processors/ruleset/processor_with_scanner_by_id.json
@@ -1,0 +1,98 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.8.0"
+  },
+  "rules": [
+    {
+      "id": "rule1",
+      "name": "rule1",
+      "tags": {
+        "type": "flow1",
+        "category": "category1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.body.schema"
+              }
+            ],
+            "value": 8,
+            "type": "unsigned"
+          },
+          "operator": "equals"
+        }
+      ]
+    }
+  ],
+  "processors": [
+    {
+      "id": "processor-001",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "value": true,
+            "type": "boolean"
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "output": "server.request.body.schema"
+          }
+        ],
+        "scanners": [
+            {
+                "id": "scanner-001"
+            }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    }
+  ],
+  "scanners": [
+    {
+      "id": "scanner-001",
+      "key": {
+          "operator": "match_regex",
+          "parameters": {
+            "regex": "(?:email|mail)",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          }
+      },
+      "value": {
+          "operator": "match_regex",
+          "parameters": {
+            "regex": "\\b[\\w!#$%&'*+\\/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+\\/=?`{|}~^-]+)*(%40|@)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}\\b",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          }
+      },
+      "tags": { "type": "email", "category": "pii" }
+    }
+  ]
+}

--- a/tests/integration/processors/ruleset/processor_with_scanner_by_tags.json
+++ b/tests/integration/processors/ruleset/processor_with_scanner_by_tags.json
@@ -1,0 +1,101 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.8.0"
+  },
+  "rules": [
+    {
+      "id": "rule1",
+      "name": "rule1",
+      "tags": {
+        "type": "flow1",
+        "category": "category1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.body.schema"
+              }
+            ],
+            "value": 8,
+            "type": "unsigned"
+          },
+          "operator": "equals"
+        }
+      ]
+    }
+  ],
+  "processors": [
+    {
+      "id": "processor-001",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "value": true,
+            "type": "boolean"
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "output": "server.request.body.schema"
+          }
+        ],
+        "scanners": [
+            {
+                "tags": {
+                    "category": "pii",
+                    "type": "email"
+                }
+            }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    }
+  ],
+  "scanners": [
+    {
+      "id": "scanner-001",
+      "key": {
+          "operator": "match_regex",
+          "parameters": {
+            "regex": "(?:email|mail)",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          }
+      },
+      "value": {
+          "operator": "match_regex",
+          "parameters": {
+            "regex": "\\b[\\w!#$%&'*+\\/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+\\/=?`{|}~^-]+)*(%40|@)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}\\b",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          }
+      },
+      "tags": { "type": "email", "category": "pii" }
+    }
+  ]
+}

--- a/tests/integration/processors/test.cpp
+++ b/tests/integration/processors/test.cpp
@@ -448,4 +448,156 @@ TEST(TestProcessors, ProcessorAndScannerUpdate)
     ddwaf_destroy(handle);
 }
 
+TEST(TestProcessors, EmptyScannerUpdate)
+{
+    auto rule = read_json_file("processor_with_scanner_by_tags.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object value;
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(
+            out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        auto new_ruleset = json_to_object(R"({"scanners":[]})");
+        auto *new_handle = ddwaf_update(handle, &new_ruleset, nullptr);
+        ddwaf_object_free(&new_ruleset);
+        ddwaf_destroy(handle);
+
+        handle = new_handle;
+    }
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(out.derivatives.array[0], R"([{"email":[8]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestProcessors, EmptyProcessorUpdate)
+{
+    auto rule = read_json_file("processor_with_scanner_by_tags.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object value;
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(
+            out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        auto new_ruleset = json_to_object(R"({"processors":[]})");
+        auto *new_handle = ddwaf_update(handle, &new_ruleset, nullptr);
+        ddwaf_object_free(&new_ruleset);
+        ddwaf_destroy(handle);
+
+        handle = new_handle;
+    }
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
 } // namespace

--- a/tests/integration/processors/test.cpp
+++ b/tests/integration/processors/test.cpp
@@ -10,7 +10,6 @@ using namespace ddwaf;
 
 namespace {
 constexpr std::string_view base_dir = "integration/processors/";
-} // namespace
 
 TEST(TestProcessors, Postprocessor)
 {
@@ -139,3 +138,314 @@ TEST(TestProcessors, Processor)
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
+
+TEST(TestProcessors, ProcessorWithScannerByTags)
+{
+    auto rule = read_json_file("processor_with_scanner_by_tags.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object value;
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+    ddwaf_object values = DDWAF_OBJECT_MAP;
+    ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+    ddwaf_object_string(&value, "data@datadoghq.com");
+    ddwaf_object_map_add(&values, "email", &value);
+    ddwaf_object_map_add(&map, "server.request.body", &values);
+
+    ddwaf_object_bool(&value, true);
+    ddwaf_object_map_add(&settings, "extract-schema", &value);
+    ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_result out;
+    ddwaf_run(context, &map, &out, 2000);
+    EXPECT_FALSE(out.timeout);
+    EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+    EXPECT_SCHEMA_EQ(
+        out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+    ddwaf_result_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestProcessors, ProcessorWithScannerByID)
+{
+    auto rule = read_json_file("processor_with_scanner_by_id.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object value;
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+    ddwaf_object values = DDWAF_OBJECT_MAP;
+    ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+    ddwaf_object_string(&value, "data@datadoghq.com");
+    ddwaf_object_map_add(&values, "email", &value);
+    ddwaf_object_map_add(&map, "server.request.body", &values);
+
+    ddwaf_object_bool(&value, true);
+    ddwaf_object_map_add(&settings, "extract-schema", &value);
+    ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_result out;
+    ddwaf_run(context, &map, &out, 2000);
+    EXPECT_FALSE(out.timeout);
+    EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+    EXPECT_SCHEMA_EQ(
+        out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+    ddwaf_result_free(&out);
+    ddwaf_context_destroy(context);
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestProcessors, ProcessorUpdate)
+{
+    auto rule = read_json_file("processor_with_scanner_by_tags.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object value;
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(
+            out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        auto new_ruleset = read_json_file("postprocessor.json", base_dir);
+        auto *new_handle = ddwaf_update(handle, &new_ruleset, nullptr);
+        ddwaf_object_free(&new_ruleset);
+        ddwaf_destroy(handle);
+
+        handle = new_handle;
+    }
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(out.derivatives.array[0], R"([{"email":[8]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestProcessors, ScannerUpdate)
+{
+    auto rule = read_json_file("processor_with_scanner_by_tags.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object value;
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(
+            out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        auto new_scanners = json_to_object(
+            R"({"scanners":[{"id":"scanner-002","value":{"operator":"match_regex","parameters":{"regex":"notanemail","options":{"case_sensitive":false,"min_length":1}}},"tags":{"type":"email","category":"pii"}}]})");
+        auto *new_handle = ddwaf_update(handle, &new_scanners, nullptr);
+        ddwaf_object_free(&new_scanners);
+        ddwaf_destroy(handle);
+
+        handle = new_handle;
+    }
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "notanemail");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(
+            out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestProcessors, ProcessorAndScannerUpdate)
+{
+    auto rule = read_json_file("processor_with_scanner_by_tags.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object value;
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(
+            out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        auto new_ruleset = read_json_file("processor_with_scanner_by_id.json", base_dir);
+        auto *new_handle = ddwaf_update(handle, &new_ruleset, nullptr);
+        ddwaf_object_free(&new_ruleset);
+        ddwaf_destroy(handle);
+
+        handle = new_handle;
+    }
+
+    {
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+        ddwaf_object values = DDWAF_OBJECT_MAP;
+        ddwaf_object settings = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_string(&value, "data@datadoghq.com");
+        ddwaf_object_map_add(&values, "email", &value);
+        ddwaf_object_map_add(&map, "server.request.body", &values);
+
+        ddwaf_object_bool(&value, true);
+        ddwaf_object_map_add(&settings, "extract-schema", &value);
+        ddwaf_object_map_add(&map, "waf.context.processor", &settings);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_result out;
+        ddwaf_run(context, &map, &out, 2000);
+        EXPECT_FALSE(out.timeout);
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        EXPECT_SCHEMA_EQ(
+            out.derivatives.array[0], R"([{"email":[8,{"category":"pii","type":"email"}]}])");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+} // namespace

--- a/tests/mkmap_test.cpp
+++ b/tests/mkmap_test.cpp
@@ -11,6 +11,8 @@
 using namespace ddwaf;
 using namespace std::literals;
 
+using rule_tag_map = ddwaf::multi_key_map<std::string_view, rule *>;
+
 namespace {
 
 TEST(TestMultiKeyMap, Find)

--- a/tests/parser_v2_input_filters_test.cpp
+++ b/tests/parser_v2_input_filters_test.cpp
@@ -218,8 +218,8 @@ TEST(TestParserV2InputFilters, ParseUnconditionalTargetID)
     EXPECT_TRUE(filter.filter);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::id);
-    EXPECT_STR(target.rule_id, "2939");
+    EXPECT_EQ(target.type, parser::reference_type::id);
+    EXPECT_STR(target.ref_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
 }
 
@@ -266,8 +266,8 @@ TEST(TestParserV2InputFilters, ParseUnconditionalTargetTags)
     EXPECT_TRUE(filter.filter);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::tags);
-    EXPECT_TRUE(target.rule_id.empty());
+    EXPECT_EQ(target.type, parser::reference_type::tags);
+    EXPECT_TRUE(target.ref_id.empty());
     EXPECT_EQ(target.tags.size(), 2);
     EXPECT_STR(target.tags.find("type")->second, "rule");
     EXPECT_STR(target.tags.find("category")->second, "unknown");
@@ -316,8 +316,8 @@ TEST(TestParserV2InputFilters, ParseUnconditionalTargetPriority)
     EXPECT_TRUE(filter.filter);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::id);
-    EXPECT_STR(target.rule_id, "2939");
+    EXPECT_EQ(target.type, parser::reference_type::id);
+    EXPECT_STR(target.ref_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
 }
 
@@ -365,15 +365,15 @@ TEST(TestParserV2InputFilters, ParseUnconditionalMultipleTargets)
 
     {
         const auto &target = filter.targets[0];
-        EXPECT_EQ(target.type, parser::target_type::id);
-        EXPECT_STR(target.rule_id, "2939");
+        EXPECT_EQ(target.type, parser::reference_type::id);
+        EXPECT_STR(target.ref_id, "2939");
         EXPECT_EQ(target.tags.size(), 0);
     }
 
     {
         const auto &target = filter.targets[1];
-        EXPECT_EQ(target.type, parser::target_type::tags);
-        EXPECT_TRUE(target.rule_id.empty());
+        EXPECT_EQ(target.type, parser::reference_type::tags);
+        EXPECT_TRUE(target.ref_id.empty());
         EXPECT_EQ(target.tags.size(), 2);
         EXPECT_STR(target.tags.find("type")->second, "rule");
         EXPECT_STR(target.tags.find("category")->second, "unknown");
@@ -425,8 +425,8 @@ TEST(TestParserV2InputFilters, ParseMultipleUnconditional)
         EXPECT_TRUE(filter.filter);
 
         const auto &target = filter.targets[0];
-        EXPECT_EQ(target.type, parser::target_type::id);
-        EXPECT_STR(target.rule_id, "2939");
+        EXPECT_EQ(target.type, parser::reference_type::id);
+        EXPECT_STR(target.ref_id, "2939");
         EXPECT_EQ(target.tags.size(), 0);
     }
 
@@ -440,8 +440,8 @@ TEST(TestParserV2InputFilters, ParseMultipleUnconditional)
         EXPECT_TRUE(filter.filter);
 
         const auto &target = filter.targets[0];
-        EXPECT_EQ(target.type, parser::target_type::tags);
-        EXPECT_TRUE(target.rule_id.empty());
+        EXPECT_EQ(target.type, parser::reference_type::tags);
+        EXPECT_TRUE(target.ref_id.empty());
         EXPECT_EQ(target.tags.size(), 2);
         EXPECT_STR(target.tags.find("type")->second, "rule");
         EXPECT_STR(target.tags.find("category")->second, "unknown");
@@ -491,8 +491,8 @@ TEST(TestParserV2InputFilters, ParseConditionalSingleCondition)
     EXPECT_TRUE(filter.filter);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::id);
-    EXPECT_STR(target.rule_id, "2939");
+    EXPECT_EQ(target.type, parser::reference_type::id);
+    EXPECT_STR(target.ref_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
 }
 
@@ -538,8 +538,8 @@ TEST(TestParserV2InputFilters, ParseConditionalMultipleConditions)
     EXPECT_TRUE(filter.filter);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::id);
-    EXPECT_STR(target.rule_id, "2939");
+    EXPECT_EQ(target.type, parser::reference_type::id);
+    EXPECT_STR(target.ref_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
 }
 

--- a/tests/parser_v2_rule_filters_test.cpp
+++ b/tests/parser_v2_rule_filters_test.cpp
@@ -175,8 +175,8 @@ TEST(TestParserV2RuleFilters, ParseUnconditionalTargetID)
     EXPECT_EQ(filter.targets.size(), 1);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::id);
-    EXPECT_STR(target.rule_id, "2939");
+    EXPECT_EQ(target.type, parser::reference_type::id);
+    EXPECT_STR(target.ref_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
 }
 
@@ -222,8 +222,8 @@ TEST(TestParserV2RuleFilters, ParseUnconditionalTargetTags)
     EXPECT_EQ(filter.targets.size(), 1);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::tags);
-    EXPECT_TRUE(target.rule_id.empty());
+    EXPECT_EQ(target.type, parser::reference_type::tags);
+    EXPECT_TRUE(target.ref_id.empty());
     EXPECT_EQ(target.tags.size(), 2);
     EXPECT_STR(target.tags.find("type")->second, "rule");
     EXPECT_STR(target.tags.find("category")->second, "unknown");
@@ -271,8 +271,8 @@ TEST(TestParserV2RuleFilters, ParseUnconditionalTargetPriority)
     EXPECT_EQ(filter.targets.size(), 1);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::id);
-    EXPECT_STR(target.rule_id, "2939");
+    EXPECT_EQ(target.type, parser::reference_type::id);
+    EXPECT_STR(target.ref_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
 }
 
@@ -319,15 +319,15 @@ TEST(TestParserV2RuleFilters, ParseUnconditionalMultipleTargets)
 
     {
         const auto &target = filter.targets[0];
-        EXPECT_EQ(target.type, parser::target_type::id);
-        EXPECT_STR(target.rule_id, "2939");
+        EXPECT_EQ(target.type, parser::reference_type::id);
+        EXPECT_STR(target.ref_id, "2939");
         EXPECT_EQ(target.tags.size(), 0);
     }
 
     {
         const auto &target = filter.targets[1];
-        EXPECT_EQ(target.type, parser::target_type::tags);
-        EXPECT_TRUE(target.rule_id.empty());
+        EXPECT_EQ(target.type, parser::reference_type::tags);
+        EXPECT_TRUE(target.ref_id.empty());
         EXPECT_EQ(target.tags.size(), 2);
         EXPECT_STR(target.tags.find("type")->second, "rule");
         EXPECT_STR(target.tags.find("category")->second, "unknown");
@@ -378,8 +378,8 @@ TEST(TestParserV2RuleFilters, ParseMultipleUnconditional)
         EXPECT_EQ(filter.targets.size(), 1);
 
         const auto &target = filter.targets[0];
-        EXPECT_EQ(target.type, parser::target_type::id);
-        EXPECT_STR(target.rule_id, "2939");
+        EXPECT_EQ(target.type, parser::reference_type::id);
+        EXPECT_STR(target.ref_id, "2939");
         EXPECT_EQ(target.tags.size(), 0);
     }
 
@@ -392,8 +392,8 @@ TEST(TestParserV2RuleFilters, ParseMultipleUnconditional)
         EXPECT_EQ(filter.targets.size(), 1);
 
         const auto &target = filter.targets[0];
-        EXPECT_EQ(target.type, parser::target_type::tags);
-        EXPECT_TRUE(target.rule_id.empty());
+        EXPECT_EQ(target.type, parser::reference_type::tags);
+        EXPECT_TRUE(target.ref_id.empty());
         EXPECT_EQ(target.tags.size(), 2);
         EXPECT_STR(target.tags.find("type")->second, "rule");
         EXPECT_STR(target.tags.find("category")->second, "unknown");
@@ -458,8 +458,8 @@ TEST(TestParserV2RuleFilters, ParseConditionalSingleCondition)
     EXPECT_EQ(filter.targets.size(), 1);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::id);
-    EXPECT_STR(target.rule_id, "2939");
+    EXPECT_EQ(target.type, parser::reference_type::id);
+    EXPECT_STR(target.ref_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
 }
 
@@ -549,8 +549,8 @@ TEST(TestParserV2RuleFilters, ParseConditionalMultipleConditions)
     EXPECT_EQ(filter.on_match, exclusion::filter_mode::bypass);
 
     const auto &target = filter.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::id);
-    EXPECT_STR(target.rule_id, "2939");
+    EXPECT_EQ(target.type, parser::reference_type::id);
+    EXPECT_STR(target.ref_id, "2939");
     EXPECT_EQ(target.tags.size(), 0);
 }
 

--- a/tests/parser_v2_rules_override_test.cpp
+++ b/tests/parser_v2_rules_override_test.cpp
@@ -124,8 +124,8 @@ TEST(TestParserV2RulesOverride, ParseRuleOverride)
     EXPECT_EQ(ovrd.targets.size(), 1);
 
     auto &target = ovrd.targets[0];
-    EXPECT_EQ(target.type, parser::target_type::tags);
-    EXPECT_TRUE(target.rule_id.empty());
+    EXPECT_EQ(target.type, parser::reference_type::tags);
+    EXPECT_TRUE(target.ref_id.empty());
     EXPECT_EQ(target.tags.size(), 1);
     EXPECT_STR(target.tags["confidence"], "1");
 }
@@ -172,8 +172,8 @@ TEST(TestParserV2RulesOverride, ParseMultipleRuleOverrides)
         EXPECT_EQ(ovrd.targets.size(), 1);
 
         auto &target = ovrd.targets[0];
-        EXPECT_EQ(target.type, parser::target_type::tags);
-        EXPECT_TRUE(target.rule_id.empty());
+        EXPECT_EQ(target.type, parser::reference_type::tags);
+        EXPECT_TRUE(target.ref_id.empty());
         EXPECT_EQ(target.tags.size(), 1);
         EXPECT_STR(target.tags["confidence"], "1");
     }
@@ -186,8 +186,8 @@ TEST(TestParserV2RulesOverride, ParseMultipleRuleOverrides)
         EXPECT_EQ(ovrd.targets.size(), 1);
 
         auto &target = ovrd.targets[0];
-        EXPECT_EQ(target.type, parser::target_type::id);
-        EXPECT_STR(target.rule_id, "1");
+        EXPECT_EQ(target.type, parser::reference_type::id);
+        EXPECT_STR(target.ref_id, "1");
         EXPECT_EQ(target.tags.size(), 0);
     }
 }

--- a/tests/parser_v2_scanner_test.cpp
+++ b/tests/parser_v2_scanner_test.cpp
@@ -1,0 +1,526 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "parser/common.hpp"
+#include "parser/parser.hpp"
+#include "test_utils.hpp"
+
+using namespace ddwaf;
+
+namespace {
+
+TEST(TestParserV2Scanner, ParseKeyOnlyScanner)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"operator":"match_regex","parameters":{"regex":"email"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("ecd"), loaded.end());
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 1);
+    EXPECT_NE(scanners.find("ecd"), scanners.end());
+
+    scanner::ptr &scnr = scanners["ecd"];
+    EXPECT_STREQ(scnr->get_id().data(), "ecd");
+    std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
+    EXPECT_EQ(scnr->get_tags(), tags);
+
+    ddwaf_object value;
+    ddwaf_object_string(&value, "dog@datadoghq.com");
+    EXPECT_TRUE(scnr->eval("email", value));
+    EXPECT_FALSE(scnr->eval("mail", value));
+    ddwaf_object_free(&value);
+
+    ddwaf_object_string(&value, "ansodinsod");
+    EXPECT_TRUE(scnr->eval("email", value));
+    ddwaf_object_free(&value);
+}
+
+TEST(TestParserV2Scanner, ParseValueOnlyScanner)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","value":{"operator":"match_regex","parameters":{"regex":"@"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("ecd"), loaded.end());
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 1);
+    EXPECT_NE(scanners.find("ecd"), scanners.end());
+
+    scanner::ptr &scnr = scanners["ecd"];
+    EXPECT_STREQ(scnr->get_id().data(), "ecd");
+    std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
+    EXPECT_EQ(scnr->get_tags(), tags);
+
+    ddwaf_object value;
+    ddwaf_object_string(&value, "dog@datadoghq.com");
+    EXPECT_TRUE(scnr->eval("email", value));
+    EXPECT_TRUE(scnr->eval("mail", value));
+    ddwaf_object_free(&value);
+
+    ddwaf_object_string(&value, "ansodinsod");
+    EXPECT_FALSE(scnr->eval("email", value));
+    ddwaf_object_free(&value);
+}
+
+TEST(TestParserV2Scanner, ParseKeyValueScanner)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"operator":"match_regex","parameters":{"regex":"email"}},"value":{"operator":"match_regex","parameters":{"regex":"@"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("ecd"), loaded.end());
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 1);
+    EXPECT_NE(scanners.find("ecd"), scanners.end());
+
+    scanner::ptr &scnr = scanners["ecd"];
+    EXPECT_STREQ(scnr->get_id().data(), "ecd");
+    std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
+    EXPECT_EQ(scnr->get_tags(), tags);
+
+    ddwaf_object value;
+    ddwaf_object_string(&value, "dog@datadoghq.com");
+    EXPECT_TRUE(scnr->eval("email", value));
+    EXPECT_FALSE(scnr->eval("mail", value));
+    ddwaf_object_free(&value);
+
+    ddwaf_object_string(&value, "ansodinsod");
+    EXPECT_FALSE(scnr->eval("email", value));
+    ddwaf_object_free(&value);
+}
+
+TEST(TestParserV2Scanner, ParseNoID)
+{
+    auto definition = json_to_object(
+        R"([{"key":{"operator":"match_regex","parameters":{"regex":"email"}},"value":{"operator":"match_regex","parameters":{"regex":"@"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("index:0"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("missing key 'id'");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("index:0"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+
+TEST(TestParserV2Scanner, ParseNoTags)
+{
+    auto definition = json_to_object(
+        R"([{"id":"error","key":{"operator":"match_regex","parameters":{"regex":"email"}},"value":{"operator":"match_regex","parameters":{"regex":"@"}}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("error"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("missing key 'tags'");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("error"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+
+TEST(TestParserV2Scanner, ParseNoKeyValue)
+{
+    auto definition =
+        json_to_object(R"([{"id":"error","tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("error"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("scanner has no key or value matcher");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("error"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+
+TEST(TestParserV2Scanner, ParseDuplicate)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"operator":"match_regex","parameters":{"regex":"email"}},"tags":{"type":"email","category":"pii"}},{"id":"ecd","key":{"operator":"match_regex","parameters":{"regex":"email"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("ecd"), loaded.end());
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("ecd"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("duplicate scanner");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("ecd"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 1);
+}
+
+TEST(TestParserV2Scanner, ParseKeyNoOperator)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"parameters":{"regex":"email"}},"value":{"operator":"match_regex","parameters":{"regex":"email"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("ecd"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("missing key 'operator'");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("ecd"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+
+TEST(TestParserV2Scanner, ParseKeyNoParameters)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"operator":"match_regex"},"value":{"operator":"match_regex","parameters":{"regex":"email"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("ecd"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("missing key 'parameters'");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("ecd"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+
+TEST(TestParserV2Scanner, ParseValueNoOperator)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"operator":"match_regex","parameters":{"regex":"email"}},"value":{"parameters":{"regex":"email"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("ecd"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("missing key 'operator'");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("ecd"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+
+TEST(TestParserV2Scanner, ParseValueNoParameters)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"operator":"match_regex","parameters":{"regex":"email"}},"value":{"operator":"match_regex"},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("ecd"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("missing key 'parameters'");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("ecd"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+
+TEST(TestParserV2Scanner, ParseUnknownMatcher)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"operator":"what","parameters":{"regex":"email"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("ecd"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("unknown matcher: what");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("ecd"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+
+TEST(TestParserV2Scanner, ParseRuleDataID)
+{
+    auto definition = json_to_object(
+        R"([{"id":"ecd","key":{"operator":"exact_match","parameters":{"data":"invalid"}},"tags":{"type":"email","category":"pii"}}])");
+    auto scanners_array = static_cast<parameter::vector>(parameter(definition));
+
+    ddwaf::ruleset_info::section_info section;
+    auto scanners = parser::v2::parse_scanners(scanners_array, section);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("ecd"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("dynamic data on scanner condition");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("ecd"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(scanners.size(), 0);
+}
+} // namespace

--- a/tests/parser_v2_scanner_test.cpp
+++ b/tests/parser_v2_scanner_test.cpp
@@ -20,6 +20,7 @@ TEST(TestParserV2Scanner, ParseKeyOnlyScanner)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -67,6 +68,7 @@ TEST(TestParserV2Scanner, ParseValueOnlyScanner)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -114,6 +116,7 @@ TEST(TestParserV2Scanner, ParseKeyValueScanner)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -161,6 +164,7 @@ TEST(TestParserV2Scanner, ParseNoID)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -198,6 +202,7 @@ TEST(TestParserV2Scanner, ParseNoTags)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -235,6 +240,7 @@ TEST(TestParserV2Scanner, ParseNoKeyValue)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -272,6 +278,7 @@ TEST(TestParserV2Scanner, ParseDuplicate)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -310,6 +317,7 @@ TEST(TestParserV2Scanner, ParseKeyNoOperator)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -347,6 +355,7 @@ TEST(TestParserV2Scanner, ParseKeyNoParameters)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -384,6 +393,7 @@ TEST(TestParserV2Scanner, ParseValueNoOperator)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -421,6 +431,7 @@ TEST(TestParserV2Scanner, ParseValueNoParameters)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -458,6 +469,7 @@ TEST(TestParserV2Scanner, ParseUnknownMatcher)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;
@@ -495,6 +507,7 @@ TEST(TestParserV2Scanner, ParseRuleDataID)
 
     ddwaf::ruleset_info::section_info section;
     auto scanners = parser::v2::parse_scanners(scanners_array, section);
+    ddwaf_object_free(&definition);
 
     {
         ddwaf::parameter root;

--- a/tests/processor_test.cpp
+++ b/tests/processor_test.cpp
@@ -50,7 +50,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalUnconditional)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), false, true};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     ddwaf_object output_map;
@@ -103,7 +103,7 @@ TEST(TestProcessor, MultiMappingOutputNoEvalUnconditional)
             "output_address.second"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), false, true};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     ddwaf_object output_map;
@@ -159,7 +159,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalTrue)
     builder.start_condition<matcher::equals<bool>>(true);
     builder.add_target("enabled?");
 
-    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), false, true};
+    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), {}, false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     ddwaf_object output_map;
@@ -203,7 +203,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
     builder.start_condition<matcher::equals<bool>>(true);
     builder.add_target("enabled?");
 
-    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), false, true};
+    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), {}, false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     ddwaf_object output_map;
@@ -262,7 +262,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalFalse)
     builder.start_condition<matcher::equals<bool>>(true);
     builder.add_target("enabled?");
 
-    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), false, true};
+    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), {}, false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     ddwaf_object output_map;
@@ -303,7 +303,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), true, false};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, false};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     processor::cache_type cache;
@@ -352,7 +352,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
     builder.start_condition<matcher::equals<bool>>(true);
     builder.add_target("enabled?");
 
-    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), true, false};
+    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), {}, true, false};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     processor::cache_type cache;
@@ -397,7 +397,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalFalse)
     builder.start_condition<matcher::equals<bool>>(true);
     builder.add_target("enabled?");
 
-    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), true, false};
+    processor proc{"id", std::move(gen), builder.build(), std::move(mappings), {}, true, false};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     processor::cache_type cache;
@@ -445,7 +445,7 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
             "output_address.second"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), true, false};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, false};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     processor::cache_type cache;
@@ -492,7 +492,7 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), true, true};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     ddwaf_object output_map;
@@ -546,7 +546,7 @@ TEST(TestProcessor, OutputAlreadyAvailableInStore)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), false, true};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     ddwaf_object output_map;
@@ -581,7 +581,7 @@ TEST(TestProcessor, OutputAlreadyGenerated)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), false, true};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     ddwaf_object output_map;
@@ -618,7 +618,7 @@ TEST(TestProcessor, EvalAlreadyAvailableInStore)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), true, false};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, false};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     processor::cache_type cache;
@@ -647,7 +647,7 @@ TEST(TestProcessor, OutputWithoutDerivedMap)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), false, true};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     processor::cache_type cache;
@@ -679,7 +679,7 @@ TEST(TestProcessor, OutputEvalWithoutDerivedMap)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), true, true};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     processor::cache_type cache;
@@ -712,7 +712,7 @@ TEST(TestProcessor, Timeout)
         {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
 
     processor proc{
-        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), true, false};
+        "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, false};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
     processor::cache_type cache;

--- a/tests/processor_test.cpp
+++ b/tests/processor_test.cpp
@@ -22,8 +22,8 @@ namespace {
 namespace mock {
 class generator : public ddwaf::generator::base {
 public:
-    MOCK_METHOD(
-        ddwaf_object, generate, (const ddwaf_object *input, ddwaf::timer &deadline), (override));
+    MOCK_METHOD(ddwaf_object, generate,
+        (const ddwaf_object *, const std::set<scanner *> &, ddwaf::timer &), (override));
 };
 
 } // namespace mock
@@ -34,7 +34,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalUnconditional)
     ddwaf_object_string(&output, "output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).WillOnce(Return(output));
+    EXPECT_CALL(*gen, generate(_, _, _)).WillOnce(Return(output));
 
     ddwaf_object input;
     ddwaf_object_string(&input, "input_string");
@@ -79,7 +79,7 @@ TEST(TestProcessor, MultiMappingOutputNoEvalUnconditional)
     ddwaf_object_string(&second_output, "second_output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _))
+    EXPECT_CALL(*gen, generate(_, _, _))
         .WillOnce(Return(first_output))
         .WillOnce(Return(second_output));
 
@@ -138,7 +138,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalTrue)
     ddwaf_object_string(&output, "output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).WillOnce(Return(output));
+    EXPECT_CALL(*gen, generate(_, _, _)).WillOnce(Return(output));
 
     ddwaf_object tmp;
     ddwaf_object input;
@@ -186,7 +186,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
     ddwaf_object_string(&output, "output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).WillOnce(Return(output));
+    EXPECT_CALL(*gen, generate(_, _, _)).WillOnce(Return(output));
 
     ddwaf_object tmp;
     ddwaf_object input_map;
@@ -287,7 +287,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
     ddwaf_object_string(&output, "output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).WillOnce(Return(output));
+    EXPECT_CALL(*gen, generate(_, _, _)).WillOnce(Return(output));
 
     ddwaf_object input;
     ddwaf_object_string(&input, "input_string");
@@ -331,7 +331,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
     ddwaf_object_string(&output, "output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).WillOnce(Return(output));
+    EXPECT_CALL(*gen, generate(_, _, _)).WillOnce(Return(output));
 
     ddwaf_object tmp;
     ddwaf_object input;
@@ -421,7 +421,7 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
     ddwaf_object_string(&second_output, "second_output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _))
+    EXPECT_CALL(*gen, generate(_, _, _))
         .WillOnce(Return(first_output))
         .WillOnce(Return(second_output));
 
@@ -476,7 +476,7 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
     ddwaf_object_string(&output, "output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).WillOnce(Return(output));
+    EXPECT_CALL(*gen, generate(_, _, _)).WillOnce(Return(output));
 
     ddwaf_object input;
     ddwaf_object_string(&input, "input_string");
@@ -529,7 +529,7 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
 TEST(TestProcessor, OutputAlreadyAvailableInStore)
 {
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).Times(0);
+    EXPECT_CALL(*gen, generate(_, _, _)).Times(0);
 
     ddwaf_object input;
     ddwaf_object_string(&input, "input_string");
@@ -565,7 +565,7 @@ TEST(TestProcessor, OutputAlreadyAvailableInStore)
 TEST(TestProcessor, OutputAlreadyGenerated)
 {
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).Times(1);
+    EXPECT_CALL(*gen, generate(_, _, _)).Times(1);
 
     ddwaf_object input;
     ddwaf_object_string(&input, "input_string");
@@ -601,7 +601,7 @@ TEST(TestProcessor, OutputAlreadyGenerated)
 TEST(TestProcessor, EvalAlreadyAvailableInStore)
 {
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).Times(0);
+    EXPECT_CALL(*gen, generate(_, _, _)).Times(0);
 
     ddwaf_object input;
     ddwaf_object_string(&input, "input_string");
@@ -631,7 +631,7 @@ TEST(TestProcessor, EvalAlreadyAvailableInStore)
 TEST(TestProcessor, OutputWithoutDerivedMap)
 {
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).Times(0);
+    EXPECT_CALL(*gen, generate(_, _, _)).Times(0);
 
     ddwaf_object input;
     ddwaf_object_string(&input, "input_string");
@@ -663,7 +663,7 @@ TEST(TestProcessor, OutputEvalWithoutDerivedMap)
     ddwaf_object_string(&output, "output_string");
 
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).WillOnce(Return(output));
+    EXPECT_CALL(*gen, generate(_, _, _)).WillOnce(Return(output));
 
     ddwaf_object input;
     ddwaf_object_string(&input, "input_string");
@@ -704,7 +704,7 @@ TEST(TestProcessor, OutputEvalWithoutDerivedMap)
 TEST(TestProcessor, Timeout)
 {
     auto gen = std::make_unique<mock::generator>();
-    EXPECT_CALL(*gen, generate(_, _)).Times(0);
+    EXPECT_CALL(*gen, generate(_, _, _)).Times(0);
 
     object_store store;
 

--- a/tests/scanner_test.cpp
+++ b/tests/scanner_test.cpp
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "matcher/exact_match.hpp"
+#include "matcher/ip_match.hpp"
+#include "scanner.hpp"
+#include "test_utils.hpp"
+
+using namespace ddwaf;
+using namespace std::literals;
+
+namespace {
+TEST(TestScanner, SimpleMatch)
+{
+    matcher::base::unique_ptr key_matcher =
+        std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
+
+    matcher::base::unique_ptr value_matcher =
+        std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
+
+    scanner scnr{"0", "test", {{"type", "PII"}, {"category", "IP"}}, std::move(key_matcher),
+        std::move(value_matcher)};
+
+    ddwaf_object key;
+    ddwaf_object value;
+
+    ddwaf_object_string(&key, "hello");
+    ddwaf_object_string(&value, "192.168.0.1");
+
+    EXPECT_TRUE(scnr.eval(key, value));
+
+    ddwaf_object_free(&key);
+    ddwaf_object_free(&value);
+}
+
+} // namespace

--- a/tests/scanner_test.cpp
+++ b/tests/scanner_test.cpp
@@ -34,7 +34,7 @@ TEST(TestScanner, SimpleMatch)
 
     EXPECT_TRUE(scnr.eval(key, value));
 
-    std::string_view key_sv{key.stringValue, key.nbEntries};
+    std::string_view key_sv{key.stringValue, static_cast<std::size_t>(key.nbEntries)};
     EXPECT_TRUE(scnr.eval(key_sv, value));
 
     ddwaf_object_free(&key);
@@ -63,7 +63,7 @@ TEST(TestScanner, NoMatchOnKey)
 
     EXPECT_FALSE(scnr.eval(key, value));
 
-    std::string_view key_sv{key.stringValue, key.nbEntries};
+    std::string_view key_sv{key.stringValue, static_cast<std::size_t>(key.nbEntries)};
     EXPECT_FALSE(scnr.eval(key_sv, value));
 
     ddwaf_object_free(&key);
@@ -91,7 +91,7 @@ TEST(TestScanner, NoMatchOnValue)
 
     EXPECT_FALSE(scnr.eval(key, value));
 
-    std::string_view key_sv{key.stringValue, key.nbEntries};
+    std::string_view key_sv{key.stringValue, static_cast<std::size_t>(key.nbEntries)};
     EXPECT_FALSE(scnr.eval(key_sv, value));
 
     ddwaf_object_free(&key);

--- a/tests/scanner_test.cpp
+++ b/tests/scanner_test.cpp
@@ -82,5 +82,4 @@ TEST(TestScanner, NoMatchOnValue)
     ddwaf_object_free(&value);
 }
 
-
 } // namespace

--- a/tests/scanner_test.cpp
+++ b/tests/scanner_test.cpp
@@ -21,7 +21,7 @@ TEST(TestScanner, SimpleMatch)
     matcher::base::unique_ptr value_matcher =
         std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    scanner scnr{"0", "test", {{"type", "PII"}, {"category", "IP"}}, std::move(key_matcher),
+    scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}}, std::move(key_matcher),
         std::move(value_matcher)};
 
     ddwaf_object key;
@@ -35,5 +35,52 @@ TEST(TestScanner, SimpleMatch)
     ddwaf_object_free(&key);
     ddwaf_object_free(&value);
 }
+
+TEST(TestScanner, NoMatchOnKey)
+{
+    matcher::base::unique_ptr key_matcher =
+        std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
+
+    matcher::base::unique_ptr value_matcher =
+        std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
+
+    scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}}, std::move(key_matcher),
+        std::move(value_matcher)};
+
+    ddwaf_object key;
+    ddwaf_object value;
+
+    ddwaf_object_string(&key, "helloo");
+    ddwaf_object_string(&value, "192.168.0.1");
+
+    EXPECT_FALSE(scnr.eval(key, value));
+
+    ddwaf_object_free(&key);
+    ddwaf_object_free(&value);
+}
+
+TEST(TestScanner, NoMatchOnValue)
+{
+    matcher::base::unique_ptr key_matcher =
+        std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
+
+    matcher::base::unique_ptr value_matcher =
+        std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
+
+    scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}}, std::move(key_matcher),
+        std::move(value_matcher)};
+
+    ddwaf_object key;
+    ddwaf_object value;
+
+    ddwaf_object_string(&key, "hello");
+    ddwaf_object_string(&value, "192.168.0.2");
+
+    EXPECT_FALSE(scnr.eval(key, value));
+
+    ddwaf_object_free(&key);
+    ddwaf_object_free(&value);
+}
+
 
 } // namespace

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -193,6 +193,16 @@ std::list<ddwaf::test::event::match> from_matches(
   }
 
 #define EXPECT_MATCHES(matches, ...) EXPECT_THAT(from_matches(matches), WithMatches({__VA_ARGS__}));
+
+#define EXPECT_SCHEMA_EQ(obtained, expected)                                                       \
+  {                                                                                                \
+    auto obtained_doc = test::object_to_rapidjson(obtained);                                       \
+    EXPECT_TRUE(ValidateSchemaSchema(obtained_doc));                                               \
+    rapidjson::Document expected_doc;                                                              \
+    expected_doc.Parse(expected);                                                                  \
+    EXPECT_FALSE(expected_doc.HasParseError());                                                    \
+    EXPECT_TRUE(json_equals(obtained_doc, expected_doc)) << test::object_to_json(obtained);        \
+  }
 // NOLINTEND(cppcoreguidelines-macro-usage)
 
 ddwaf_object read_file(std::string_view filename, std::string_view base = "./");


### PR DESCRIPTION
This PR introduces a new high-level feature called `scanner` which is used by the schema extraction generator to attempt to infer the nature and semantics of key-value pairs which, in this context, is known as classification. Scanners are meant to be a generic tool for processors, for example an obfuscation processor could use scanners to determine what to obfuscate in a more configurable manner.

The main changes introduced in this PR:

- Scanner class: it's an extremely simple class, which takes an ID and two matchers, one for keys and another one for values. The caller can then provide keys and values to obtain a verdict.
- The schema extraction generator has been updated to evaluate scanners on each string and add metadata to the schema.
- The parser can now parse scanners and also parses processors into an intermediate representation.
- The ruleset builder can now generate processors when either processors or scanners have changed.