### PR TITLE
Remove ptr typedefs

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -15,7 +15,7 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
     memory::unordered_map<ddwaf::rule *, rule::cache_type> &cache,
     const memory::unordered_map<ddwaf::rule *, exclusion::filter_mode> &rules_to_exclude,
     const memory::unordered_map<ddwaf::rule *, collection::object_set> &objects_to_exclude,
-    const std::unordered_map<std::string, matcher::base::shared_ptr> &dynamic_matchers,
+    const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers,
     ddwaf::timer &deadline)
 {
     const auto &id = rule->get_id();
@@ -79,7 +79,7 @@ void base_collection<Derived>::match(memory::vector<event> &events, const object
     collection_cache &cache,
     const memory::unordered_map<ddwaf::rule *, exclusion::filter_mode> &rules_to_exclude,
     const memory::unordered_map<rule *, object_set> &objects_to_exclude,
-    const std::unordered_map<std::string, matcher::base::shared_ptr> &dynamic_matchers,
+    const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers,
     ddwaf::timer &deadline) const
 {
     if (cache.result >= Derived::type()) {

--- a/src/collection.hpp
+++ b/src/collection.hpp
@@ -46,7 +46,7 @@ public:
     base_collection &operator=(const base_collection &) = default;
     base_collection &operator=(base_collection &&) noexcept = default;
 
-    void insert(const rule::ptr &rule) { rules_.emplace_back(rule.get()); }
+    void insert(const std::shared_ptr<rule> &rule) { rules_.emplace_back(rule.get()); }
 
     void match(memory::vector<event> &events /* output */, const object_store &store,
         collection_cache &cache,

--- a/src/collection.hpp
+++ b/src/collection.hpp
@@ -52,7 +52,7 @@ public:
         collection_cache &cache,
         const memory::unordered_map<ddwaf::rule *, exclusion::filter_mode> &rules_to_exclude,
         const memory::unordered_map<ddwaf::rule *, object_set> &objects_to_exclude,
-        const std::unordered_map<std::string, matcher::base::shared_ptr> &dynamic_matchers,
+        const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers,
         ddwaf::timer &deadline) const;
 
 protected:

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -28,7 +28,7 @@ class context {
 public:
     using object_set = std::unordered_set<const ddwaf_object *>;
 
-    explicit context(ruleset::ptr ruleset) : ruleset_(std::move(ruleset))
+    explicit context(std::shared_ptr<ruleset> ruleset) : ruleset_(std::move(ruleset))
     {
         rule_filter_cache_.reserve(ruleset_->rule_filters.size());
         input_filter_cache_.reserve(ruleset_->input_filters.size());
@@ -75,7 +75,7 @@ protected:
         }
         return false;
     }
-    ruleset::ptr ruleset_;
+    std::shared_ptr<ruleset> ruleset_;
     ddwaf::object_store store_;
 
     using input_filter = exclusion::input_filter;
@@ -96,7 +96,7 @@ protected:
 
 class context_wrapper {
 public:
-    explicit context_wrapper(ruleset::ptr ruleset)
+    explicit context_wrapper(std::shared_ptr<ruleset> ruleset)
     {
         memory::memory_resource_guard guard(&mr_);
         ctx_ = static_cast<context *>(mr_.allocate(sizeof(context), alignof(context)));

--- a/src/exclusion/input_filter.cpp
+++ b/src/exclusion/input_filter.cpp
@@ -11,8 +11,8 @@ namespace ddwaf::exclusion {
 
 using excluded_set = input_filter::excluded_set;
 
-input_filter::input_filter(std::string id, expression::ptr expr, std::set<rule *> rule_targets,
-    std::shared_ptr<object_filter> filter)
+input_filter::input_filter(std::string id, std::shared_ptr<expression> expr,
+    std::set<rule *> rule_targets, std::shared_ptr<object_filter> filter)
     : id_(std::move(id)), expr_(std::move(expr)), rule_targets_(std::move(rule_targets)),
       filter_(std::move(filter))
 {

--- a/src/exclusion/input_filter.hpp
+++ b/src/exclusion/input_filter.hpp
@@ -19,8 +19,6 @@ namespace ddwaf::exclusion {
 
 class input_filter {
 public:
-    using ptr = std::shared_ptr<input_filter>;
-
     struct excluded_set {
         const std::set<rule *> &rules;
         memory::unordered_set<const ddwaf_object *> objects;
@@ -31,7 +29,7 @@ public:
         object_filter::cache_type object_filter_cache;
     };
 
-    input_filter(std::string id, expression::ptr expr, std::set<rule *> rule_targets,
+    input_filter(std::string id, std::shared_ptr<expression> expr, std::set<rule *> rule_targets,
         std::shared_ptr<object_filter> filter);
     input_filter(const input_filter &) = delete;
     input_filter &operator=(const input_filter &) = delete;
@@ -52,7 +50,7 @@ public:
 
 protected:
     std::string id_;
-    expression::ptr expr_;
+    std::shared_ptr<expression> expr_;
     const std::set<rule *> rule_targets_;
     std::shared_ptr<object_filter> filter_;
 };

--- a/src/exclusion/rule_filter.cpp
+++ b/src/exclusion/rule_filter.cpp
@@ -9,8 +9,8 @@
 
 namespace ddwaf::exclusion {
 
-rule_filter::rule_filter(
-    std::string id, expression::ptr expr, std::set<rule *> rule_targets, filter_mode mode)
+rule_filter::rule_filter(std::string id, std::shared_ptr<expression> expr,
+    std::set<rule *> rule_targets, filter_mode mode)
     : id_(std::move(id)), expr_(std::move(expr)), mode_(mode)
 {
     if (!expr_) {

--- a/src/exclusion/rule_filter.hpp
+++ b/src/exclusion/rule_filter.hpp
@@ -20,10 +20,9 @@ enum class filter_mode { bypass, monitor };
 
 class rule_filter {
 public:
-    using ptr = std::shared_ptr<rule_filter>;
     using cache_type = expression::cache_type;
 
-    rule_filter(std::string id, expression::ptr expr, std::set<rule *> rule_targets,
+    rule_filter(std::string id, std::shared_ptr<expression> expr, std::set<rule *> rule_targets,
         filter_mode mode = filter_mode::bypass);
     rule_filter(const rule_filter &) = delete;
     rule_filter &operator=(const rule_filter &) = delete;
@@ -44,7 +43,7 @@ public:
 
 protected:
     std::string id_;
-    expression::ptr expr_;
+    std::shared_ptr<expression> expr_;
     std::unordered_set<rule *> rule_targets_;
     filter_mode mode_;
 };

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -174,7 +174,7 @@ bool expression::evaluator::eval()
     // run, then they having new data will make them match again. The condition
     // that failed (and stopped the processing), we can run it again, but only
     // on the new data. The subsequent conditions, we need to run with all data.
-    std::vector<condition::ptr>::const_iterator cond_iter;
+    std::vector<std::unique_ptr<expression::condition>>::const_iterator cond_iter;
     bool run_on_new;
     if (cache.last_cond.has_value()) {
         cond_iter = *cache.last_cond;

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -174,7 +174,7 @@ bool expression::evaluator::eval()
     // run, then they having new data will make them match again. The condition
     // that failed (and stopped the processing), we can run it again, but only
     // on the new data. The subsequent conditions, we need to run with all data.
-    std::vector<std::unique_ptr<expression::condition>>::const_iterator cond_iter;
+    std::vector<std::unique_ptr<condition>>::const_iterator cond_iter;
     bool run_on_new;
     if (cache.last_cond.has_value()) {
         cond_iter = *cache.last_cond;

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -203,7 +203,7 @@ bool expression::evaluator::eval()
 
 bool expression::eval(cache_type &cache, const object_store &store,
     const std::unordered_set<const ddwaf_object *> &objects_excluded,
-    const std::unordered_map<std::string, matcher::base::shared_ptr> &dynamic_matchers,
+    const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers,
     ddwaf::timer &deadline) const
 {
     if (cache.result || conditions_.empty()) {

--- a/src/expression.hpp
+++ b/src/expression.hpp
@@ -54,8 +54,7 @@ public:
     struct cache_type {
         bool result{false};
         memory::vector<event::match> matches{};
-        std::optional<std::vector<std::unique_ptr<expression::condition>>::const_iterator>
-            last_cond{};
+        std::optional<std::vector<std::unique_ptr<condition>>::const_iterator> last_cond{};
     };
 
     struct evaluator {
@@ -73,7 +72,7 @@ public:
 
         ddwaf::timer &deadline;
         const ddwaf::object_limits &limits;
-        const std::vector<std::unique_ptr<expression::condition>> &conditions;
+        const std::vector<std::unique_ptr<condition>> &conditions;
         const object_store &store;
         const std::unordered_set<const ddwaf_object *> &objects_excluded;
         const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers;
@@ -82,8 +81,8 @@ public:
 
     expression() = default;
 
-    explicit expression(std::vector<std::unique_ptr<expression::condition>> &&conditions,
-        ddwaf::object_limits limits = {})
+    explicit expression(
+        std::vector<std::unique_ptr<condition>> &&conditions, ddwaf::object_limits limits = {})
         : limits_(limits), conditions_(std::move(conditions))
     {}
 
@@ -113,7 +112,7 @@ public:
 
 protected:
     ddwaf::object_limits limits_;
-    std::vector<std::unique_ptr<expression::condition>> conditions_;
+    std::vector<std::unique_ptr<condition>> conditions_;
 };
 
 class expression_builder {

--- a/src/expression.hpp
+++ b/src/expression.hpp
@@ -47,7 +47,7 @@ public:
         };
 
         std::vector<target_type> targets;
-        matcher::base::unique_ptr matcher;
+        std::unique_ptr<matcher::base> matcher;
         std::string data_id;
     };
 
@@ -76,7 +76,7 @@ public:
         const std::vector<std::unique_ptr<expression::condition>> &conditions;
         const object_store &store;
         const std::unordered_set<const ddwaf_object *> &objects_excluded;
-        const std::unordered_map<std::string, matcher::base::shared_ptr> &dynamic_matchers;
+        const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers;
         cache_type &cache;
     };
 
@@ -89,7 +89,7 @@ public:
 
     bool eval(cache_type &cache, const object_store &store,
         const std::unordered_set<const ddwaf_object *> &objects_excluded,
-        const std::unordered_map<std::string, matcher::base::shared_ptr> &dynamic_matchers,
+        const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers,
         ddwaf::timer &deadline) const;
 
     void get_addresses(std::unordered_map<target_index, std::string> &addresses) const
@@ -151,7 +151,7 @@ public:
         cond->matcher = std::make_unique<T>(args...);
     }
 
-    void set_matcher(matcher::base::unique_ptr &&matcher)
+    void set_matcher(std::unique_ptr<matcher::base> &&matcher)
     {
         auto &cond = conditions_.back();
         cond->matcher = std::move(matcher);

--- a/src/generator/base.hpp
+++ b/src/generator/base.hpp
@@ -20,8 +20,6 @@ namespace ddwaf::generator {
 
 class base {
 public:
-    using ptr = std::unique_ptr<base>;
-
     base() = default;
     virtual ~base() = default;
     base(const base &) = default;

--- a/src/matcher/base.hpp
+++ b/src/matcher/base.hpp
@@ -19,9 +19,6 @@ namespace ddwaf::matcher {
 
 class base {
 public:
-    using shared_ptr = std::shared_ptr<base>;
-    using unique_ptr = std::unique_ptr<base>;
-
     base() = default;
     virtual ~base() = default;
     base(const base &) = default;

--- a/src/matcher/base.hpp
+++ b/src/matcher/base.hpp
@@ -43,8 +43,6 @@ public:
 
 template <typename T> class base_impl : public base {
 public:
-    using ptr = std::shared_ptr<base>;
-
     base_impl() = default;
     ~base_impl() override = default;
     base_impl(const base_impl &) = default;

--- a/src/parser/parser_v1.cpp
+++ b/src/parser/parser_v1.cpp
@@ -25,7 +25,7 @@ namespace ddwaf::parser::v1 {
 
 namespace {
 
-expression::ptr parse_expression(parameter::vector &conditions_array,
+std::shared_ptr<expression> parse_expression(parameter::vector &conditions_array,
     const std::vector<transformer_id> &transformers, ddwaf::object_limits limits)
 {
     expression_builder builder(conditions_array.size(), limits);

--- a/src/parser/parser_v1.cpp
+++ b/src/parser/parser_v1.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<expression> parse_expression(parameter::vector &conditions_array
         auto params = at<parameter::map>(cond, "parameters");
 
         parameter::map options;
-        matcher::base::unique_ptr matcher;
+        std::unique_ptr<matcher::base> matcher;
         if (matcher_name == "phrase_match") {
             auto list = at<parameter::vector>(params, "list");
 

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -145,7 +145,7 @@ std::vector<transformer_id> parse_transformers(
     return transformers;
 }
 
-expression::ptr parse_expression(const parameter::vector &conditions_array,
+std::shared_ptr<expression> parse_expression(const parameter::vector &conditions_array,
     std::unordered_map<std::string, std::string> &rule_data_ids, expression::data_source source,
     const std::vector<transformer_id> &transformers, const object_limits &limits)
 {
@@ -304,7 +304,7 @@ std::pair<override_spec, reference_type> parse_override(const parameter::map &no
     return {current, type};
 }
 
-expression::ptr parse_simplified_expression(
+std::shared_ptr<expression> parse_simplified_expression(
     const parameter::vector &conditions_array, const object_limits &limits)
 {
     expression_builder builder(conditions_array.size(), limits);

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -34,7 +34,7 @@ namespace ddwaf::parser::v2 {
 
 namespace {
 
-std::pair<std::string, matcher::base::unique_ptr> parse_matcher(
+std::pair<std::string, std::unique_ptr<matcher::base>> parse_matcher(
     std::string_view name, const parameter::map &params)
 {
     parameter::map options;
@@ -457,7 +457,7 @@ std::vector<processor::target_mapping> parse_processor_mappings(const parameter:
     return mappings;
 }
 
-matcher::base::unique_ptr parse_scanner_matcher(const parameter::map &root)
+std::unique_ptr<matcher::base> parse_scanner_matcher(const parameter::map &root)
 {
     auto matcher_name = at<std::string_view>(root, "operator");
     auto matcher_params = at<parameter::map>(root, "parameters");
@@ -539,7 +539,7 @@ rule_data_container parse_rule_data(parameter::vector &rule_data, base_section_i
                 matcher_name = it->second;
             }
 
-            matcher::base::shared_ptr matcher;
+            std::shared_ptr<matcher::base> matcher;
             if (matcher_name == "ip_match") {
                 using rule_data_type = matcher::ip_match::rule_data_type;
                 auto parsed_data = parser::parse_rule_data<rule_data_type>(type, data);
@@ -741,8 +741,8 @@ scanner_container parse_scanners(parameter::vector &scanner_array, base_section_
                 }
             }
 
-            matcher::base::unique_ptr key_matcher{};
-            matcher::base::unique_ptr value_matcher{};
+            std::unique_ptr<matcher::base> key_matcher{};
+            std::unique_ptr<matcher::base> value_matcher{};
 
             auto it = node.find("key");
             if (it != node.end()) {

--- a/src/parser/specification.hpp
+++ b/src/parser/specification.hpp
@@ -65,7 +65,7 @@ struct processor_spec {
 
 // Containers
 using rule_spec_container = std::unordered_map<std::string, rule_spec>;
-using rule_data_container = std::unordered_map<std::string, matcher::base::shared_ptr>;
+using rule_data_container = std::unordered_map<std::string, std::shared_ptr<matcher::base>>;
 using scanner_container = std::unordered_map<std::string_view, std::shared_ptr<scanner>>;
 
 struct processor_container {

--- a/src/parser/specification.hpp
+++ b/src/parser/specification.hpp
@@ -24,7 +24,7 @@ struct rule_spec {
     rule::source_type source;
     std::string name;
     std::unordered_map<std::string, std::string> tags;
-    expression::ptr expr;
+    std::shared_ptr<expression> expr;
     std::vector<std::string> actions;
 };
 
@@ -43,20 +43,20 @@ struct override_spec {
 };
 
 struct rule_filter_spec {
-    expression::ptr expr;
+    std::shared_ptr<expression> expr;
     std::vector<reference_spec> targets;
     exclusion::filter_mode on_match;
 };
 
 struct input_filter_spec {
-    expression::ptr expr;
+    std::shared_ptr<expression> expr;
     std::shared_ptr<exclusion::object_filter> filter;
     std::vector<reference_spec> targets;
 };
 
 struct processor_spec {
     std::shared_ptr<generator::base> generator;
-    expression::ptr expr;
+    std::shared_ptr<expression> expr;
     std::vector<processor::target_mapping> mappings;
     std::vector<reference_spec> scanners;
     bool evaluate{false};
@@ -66,7 +66,7 @@ struct processor_spec {
 // Containers
 using rule_spec_container = std::unordered_map<std::string, rule_spec>;
 using rule_data_container = std::unordered_map<std::string, matcher::base::shared_ptr>;
-using scanner_container = std::unordered_map<std::string_view, scanner::ptr>;
+using scanner_container = std::unordered_map<std::string_view, std::shared_ptr<scanner>>;
 
 struct processor_container {
     [[nodiscard]] bool empty() const { return pre.empty() && post.empty(); }

--- a/src/processor.hpp
+++ b/src/processor.hpp
@@ -19,7 +19,6 @@ namespace ddwaf {
 
 class processor {
 public:
-    using ptr = std::shared_ptr<processor>;
     struct target_mapping {
         // TODO implement n:1 support
         target_index input;
@@ -32,9 +31,9 @@ public:
         std::unordered_set<target_index> generated;
     };
 
-    processor(std::string id, std::shared_ptr<generator::base> generator, expression::ptr expr,
-        std::vector<target_mapping> mappings, std::set<scanner *> scanners, bool evaluate,
-        bool output)
+    processor(std::string id, std::shared_ptr<generator::base> generator,
+        std::shared_ptr<expression> expr, std::vector<target_mapping> mappings,
+        std::set<scanner *> scanners, bool evaluate, bool output)
         : id_(std::move(id)), generator_(std::move(generator)), expr_(std::move(expr)),
           mappings_(std::move(mappings)), scanners_(std::move(scanners)), evaluate_(evaluate),
           output_(output)
@@ -55,7 +54,7 @@ public:
 protected:
     std::string id_;
     std::shared_ptr<generator::base> generator_;
-    expression::ptr expr_;
+    std::shared_ptr<expression> expr_;
     std::vector<target_mapping> mappings_;
     std::set<scanner *> scanners_;
     bool evaluate_{false};

--- a/src/rule.cpp
+++ b/src/rule.cpp
@@ -17,7 +17,7 @@ namespace ddwaf {
 
 std::optional<event> rule::match(const object_store &store, cache_type &cache,
     const std::unordered_set<const ddwaf_object *> &objects_excluded,
-    const std::unordered_map<std::string, matcher::base::shared_ptr> &dynamic_matchers,
+    const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers,
     ddwaf::timer &deadline) const
 {
     if (expression::get_result(cache)) {

--- a/src/rule.hpp
+++ b/src/rule.hpp
@@ -63,7 +63,7 @@ public:
 
     virtual std::optional<event> match(const object_store &store, cache_type &cache,
         const std::unordered_set<const ddwaf_object *> &objects_excluded,
-        const std::unordered_map<std::string, matcher::base::shared_ptr> &dynamic_matchers,
+        const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &dynamic_matchers,
         ddwaf::timer &deadline) const;
 
     [[nodiscard]] bool is_enabled() const { return enabled_; }

--- a/src/rule.hpp
+++ b/src/rule.hpp
@@ -23,15 +23,13 @@ namespace ddwaf {
 
 class rule {
 public:
-    using ptr = std::shared_ptr<rule>;
-
     enum class source_type : uint8_t { base = 1, user = 2 };
 
     using cache_type = expression::cache_type;
 
     rule(std::string id, std::string name, std::unordered_map<std::string, std::string> tags,
-        expression::ptr expr, std::vector<std::string> actions = {}, bool enabled = true,
-        source_type source = source_type::base)
+        std::shared_ptr<expression> expr, std::vector<std::string> actions = {},
+        bool enabled = true, source_type source = source_type::base)
         : enabled_(enabled), source_(source), id_(std::move(id)), name_(std::move(name)),
           tags_(std::move(tags)), expr_(std::move(expr)), actions_(std::move(actions))
     {
@@ -98,7 +96,7 @@ protected:
     std::string id_;
     std::string name_;
     std::unordered_map<std::string, std::string> tags_;
-    expression::ptr expr_;
+    std::shared_ptr<expression> expr_;
     std::vector<std::string> actions_;
 };
 

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -108,7 +108,7 @@ struct ruleset {
     std::unordered_map<std::string_view, std::shared_ptr<exclusion::input_filter>> input_filters;
 
     std::vector<std::shared_ptr<rule>> rules;
-    std::unordered_map<std::string, matcher::base::shared_ptr> dynamic_matchers;
+    std::unordered_map<std::string, std::shared_ptr<matcher::base>> dynamic_matchers;
 
     std::unordered_map<std::string_view, std::shared_ptr<scanner>> scanners;
 

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -24,9 +24,8 @@
 namespace ddwaf {
 
 struct ruleset {
-    using ptr = std::shared_ptr<ruleset>;
 
-    void insert_rule(const rule::ptr &rule)
+    void insert_rule(const std::shared_ptr<rule> &rule)
     {
         rules.emplace_back(rule);
         std::string_view type = rule->get_tag("type");
@@ -47,7 +46,7 @@ struct ruleset {
         rule->get_addresses(rule_addresses);
     }
 
-    void insert_rules(const std::unordered_map<std::string_view, rule::ptr> &rules_)
+    void insert_rules(const std::unordered_map<std::string_view, std::shared_ptr<rule>> &rules_)
     {
         for (const auto &[id, rule] : rules_) { insert_rule(rule); }
     }
@@ -102,16 +101,16 @@ struct ruleset {
     ddwaf_object_free_fn free_fn{ddwaf_object_free};
     std::shared_ptr<ddwaf::obfuscator> event_obfuscator;
 
-    std::unordered_map<std::string_view, processor::ptr> preprocessors;
-    std::unordered_map<std::string_view, processor::ptr> postprocessors;
+    std::unordered_map<std::string_view, std::shared_ptr<processor>> preprocessors;
+    std::unordered_map<std::string_view, std::shared_ptr<processor>> postprocessors;
 
-    std::unordered_map<std::string_view, exclusion::rule_filter::ptr> rule_filters;
-    std::unordered_map<std::string_view, exclusion::input_filter::ptr> input_filters;
+    std::unordered_map<std::string_view, std::shared_ptr<exclusion::rule_filter>> rule_filters;
+    std::unordered_map<std::string_view, std::shared_ptr<exclusion::input_filter>> input_filters;
 
-    std::vector<rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     std::unordered_map<std::string, matcher::base::shared_ptr> dynamic_matchers;
 
-    std::unordered_map<std::string_view, scanner::ptr> scanners;
+    std::unordered_map<std::string_view, std::shared_ptr<scanner>> scanners;
 
     // The key used to organise collections is rule.type
     std::unordered_set<std::string_view> collection_types;

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -34,7 +34,8 @@ constexpr ruleset_builder::change_state operator&(
 namespace {
 
 std::set<rule *> references_to_rules(const std::vector<parser::reference_spec> &references,
-    const std::unordered_map<std::string_view, rule::ptr> &rules, const rule_tag_map &rules_by_tags)
+    const std::unordered_map<std::string_view, std::shared_ptr<rule>> &rules,
+    const rule_tag_map &rules_by_tags)
 {
     std::set<rule *> rule_refs;
     if (!references.empty()) {

--- a/src/ruleset_builder.hpp
+++ b/src/ruleset_builder.hpp
@@ -23,8 +23,6 @@ using scanner_tag_map = ddwaf::multi_key_map<std::string_view, scanner *>;
 
 class ruleset_builder {
 public:
-    using ptr = std::shared_ptr<ruleset_builder>;
-
     ruleset_builder(object_limits limits, ddwaf_object_free_fn free_fn,
         std::shared_ptr<ddwaf::obfuscator> event_obfuscator)
         : limits_(limits), free_fn_(free_fn), event_obfuscator_(std::move(event_obfuscator))
@@ -96,23 +94,23 @@ protected:
     // These are the contents of the latest generated ruleset
 
     // Rules
-    std::unordered_map<std::string_view, rule::ptr> final_base_rules_;
-    std::unordered_map<std::string_view, rule::ptr> final_user_rules_;
+    std::unordered_map<std::string_view, std::shared_ptr<rule>> final_base_rules_;
+    std::unordered_map<std::string_view, std::shared_ptr<rule>> final_user_rules_;
 
     // An mkmap organising rules by their tags, used for overrides and exclusion filters
     rule_tag_map base_rules_by_tags_;
     rule_tag_map user_rules_by_tags_;
 
     // Filters
-    std::unordered_map<std::string_view, exclusion::rule_filter::ptr> rule_filters_;
-    std::unordered_map<std::string_view, exclusion::input_filter::ptr> input_filters_;
+    std::unordered_map<std::string_view, std::shared_ptr<exclusion::rule_filter>> rule_filters_;
+    std::unordered_map<std::string_view, std::shared_ptr<exclusion::input_filter>> input_filters_;
 
     // An mkmap organising scanners by their tags, used for processors
     scanner_tag_map scanners_by_tags_;
 
     // Processors
-    std::unordered_map<std::string_view, processor::ptr> preprocessors_;
-    std::unordered_map<std::string_view, processor::ptr> postprocessors_;
+    std::unordered_map<std::string_view, std::shared_ptr<processor>> preprocessors_;
+    std::unordered_map<std::string_view, std::shared_ptr<processor>> postprocessors_;
 };
 
 } // namespace ddwaf

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -16,7 +16,7 @@ namespace ddwaf {
 class scanner {
 public:
     scanner(std::string id, std::unordered_map<std::string, std::string> tags,
-        matcher::base::unique_ptr key_matcher, matcher::base::unique_ptr value_matcher)
+        std::unique_ptr<matcher::base> key_matcher, std::unique_ptr<matcher::base> value_matcher)
         : id_(std::move(id)), tags_(std::move(tags)), key_matcher_(std::move(key_matcher)),
           value_matcher_(std::move(value_matcher))
     {}
@@ -49,7 +49,7 @@ public:
     std::string_view get_id() const { return id_; }
 
 protected:
-    static bool eval_matcher(const matcher::base::unique_ptr &matcher, const ddwaf_object &obj)
+    static bool eval_matcher(const std::unique_ptr<matcher::base> &matcher, const ddwaf_object &obj)
     {
         if (!matcher || obj.type == DDWAF_OBJ_INVALID) {
             return true;
@@ -59,8 +59,8 @@ protected:
 
     std::string id_;
     std::unordered_map<std::string, std::string> tags_;
-    matcher::base::unique_ptr key_matcher_;
-    matcher::base::unique_ptr value_matcher_;
+    std::unique_ptr<matcher::base> key_matcher_;
+    std::unique_ptr<matcher::base> value_matcher_;
 };
 
 } // namespace ddwaf

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -15,8 +15,6 @@
 namespace ddwaf {
 class scanner {
 public:
-    using ptr = std::shared_ptr<scanner>;
-
     scanner(std::string id, std::unordered_map<std::string, std::string> tags,
         matcher::base::unique_ptr key_matcher, matcher::base::unique_ptr value_matcher)
         : id_(std::move(id)), tags_(std::move(tags)), key_matcher_(std::move(key_matcher)),

--- a/src/waf.hpp
+++ b/src/waf.hpp
@@ -31,12 +31,12 @@ public:
     }
 
 protected:
-    waf(ddwaf::ruleset_builder::ptr builder, ddwaf::ruleset::ptr ruleset)
+    waf(std::shared_ptr<ruleset_builder> builder, std::shared_ptr<ruleset> ruleset)
         : builder_(std::move(builder)), ruleset_(std::move(ruleset))
     {}
 
-    ddwaf::ruleset_builder::ptr builder_;
-    ddwaf::ruleset::ptr ruleset_;
+    std::shared_ptr<ruleset_builder> builder_;
+    std::shared_ptr<ruleset> ruleset_;
 };
 
 } // namespace ddwaf

--- a/tests/collection_test.cpp
+++ b/tests/collection_test.cpp
@@ -69,7 +69,7 @@ TYPED_TEST(TestCollection, SingleRuleMatch)
 // Validate that once there's a match for a collection, a second match isn't possible
 TYPED_TEST(TestCollection, MultipleRuleCachedMatch)
 {
-    std::vector<rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     TypeParam rule_collection;
     {
         expression_builder builder(1);
@@ -135,7 +135,7 @@ TYPED_TEST(TestCollection, MultipleRuleCachedMatch)
 // Validate that after a failed match, the collection can still produce a match
 TYPED_TEST(TestCollection, MultipleRuleFailAndMatch)
 {
-    std::vector<rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     TypeParam rule_collection;
     {
         expression_builder builder(1);
@@ -252,7 +252,7 @@ TYPED_TEST(TestCollection, SingleRuleMultipleCalls)
 // Validate that a match in a priority collection prevents further regular matches
 TEST(TestPriorityCollection, NoRegularMatchAfterPriorityMatch)
 {
-    std::vector<rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     collection regular;
     priority_collection priority;
     {
@@ -322,7 +322,7 @@ TEST(TestPriorityCollection, NoRegularMatchAfterPriorityMatch)
 // priority collection
 TEST(TestPriorityCollection, PriorityMatchAfterRegularMatch)
 {
-    std::vector<rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     collection regular;
     priority_collection priority;
     {
@@ -393,7 +393,7 @@ TEST(TestPriorityCollection, PriorityMatchAfterRegularMatch)
 // Validate that a match in a priority collection prevents another match
 TEST(TestPriorityCollection, NoPriorityMatchAfterPriorityMatch)
 {
-    std::vector<rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     priority_collection priority;
     {
         expression_builder builder(1);

--- a/tests/context_test.cpp
+++ b/tests/context_test.cpp
@@ -53,7 +53,8 @@ public:
     MOCK_METHOD(std::optional<event>, match,
         (const object_store &, rule::cache_type &,
             (const std::unordered_set<const ddwaf_object *> &),
-            (const std::unordered_map<std::string, matcher::base::shared_ptr> &), ddwaf::timer &),
+            (const std::unordered_map<std::string, std::shared_ptr<matcher::base>> &),
+            ddwaf::timer &),
         (const override));
 };
 

--- a/tests/context_test.cpp
+++ b/tests/context_test.cpp
@@ -43,8 +43,8 @@ public:
     using ptr = std::shared_ptr<mock::rule>;
 
     rule(std::string id, std::string name, std::unordered_map<std::string, std::string> tags,
-        expression::ptr expr, std::vector<std::string> actions = {}, bool enabled = true,
-        source_type source = source_type::base)
+        std::shared_ptr<expression> expr, std::vector<std::string> actions = {},
+        bool enabled = true, source_type source = source_type::base)
         : ddwaf::rule(std::move(id), std::move(name), std::move(tags), std::move(expr),
               std::move(actions), enabled, source)
     {}
@@ -61,8 +61,8 @@ class rule_filter : public ddwaf::exclusion::rule_filter {
 public:
     using ptr = std::shared_ptr<mock::rule_filter>;
 
-    rule_filter(std::string id, expression::ptr expr, std::set<ddwaf::rule *> rule_targets,
-        filter_mode mode = filter_mode::bypass)
+    rule_filter(std::string id, std::shared_ptr<expression> expr,
+        std::set<ddwaf::rule *> rule_targets, filter_mode mode = filter_mode::bypass)
         : exclusion::rule_filter(std::move(id), std::move(expr), std::move(rule_targets), mode)
     {}
     ~rule_filter() override = default;
@@ -75,8 +75,8 @@ class input_filter : public ddwaf::exclusion::input_filter {
 public:
     using ptr = std::shared_ptr<mock::input_filter>;
 
-    input_filter(std::string id, expression::ptr expr, std::set<ddwaf::rule *> rule_targets,
-        std::shared_ptr<object_filter> filter)
+    input_filter(std::string id, std::shared_ptr<expression> expr,
+        std::set<ddwaf::rule *> rule_targets, std::shared_ptr<object_filter> filter)
         : exclusion::input_filter(
               std::move(id), std::move(expr), std::move(rule_targets), std::move(filter))
     {}
@@ -931,8 +931,8 @@ TEST(TestContext, SkipRuleFilterNoTargets)
     auto ruleset = std::make_shared<ddwaf::ruleset>();
 
     // Generate rule
-    mock::rule::ptr rule;
-    mock::rule_filter::ptr filter;
+    std::shared_ptr<mock::rule> rule;
+    std::shared_ptr<mock::rule_filter> filter;
     {
         expression_builder builder(1);
         builder.start_condition<matcher::exact_match>(std::vector<std::string>{"admin"});
@@ -977,8 +977,8 @@ TEST(TestContext, SkipRuleButNotRuleFilterNoTargets)
     auto ruleset = std::make_shared<ddwaf::ruleset>();
 
     // Generate rule
-    mock::rule::ptr rule;
-    mock::rule_filter::ptr filter;
+    std::shared_ptr<mock::rule> rule;
+    std::shared_ptr<mock::rule_filter> filter;
     {
         expression_builder builder(1);
         builder.start_condition<matcher::exact_match>(std::vector<std::string>{"admin"});
@@ -1023,7 +1023,7 @@ TEST(TestContext, RuleFilterWithCondition)
     auto ruleset = std::make_shared<ddwaf::ruleset>();
 
     // Generate rule
-    ddwaf::rule::ptr rule;
+    std::shared_ptr<rule> rule;
     {
         expression_builder builder(1);
         builder.start_condition<matcher::exact_match>(std::vector<std::string>{"admin"});
@@ -1071,7 +1071,7 @@ TEST(TestContext, RuleFilterTimeout)
     auto ruleset = std::make_shared<ddwaf::ruleset>();
 
     // Generate rule
-    ddwaf::rule::ptr rule;
+    std::shared_ptr<rule> rule;
     {
         expression_builder builder(1);
         builder.start_condition<matcher::exact_match>(std::vector<std::string>{"admin"});
@@ -1114,7 +1114,7 @@ TEST(TestContext, NoRuleFilterWithCondition)
     auto ruleset = std::make_shared<ddwaf::ruleset>();
 
     // Generate rule
-    ddwaf::rule::ptr rule;
+    std::shared_ptr<rule> rule;
     {
         expression_builder builder(1);
         builder.start_condition<matcher::exact_match>(std::vector<std::string>{"admin"});
@@ -1162,7 +1162,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRules)
 
     // Generate rule
     constexpr unsigned num_rules = 9;
-    std::vector<ddwaf::rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     rules.reserve(num_rules);
     for (unsigned i = 0; i < num_rules; i++) {
 
@@ -1235,7 +1235,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRules)
 
     // Generate rule
     constexpr unsigned num_rules = 9;
-    std::vector<ddwaf::rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     rules.reserve(num_rules);
     for (unsigned i = 0; i < num_rules; i++) {
         std::string id = "id" + std::to_string(i);
@@ -1345,7 +1345,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRulesWithConditions)
 
     // Generate rule
     constexpr unsigned num_rules = 10;
-    std::vector<ddwaf::rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     rules.reserve(num_rules);
     for (unsigned i = 0; i < num_rules; i++) {
         std::string id = "id" + std::to_string(i);
@@ -1428,7 +1428,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRulesWithConditions)
 
     // Generate rule
     constexpr unsigned num_rules = 10;
-    std::vector<ddwaf::rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     rules.reserve(num_rules);
     for (unsigned i = 0; i < num_rules; i++) {
         std::string id = "id" + std::to_string(i);
@@ -1512,8 +1512,8 @@ TEST(TestContext, SkipInputFilterNoTargets)
     auto ruleset = std::make_shared<ddwaf::ruleset>();
 
     // Generate rule
-    mock::rule::ptr rule;
-    mock::input_filter::ptr filter;
+    std::shared_ptr<mock::rule> rule;
+    std::shared_ptr<mock::input_filter> filter;
     {
         expression_builder builder(1);
         builder.start_condition<matcher::exact_match>(std::vector<std::string>{"admin"});
@@ -1557,8 +1557,8 @@ TEST(TestContext, SkipRuleButNotInputFilterNoTargets)
     auto ruleset = std::make_shared<ddwaf::ruleset>();
 
     // Generate rule
-    mock::rule::ptr rule;
-    mock::input_filter::ptr filter;
+    std::shared_ptr<mock::rule> rule;
+    std::shared_ptr<mock::input_filter> filter;
     {
         expression_builder builder(1);
         builder.start_condition<matcher::exact_match>(std::vector<std::string>{"admin"});

--- a/tests/mkmap_test.cpp
+++ b/tests/mkmap_test.cpp
@@ -35,7 +35,7 @@ TEST(TestMultiKeyMap, Find)
         {"id6", "type1", "category1", {{"key", "value0"}}},
         {"id7", "type1", "category1", {{"key", "value1"}}}};
 
-    std::vector<ddwaf::rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     for (const auto &spec : specs) {
         std::unordered_map<std::string, std::string> tags = spec.tags;
         tags.emplace("type", spec.type);
@@ -100,7 +100,7 @@ TEST(TestMultiKeyMap, Multifind)
         {"id6", "type1", "category1", {{"key", "value0"}}},
         {"id7", "type1", "category1", {{"key", "value1"}}}};
 
-    std::vector<ddwaf::rule::ptr> rules;
+    std::vector<std::shared_ptr<rule>> rules;
     for (const auto &spec : specs) {
         std::unordered_map<std::string, std::string> tags = spec.tags;
         tags.emplace("type", spec.type);

--- a/tests/parser_v2_scanner_test.cpp
+++ b/tests/parser_v2_scanner_test.cpp
@@ -44,7 +44,7 @@ TEST(TestParserV2Scanner, ParseKeyOnlyScanner)
     EXPECT_EQ(scanners.size(), 1);
     EXPECT_NE(scanners.find("ecd"), scanners.end());
 
-    scanner::ptr &scnr = scanners["ecd"];
+    std::shared_ptr<scanner> &scnr = scanners["ecd"];
     EXPECT_STREQ(scnr->get_id().data(), "ecd");
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr->get_tags(), tags);
@@ -92,7 +92,7 @@ TEST(TestParserV2Scanner, ParseValueOnlyScanner)
     EXPECT_EQ(scanners.size(), 1);
     EXPECT_NE(scanners.find("ecd"), scanners.end());
 
-    scanner::ptr &scnr = scanners["ecd"];
+    std::shared_ptr<scanner> &scnr = scanners["ecd"];
     EXPECT_STREQ(scnr->get_id().data(), "ecd");
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr->get_tags(), tags);
@@ -140,7 +140,7 @@ TEST(TestParserV2Scanner, ParseKeyValueScanner)
     EXPECT_EQ(scanners.size(), 1);
     EXPECT_NE(scanners.find("ecd"), scanners.end());
 
-    scanner::ptr &scnr = scanners["ecd"];
+    std::shared_ptr<scanner> &scnr = scanners["ecd"];
     EXPECT_STREQ(scnr->get_id().data(), "ecd");
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr->get_tags(), tags);

--- a/tests/ruleset_test.cpp
+++ b/tests/ruleset_test.cpp
@@ -10,7 +10,7 @@
 using namespace ddwaf;
 
 namespace {
-rule::ptr make_rule(std::string id, std::string name,
+std::shared_ptr<rule> make_rule(std::string id, std::string name,
     std::unordered_map<std::string, std::string> tags, std::vector<std::string> actions,
     rule::source_type source = rule::source_type::base)
 {
@@ -20,7 +20,7 @@ rule::ptr make_rule(std::string id, std::string name,
 
 TEST(TestRuleset, InsertSingleRegularBaseRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {}),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {}),
         make_rule("id2", "name", {{"type", "type1"}, {"category", "category0"}}, {}),
@@ -42,7 +42,7 @@ TEST(TestRuleset, InsertSingleRegularBaseRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 
@@ -56,7 +56,7 @@ TEST(TestRuleset, InsertSingleRegularBaseRules)
 
 TEST(TestRuleset, InsertSinglePriorityBaseRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {"block"}),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {"block"}),
         make_rule("id2", "name", {{"type", "type1"}, {"category", "category0"}}, {"block"}),
@@ -78,7 +78,7 @@ TEST(TestRuleset, InsertSinglePriorityBaseRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 
@@ -92,7 +92,7 @@ TEST(TestRuleset, InsertSinglePriorityBaseRules)
 
 TEST(TestRuleset, InsertSingleMixedBaseRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {}),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {}),
         make_rule("id2", "name", {{"type", "type1"}, {"category", "category0"}}, {"block"}),
@@ -114,7 +114,7 @@ TEST(TestRuleset, InsertSingleMixedBaseRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 
@@ -128,7 +128,7 @@ TEST(TestRuleset, InsertSingleMixedBaseRules)
 
 TEST(TestRuleset, InsertSingleRegularUserRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {},
             rule::source_type::user),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {},
@@ -157,7 +157,7 @@ TEST(TestRuleset, InsertSingleRegularUserRules)
     {
         ddwaf::ruleset ruleset;
 
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 
@@ -171,7 +171,7 @@ TEST(TestRuleset, InsertSingleRegularUserRules)
 
 TEST(TestRuleset, InsertSinglePriorityUserRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {"block"},
             rule::source_type::user),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {"block"},
@@ -198,7 +198,7 @@ TEST(TestRuleset, InsertSinglePriorityUserRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 
@@ -212,7 +212,7 @@ TEST(TestRuleset, InsertSinglePriorityUserRules)
 
 TEST(TestRuleset, InsertSingleMixedUserRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {},
             rule::source_type::user),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {},
@@ -240,7 +240,7 @@ TEST(TestRuleset, InsertSingleMixedUserRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 
@@ -254,7 +254,7 @@ TEST(TestRuleset, InsertSingleMixedUserRules)
 
 TEST(TestRuleset, InsertSingleRegularMixedRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {},
             rule::source_type::base),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {},
@@ -282,7 +282,7 @@ TEST(TestRuleset, InsertSingleRegularMixedRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 
@@ -296,7 +296,7 @@ TEST(TestRuleset, InsertSingleRegularMixedRules)
 
 TEST(TestRuleset, InsertSinglePriorityMixedRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {"block"},
             rule::source_type::base),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {"block"},
@@ -323,7 +323,7 @@ TEST(TestRuleset, InsertSinglePriorityMixedRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 
@@ -337,7 +337,7 @@ TEST(TestRuleset, InsertSinglePriorityMixedRules)
 
 TEST(TestRuleset, InsertSingleMixedMixedRules)
 {
-    std::vector<ddwaf::rule::ptr> rules{
+    std::vector<std::shared_ptr<rule>> rules{
         make_rule("id0", "name", {{"type", "type0"}, {"category", "category0"}}, {},
             rule::source_type::user),
         make_rule("id1", "name", {{"type", "type1"}, {"category", "category0"}}, {},
@@ -371,7 +371,7 @@ TEST(TestRuleset, InsertSingleMixedMixedRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, rule::ptr> final_rules;
+        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
         for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
         ruleset.insert_rules(final_rules);
 

--- a/tests/scanner_test.cpp
+++ b/tests/scanner_test.cpp
@@ -15,10 +15,10 @@ using namespace std::literals;
 namespace {
 TEST(TestScanner, SimpleMatch)
 {
-    matcher::base::unique_ptr key_matcher =
+    std::unique_ptr<matcher::base> key_matcher =
         std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
 
-    matcher::base::unique_ptr value_matcher =
+    std::unique_ptr<matcher::base> value_matcher =
         std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
     std::unordered_map<std::string, std::string> tags{{"type", "PII"}, {"category", "IP"}};
@@ -43,10 +43,10 @@ TEST(TestScanner, SimpleMatch)
 
 TEST(TestScanner, NoMatchOnKey)
 {
-    matcher::base::unique_ptr key_matcher =
+    std::unique_ptr<matcher::base> key_matcher =
         std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
 
-    matcher::base::unique_ptr value_matcher =
+    std::unique_ptr<matcher::base> value_matcher =
         std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
     std::unordered_map<std::string, std::string> tags{
@@ -72,10 +72,10 @@ TEST(TestScanner, NoMatchOnKey)
 
 TEST(TestScanner, NoMatchOnValue)
 {
-    matcher::base::unique_ptr key_matcher =
+    std::unique_ptr<matcher::base> key_matcher =
         std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
 
-    matcher::base::unique_ptr value_matcher =
+    std::unique_ptr<matcher::base> value_matcher =
         std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
     std::unordered_map<std::string, std::string> tags{};

--- a/tools/verify_ruleset.cpp
+++ b/tools/verify_ruleset.cpp
@@ -22,7 +22,8 @@ int main(int argc, char *argv[])
     std::string rule_str = read_file(argv[1]);
     auto rule = json_to_object(rule_str);
 
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ddwaf_object diagnostics;
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, &diagnostics);
     ddwaf_object_free(&rule);
 
     if (handle == nullptr) {
@@ -31,6 +32,9 @@ int main(int argc, char *argv[])
     }
 
     DDWAF_INFO("Ruleset loaded successfully");
+
+    DDWAF_INFO("Diagnostics:\n%s", object_to_json(diagnostics).c_str());
+    ddwaf_object_free(&diagnostics);
 
     uint32_t required_size;
     const char *const *required = ddwaf_required_addresses(handle, &required_size);


### PR DESCRIPTION
For convenience and reducing characters, I introduced a  `ptr` typedef (using declaration) on certain classes which were typically used as a `shared_ptr`. Over time the use of this `ptr` typedef was extended to other classes, some as `shared_ptr` and some as `unique_ptr`, which has made it very difficult to understand the underlying pointer type.  This PR removes them to make the underlying pointer type more explicit.