### PR TITLE
Address diagnostics

### DIFF
--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -231,19 +231,24 @@ ddwaf_handle ddwaf_update(ddwaf_handle handle, const ddwaf_object *ruleset,
 void ddwaf_destroy(ddwaf_handle handle);
 
 /**
- * ddwaf_required_addresses
+ * ddwaf_known_addresses
  *
- * Get an array of required (root) addresses. The memory is owned by the WAF and
- * should not be freed.
+ * Get an array of known (root) addresses used by rules, exclusion filters and
+ * processors. This array contains both required and optional addresses. A more
+ * accurate distinction between required and optional addresses is provided
+ * within the diagnostics.
+ *
+ * The memory is owned by the WAF and should not be freed.
  *
  * @param Handle to the WAF instance.
  * @param size Output parameter in which the size will be returned. The value of
  *             size will be 0 if the return value is NULL.
  * @return NULL if empty, otherwise a pointer to an array with size elements.
  *
- * @Note The returned array should be considered invalid after calling ddwaf_destroy on the handle used to obtain it.
+ * @Note The returned array should be considered invalid after calling ddwaf_destroy
+ *       on the handle used to obtain it.
  **/
-const char* const* ddwaf_required_addresses(const ddwaf_handle handle, uint32_t *size);
+const char* const* ddwaf_known_addresses(const ddwaf_handle handle, uint32_t *size);
 
 /**
  * ddwaf_context_init

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -3,7 +3,7 @@ EXPORTS
   ddwaf_init
   ddwaf_update
   ddwaf_destroy
-  ddwaf_required_addresses
+  ddwaf_known_addresses
   ddwaf_context_init
   ddwaf_run
   ddwaf_context_destroy

--- a/perf/main.cpp
+++ b/perf/main.cpp
@@ -219,7 +219,7 @@ benchmark::settings generate_settings(int argc, char *argv[])
 void initialise_runner(benchmark::runner &runner, ddwaf_handle handle, benchmark::settings &s)
 {
     uint32_t addrs_len;
-    const auto *const addrs = ddwaf_required_addresses(handle, &addrs_len);
+    const auto *const addrs = ddwaf_known_addresses(handle, &addrs_len);
 
     std::vector<std::string_view> addresses{addrs, addrs + static_cast<size_t>(addrs_len)};
 

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -152,7 +152,7 @@ void ddwaf_destroy(ddwaf::waf *handle)
     }
 }
 
-const char *const *ddwaf_required_addresses(ddwaf::waf *handle, uint32_t *size)
+const char *const *ddwaf_known_addresses(ddwaf::waf *handle, uint32_t *size)
 {
     if (handle == nullptr) {
         *size = 0;

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -685,7 +685,7 @@ processor_container parse_processors(
             address_container addresses;
 
             id = at<std::string>(node, "id");
-            if (known_processors.find(id) != known_processors.end()) {
+            if (known_processors.contains(id)) {
                 DDWAF_WARN("Duplicate processor: %s", id.c_str());
                 info.add_failed(id, "duplicate processor");
                 continue;
@@ -727,6 +727,7 @@ processor_container parse_processors(
             }
 
             DDWAF_DEBUG("Parsed processor %s", id.c_str());
+            known_processors.emplace(id);
             info.add_loaded(id);
             add_addresses_to_info(addresses, info);
 

--- a/src/processor.hpp
+++ b/src/processor.hpp
@@ -22,6 +22,7 @@ public:
     struct target_mapping {
         // TODO implement n:1 support
         target_index input;
+        std::string input_address;
         target_index output;
         std::string output_address;
     };
@@ -50,6 +51,12 @@ public:
         ddwaf::timer &deadline) const;
 
     [[nodiscard]] const std::string &get_id() const { return id_; }
+
+    void get_addresses(std::unordered_map<target_index, std::string> &addresses) const
+    {
+        expr_->get_addresses(addresses);
+        for (auto mapping : mappings_) { addresses.emplace(mapping.input, mapping.input_address); }
+    }
 
 protected:
     std::string id_;

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -195,11 +195,9 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
     rs->insert_rules(final_user_rules_.items());
     rs->insert_filters(rule_filters_);
     rs->insert_filters(input_filters_);
+    rs->insert_preprocessors(preprocessors_);
+    rs->insert_postprocessors(postprocessors_);
     rs->dynamic_matchers = dynamic_matchers_;
-    rs->rule_filters = rule_filters_;
-    rs->input_filters = input_filters_;
-    rs->preprocessors = preprocessors_;
-    rs->postprocessors = postprocessors_;
     rs->scanners = scanners_.items();
     rs->free_fn = free_fn_;
     rs->event_obfuscator = event_obfuscator_;

--- a/src/ruleset_builder.hpp
+++ b/src/ruleset_builder.hpp
@@ -87,7 +87,6 @@ protected:
     parser::filter_spec_container exclusions_;
     // Obtained from 'processors'
     parser::processor_container processors_;
-
     // These are the contents of the latest generated ruleset
 
     // Rules

--- a/src/ruleset_info.cpp
+++ b/src/ruleset_info.cpp
@@ -53,4 +53,28 @@ void ruleset_info::section_info::add_failed(std::string_view id, std::string_vie
     ddwaf_object_array_add(&failed_, &id_str);
 }
 
+void ruleset_info::section_info::add_required_address(std::string_view address)
+{
+    if (!required_addresses_set_.contains(address)) {
+        ddwaf_object address_str;
+        ddwaf_object_stringl(&address_str, address.data(), address.size());
+        ddwaf_object_array_add(&required_addresses_, &address_str);
+
+        required_addresses_set_.emplace(
+            address_str.stringValue, static_cast<std::size_t>(address_str.nbEntries));
+    }
+}
+
+void ruleset_info::section_info::add_optional_address(std::string_view address)
+{
+    if (!optional_addresses_set_.contains(address)) {
+        ddwaf_object address_str;
+        ddwaf_object_stringl(&address_str, address.data(), address.size());
+        ddwaf_object_array_add(&optional_addresses_, &address_str);
+
+        optional_addresses_set_.emplace(
+            address_str.stringValue, static_cast<std::size_t>(address_str.nbEntries));
+    }
+}
+
 } // namespace ddwaf

--- a/src/ruleset_info.hpp
+++ b/src/ruleset_info.hpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 
 namespace ddwaf {
 
@@ -28,6 +29,8 @@ public:
         virtual void set_error(std::string_view error) = 0;
         virtual void add_loaded(std::string_view id) = 0;
         virtual void add_failed(std::string_view id, std::string_view error) = 0;
+        virtual void add_required_address(std::string_view address) = 0;
+        virtual void add_optional_address(std::string_view address) = 0;
     };
 
     base_ruleset_info() = default;
@@ -57,6 +60,8 @@ public:
         void set_error(std::string_view /*error*/) override {}
         void add_loaded(std::string_view /*id*/) override {}
         void add_failed(std::string_view /*id*/, std::string_view /*error*/) override {}
