### PR TITLE
Phrase match: enforce word boundary option

### DIFF
--- a/benchmark/scenarios/phrase_match_matcher_enforce_word_boundary.json
+++ b/benchmark/scenarios/phrase_match_matcher_enforce_word_boundary.json
@@ -1,0 +1,49 @@
+{
+  "scenario": "phrase_match_matcher",
+  "ruleset": {
+    "rules": [
+      {
+        "id": "crs-913-110",
+        "name": "Acunetix",
+        "tags": {
+          "type": "commercial_scanner",
+          "category": "attack_attempt"
+        },
+        "conditions": [
+          {
+            "parameters": {
+              "inputs": [
+                {
+                  "address": "server.request.headers.no_cookies"
+                }
+              ],
+              "list": [
+                "acunetix-product",
+                "(acunetix web vulnerability scanner",
+                "acunetix-scanning-agreement",
+                "acunetix-user-agreement",
+                "md5(acunetix_wvs_security_test)"
+              ],
+              "options": {
+                  "enforce_word_boundary": true
+              }
+            },
+            "operator": "phrase_match"
+          }
+        ],
+        "transformers": []
+      }
+    ]
+  },
+  "fixtures": {
+    "eval.valid": {
+      "server.request.headers.no_cookies": [
+        "acunetix-product",
+        "(acunetix web vulnerability scanner",
+        "acunetix-scanning-agreement",
+        "acunetix-user-agreement",
+        "md5(acunetix_wvs_security_test)"
+      ]
+    }
+  }
+}

