### PR TITLE
[APPSEC-11574] Schema extraction scanners: reduce false positives on arrays

### DIFF
--- a/src/generator/extract_schema.cpp
+++ b/src/generator/extract_schema.cpp
@@ -319,7 +319,7 @@ base_node generate_helper(const ddwaf_object *object, std::string_view key,
         array->children.reserve(length);
         for (std::size_t i = 0; i < length && depth > 1; i++) {
             const auto *child = &object->array[i];
-            auto schema = generate_helper(child, {}, scanners, depth - 1, deadline);
+            auto schema = generate_helper(child, key, scanners, depth - 1, deadline);
             array->children.emplace(std::move(schema));
         }
         return array;

--- a/src/scanner.hpp
+++ b/src/scanner.hpp
@@ -53,8 +53,11 @@ public:
 protected:
     static bool eval_matcher(const std::unique_ptr<matcher::base> &matcher, const ddwaf_object &obj)
     {
-        if (!matcher || obj.type == DDWAF_OBJ_INVALID) {
+        if (!matcher) {
             return true;
+        }
+        if (obj.type == DDWAF_OBJ_INVALID) {
+            return false;
         }
         return matcher->match(obj).first;
     }

--- a/tests/scanner_test.cpp
+++ b/tests/scanner_test.cpp
@@ -41,6 +41,56 @@ TEST(TestScanner, SimpleMatch)
     ddwaf_object_free(&value);
 }
 
+TEST(TestScanner, SimpleMatchNoKeyMatcher)
+{
+    std::unique_ptr<matcher::base> value_matcher =
+        std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
+
+    std::unordered_map<std::string, std::string> tags{{"type", "PII"}, {"category", "IP"}};
+    scanner scnr{"something", tags, {}, std::move(value_matcher)};
+    EXPECT_STREQ(scnr.get_id().data(), "something");
+    EXPECT_EQ(scnr.get_tags(), tags);
+
+    ddwaf_object key;
+    ddwaf_object value;
+
+    ddwaf_object_string(&key, "hello");
+    ddwaf_object_string(&value, "192.168.0.1");
+
+    EXPECT_TRUE(scnr.eval(key, value));
+
+    std::string_view key_sv{key.stringValue, static_cast<std::size_t>(key.nbEntries)};
+    EXPECT_TRUE(scnr.eval(key_sv, value));
+
+    ddwaf_object_free(&key);
+    ddwaf_object_free(&value);
+}
+
+TEST(TestScanner, SimpleMatchNoValueMatcher)
+{
+    std::unique_ptr<matcher::base> key_matcher =
+        std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
+
+    std::unordered_map<std::string, std::string> tags{{"type", "PII"}, {"category", "IP"}};
+    scanner scnr{"something", tags, std::move(key_matcher), {}};
+    EXPECT_STREQ(scnr.get_id().data(), "something");
+    EXPECT_EQ(scnr.get_tags(), tags);
+
+    ddwaf_object key;
+    ddwaf_object value;
+
+    ddwaf_object_string(&key, "hello");
+    ddwaf_object_string(&value, "192.168.0.1");
+
+    EXPECT_TRUE(scnr.eval(key, value));
+
+    std::string_view key_sv{key.stringValue, static_cast<std::size_t>(key.nbEntries)};
+    EXPECT_TRUE(scnr.eval(key_sv, value));
+
+    ddwaf_object_free(&key);
+    ddwaf_object_free(&value);
+}
+
 TEST(TestScanner, NoMatchOnKey)
 {
     std::unique_ptr<matcher::base> key_matcher =
@@ -88,6 +138,63 @@ TEST(TestScanner, NoMatchOnValue)
 
     ddwaf_object_string(&key, "hello");
     ddwaf_object_string(&value, "192.168.0.2");
+
+    EXPECT_FALSE(scnr.eval(key, value));
+
+    std::string_view key_sv{key.stringValue, static_cast<std::size_t>(key.nbEntries)};
+    EXPECT_FALSE(scnr.eval(key_sv, value));
+
+    ddwaf_object_free(&key);
+    ddwaf_object_free(&value);
+}
+
+TEST(TestScanner, InvalidKey)
+{
+    std::unique_ptr<matcher::base> key_matcher =
+        std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
+
+    std::unique_ptr<matcher::base> value_matcher =
+        std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
+
+    std::unordered_map<std::string, std::string> tags{
+        {"type", "PII"}, {"category", "IP"}, {"danger", "0"}};
+    scanner scnr{"0", tags, std::move(key_matcher), std::move(value_matcher)};
+    EXPECT_STREQ(scnr.get_id().data(), "0");
+    EXPECT_EQ(scnr.get_tags(), tags);
+
+    ddwaf_object key;
+    ddwaf_object value;
+
+    ddwaf_object_invalid(&key);
+    ddwaf_object_string(&value, "192.168.0.1");
+
+    EXPECT_FALSE(scnr.eval(key, value));
+
+    std::string_view key_sv{};
+    EXPECT_FALSE(scnr.eval(key_sv, value));
+
+    ddwaf_object_free(&key);
+    ddwaf_object_free(&value);
+}
+
+TEST(TestScanner, InvalidValue)
+{
+    std::unique_ptr<matcher::base> key_matcher =
+        std::make_unique<matcher::exact_match>(std::vector<std::string>{"hello", "goodbye"});
+
+    std::unique_ptr<matcher::base> value_matcher =
+        std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
+
+    std::unordered_map<std::string, std::string> tags{};
+    scanner scnr{"null", tags, std::move(key_matcher), std::move(value_matcher)};
+    EXPECT_STREQ(scnr.get_id().data(), "null");
+    EXPECT_EQ(scnr.get_tags(), tags);
+
+    ddwaf_object key;
+    ddwaf_object value;
+
+    ddwaf_object_string(&key, "hello");
+    ddwaf_object_invalid(&value);
 
     EXPECT_FALSE(scnr.eval(key, value));
 


### PR DESCRIPTION
- Propagate ancestor keys for scanner evaluation during schema extraction.
- Fail scanner evaluation if key is invalid and a matcher is available.