+        void add_required_address(std::string_view /*address*/) override {}
+        void add_optional_address(std::string_view /*address*/) override {}
     };
 
     null_ruleset_info() = default;
@@ -86,6 +91,8 @@ public:
             ddwaf_object_array(&loaded_);
             ddwaf_object_array(&failed_);
             ddwaf_object_map(&errors_);
+            ddwaf_object_array(&required_addresses_);
+            ddwaf_object_array(&optional_addresses_);
         }
 
         ~section_info() override
@@ -93,6 +100,8 @@ public:
             ddwaf_object_free(&loaded_);
             ddwaf_object_free(&failed_);
             ddwaf_object_free(&errors_);
+            ddwaf_object_free(&required_addresses_);
+            ddwaf_object_free(&optional_addresses_);
         }
 
         section_info(const section_info &) = delete;
@@ -103,6 +112,8 @@ public:
         void set_error(std::string_view error) override { error_ = error; }
         void add_loaded(std::string_view id) override;
         void add_failed(std::string_view id, std::string_view error) override;
+        void add_required_address(std::string_view address) override;
+        void add_optional_address(std::string_view address) override;
 
         // This matcher effectively moves the contents
         void to_object(ddwaf_object &output)
@@ -118,10 +129,25 @@ public:
                 ddwaf_object_map_add(&output, "failed", &failed_);
                 ddwaf_object_map_add(&output, "errors", &errors_);
 
