### PR TITLE
Reduce linux binary size and fix some flaky tests

### DIFF
--- a/docker/libddwaf/build/Dockerfile
+++ b/docker/libddwaf/build/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p build
 RUN cd build && cmake \
     -G Ninja \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    -DCMAKE_TOOLCHAIN_FILE=/sysroot/${ARCH}-none-linux-musl/Toolchain.cmake \
+    -DCMAKE_TOOLCHAIN_FILE=/libddwaf/docker/libddwaf/sysroot/Toolchain.cmake.${ARCH} \
     ../libddwaf && ninja
 RUN patchelf --remove-needed $(basename /sysroot/${ARCH}-none-linux-musl/lib/libc.musl-*.so.1) /build/libddwaf.so
 
@@ -24,7 +24,7 @@ RUN cd /build && \
     mv libddwaf-combined.a libddwaf.a
 
 # Strip archive
-RUN cd /build && stripcmd=$(egrep -o "/usr/bin/[a-z0-9\_-]*-strip" /sysroot/${ARCH}-none-linux-musl/Toolchain.cmake) ; $stripcmd -x -S libddwaf.a -o libddwaf.a.stripped
+RUN cd /build && stripcmd=$(egrep -o "/usr/bin/[a-z0-9\_-]*-strip" /libddwaf/docker/libddwaf/sysroot/Toolchain.cmake.${ARCH}) ; $stripcmd -x -S libddwaf.a -o libddwaf.a.stripped
 
 RUN cd /build && ninja package && \
     new_name=$(ls libddwaf-*.tar.gz | head -n1 | sed "s/\(libddwaf-[\.0-9]*\)-linux-\([_a-zA-Z0-9]*\)\(-\?[a-zA-Z0-9]*.tar.gz\)/\1-\2-linux-musl\3/g") ; \

--- a/docker/libddwaf/sysroot/Toolchain.cmake.aarch64
+++ b/docker/libddwaf/sysroot/Toolchain.cmake.aarch64
@@ -10,13 +10,13 @@ set(CMAKE_ASM_COMPILER_TARGET ${triple})
 set(CMAKE_C_COMPILER /usr/bin/clang-16)
 set(CMAKE_C_COMPILER_TARGET ${triple})
 
-set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer")
+set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer -ffunction-sections -fdata-sections")
 set(CMAKE_C_FLAGS ${c_cxx_flags})
 set(CMAKE_CXX_COMPILER /usr/bin/clang++-16)
 set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${c_cxx_flags}")
 
-set(linker_flags "-v -fuse-ld=lld-16 -nodefaultlibs -Wl,-Bstatic -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -Wl,-Bdynamic -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -Wl,--dynamic-linker,${sysroot}/lib/${interpreter} -Wl,-rpath=${sysroot} -resource-dir ${sysroot}/usr/lib/resource_dir")
+set(linker_flags "-v -fuse-ld=lld-16 -nodefaultlibs -Wl,-Bstatic -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -Wl,-Bdynamic -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -Wl,--dynamic-linker,${sysroot}/lib/${interpreter} -Wl,-rpath=${sysroot} -resource-dir ${sysroot}/usr/lib/resource_dir -Wl,--gc-sections -Wl,--discard-all -Wl,--icf=safe -Wl,--print-icf-sections")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "${linker_flags} -Wl,--dynamic-linker,${sysroot}/lib/${interpreter}")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT ${linker_flags})
 

--- a/docker/libddwaf/sysroot/Toolchain.cmake.armv7
+++ b/docker/libddwaf/sysroot/Toolchain.cmake.armv7
@@ -10,13 +10,13 @@ set(CMAKE_ASM_COMPILER_TARGET ${triple})
 set(CMAKE_C_COMPILER /usr/bin/clang-16)
 set(CMAKE_C_COMPILER_TARGET ${triple})
 
