### PR TITLE
SECRES-1649 - Address a libinjection false positive

### DIFF
--- a/src/vendor/libinjection/src/libinjection_sqli.c
+++ b/src/vendor/libinjection/src/libinjection_sqli.c
@@ -293,17 +293,19 @@ static void st_clear(stoken_t * st)
 static void st_assign(stoken_t * st, const char stype,
                       size_t pos, size_t len, const char* value)
 {
-    const size_t MSIZE = LIBINJECTION_SQLI_TOKEN_SIZE;
-    size_t last = len < MSIZE ? len : (MSIZE - 1);
     st->type = (char) stype;
     st->pos = pos;
-    st->len = last;
-    if(len == 1) {
+    if (len == 1) {
+        st->len = 1;
         st->val[0] = *value;
+        st->val[1] = CHAR_NULL;
     } else {
+        const size_t MSIZE = LIBINJECTION_SQLI_TOKEN_SIZE;
+        size_t last = len < MSIZE ? len : (MSIZE - 1);
+        st->len = last;
         memcpy(st->val, value, last);
+        st->val[last] = CHAR_NULL;
     }
-    st->val[last] = CHAR_NULL;
 }
 
 static void sf_update_state(struct libinjection_sqli_state * sf, const char stype,

--- a/src/vendor/libinjection/src/libinjection_sqli.c
+++ b/src/vendor/libinjection/src/libinjection_sqli.c
@@ -298,7 +298,11 @@ static void st_assign(stoken_t * st, const char stype,
     st->type = (char) stype;
     st->pos = pos;
     st->len = last;
-    memcpy(st->val, value, last);
+    if(len == 1) {
+        st->val[0] = *value;
+    } else {
+        memcpy(st->val, value, last);
+    }
     st->val[last] = CHAR_NULL;
 }
 

--- a/src/vendor/libinjection/src/libinjection_sqli.h
+++ b/src/vendor/libinjection/src/libinjection_sqli.h
@@ -18,6 +18,7 @@ extern "C" {
  * Pull in size_t
  */
 #include <string.h>
+#include <stdbool.h>
 
 enum sqli_flags {
     FLAG_NONE            = 0
@@ -121,6 +122,9 @@ struct libinjection_sqli_state {
      * Minimum of 8 bytes to add gcc's -fstack-protector to work
      */
     char fingerprint[8];
+    
+    bool hadWordBoundary;
+    bool illegalState;
 
     /*
      * Line number of code that said decided if the input was SQLi or

--- a/src/vendor/libinjection/src/libinjection_sqli.h
+++ b/src/vendor/libinjection/src/libinjection_sqli.h
@@ -123,9 +123,6 @@ struct libinjection_sqli_state {
      */
     char fingerprint[8];
     
-    bool hadWordBoundary;
-    bool illegalState;
-
     /*
      * Line number of code that said decided if the input was SQLi or
      * not.  Most of the time it's line that said "it's not a matching
@@ -174,7 +171,9 @@ struct libinjection_sqli_state {
      * total tokens processed
      */
     int stats_tokens;
-
+    
+    bool hadWordBoundary;
+    bool illegalState;
 };
 
 typedef struct libinjection_sqli_state sfilter;

--- a/tests/matcher/is_sqli_test.cpp
+++ b/tests/matcher/is_sqli_test.cpp
@@ -36,7 +36,7 @@ TEST(TestIsSQLi, TestNoMatch)
     for (auto pattern : no_match) {
         ddwaf_object param;
         ddwaf_object_string(&param, pattern);
-        EXPECT_FALSE(matcher.match(param));
+        EXPECT_FALSE(matcher.match(param).first);
         ddwaf_object_free(&param);
     }
 }

--- a/tests/matcher/is_sqli_test.cpp
+++ b/tests/matcher/is_sqli_test.cpp
@@ -37,14 +37,9 @@ TEST(TestIsSQLi, TestNoMatch)
     };
     
     for (auto pattern : no_match) {
-        std::cout << pattern << std::endl;
         ddwaf_object param;
         ddwaf_object_string(&param, pattern);
-
-        auto match = matcher.match(param);
-        EXPECT_FALSE(match.first);
-        std::cout << match.second << std::endl;
-
+        EXPECT_FALSE(matcher.match(param));        
         ddwaf_object_free(&param);        
     }
 }

--- a/tests/matcher/is_sqli_test.cpp
+++ b/tests/matcher/is_sqli_test.cpp
@@ -27,6 +27,20 @@ TEST(TestIsSQLi, TestBasic)
     ddwaf_object_free(&param);
 }
 
+TEST(TestIsSQLi, TestMatch)
+{
+    is_sqli matcher;
+
+    auto match = {"1, -sin(1)) UNION SELECT 1"};
+
+    for (auto pattern : match) {
+        ddwaf_object param;
+        ddwaf_object_string(&param, pattern);
+        EXPECT_TRUE(matcher.match(param).first);
+        ddwaf_object_free(&param);
+    }
+}
+
 TEST(TestIsSQLi, TestNoMatch)
 {
     is_sqli matcher;

--- a/tests/matcher/is_sqli_test.cpp
+++ b/tests/matcher/is_sqli_test.cpp
@@ -31,12 +31,22 @@ TEST(TestIsSQLi, TestNoMatch)
 {
     is_sqli matcher;
 
-    ddwaf_object param;
-    ddwaf_object_string(&param, "*");
+    auto no_match = {
+        "*",
+        "00119007249934829312950000808000953OR-240128165430155"
+    };
+    
+    for (auto pattern : no_match) {
+        std::cout << pattern << std::endl;
+        ddwaf_object param;
+        ddwaf_object_string(&param, pattern);
 
-    EXPECT_FALSE(matcher.match(param).first);
+        auto match = matcher.match(param);
+        EXPECT_FALSE(match.first);
+        std::cout << match.second << std::endl;
 
-    ddwaf_object_free(&param);
+        ddwaf_object_free(&param);        
+    }
 }
 
 TEST(TestIsSQLi, TestInvalidInput)

--- a/tests/matcher/is_sqli_test.cpp
+++ b/tests/matcher/is_sqli_test.cpp
@@ -31,16 +31,13 @@ TEST(TestIsSQLi, TestNoMatch)
 {
     is_sqli matcher;
 
-    auto no_match = {
-        "*",
-        "00119007249934829312950000808000953OR-240128165430155"
-    };
-    
+    auto no_match = {"*", "00119007249934829312950000808000953OR-240128165430155"};
+
     for (auto pattern : no_match) {
         ddwaf_object param;
         ddwaf_object_string(&param, pattern);
-        EXPECT_FALSE(matcher.match(param));        
-        ddwaf_object_free(&param);        
+        EXPECT_FALSE(matcher.match(param));
+        ddwaf_object_free(&param);
     }
 }
 


### PR DESCRIPTION
libinjection interpret invalid sequences (such as words starting after a number without separators, which is causing false positives.