### PR TITLE
Build tools on CI to avoid breaking tool users

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,9 @@ name: Benchmark
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches:
+      - "**"
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,3 +194,29 @@ jobs:
       - name: Tidy
         run: make tidy || true
         working-directory: Debug
+
+  tools:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Create directories
+        run: mkdir Debug
+
+      - name: CMake
+        env:
+          CC: gcc-12
+          CXX: g++-12
+        run: |
+          cmake .. -DCMAKE_BUILD_TYPE=Debug 
+        working-directory: Debug
+
+      - name: Build
+        run: VERBOSE=1 make -j $(nproc) verify_rule verify_ruleset waf_runner validate_schema
+        working-directory: Debug
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This new version of the WAF includes the following new features:
 - Naive duplicate address support on input filters
 - Required / Optional address diagnostics
 
-The [upgrading guide](UGRADING.md) has also been updated to cover the new changes.
+The [upgrading guide](UPGRADING.md) has also been updated to cover the new changes.
 
 #### API & Breaking Changes
 - Support ephemeral addresses on `ddwaf_run` ([#219](https://github.com/DataDog/libddwaf/pull/219))
@@ -66,7 +66,7 @@ This new version of the WAF includes the following new features:
 - Equals operator for arbitrary type equality comparison within conditions
 - Many other quality of life, correctness and performance improvements
 
-The [upgrading guide](UGRADING.md) has also been updated to cover the new changes.
+The [upgrading guide](UPGRADING.md) has also been updated to cover the new changes.
 
 #### API & Breaking Changes
 - Add object types `DDWAF_OBJ_FLOAT` and `DDWAF_OBJ_NULL` ([#197](https://github.com/DataDog/libddwaf/pull/197))


### PR DESCRIPTION
Rule writers use some existing WAF tools to validate new rules, this change adds a CI job to verify that the tools are building as expected.