### PR TITLE
Duplicate address support on input/object filters

### DIFF
--- a/src/exclusion/object_filter.cpp
+++ b/src/exclusion/object_filter.cpp
@@ -100,17 +100,13 @@ memory::unordered_set<const ddwaf_object *> object_filter::match(
             throw ddwaf::timeout_exception();
         }
 
-        if (cache.find(target) != cache.end()) {
-            continue;
-        }
-
         auto *object = store.get_target(target);
-        if (object == nullptr) {
+        if (object == nullptr || cache.contains(object)) {
             continue;
         }
         iterate_object(filter.get_traverser(), object, objects_to_exclude, limits_);
 
-        cache.emplace(target);
+        cache.emplace(object);
     }
 
     return objects_to_exclude;

--- a/src/exclusion/object_filter.hpp
+++ b/src/exclusion/object_filter.hpp
@@ -236,7 +236,7 @@ inline std::ostream &operator<<(std::ostream &os, const path_trie::traverser::st
 
 class object_filter {
 public:
-    using cache_type = std::unordered_set<target_index>;
+    using cache_type = memory::unordered_set<ddwaf_object *>;
 
     explicit object_filter(const ddwaf::object_limits &limits = {}) : limits_(limits) {}
 

--- a/tests/object_filter_test.cpp
+++ b/tests/object_filter_test.cpp
@@ -93,7 +93,9 @@ TEST(TestObjectFilter, DuplicateCachedTarget)
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
 
-    ddwaf_object root, child, tmp;
+    ddwaf_object root;
+    ddwaf_object child;
+    ddwaf_object tmp;
     ddwaf_object_map(&child);
     ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
     ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));

--- a/tests/object_filter_test.cpp
+++ b/tests/object_filter_test.cpp
@@ -38,6 +38,49 @@ TEST(TestObjectFilter, RootTarget)
     EXPECT_NE(objects_filtered.find(&root.array[0]), objects_filtered.end());
 }
 
+TEST(TestObjectFilter, DuplicateTarget)
+{
+    auto query = get_target_index("query");
+
+    object_store store;
+
+    object_filter filter;
+    filter.insert(query, "query", {});
+
+    ddwaf::timer deadline{2s};
+    object_filter::cache_type cache;
+
+    {
+        ddwaf_object root, child, tmp;
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+
+        ASSERT_EQ(objects_filtered.size(), 1);
+        EXPECT_NE(objects_filtered.find(&root.array[0]), objects_filtered.end());
+    }
+
+    {
+        ddwaf_object root, child, tmp;
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+
+        ASSERT_EQ(objects_filtered.size(), 1);
+        EXPECT_NE(objects_filtered.find(&root.array[0]), objects_filtered.end());
+    }
+}
+
 TEST(TestObjectFilter, SingleTarget)
 {
     auto query = get_target_index("query");
@@ -62,6 +105,49 @@ TEST(TestObjectFilter, SingleTarget)
 
     ASSERT_EQ(objects_filtered.size(), 1);
     EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
+}
+
+TEST(TestObjectFilter, DuplicateSingleTarget)
+{
+    auto query = get_target_index("query");
+
+    object_store store;
+
+    object_filter filter;
+    filter.insert(query, "query", {"params"});
+
+    ddwaf::timer deadline{2s};
+    object_filter::cache_type cache;
+
+    {
+        ddwaf_object root, child, tmp;
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        ASSERT_EQ(objects_filtered.size(), 1);
+        EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
+    }
+
+    {
+        ddwaf_object root, child, tmp;
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+        ASSERT_EQ(objects_filtered.size(), 1);
+        EXPECT_NE(objects_filtered.find(&child.array[0]), objects_filtered.end());
+    }
 }
 
 TEST(TestObjectFilter, MultipleTargets)
@@ -105,6 +191,81 @@ TEST(TestObjectFilter, MultipleTargets)
     ASSERT_EQ(objects_filtered.size(), 2);
     EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
     EXPECT_NE(objects_filtered.find(&object.array[0]), objects_filtered.end());
+}
+
+TEST(TestObjectFilter, DuplicateMultipleTargets)
+{
+    auto query = get_target_index("query");
+    auto path_params = get_target_index("path_params");
+
+    object_store store;
+
+    ddwaf_object root, child, sibling, object, tmp;
+
+    object_filter filter;
+    filter.insert(query, "query", {"uri"});
+    filter.insert(path_params, "path_params", {"token", "value"});
+
+    ddwaf::timer deadline{2s};
+    object_filter::cache_type cache;
+
+    {
+        // Query
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+
+        // Path Params
+        ddwaf_object_map(&object);
+        ddwaf_object_map_add(&object, "value", ddwaf_object_string(&tmp, "naskjdnakjsd"));
+        ddwaf_object_map_add(&object, "expiration", ddwaf_object_string(&tmp, "yesterday"));
+
+        ddwaf_object_map(&sibling);
+        ddwaf_object_map_add(&sibling, "token", &object);
+        ddwaf_object_map_add(&sibling, "username", ddwaf_object_string(&tmp, "Paco"));
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+        ddwaf_object_map_add(&root, "path_params", &sibling);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+
+        ASSERT_EQ(objects_filtered.size(), 2);
+        EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&object.array[0]), objects_filtered.end());
+    }
+
+    {
+        // Query
+        ddwaf_object_map(&child);
+        ddwaf_object_map_add(&child, "params", ddwaf_object_string(&tmp, "paramsvalue"));
+        ddwaf_object_map_add(&child, "uri", ddwaf_object_string(&tmp, "uri_value"));
+
+        // Path Params
+        ddwaf_object_map(&object);
+        ddwaf_object_map_add(&object, "value", ddwaf_object_string(&tmp, "naskjdnakjsd"));
+        ddwaf_object_map_add(&object, "expiration", ddwaf_object_string(&tmp, "yesterday"));
+
+        ddwaf_object_map(&sibling);
+        ddwaf_object_map_add(&sibling, "token", &object);
+        ddwaf_object_map_add(&sibling, "username", ddwaf_object_string(&tmp, "Paco"));
+
+        // Root object
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "query", &child);
+        ddwaf_object_map_add(&root, "path_params", &sibling);
+
+        store.insert(root);
+
+        auto objects_filtered = filter.match(store, cache, deadline);
+
+        ASSERT_EQ(objects_filtered.size(), 2);
+        EXPECT_NE(objects_filtered.find(&child.array[1]), objects_filtered.end());
+        EXPECT_NE(objects_filtered.find(&object.array[0]), objects_filtered.end());
+    }
 }
 
 TEST(TestObjectFilter, MissingTarget)


### PR DESCRIPTION
The WAF offers naive support for duplicate addresses across calls to `ddwaf_run`, however object filters do not support this feature due to the way they cache targets. This change allows the object filter to efficiently cache targets whilst providing support for duplicate addresses.

Related Jira: [APPSEC-11672]

[APPSEC-11672]: https://datadoghq.atlassian.net/browse/APPSEC-11672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