+                if (!required_addresses_set_.empty() || !optional_addresses_set_.empty()) {
+                    ddwaf_object addresses;
+                    ddwaf_object_map(&addresses);
+                    ddwaf_object_map_add(&addresses, "required", &required_addresses_);
+                    ddwaf_object_map_add(&addresses, "optional", &optional_addresses_);
+                    ddwaf_object_map_add(&output, "addresses", &addresses);
+                }
+
                 ddwaf_object_invalid(&loaded_);
                 ddwaf_object_invalid(&failed_);
+
                 ddwaf_object_invalid(&errors_);
                 error_obj_cache_.clear();
+
+                ddwaf_object_invalid(&required_addresses_);
+                required_addresses_set_.clear();
+
+                ddwaf_object_invalid(&optional_addresses_);
+                optional_addresses_set_.clear();
             }
         }
 
@@ -135,6 +161,14 @@ public:
          *  that error was raised. {error: [ids]} **/
         ddwaf_object errors_{};
         std::map<std::string_view, uint64_t> error_obj_cache_;
+
+        /** Array of required addresses **/
+        ddwaf_object required_addresses_{};
+        std::unordered_set<std::string_view> required_addresses_set_{};
+
+        /** Array of optional addresses **/
+        ddwaf_object optional_addresses_{};
+        std::unordered_set<std::string_view> optional_addresses_set_{};
     };
 
     ruleset_info() = default;

--- a/tests/integration/diagnostics/test.cpp
+++ b/tests/integration/diagnostics/test.cpp
@@ -35,20 +35,34 @@ TEST(TestDiagnosticsIntegration, Rules)
         EXPECT_STR(version, "5.4.2");
 
         auto rules = ddwaf::parser::at<parameter::map>(root_map, "rules");
-        EXPECT_EQ(rules.size(), 3);
+        EXPECT_EQ(rules.size(), 4);
 
         auto loaded = ddwaf::parser::at<parameter::string_set>(rules, "loaded");
         EXPECT_EQ(loaded.size(), 4);
-        EXPECT_NE(loaded.find("rule1"), loaded.end());
-        EXPECT_NE(loaded.find("rule2"), loaded.end());
-        EXPECT_NE(loaded.find("rule3"), loaded.end());
-        EXPECT_NE(loaded.find("rule4"), loaded.end());
+        EXPECT_TRUE(loaded.contains("rule1"));
+        EXPECT_TRUE(loaded.contains("rule2"));
+        EXPECT_TRUE(loaded.contains("rule3"));
+        EXPECT_TRUE(loaded.contains("rule4"));
 
         auto failed = ddwaf::parser::at<parameter::string_set>(rules, "failed");
         EXPECT_EQ(failed.size(), 0);
 
         auto errors = ddwaf::parser::at<parameter::map>(rules, "errors");
         EXPECT_EQ(errors.size(), 0);
+
+        auto addresses = ddwaf::parser::at<parameter::map>(rules, "addresses");
+        EXPECT_EQ(addresses.size(), 2);
+
+        auto required = ddwaf::parser::at<parameter::string_set>(addresses, "required");
+        EXPECT_EQ(required.size(), 5);
+        EXPECT_TRUE(required.contains("value1"));
+        EXPECT_TRUE(required.contains("value2"));
+        EXPECT_TRUE(required.contains("value3"));
+        EXPECT_TRUE(required.contains("value4"));
+        EXPECT_TRUE(required.contains("value34"));
+
+        auto optional = ddwaf::parser::at<parameter::string_set>(addresses, "optional");
+        EXPECT_EQ(optional.size(), 0);
 
         ddwaf_object_free(&root);
     }
@@ -76,19 +90,19 @@ TEST(TestDiagnosticsIntegration, RulesWithErrors)
         EXPECT_STR(version, "5.4.1");
 
         auto rules = ddwaf::parser::at<parameter::map>(root_map, "rules");