--- a/benchmark/scenarios/phrase_match_matcher_enforce_word_boundary.json
+++ b/benchmark/scenarios/phrase_match_matcher_enforce_word_boundary.json
@@ -1,5 +1,5 @@
 {
-  "scenario": "phrase_match_matcher",
+  "scenario": "phrase_match_matcher.enforce_word_boundary",
   "ruleset": {
     "rules": [
       {

--- a/fuzzing/scripts/build_corpus.py
+++ b/fuzzing/scripts/build_corpus.py
@@ -391,6 +391,9 @@ class InitPayloadGenerator:
 
             if operator == "phrase_match":
                 result["parameters"]["list"] = [get_random_value(addresses) for _ in range(randint(1, 200))]
+                result["parameters"]["options"] = {
+                  "enforce_word_boundary": choice((True, False))
+                }
             elif operator == "match_regex":
                 temp = choice(self.regexs)
 

--- a/src/matcher/phrase_match.cpp
+++ b/src/matcher/phrase_match.cpp
@@ -55,19 +55,16 @@ std::pair<bool, std::string> phrase_match::match_impl(std::string_view pattern) 
     auto match_begin = static_cast<std::size_t>(result.match_begin);
     auto match_end = static_cast<std::size_t>(result.match_end);
 
-    if (match_begin < 0 || match_end < 0 || match_begin >= match_end) {
+    if (result.match_begin < 0 || result.match_end < 0 || match_begin >= match_end ||
+        (enforce_word_boundary_ && !is_bounded_word(pattern, match_end))) {
         return {false, {}};
     }
 
-    if (enforce_word_boundary_ && !is_bounded_word(pattern, match_end)) {
-        return {false, {}};
+    if (pattern.size() <= match_end) [[unlikely]] {
+        return {true, {}};
     }
 
-    if (pattern.size() > match_end) {
-        return {true, std::string{pattern.substr(match_begin, (match_end - match_begin + 1))}};
-    }
-
-    return {true, {}};
+    return {true, std::string{pattern.substr(match_begin, (match_end - match_begin + 1))}};
 }
 
 } // namespace ddwaf::matcher

--- a/src/matcher/phrase_match.cpp
+++ b/src/matcher/phrase_match.cpp
@@ -15,8 +15,7 @@ namespace ddwaf::matcher {
 namespace {
 bool is_bounded_word(std::string_view pattern, std::size_t begin, std::size_t end)
 {
-    return ((end + 1 >= pattern.size()) ||
-               ((end + 1 < pattern.size()) && isboundary(pattern[end + 1]))) &&
+    return ((end + 1 >= pattern.size()) || isboundary(pattern[end + 1])) &&
            (begin == 0 || isboundary(pattern[begin - 1]));
 }
 

--- a/src/matcher/phrase_match.cpp
+++ b/src/matcher/phrase_match.cpp
@@ -15,7 +15,7 @@ namespace ddwaf::matcher {
 namespace {
 bool is_bounded_word(std::string_view pattern, std::size_t end)
 {
-    return (end + 1 == pattern.size()) ||
+    return (end + 1 >= pattern.size()) ||
            ((end + 1 < pattern.size()) && isboundary(pattern[end + 1]));
 }
 

--- a/src/matcher/phrase_match.cpp
+++ b/src/matcher/phrase_match.cpp
@@ -15,8 +15,9 @@ namespace ddwaf::matcher {
 namespace {
 bool is_bounded_word(std::string_view pattern, std::size_t begin, std::size_t end)
 {
-    return ((end + 1 >= pattern.size()) || isboundary(pattern[end + 1])) &&
-           (begin == 0 || isboundary(pattern[begin - 1]));
+    return ((end + 1 >= pattern.size()) || isboundary(pattern[end]) ||
+               isboundary(pattern[end + 1])) &&
+           (begin == 0 || (isboundary(pattern[begin]) || isboundary(pattern[begin - 1])));
 }
 
 } // namespace

--- a/src/matcher/phrase_match.hpp
+++ b/src/matcher/phrase_match.hpp
@@ -15,7 +15,8 @@ namespace ddwaf::matcher {
 
 class phrase_match : public base_impl<phrase_match> {
 public:
-    phrase_match(std::vector<const char *> pattern, std::vector<uint32_t> lengths);
+    phrase_match(std::vector<const char *> pattern, std::vector<uint32_t> lengths,
+        bool enforce_word_boundary = false);
     ~phrase_match() override = default;
     phrase_match(const phrase_match &) = delete;
     phrase_match(phrase_match &&) noexcept = default;
@@ -29,6 +30,7 @@ protected:
 
     [[nodiscard]] std::pair<bool, std::string> match_impl(std::string_view pattern) const;
 
+    bool enforce_word_boundary_{false};
     std::unique_ptr<ac_t, void (*)(void *)> ac{nullptr, nullptr};
 
     friend class base_impl<phrase_match>;

--- a/src/parser/parser_v2.cpp
+++ b/src/parser/parser_v2.cpp
@@ -50,6 +50,8 @@ std::pair<std::string, std::unique_ptr<matcher::base>> parse_matcher(
 
     if (name == "phrase_match") {
         auto list = at<parameter::vector>(params, "list");
+        options = at<parameter::map>(params, "options", options);
+        auto word_boundary = at<bool>(options, "enforce_word_boundary", false);
 
         std::vector<const char *> patterns;
         std::vector<uint32_t> lengths;
@@ -66,7 +68,7 @@ std::pair<std::string, std::unique_ptr<matcher::base>> parse_matcher(
             lengths.push_back((uint32_t)pattern.nbEntries);
         }
 
-        matcher = std::make_unique<matcher::phrase_match>(patterns, lengths);
+        matcher = std::make_unique<matcher::phrase_match>(patterns, lengths, word_boundary);
     } else if (name == "match_regex") {
         auto regex = at<std::string>(params, "regex");
         options = at<parameter::map>(params, "options", options);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -112,6 +112,7 @@ inline bool isspace(char c)
 inline bool isupper(char c) { return static_cast<unsigned>(c) - 'A' < 26; }
 inline bool islower(char c) { return static_cast<unsigned>(c) - 'a' < 26; }
 inline bool isalnum(char c) { return isalpha(c) || isdigit(c); }
+inline bool isboundary(char c) { return !isalnum(c) && c != '_'; }
 inline char tolower(char c) { return isupper(c) ? static_cast<char>(c | 32) : c; }
 inline uint8_t from_hex(char c)
 {

--- a/tests/integration/matchers/yaml/phrase_match.yaml
+++ b/tests/integration/matchers/yaml/phrase_match.yaml
@@ -1,0 +1,30 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1-phrase-match
+    tags:
+      type: flow
+      category: category
+    conditions:
+      - operator: phrase_match
+        parameters:
+          inputs:
+            - address: input1
+          list:
+            - string00
+            - string01
+  - id: 2
+    name: rule2-phrase-match-word-bound
+    tags:
+      type: flow
+      category: category
+    conditions:
+      - operator: phrase_match
+        parameters:
+          inputs:
+            - address: input2
+          list:
+            - string00
+            - string01
+          options:
+            enforce_word_boundary: true

--- a/tests/matcher/phrase_match_test.cpp
+++ b/tests/matcher/phrase_match_test.cpp
@@ -97,7 +97,7 @@ TEST(TestPhraseMatch, TestComplex)
 
 TEST(TestPhraseMatch, TestWordBoundary)
 {
-    std::vector<const char *> strings{"String1", "string2", "string 3", "string_4", "string21"};
+    std::vector<const char *> strings{"banana", "$apple", "orange$", "$pear$"};
     std::vector<uint32_t> lengths(strings.size());
     std::generate(lengths.begin(), lengths.end(),
         [i = 0, &strings]() mutable { return strlen(strings[i++]); });
@@ -117,28 +117,65 @@ TEST(TestPhraseMatch, TestWordBoundary)
         ddwaf_object_free(&param);
     };
 
-    run("\xF0\x82\x82\xAC\xC1string2\xF0\x82\x82\xAC\xC1", "string2");
-    run("bla@string 3", "string 3");
-    run("string21", "string21");
-    run("string21 ", "string21");
-    run(" string21 ", "string21");
-    run("asdnjd;string21;", "string21");
-    run("   string_4", "string_4");
-    run("*****string_4****", "string_4");
-    run("____ String1\n", "String1");
+    run("banana", "banana");
+    run(" banana", "banana");
+    run("banana ", "banana");
+    run("word banana word", "banana");
+    run("word   ;banana/ word", "banana");
 
-    run("", nullptr);
-    run("String", nullptr);
-    run("string_", nullptr);
-    run("String21", nullptr);
-    run("astring21", nullptr);
-    run("astring21b", nullptr);
-    run("string21b", nullptr);
-    run("nonsense", nullptr);
-    run("string213", nullptr);
-    run("string21_", nullptr);
-    run("string_4bla", nullptr);
-    run("bla_String1_bla", nullptr);
+    run("banan", nullptr);
+    run("abanana", nullptr);
+    run("bananaa", nullptr);
+    run("abananaa", nullptr);
+    run("banana_", nullptr);
+    run("_banana", nullptr);
+    run("_banana_", nullptr);
+    run("   _banana   ", nullptr);
+    run("   banana_   ", nullptr);
+    run("   _banana_   ", nullptr);
+
+    run("$apple", "$apple");
+    run("s$apple", "$apple");
+    run(";$apple", "$apple");
+    run(";$apple;", "$apple");
+    run("$apple;", "$apple");
+    run("word $apple word", "$apple");
+
+    run("apple", nullptr);
+    run("$applea", nullptr);
+    run("a$applea", nullptr);
+    run("$apple_", nullptr);
+    run("_$apple_", nullptr);
+    run("   $apple_   ", nullptr);
+    run("   _$apple_   ", nullptr);
+
+    run("orange$", "orange$");
+    run("orange$s", "orange$");
+    run(";orange$", "orange$");
+    run(";orange$;", "orange$");
+    run("orange$;", "orange$");
+    run("word orange$word", "orange$");
+
+    run("orange", nullptr);
+    run("aorange$", nullptr);
+    run("aorange$a", nullptr);
+    run("_orange$", nullptr);
+    run("_orange$_", nullptr);
+    run("   _orange$   ", nullptr);
+    run("   _orange$_   ", nullptr);
+
+    run("$pear$", "$pear$");
+    run("$pear$s", "$pear$");
+    run("s$pear$", "$pear$");
+    run("s$pear$s", "$pear$");
+    run(";$pear$", "$pear$");
+    run(";$pear$;", "$pear$");
+    run("$pear$;", "$pear$");
+    run("word$pear$word", "$pear$");
+    run("word $pear$ word", "$pear$");
+
+    run("pear$", nullptr);
+    run("$pear", nullptr);
 }
 
 TEST(TestPhraseMatch, TestInvalidInput)

--- a/tests/matcher/phrase_match_test.cpp
+++ b/tests/matcher/phrase_match_test.cpp
@@ -117,17 +117,24 @@ TEST(TestPhraseMatch, TestWordBoundary)
         ddwaf_object_free(&param);
     };
 
-    run("bla_String1_bla", nullptr);
     run("\xF0\x82\x82\xAC\xC1string2\xF0\x82\x82\xAC\xC1", "string2");
     run("bla_string 3", "string 3");
-    run("string_4bla", nullptr);
     run("string21", "string21");
+    run("string21 ", "string21");
+    run("asdnjdstring21;", "string21");
+    run("   string_4", "string_4");
+    run("*****string_4****", "string_4");
+    run("____String1\n", "String1");
 
     run("", nullptr);
     run("String", nullptr);
     run("string_", nullptr);
     run("String21", nullptr);
     run("nonsense", nullptr);
+    run("string213", nullptr);
+    run("string21_", nullptr);
+    run("string_4bla", nullptr);
+    run("bla_String1_bla", nullptr);
 }
 
 TEST(TestPhraseMatch, TestInvalidInput)

--- a/tests/matcher/phrase_match_test.cpp
+++ b/tests/matcher/phrase_match_test.cpp
@@ -118,18 +118,22 @@ TEST(TestPhraseMatch, TestWordBoundary)
     };
 
     run("\xF0\x82\x82\xAC\xC1string2\xF0\x82\x82\xAC\xC1", "string2");
-    run("bla_string 3", "string 3");
+    run("bla@string 3", "string 3");
     run("string21", "string21");
     run("string21 ", "string21");
-    run("asdnjdstring21;", "string21");
+    run(" string21 ", "string21");
+    run("asdnjd;string21;", "string21");
     run("   string_4", "string_4");
     run("*****string_4****", "string_4");
-    run("____String1\n", "String1");
+    run("____ String1\n", "String1");
 
     run("", nullptr);
     run("String", nullptr);
     run("string_", nullptr);
     run("String21", nullptr);
+    run("astring21", nullptr);
+    run("astring21b", nullptr);
+    run("string21b", nullptr);
     run("nonsense", nullptr);
     run("string213", nullptr);
     run("string21_", nullptr);

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -90,6 +90,17 @@ TEST(TestUtils, IsAlnum)
     }
 }
 
+TEST(TestUtils, IsBoundary)
+{
+    for (char c = char_min; c < char_max; ++c) {
+        if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+            c == '_') {
+            EXPECT_FALSE(isboundary(c));
+        } else {
+            EXPECT_TRUE(isboundary(c));
+        }
+    }
+}
 TEST(TestUtils, ToLower)
 {
     std::unordered_map<char, char> mapping{{'A', 'a'}, {'B', 'b'}, {'C', 'c'}, {'D', 'd'},

--- a/validator/tests/rules/operators/phrase_match/001_rule1_pm_match.yaml
+++ b/validator/tests/rules/operators/phrase_match/001_rule1_pm_match.yaml
@@ -1,0 +1,22 @@
+{
+  name: "Basic run with phrase_match",
+  runs: [
+    {
+      persistent-input: {
+        rule1-input: "asjkdansdstring00asdkjasndk"
+      },
+      rules: [
+        {
+          1: [
+            {
+              address: rule1-input,
+              value: "asjkdansdstring00asdkjasndk",
+              highlight: "string00"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/phrase_match/002_rule1_pm_no_match.yaml
+++ b/validator/tests/rules/operators/phrase_match/002_rule1_pm_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with phrase_match, no match",
+  runs: [
+    {
+      persistent-input: {
+        rule1-input: "asjkdansdstring0asdkjasndk"
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/phrase_match/003_rule2_pm_word_bound_match.yaml
+++ b/validator/tests/rules/operators/phrase_match/003_rule2_pm_word_bound_match.yaml
@@ -1,0 +1,22 @@
+{
+  name: "Basic run with phrase_match and word bounding",
+  runs: [
+    {
+      persistent-input: {
+        rule2-input: "asjkdansdstring00 asdkjasndk"
+      },
+      rules: [
+        {
+          2: [
+            {
+              address: rule2-input,
+              value: "asjkdansdstring00 asdkjasndk",
+              highlight: "string00"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/phrase_match/003_rule2_pm_word_bound_match.yaml
+++ b/validator/tests/rules/operators/phrase_match/003_rule2_pm_word_bound_match.yaml
@@ -3,14 +3,14 @@
   runs: [
     {
       persistent-input: {
-        rule2-input: "asjkdansdstring00 asdkjasndk"
+        rule2-input: "asjkdansd;string00 asdkjasndk"
       },
       rules: [
         {
           2: [
             {
               address: rule2-input,
-              value: "asjkdansdstring00 asdkjasndk",
+              value: "asjkdansd;string00 asdkjasndk",
               highlight: "string00"
             }
           ]

--- a/validator/tests/rules/operators/phrase_match/004_rule2_pm_word_bound_no_match.yaml
+++ b/validator/tests/rules/operators/phrase_match/004_rule2_pm_word_bound_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with phrase_match and word bounding, no match",
+  runs: [
+    {
+      persistent-input: {
+        rule2-input: "asjkdansdstring00asdkjasndk"
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/phrase_match/ruleset.yaml
+++ b/validator/tests/rules/operators/phrase_match/ruleset.yaml
@@ -1,0 +1,30 @@
+version: '2.1'
+rules:
+  - id: "1"
+    name: rule1-phrase-match
+    tags:
+      type: flow
+      category: category
+    conditions:
+      - operator: phrase_match
+        parameters:
+          inputs:
+            - address: rule1-input
+          list:
+            - string00
+            - string01
+  - id: "2"
+    name: rule2-phrase-match-word-bound
+    tags:
+      type: flow
+      category: category
+    conditions:
+      - operator: phrase_match
+        parameters:
+          inputs:
+            - address: rule2-input
+          list:
+            - string00
+            - string01
+          options:
+            enforce_word_boundary: true


### PR DESCRIPTION
Add option to phrase match operator to enforce word boundaries on all matches.

```
      - operator: phrase_match
        parameters:
          inputs: [ ... ]
          list: [ ... ]
          options:
            enforce_word_boundary: true
```

Some notable things to consider:
- When `enforce_word_boundary` is set to true, the algorithm will always try to find the longest match to increase the likelihood of word boundaries.
- If the match found doesn't have word boundaries around it, no other match is provided.