-set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -march=armv7-a -mfloat-abi=hard -fno-omit-frame-pointer")
+set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -march=armv7-a -mfloat-abi=hard -fno-omit-frame-pointer -ffunction-sections -fdata-sections")
 set(CMAKE_C_FLAGS ${c_cxx_flags})
 set(CMAKE_CXX_COMPILER /usr/bin/clang++-16)
 set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${c_cxx_flags}")
 
-set(linker_flags "-v -fuse-ld=lld-16 -nodefaultlibs -Wl,-Bstatic -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -Wl,-Bdynamic -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -Wl,--dynamic-linker,${sysroot}/lib/${interpreter} -Wl,-rpath=${sysroot} -resource-dir ${sysroot}/usr/lib/resource_dir")
+set(linker_flags "-v -fuse-ld=lld-16 -nodefaultlibs -Wl,-Bstatic -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -Wl,-Bdynamic -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -Wl,--dynamic-linker,${sysroot}/lib/${interpreter} -Wl,-rpath=${sysroot} -resource-dir ${sysroot}/usr/lib/resource_dir -Wl,--gc-sections -Wl,--discard-all -Wl,--icf=safe -Wl,--print-icf-sections")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "${linker_flags} -Wl,--dynamic-linker,${sysroot}/lib/${interpreter}")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT ${linker_flags})
 

--- a/docker/libddwaf/sysroot/Toolchain.cmake.i386
+++ b/docker/libddwaf/sysroot/Toolchain.cmake.i386
@@ -10,13 +10,13 @@ set(CMAKE_ASM_COMPILER_TARGET ${triple})
 set(CMAKE_C_COMPILER /usr/bin/clang-16)
 set(CMAKE_C_COMPILER_TARGET ${triple})
 
-set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer")
+set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer -ffunction-sections -fdata-sections")
 set(CMAKE_C_FLAGS ${c_cxx_flags})
 set(CMAKE_CXX_COMPILER /usr/bin/clang++-16)
 set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${c_cxx_flags}")
 
-set(linker_flags "-v -fuse-ld=lld-16 -nodefaultlibs -Wl,-Bstatic -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -Wl,-Bdynamic -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -Wl,--dynamic-linker,${sysroot}/lib/${interpreter} -Wl,-rpath=${sysroot} -resource-dir ${sysroot}/usr/lib/resource_dir")
+set(linker_flags "-v -fuse-ld=lld-16 -nodefaultlibs -Wl,-Bstatic -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -Wl,-Bdynamic -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -Wl,--dynamic-linker,${sysroot}/lib/${interpreter} -Wl,-rpath=${sysroot} -resource-dir ${sysroot}/usr/lib/resource_dir -Wl,--gc-sections -Wl,--discard-all -Wl,--icf=safe -Wl,--print-icf-sections")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "${linker_flags} -Wl,--dynamic-linker,${sysroot}/lib/${interpreter}")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT ${linker_flags})
 

--- a/docker/libddwaf/sysroot/Toolchain.cmake.x86_64
+++ b/docker/libddwaf/sysroot/Toolchain.cmake.x86_64
@@ -10,13 +10,13 @@ set(CMAKE_ASM_COMPILER_TARGET ${triple})
 set(CMAKE_C_COMPILER /usr/bin/clang-16)
 set(CMAKE_C_COMPILER_TARGET ${triple})
 
-set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer")
+set(c_cxx_flags "-Qunused-arguments -rtlib=compiler-rt -unwindlib=libunwind -static-libgcc -fno-omit-frame-pointer -ffunction-sections -fdata-sections")
 set(CMAKE_C_FLAGS ${c_cxx_flags})
 set(CMAKE_CXX_COMPILER /usr/bin/clang++-16)
 set(CMAKE_CXX_COMPILER_TARGET ${triple})
 set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${c_cxx_flags}")
 