-        EXPECT_EQ(rules.size(), 3);
+        EXPECT_EQ(rules.size(), 4);
 
         auto loaded = ddwaf::parser::at<parameter::string_set>(rules, "loaded");
         EXPECT_EQ(loaded.size(), 1);
-        EXPECT_NE(loaded.find("rule1"), loaded.end());
+        EXPECT_TRUE(loaded.contains("rule1"));
 
         auto failed = ddwaf::parser::at<parameter::string_set>(rules, "failed");
         EXPECT_EQ(failed.size(), 5);
-        EXPECT_NE(failed.find("rule1"), failed.end());
-        EXPECT_NE(failed.find("index:2"), failed.end());
-        EXPECT_NE(failed.find("rule4"), failed.end());
-        EXPECT_NE(failed.find("rule5"), failed.end());
-        EXPECT_NE(failed.find("rule6"), failed.end());
+        EXPECT_TRUE(failed.contains("rule1"));
+        EXPECT_TRUE(failed.contains("index:2"));
+        EXPECT_TRUE(failed.contains("rule4"));
+        EXPECT_TRUE(failed.contains("rule5"));
+        EXPECT_TRUE(failed.contains("rule6"));
 
         auto errors = ddwaf::parser::at<parameter::map>(rules, "errors");
         EXPECT_EQ(errors.size(), 4);
@@ -99,7 +113,7 @@ TEST(TestDiagnosticsIntegration, RulesWithErrors)
 
             auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
             EXPECT_EQ(error_rules.size(), 1);
-            EXPECT_NE(error_rules.find("rule1"), error_rules.end());
+            EXPECT_TRUE(error_rules.contains("rule1"));
         }
 
         {
@@ -108,7 +122,7 @@ TEST(TestDiagnosticsIntegration, RulesWithErrors)
 
             auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
             EXPECT_EQ(error_rules.size(), 1);
-            EXPECT_NE(error_rules.find("index:2"), error_rules.end());
+            EXPECT_TRUE(error_rules.contains("index:2"));
         }
 
         {
@@ -117,8 +131,8 @@ TEST(TestDiagnosticsIntegration, RulesWithErrors)
 
             auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
             EXPECT_EQ(error_rules.size(), 2);
-            EXPECT_NE(error_rules.find("rule4"), error_rules.end());
-            EXPECT_NE(error_rules.find("rule5"), error_rules.end());
+            EXPECT_TRUE(error_rules.contains("rule4"));
+            EXPECT_TRUE(error_rules.contains("rule5"));
         }
 
         {
@@ -127,8 +141,18 @@ TEST(TestDiagnosticsIntegration, RulesWithErrors)
 
             auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
             EXPECT_EQ(error_rules.size(), 1);
-            EXPECT_NE(error_rules.find("rule6"), error_rules.end());
+            EXPECT_TRUE(error_rules.contains("rule6"));
         }
+
+        auto addresses = ddwaf::parser::at<parameter::map>(rules, "addresses");
+        EXPECT_EQ(addresses.size(), 2);
+
+        auto required = ddwaf::parser::at<parameter::string_set>(addresses, "required");
+        EXPECT_EQ(required.size(), 1);
+        EXPECT_TRUE(required.contains("value1"));
+
+        auto optional = ddwaf::parser::at<parameter::string_set>(addresses, "optional");
+        EXPECT_EQ(optional.size(), 0);
 
         ddwaf_object_free(&root);
     }
@@ -156,20 +180,34 @@ TEST(TestDiagnosticsIntegration, CustomRules)
         EXPECT_STR(version, "5.4.3");
 
         auto rules = ddwaf::parser::at<parameter::map>(root_map, "custom_rules");
-        EXPECT_EQ(rules.size(), 3);
+        EXPECT_EQ(rules.size(), 4);
 
         auto loaded = ddwaf::parser::at<parameter::string_set>(rules, "loaded");
         EXPECT_EQ(loaded.size(), 4);
