### PR TITLE
Improvements to WAF Runner utility

### DIFF
--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -676,7 +676,7 @@ processor_container parse_processors(
     parameter::vector &processor_array, base_section_info &info, const object_limits &limits)
 {
     processor_container processors;
-    std::unordered_set<std::string_view> known_processors;
+    std::unordered_set<std::string> known_processors;
 
     for (unsigned i = 0; i < processor_array.size(); i++) {
         const auto &node_param = processor_array[i];

--- a/tools/common/utils.cpp
+++ b/tools/common/utils.cpp
@@ -53,8 +53,30 @@ ddwaf_object yaml_to_object(const Node& node)
         }
         case NodeType::Scalar:
         {
-            const std::string& value = node.Scalar();
             ddwaf_object arg;
+            if (node.Tag() == "?") {
+                try {
+                    ddwaf_object_unsigned(&arg, node.as<uint64_t>());
+                    return arg;
+                } catch (...) {}
+
+                try {
+                    ddwaf_object_signed(&arg, node.as<int64_t>());
+                    return arg;
+                } catch (...) {}
+
+                try {
+                    ddwaf_object_float(&arg, node.as<double>());
+                    return arg;
+                } catch (...) {}
+
+                try {
+                    ddwaf_object_bool(&arg, node.as<bool>());
+                    return arg;
+                } catch (...) {}
+            }
+
+            const std::string &value = node.Scalar();
             ddwaf_object_stringl(&arg, value.c_str(), value.size());
             return arg;
         }

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -3,77 +3,128 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
+
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+#include <yaml-cpp/emitter.h>
+#include <yaml-cpp/emittermanip.h>
+#include <yaml-cpp/node/parse.h>
+
 #include "common/utils.hpp"
 #include "ddwaf.h"
+
+// NOLINTNEXTLINE
+auto parse_args(int argc, char *argv[])
+{
+    const std::map<std::string, std::string, std::less<>> arg_mapping{
+        {"-r", "--ruleset"}, {"-d", "--data"}, {"--ruleset", "--ruleset"}, {"--data", "--data"}};
+
+    std::unordered_map<std::string, std::vector<std::string>> args;
+    auto last_arg = args.end();
+    for (int i = 1; i < argc; i++) {
+        std::string_view arg = argv[i];
+        if (arg.starts_with('-')) {
+            if (auto long_arg = arg_mapping.find(arg); long_arg != arg_mapping.end()) {
+                arg = long_arg->second;
+            } else {
+                continue; // Unknown option
+            }
+
+            auto [it, res] = args.emplace(arg, std::vector<std::string>{});
+            last_arg = it;
+        } else if (last_arg != args.end()) {
+            last_arg->second.emplace_back(arg);
+        }
+    }
+    return args;
+}
 
 int main(int argc, char *argv[])
 {
     ddwaf_set_log_cb(log_cb, DDWAF_LOG_OFF);
-    if (argc < 3) {
-        std::cout << "Usage: " << argv[0] << " <json/yaml file> [<json/yaml file>] <json input>\n";
+
+    auto args = parse_args(argc, argv);
+
+    const std::vector<std::string> rulesets = args["--ruleset"];
+    const std::vector<std::string> inputs = args["--data"];
+    if (rulesets.empty() || inputs.empty()) {
+        std::cout << "Usage: " << argv[0] << " --ruleset <json/yaml file> [<json/yaml file>..]"
+                  << " --data <json input> [<json input>..]\n";
         return EXIT_FAILURE;
     }
 
-    std::string rule_str = read_file(argv[1]);
-    auto rule = YAML::Load(rule_str).as<ddwaf_object>();
-
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
-    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
-    ddwaf_object_free(&rule);
-    if (handle == nullptr) {
-        std::cout << "Failed to load " << argv[1] << '\n';
-        return EXIT_FAILURE;
-    }
-
-    auto input = YAML::Load(argv[argc - 1]).as<ddwaf_object>();
-    unsigned num_configs = argc - 2;
-    for (unsigned i = 0; i < num_configs; ++i) {
-        const char *config = argv[i + 1];
-        if (i > 0) {
-            std::string update_str = read_file(config);
-            auto update = YAML::Load(update_str).as<ddwaf_object>();
-
-            ddwaf_handle updated_handle = ddwaf_update(handle, &update, nullptr);
-            ddwaf_object_free(&update);
-
-            if (updated_handle == nullptr) {
-                std::cout << "Failed to load " << config << '\n';
-                return EXIT_FAILURE;
-            }
-
+    ddwaf_handle handle = nullptr;
+    for (const auto &ruleset : rulesets) {
+        auto rule = YAML::Load(read_file(ruleset)).as<ddwaf_object>();
+        if (handle == nullptr) {
+            const ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, ddwaf_object_free};
+            handle = ddwaf_init(&rule, &config, nullptr);
+        } else {
+            auto *updated_handle = ddwaf_update(handle, &rule, nullptr);
             ddwaf_destroy(handle);
             handle = updated_handle;
         }
 
-        std::cout << "Run with " << config << " :\n";
+        ddwaf_object_free(&rule);
+        if (handle == nullptr) {
+            std::cout << "Failed to load " << ruleset << '\n';
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "-- Run with " << ruleset << '\n';
 
         ddwaf_context context = ddwaf_context_init(handle);
         if (context == nullptr) {
             ddwaf_destroy(handle);
+            std::cout << "Failed to initialise context\n";
             return EXIT_FAILURE;
         }
 
-        ddwaf_result ret;
-        auto code = ddwaf_run(context, &input, nullptr, &ret, std::numeric_limits<uint32_t>::max());
-        if (code == DDWAF_MATCH && ddwaf_object_size(&ret.events) > 0) {
-            std::stringstream ss;
-            YAML::Emitter out(ss);
-            out.SetIndent(2);
-            out.SetMapFormat(YAML::Block);
-            out.SetSeqFormat(YAML::Block);
-            out << object_to_yaml(ret.events);
+        for (const auto &json_str : inputs) {
 
-            std::cout << ss.str() << '\n';
-        } else {
-            std::cout << "Nothing found\n";
+            std::cout << "---- Run with " << json_str << '\n';
+            auto input = YAML::Load(json_str).as<ddwaf_object>();
+
+            ddwaf_result ret;
+            auto code =
+                ddwaf_run(context, &input, nullptr, &ret, std::numeric_limits<uint32_t>::max());
+            if (code == DDWAF_MATCH && ddwaf_object_size(&ret.events) > 0) {
+                std::stringstream ss;
+                YAML::Emitter out(ss);
+                out.SetIndent(2);
+                out.SetMapFormat(YAML::Block);
+                out.SetSeqFormat(YAML::Block);
+                out << object_to_yaml(ret.events);
+
+                std::cout << "Events:\n" << ss.str() << "\n\n";
+            }
+
+            if (ddwaf_object_size(&ret.derivatives) > 0) {
+                std::stringstream ss;
+                YAML::Emitter out(ss);
+                out.SetIndent(2);
+                out.SetMapFormat(YAML::Block);
+                out.SetSeqFormat(YAML::Block);
+                out << object_to_yaml(ret.derivatives);
+
+                std::cout << "Derivatives:\n" << ss.str() << "\n\n";
+            }
+
+            ddwaf_result_free(&ret);
         }
-        std::cout << std::endl;
 
-        ddwaf_result_free(&ret);
         ddwaf_context_destroy(context);
     }
 
-    ddwaf_object_free(&input);
     ddwaf_destroy(handle);
 
     return EXIT_SUCCESS;

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -108,6 +108,17 @@ int main(int argc, char *argv[])
                 std::cout << "Events:\n" << ss.str() << "\n\n";
             }
 
+            if (code == DDWAF_MATCH && ddwaf_object_size(&ret.actions) > 0) {
+                std::stringstream ss;
+                YAML::Emitter out(ss);
+                out.SetIndent(2);
+                out.SetMapFormat(YAML::Block);
+                out.SetSeqFormat(YAML::Block);
+                out << object_to_yaml(ret.actions);
+
+                std::cout << "Actions:\n" << ss.str() << "\n\n";
+            }
+
             if (ddwaf_object_size(&ret.derivatives) > 0) {
                 std::stringstream ss;
                 YAML::Emitter out(ss);

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -26,7 +26,7 @@
 auto parse_args(int argc, char *argv[])
 {
     const std::map<std::string, std::string, std::less<>> arg_mapping{
-        {"-r", "--ruleset"}, {"-d", "--data"}, {"--ruleset", "--ruleset"}, {"--data", "--data"}};
+        {"-r", "--ruleset"}, {"-i", "--input"}, {"--ruleset", "--ruleset"}, {"--input", "--input"}};
 
     std::unordered_map<std::string, std::vector<std::string>> args;
     auto last_arg = args.end();
@@ -55,10 +55,10 @@ int main(int argc, char *argv[])
     auto args = parse_args(argc, argv);
 
     const std::vector<std::string> rulesets = args["--ruleset"];
-    const std::vector<std::string> inputs = args["--data"];
+    const std::vector<std::string> inputs = args["--input"];
     if (rulesets.empty() || inputs.empty()) {
         std::cout << "Usage: " << argv[0] << " --ruleset <json/yaml file> [<json/yaml file>..]"
-                  << " --data <json input> [<json input>..]\n";
+                  << " --input <json input> [<json input>..]\n";
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
WAF Runner Improvements:

- Run on multiple inputs with `--input <json input> [<json input>..]`
- Run on multiple configs with `--ruleset <json/yaml file> [<json/yaml file>..]`
- Print events, actions and derivatives