-set(linker_flags "-v -fuse-ld=lld-16 -nodefaultlibs -Wl,-Bstatic -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -Wl,-Bdynamic -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -Wl,--dynamic-linker,${sysroot}/lib/${interpreter} -Wl,-rpath=${sysroot} -resource-dir ${sysroot}/usr/lib/resource_dir")
+set(linker_flags "-v -fuse-ld=lld-16 -nodefaultlibs -Wl,-Bstatic -lc++ -lc++abi ${sysroot}/usr/lib/libclang_rt.builtins.a -lunwind -Wl,-Bdynamic -lc ${sysroot}/usr/lib/libclang_rt.builtins.a -Wl,--dynamic-linker,${sysroot}/lib/${interpreter} -Wl,-rpath=${sysroot} -resource-dir ${sysroot}/usr/lib/resource_dir -Wl,--gc-sections -Wl,--discard-all -Wl,--icf=safe -Wl,--print-icf-sections")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "${linker_flags} -Wl,--dynamic-linker,${sysroot}/lib/${interpreter}")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT ${linker_flags})
 

--- a/tests/integration/matchers/test.cpp
+++ b/tests/integration/matchers/test.cpp
@@ -28,7 +28,7 @@ TEST(TestIntegrationOperation, StringEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(
         out, {.id = "1",
@@ -59,7 +59,7 @@ TEST(TestIntegrationOperation, BoolEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out,
         {.id = "2",
@@ -89,7 +89,7 @@ TEST(TestIntegrationOperation, SignedEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out,
         {.id = "3",
@@ -119,7 +119,7 @@ TEST(TestIntegrationOperation, UnsignedEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out,
         {.id = "4",
@@ -149,7 +149,7 @@ TEST(TestIntegrationOperation, FloatEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out,
         {.id = "5",

--- a/tests/integration/processors/test.cpp
+++ b/tests/integration/processors/test.cpp
@@ -42,7 +42,7 @@ TEST(TestProcessors, Postprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
     EXPECT_FALSE(out.timeout);
 
     EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
@@ -86,7 +86,7 @@ TEST(TestProcessors, Preprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
 
     EXPECT_EVENTS(out, {.id = "rule1",
@@ -138,7 +138,7 @@ TEST(TestProcessors, Processor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
 
     EXPECT_EVENTS(out, {.id = "rule1",
@@ -186,7 +186,7 @@ TEST(TestProcessors, ProcessorWithScannerByTags)
     ASSERT_NE(context, nullptr);
 
     ddwaf_result out;
-    ddwaf_run(context, &map, nullptr, &out, 2000);
+    ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
     EXPECT_FALSE(out.timeout);
     EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -223,7 +223,7 @@ TEST(TestProcessors, ProcessorWithScannerByID)
     ASSERT_NE(context, nullptr);
 
     ddwaf_result out;
-    ddwaf_run(context, &map, nullptr, &out, 2000);
+    ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
     EXPECT_FALSE(out.timeout);
     EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -263,7 +263,7 @@ TEST(TestProcessors, ProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -300,7 +300,7 @@ TEST(TestProcessors, ProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -340,7 +340,7 @@ TEST(TestProcessors, ScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -378,7 +378,7 @@ TEST(TestProcessors, ScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -419,7 +419,7 @@ TEST(TestProcessors, ProcessorAndScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -456,7 +456,7 @@ TEST(TestProcessors, ProcessorAndScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -497,7 +497,7 @@ TEST(TestProcessors, EmptyScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -534,7 +534,7 @@ TEST(TestProcessors, EmptyScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -574,7 +574,7 @@ TEST(TestProcessors, EmptyProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
 
@@ -611,7 +611,7 @@ TEST(TestProcessors, EmptyProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_result out;
-        ddwaf_run(context, &map, nullptr, &out, 2000);
+        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
         EXPECT_FALSE(out.timeout);
         EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
 

--- a/tests/integration/regressions/test.cpp
+++ b/tests/integration/regressions/test.cpp
@@ -33,7 +33,7 @@ TEST(TestRegressionsIntegration, TruncatedUTF8)
     ddwaf_object_map_add(&map, "value", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
 
     // The emoji should be trimmed out of the result

--- a/tests/integration/transformers/test.cpp
+++ b/tests/integration/transformers/test.cpp
@@ -28,7 +28,7 @@ TEST(TestTransformers, Base64Decode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -60,7 +60,7 @@ TEST(TestTransformers, Base64DecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -92,7 +92,7 @@ TEST(TestTransformers, Base64Encode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -125,7 +125,7 @@ TEST(TestTransformers, Base64EncodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -158,7 +158,7 @@ TEST(TestTransformers, CompressWhitespace)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -191,7 +191,7 @@ TEST(TestTransformers, CompressWhitespaceAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -224,7 +224,7 @@ TEST(TestTransformers, CssDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -257,7 +257,7 @@ TEST(TestTransformers, CssDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -290,7 +290,7 @@ TEST(TestTransformers, HtmlEntityDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -323,7 +323,7 @@ TEST(TestTransformers, HtmlEntityDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -356,7 +356,7 @@ TEST(TestTransformers, JsDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -389,7 +389,7 @@ TEST(TestTransformers, JsDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -422,7 +422,7 @@ TEST(TestTransformers, Lowercase)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -455,7 +455,7 @@ TEST(TestTransformers, NormalizePath)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -488,7 +488,7 @@ TEST(TestTransformers, NormalizePathAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -521,7 +521,7 @@ TEST(TestTransformers, NormalizePathWin)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -554,7 +554,7 @@ TEST(TestTransformers, NormalizePathAliasWin)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -587,7 +587,7 @@ TEST(TestTransformers, RemoveComments)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -620,7 +620,7 @@ TEST(TestTransformers, RemoveCommentsAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -653,7 +653,7 @@ TEST(TestTransformers, RemoveNulls)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -686,7 +686,7 @@ TEST(TestTransformers, RemoveNullsAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -719,7 +719,7 @@ TEST(TestTransformers, ShellUnescape)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -752,7 +752,7 @@ TEST(TestTransformers, ShellUnescapeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -785,7 +785,7 @@ TEST(TestTransformers, UnicodeNormalize)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -818,7 +818,7 @@ TEST(TestTransformers, UrlBasename)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -851,7 +851,7 @@ TEST(TestTransformers, UrlBasenameAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -884,7 +884,7 @@ TEST(TestTransformers, UrlDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -917,7 +917,7 @@ TEST(TestTransformers, UrlDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -950,7 +950,7 @@ TEST(TestTransformers, UrlDecodeIis)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -983,7 +983,7 @@ TEST(TestTransformers, UrlDecodeIisAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -1016,7 +1016,7 @@ TEST(TestTransformers, UrlPath)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -1049,7 +1049,7 @@ TEST(TestTransformers, UrlPathAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -1082,7 +1082,7 @@ TEST(TestTransformers, UrlQuerystring)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -1115,7 +1115,7 @@ TEST(TestTransformers, UrlQuerystringAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -1148,7 +1148,7 @@ TEST(TestTransformers, Mixed)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_result out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, 2000), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_FALSE(out.timeout);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",


### PR DESCRIPTION
Attempt to reduce binary size:
* Unused section elimination: `-ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,--discard-all ` 
* Identical code folding: `-Wl,--icf=safe -Wl,--print-icf-sections`

This PR also changes the toolchain file used to allow changes without rebuild.

Using `-flto` seems to cause some issues with the static libraries.

Results for `libddwaf.so`:
```
+---------+---------+---------+------------+
| Arch    | 1.14.0  | 1.15.0  | Difference |
+---------+---------+---------+------------+
| Aarch64 | 2523712 | 2127104 | 15.72%     |
| x86_64  | 2595272 | 2195224 | 15.41%     |
| armv7   | 2100652 | 1725020 | 17.88%     |
| i386    | 2302492 | 1908688 | 17.10%     |
+---------+---------+---------+------------+
| Average | 2380532 | 1989009 | 16.53%     |
+---------+---------+---------+------------+
```