-        EXPECT_NE(loaded.find("custom_rule1"), loaded.end());
-        EXPECT_NE(loaded.find("custom_rule2"), loaded.end());
-        EXPECT_NE(loaded.find("custom_rule3"), loaded.end());
-        EXPECT_NE(loaded.find("custom_rule4"), loaded.end());
+        EXPECT_TRUE(loaded.contains("custom_rule1"));
+        EXPECT_TRUE(loaded.contains("custom_rule2"));
+        EXPECT_TRUE(loaded.contains("custom_rule3"));
+        EXPECT_TRUE(loaded.contains("custom_rule4"));
 
         auto failed = ddwaf::parser::at<parameter::string_set>(rules, "failed");
         EXPECT_EQ(failed.size(), 0);
 
         auto errors = ddwaf::parser::at<parameter::map>(rules, "errors");
         EXPECT_EQ(errors.size(), 0);
+
+        auto addresses = ddwaf::parser::at<parameter::map>(rules, "addresses");
+        EXPECT_EQ(addresses.size(), 2);
+
+        auto required = ddwaf::parser::at<parameter::string_set>(addresses, "required");
+        EXPECT_EQ(required.size(), 5);
+        EXPECT_TRUE(required.contains("value1"));
+        EXPECT_TRUE(required.contains("value2"));
+        EXPECT_TRUE(required.contains("value3"));
+        EXPECT_TRUE(required.contains("value4"));
+        EXPECT_TRUE(required.contains("value34"));
+
+        auto optional = ddwaf::parser::at<parameter::string_set>(addresses, "optional");
+        EXPECT_EQ(optional.size(), 0);
 
         ddwaf_object_free(&root);
     }
@@ -194,16 +232,28 @@ TEST(TestDiagnosticsIntegration, Processor)
         auto root_map = static_cast<parameter::map>(root);
 
         auto processor = ddwaf::parser::at<parameter::map>(root_map, "processors");
+        EXPECT_EQ(processor.size(), 4);
 
         auto loaded = ddwaf::parser::at<parameter::string_set>(processor, "loaded");
         EXPECT_EQ(loaded.size(), 1);
-        EXPECT_NE(loaded.find("processor-001"), loaded.end());
+        EXPECT_TRUE(loaded.contains("processor-001"));
 
         auto failed = ddwaf::parser::at<parameter::string_set>(processor, "failed");
         EXPECT_EQ(failed.size(), 0);
 
         auto errors = ddwaf::parser::at<parameter::map>(processor, "errors");
         EXPECT_EQ(errors.size(), 0);
+
+        auto addresses = ddwaf::parser::at<parameter::map>(processor, "addresses");
+        EXPECT_EQ(addresses.size(), 2);
+
+        auto required = ddwaf::parser::at<parameter::string_set>(addresses, "required");
+        EXPECT_EQ(required.size(), 1);
+        EXPECT_TRUE(required.contains("waf.context.processor"));
+
+        auto optional = ddwaf::parser::at<parameter::string_set>(addresses, "optional");
+        EXPECT_EQ(optional.size(), 1);
+        EXPECT_TRUE(optional.contains("server.request.body"));
 
         ddwaf_object_free(&root);
     }

--- a/tests/integration/diagnostics/yaml/input_filter.yaml
+++ b/tests/integration/diagnostics/yaml/input_filter.yaml
@@ -1,0 +1,29 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: exclusion-filter-1-input
+          regex: exclusion-filter-1
+    inputs:
+      - address: rule1-input1
+        key_path: [parent]
+      - address: rule1-input2
+
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: rule1-input1
+            - address: rule1-input2
+          regex: rule1

--- a/tests/integration/diagnostics/yaml/rule_data.yaml
+++ b/tests/integration/diagnostics/yaml/rule_data.yaml
@@ -1,0 +1,35 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+              - address: http.client_ip
+          data: ip_data
+  - id: 2
+    name: rule2
+    tags:
+      type: flow2
+      category: category2
+    conditions:
+      - operator: exact_match
+        parameters:
+          inputs:
+              - address: usr.id
+          data: usr_data
+rules_data:
+    - id: ip_data
+      type: ip_with_expiration
+      data:
+        - value: 192.168.1.1
+          expiration: 0
+    - id: usr_data
+      type: data_with_expiration
+      data:
+        - value: paco
+          expiration: 0

