### PR TITLE
Indexer abstraction to encapsulate rule and scanner search and storage

### DIFF
--- a/src/indexer.hpp
+++ b/src/indexer.hpp
@@ -19,6 +19,7 @@ template <typename T>
 class indexer {
 public:
     using iterator = typename std::vector<std::shared_ptr<T>>::iterator;
+    using const_iterator = typename std::vector<std::shared_ptr<T>>::const_iterator;
 
     void emplace(const std::shared_ptr<T> &item) {
         items_.emplace_back(item);
@@ -46,6 +47,9 @@ public:
 
     iterator begin() { return items_.begin(); }
     iterator end() { return items_.end(); }
+
+    const_iterator begin() const { return items_.begin(); }
+    const_iterator end() const { return items_.end(); }
 
     const std::vector<std::shared_ptr<T>> &items() const { return items_; }
 

--- a/src/indexer.hpp
+++ b/src/indexer.hpp
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+#include "mkmap.hpp"
+
+namespace ddwaf {
+
+template <typename T>
+class indexer {
+public:
+    using iterator = typename std::vector<std::shared_ptr<T>>::iterator;
+
+    void emplace(const std::shared_ptr<T> &item) {
+        items_.emplace_back(item);
+        by_id_.emplace(item->get_id(), item.get());
+        by_tags_.insert(item->get_tags(), item.get());
+    }
+
+    T* find_by_id(std::string_view id) const {
+        auto it = by_id_.find(id);
+        return it != by_id_.end() ? it->second : nullptr;
+    }
+
+    template <typename U>
+    std::set<T*> find_by_tags(const U &tags) const {
+        return by_tags_.multifind(tags);
+    }
+
+    [[nodiscard]] std::size_t size() const { return items_.size(); }
+
+    void clear() {
+        items_.clear();
+        by_id_.clear();
+        by_tags_.clear();
+    }
+
+    iterator begin() { return items_.begin(); }
+    iterator end() { return items_.end(); }
+
+    const std::vector<std::shared_ptr<T>> &items() const { return items_; }
+
+protected:
+    std::vector<std::shared_ptr<T>> items_;
+    std::unordered_map<std::string_view, T*> by_id_;
+    multi_key_map<std::string_view, T*> by_tags_;
+};
+
+} // namespace ddwaf

--- a/src/parser/parser.hpp
+++ b/src/parser/parser.hpp
@@ -15,6 +15,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "indexer.hpp"
+
 using base_section_info = ddwaf::base_ruleset_info::base_section_info;
 
 namespace ddwaf::parser {
@@ -42,7 +44,7 @@ filter_spec_container parse_filters(
 processor_container parse_processors(
     parameter::vector &processor_array, base_section_info &info, const object_limits &limits);
 
-scanner_container parse_scanners(parameter::vector &scanner_array, base_section_info &info);
+indexer<scanner> parse_scanners(parameter::vector &scanner_array, base_section_info &info);
 
 } // namespace v2
 } // namespace ddwaf::parser

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -5,6 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 
 #include "generator/extract_schema.hpp"
+#include "indexer.hpp"
 #include "utils.hpp"
 #include <algorithm>
 #include <exception.hpp>
@@ -717,16 +718,16 @@ processor_container parse_processors(
     return processors;
 }
 
-scanner_container parse_scanners(parameter::vector &scanner_array, base_section_info &info)
+indexer<scanner> parse_scanners(parameter::vector &scanner_array, base_section_info &info)
 {
-    scanner_container scanners;
+    indexer<scanner> scanners;
     for (unsigned i = 0; i < scanner_array.size(); i++) {
         const auto &node_param = scanner_array[i];
         auto node = static_cast<parameter::map>(node_param);
         std::string id;
         try {
             id = at<std::string>(node, "id");
-            if (scanners.find(id) != scanners.end()) {
+            if (scanners.find_by_id(id) != nullptr) {
                 DDWAF_WARN("Duplicate scanner: %s", id.c_str());
                 info.add_failed(id, "duplicate scanner");
                 continue;
@@ -765,7 +766,7 @@ scanner_container parse_scanners(parameter::vector &scanner_array, base_section_
             DDWAF_DEBUG("Parsed scanner %s", id.c_str());
             auto scnr = std::make_shared<scanner>(scanner{
                 std::move(id), std::move(tags), std::move(key_matcher), std::move(value_matcher)});
-            scanners.emplace(scnr->get_id(), scnr);
+            scanners.emplace(scnr);
             info.add_loaded(scnr->get_id());
         } catch (const std::exception &e) {
             if (id.empty()) {

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -110,7 +110,7 @@ struct ruleset {
     std::vector<std::shared_ptr<rule>> rules;
     std::unordered_map<std::string, std::shared_ptr<matcher::base>> dynamic_matchers;
 
-    std::unordered_map<std::string_view, std::shared_ptr<scanner>> scanners;
+    std::vector<std::shared_ptr<scanner>> scanners;
 
     // The key used to organise collections is rule.type
     std::unordered_set<std::string_view> collection_types;

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -46,9 +46,9 @@ struct ruleset {
         rule->get_addresses(rule_addresses);
     }
 
-    void insert_rules(const std::unordered_map<std::string_view, std::shared_ptr<rule>> &rules_)
+    void insert_rules(const std::vector<std::shared_ptr<rule>> &rules_)
     {
-        for (const auto &[id, rule] : rules_) { insert_rule(rule); }
+        for (const auto &rule : rules_) { insert_rule(rule); }
     }
 
     template <typename T>

--- a/src/ruleset_builder.hpp
+++ b/src/ruleset_builder.hpp
@@ -16,6 +16,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "indexer.hpp"
+
 namespace ddwaf {
 
 using rule_tag_map = ddwaf::multi_key_map<std::string_view, rule *>;
@@ -88,8 +90,6 @@ protected:
     parser::filter_spec_container exclusions_;
     // Obtained from 'processors'
     parser::processor_container processors_;
-    // Obtained from 'scanners'
-    parser::scanner_container scanners_;
 
     // These are the contents of the latest generated ruleset
 
@@ -111,6 +111,9 @@ protected:
     // Processors
     std::unordered_map<std::string_view, std::shared_ptr<processor>> preprocessors_;
     std::unordered_map<std::string_view, std::shared_ptr<processor>> postprocessors_;
+
+    // Scanners
+    indexer<scanner> scanners_;
 };
 
 } // namespace ddwaf

--- a/src/ruleset_builder.hpp
+++ b/src/ruleset_builder.hpp
@@ -20,9 +20,6 @@
 
 namespace ddwaf {
 
-using rule_tag_map = ddwaf::multi_key_map<std::string_view, rule *>;
-using scanner_tag_map = ddwaf::multi_key_map<std::string_view, scanner *>;
-
 class ruleset_builder {
 public:
     ruleset_builder(object_limits limits, ddwaf_object_free_fn free_fn,
@@ -94,19 +91,12 @@ protected:
     // These are the contents of the latest generated ruleset
 
     // Rules
-    std::unordered_map<std::string_view, std::shared_ptr<rule>> final_base_rules_;
-    std::unordered_map<std::string_view, std::shared_ptr<rule>> final_user_rules_;
-
-    // An mkmap organising rules by their tags, used for overrides and exclusion filters
-    rule_tag_map base_rules_by_tags_;
-    rule_tag_map user_rules_by_tags_;
+    indexer<rule> final_base_rules_;
+    indexer<rule> final_user_rules_;
 
     // Filters
     std::unordered_map<std::string_view, std::shared_ptr<exclusion::rule_filter>> rule_filters_;
     std::unordered_map<std::string_view, std::shared_ptr<exclusion::input_filter>> input_filters_;
-
-    // An mkmap organising scanners by their tags, used for processors
-    scanner_tag_map scanners_by_tags_;
 
     // Processors
     std::unordered_map<std::string_view, std::shared_ptr<processor>> preprocessors_;

--- a/tests/parser_v2_scanner_test.cpp
+++ b/tests/parser_v2_scanner_test.cpp
@@ -42,9 +42,10 @@ TEST(TestParserV2Scanner, ParseKeyOnlyScanner)
     }
 
     EXPECT_EQ(scanners.size(), 1);
-    EXPECT_NE(scanners.find("ecd"), scanners.end());
+    EXPECT_NE(scanners.find_by_id("ecd"), nullptr);
 
-    std::shared_ptr<scanner> &scnr = scanners["ecd"];
+    auto *scnr = scanners.find_by_id("ecd");
+    ;
     EXPECT_STREQ(scnr->get_id().data(), "ecd");
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr->get_tags(), tags);
@@ -90,9 +91,10 @@ TEST(TestParserV2Scanner, ParseValueOnlyScanner)
     }
 
     EXPECT_EQ(scanners.size(), 1);
-    EXPECT_NE(scanners.find("ecd"), scanners.end());
+    EXPECT_NE(scanners.find_by_id("ecd"), nullptr);
 
-    std::shared_ptr<scanner> &scnr = scanners["ecd"];
+    auto *scnr = scanners.find_by_id("ecd");
+    ;
     EXPECT_STREQ(scnr->get_id().data(), "ecd");
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr->get_tags(), tags);
@@ -138,9 +140,10 @@ TEST(TestParserV2Scanner, ParseKeyValueScanner)
     }
 
     EXPECT_EQ(scanners.size(), 1);
-    EXPECT_NE(scanners.find("ecd"), scanners.end());
+    EXPECT_NE(scanners.find_by_id("ecd"), nullptr);
 
-    std::shared_ptr<scanner> &scnr = scanners["ecd"];
+    auto *scnr = scanners.find_by_id("ecd");
+    ;
     EXPECT_STREQ(scnr->get_id().data(), "ecd");
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr->get_tags(), tags);

--- a/tests/ruleset_test.cpp
+++ b/tests/ruleset_test.cpp
@@ -42,9 +42,7 @@ TEST(TestRuleset, InsertSingleRegularBaseRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 6);
         EXPECT_EQ(ruleset.base_collections.size(), 3);
@@ -78,9 +76,7 @@ TEST(TestRuleset, InsertSinglePriorityBaseRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 6);
         EXPECT_EQ(ruleset.base_collections.size(), 0);
@@ -114,9 +110,7 @@ TEST(TestRuleset, InsertSingleMixedBaseRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 6);
         EXPECT_EQ(ruleset.base_collections.size(), 3);
@@ -157,9 +151,7 @@ TEST(TestRuleset, InsertSingleRegularUserRules)
     {
         ddwaf::ruleset ruleset;
 
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 6);
         EXPECT_EQ(ruleset.base_collections.size(), 0);
@@ -198,9 +190,7 @@ TEST(TestRuleset, InsertSinglePriorityUserRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 6);
         EXPECT_EQ(ruleset.base_collections.size(), 0);
@@ -240,9 +230,7 @@ TEST(TestRuleset, InsertSingleMixedUserRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 6);
         EXPECT_EQ(ruleset.base_collections.size(), 0);
@@ -282,9 +270,7 @@ TEST(TestRuleset, InsertSingleRegularMixedRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 6);
         EXPECT_EQ(ruleset.base_collections.size(), 3);
@@ -323,9 +309,7 @@ TEST(TestRuleset, InsertSinglePriorityMixedRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 6);
         EXPECT_EQ(ruleset.base_collections.size(), 0);
@@ -371,9 +355,7 @@ TEST(TestRuleset, InsertSingleMixedMixedRules)
 
     {
         ddwaf::ruleset ruleset;
-        std::unordered_map<std::string_view, std::shared_ptr<rule>> final_rules;
-        for (const auto &rule : rules) { final_rules.emplace(rule->get_id(), rule); }
-        ruleset.insert_rules(final_rules);
+        ruleset.insert_rules(rules);
 
         EXPECT_EQ(ruleset.rules.size(), 12);
         EXPECT_EQ(ruleset.base_collections.size(), 3);


### PR DESCRIPTION
Currently scanners and rules have a companion `*_by_tags_" container which is used to search a set of rules or scanners based on their tags and values. Similarly, rules and scanners are organised in an `unordered_map` based on their ID; this container also has ownership of the objects themselves.

To avoid a case in which a container has dangling pointers due to the owning container being destroyed and to simplify the code, an indexer structure has been introduced which:

- Stores shared pointers to owned objects in an `std::vector`, which can be directly referenced and iterated.
- Stores raw pointers to objects in a map, indexing them by ID.
- Stores raw pointers to objects in an mkmap, indexing them by tags.
- Provides sufficient functionality to search based on ID and tags.