--- a/tests/integration/processors/test.cpp
+++ b/tests/integration/processors/test.cpp
@@ -19,6 +19,13 @@ TEST(TestProcessors, Postprocessor)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    uint32_t size;
+    const char *const *addresses = ddwaf_known_addresses(handle, &size);
+    EXPECT_EQ(size, 2);
+    std::unordered_set<std::string_view> address_set(addresses, addresses + size);
+    EXPECT_TRUE(address_set.contains("server.request.body"));
+    EXPECT_TRUE(address_set.contains("waf.context.processor"));
+
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
@@ -56,6 +63,13 @@ TEST(TestProcessors, Preprocessor)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    uint32_t size;
+    const char *const *addresses = ddwaf_known_addresses(handle, &size);
+    EXPECT_EQ(size, 3);
+    std::unordered_set<std::string_view> address_set(addresses, addresses + size);
+    EXPECT_TRUE(address_set.contains("server.request.body"));
+    EXPECT_TRUE(address_set.contains("server.request.body.schema"));
+    EXPECT_TRUE(address_set.contains("waf.context.processor"));
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
@@ -99,6 +113,14 @@ TEST(TestProcessors, Processor)
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    uint32_t size;
+    const char *const *addresses = ddwaf_known_addresses(handle, &size);
+    EXPECT_EQ(size, 3);
+    std::unordered_set<std::string_view> address_set(addresses, addresses + size);
+    EXPECT_TRUE(address_set.contains("server.request.body"));
+    EXPECT_TRUE(address_set.contains("server.request.body.schema"));
+    EXPECT_TRUE(address_set.contains("waf.context.processor"));
 
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);

--- a/tests/interface_test.cpp
+++ b/tests/interface_test.cpp
@@ -32,7 +32,7 @@ TEST(TestInterface, RootAddresses)
     ddwaf_object_free(&rule);
 
     uint32_t size;
-    const char *const *addresses = ddwaf_required_addresses(handle, &size);
+    const char *const *addresses = ddwaf_known_addresses(handle, &size);
     EXPECT_EQ(size, 2);
 
     std::set<std::string_view> available_addresses{"value1", "value2"};
@@ -1807,7 +1807,7 @@ TEST(TestInterface, UpdateEverything)
 
     for (auto *handle : {handle1, handle2, handle3, handle4, handle6, handle7, handle8, handle9}) {
         uint32_t size;
-        const char *const *addresses = ddwaf_required_addresses(handle, &size);
+        const char *const *addresses = ddwaf_known_addresses(handle, &size);
         EXPECT_EQ(size, 4);
 
         std::set<std::string_view> available_addresses{"http.client_ip", "server.request.query",
@@ -1819,7 +1819,7 @@ TEST(TestInterface, UpdateEverything)
 
     for (auto *handle : {handle5}) {
         uint32_t size;
-        const char *const *addresses = ddwaf_required_addresses(handle, &size);
+        const char *const *addresses = ddwaf_known_addresses(handle, &size);
         EXPECT_EQ(size, 3);
 
         // While the ruleset contains 2 addresses, an existing object filter

--- a/tests/processor_test.cpp
+++ b/tests/processor_test.cpp
@@ -46,8 +46,8 @@ TEST(TestProcessor, SingleMappingOutputNoEvalUnconditional)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
@@ -97,10 +97,10 @@ TEST(TestProcessor, MultiMappingOutputNoEvalUnconditional)
     store.insert(input_map);
 
     std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address.first"), get_target_index("output_address.first"),
-            "output_address.first"},
-        {get_target_index("input_address.second"), get_target_index("output_address.second"),
-            "output_address.second"}};
+        {get_target_index("input_address.first"), "input_address.first",
+            get_target_index("output_address.first"), "output_address.first"},
+        {get_target_index("input_address.second"), "input_address.second",
+            get_target_index("output_address.second"), "output_address.second"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
@@ -152,8 +152,8 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalTrue)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     expression_builder builder(1);
     builder.start_condition<matcher::equals<bool>>(true);
@@ -196,8 +196,8 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     expression_builder builder(1);
     builder.start_condition<matcher::equals<bool>>(true);
@@ -255,8 +255,8 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalFalse)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     expression_builder builder(1);
     builder.start_condition<matcher::equals<bool>>(true);
@@ -299,8 +299,8 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, false};
@@ -345,8 +345,8 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     expression_builder builder(1);
     builder.start_condition<matcher::equals<bool>>(true);
@@ -390,8 +390,8 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalFalse)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     expression_builder builder(1);
     builder.start_condition<matcher::equals<bool>>(true);
@@ -439,10 +439,10 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
     store.insert(input_map);
 
     std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address.first"), get_target_index("output_address.first"),
-            "output_address.first"},
-        {get_target_index("input_address.second"), get_target_index("output_address.second"),
-            "output_address.second"}};
+        {get_target_index("input_address.first"), "input_address.first",
+            get_target_index("output_address.first"), "output_address.first"},
+        {get_target_index("input_address.second"), "input_address.second",
+            get_target_index("output_address.second"), "output_address.second"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, false};
@@ -488,8 +488,8 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, true};
@@ -542,8 +542,8 @@ TEST(TestProcessor, OutputAlreadyAvailableInStore)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
@@ -577,8 +577,8 @@ TEST(TestProcessor, OutputAlreadyGenerated)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
@@ -614,8 +614,8 @@ TEST(TestProcessor, EvalAlreadyAvailableInStore)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, false};
@@ -643,8 +643,8 @@ TEST(TestProcessor, OutputWithoutDerivedMap)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, false, true};
@@ -675,8 +675,8 @@ TEST(TestProcessor, OutputEvalWithoutDerivedMap)
     object_store store;
     store.insert(input_map);
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, true};
@@ -708,8 +708,8 @@ TEST(TestProcessor, Timeout)
 
     object_store store;
 
-    std::vector<processor::target_mapping> mappings{
-        {get_target_index("input_address"), get_target_index("output_address"), "output_address"}};
+    std::vector<processor::target_mapping> mappings{{get_target_index("input_address"),
+        "input_address", get_target_index("output_address"), "output_address"}};
 
     processor proc{
         "id", std::move(gen), std::make_shared<expression>(), std::move(mappings), {}, true, false};

--- a/tools/verify_ruleset.cpp
+++ b/tools/verify_ruleset.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
     ddwaf_object_free(&diagnostics);
 
     uint32_t required_size;
-    const char *const *required = ddwaf_required_addresses(handle, &required_size);
+    const char *const *required = ddwaf_known_addresses(handle, &required_size);
     DDWAF_INFO("Required addresses: %u", required_size);
     for (uint32_t i = 0; i < required_size; i++) { DDWAF_INFO("    - %s", required[i]); }
     ddwaf_destroy(handle);


### PR DESCRIPTION
This PR introduces information regarding addresses to the diagnostics for each of the different features. This includes both required and optional addresses, for example:
```
  "processors": {
    "loaded": [
      "processor-001"
    ],
    "failed": [],
    "errors": {},
    "addresses": {
      "required": [ ... ],
      "optional": [ ... ]
    }
  },
  ```
  
This allows the WAF user to distinguish which addresses they actually need to provide (required) from those which are opportunistically used (optionals) . It also allows distinguishing addresses which are used in potentially disabled features, for example, the processors section would provide insights into the addresses used for schema extraction:
- Required refers to the condition addresses.
- Optional refers to the mappings used to generate schemas, these are not "required" to run the processor but if available they will be used.

Unfortunately, it's not possible to distinguish which addresses correspond to the schema extraction processor, although if more processors are included in the future, this might be required.

Finally, this PR also renames `ddwaf_required_addresses` to `ddwaf_known_addresses` to better reflect the actual contents. This function now also returns optional addresses (processor mappings, object filter addresses) and required addresses (mainly condition addresses).

Related Jira [APPSEC-11125]

[APPSEC-11125]: https://datadoghq.atlassian.net/browse/APPSEC-11125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