### PR TITLE
Add support for old glibc (e.g. RHEL 6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,25 +213,21 @@ jobs:
           - name: aarch64
             arch: aarch64
             qemu_action_arch: arm64
-            manylinux_arch: aarch64
             platform: linux/arm64
             package: libddwaf-aarch64-linux-musl
           - name: x86_64
             arch: x86_64
             qemu_action_arch: amd64
-            manylinux_arch: x86_64
             platform: linux/amd64
             package: libddwaf-x86_64-linux-musl
           - name: i386
             arch: i386
             qemu_action_arch: i386
-            manylinux_arch: i686
             platform: linux/386
             package: libddwaf-i386-linux-musl
           - name: armv7
             arch: armv7
             qemu_action_arch: arm
-            manylinux_arch: armv7l
             platform: linux/arm/v7
             package: libddwaf-armv7-linux-musl
     steps:
@@ -254,7 +250,8 @@ jobs:
       - name: Smoketest gnu (gcc)
         run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/gnu/Dockerfile  .
       - name: Smoketest gnu rhel 6 (gcc)
-        run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" --build-arg "MANYLINUX_ARCH=${{ matrix.target.manylinux_arch }}" -f docker/libddwaf/smoketest/gnu_rhel6/Dockerfile  .
+        if: matrix.target.qemu_action_arch == 'amd64'
+        run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/gnu_rhel6/Dockerfile  .
       - name: Generate Package sha256
         working-directory: packages
         run: for file in *.tar.gz; do sha256sum "$file" > "$file.sha256"; done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,21 +213,25 @@ jobs:
           - name: aarch64
             arch: aarch64
             qemu_action_arch: arm64
+            manylinux_arch: aarch64
             platform: linux/arm64
             package: libddwaf-aarch64-linux-musl
           - name: x86_64
             arch: x86_64
             qemu_action_arch: amd64
+            manylinux_arch: x86_64
             platform: linux/amd64
             package: libddwaf-x86_64-linux-musl
           - name: i386
             arch: i386
             qemu_action_arch: i386
+            manylinux_arch: i686
             platform: linux/386
             package: libddwaf-i386-linux-musl
           - name: armv7
             arch: armv7
             qemu_action_arch: arm
+            manylinux_arch: armv7l
             platform: linux/arm/v7
             package: libddwaf-armv7-linux-musl
     steps:
@@ -250,7 +254,7 @@ jobs:
       - name: Smoketest gnu (gcc)
         run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/gnu/Dockerfile  .
       - name: Smoketest gnu rhel 6 (gcc)
-        run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/gnu_rhel6/Dockerfile  .
+        run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" --build-arg "MANYLINUX_ARCH=${{ matric.target.manylinux_arch }}" -f docker/libddwaf/smoketest/gnu_rhel6/Dockerfile  .
       - name: Generate Package sha256
         working-directory: packages
         run: for file in *.tar.gz; do sha256sum "$file" > "$file.sha256"; done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Smoketest gnu (gcc)
         run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/gnu/Dockerfile  .
       - name: Smoketest gnu rhel 6 (gcc)
-        run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" --build-arg "MANYLINUX_ARCH=${{ matric.target.manylinux_arch }}" -f docker/libddwaf/smoketest/gnu_rhel6/Dockerfile  .
+        run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" --build-arg "MANYLINUX_ARCH=${{ matrix.target.manylinux_arch }}" -f docker/libddwaf/smoketest/gnu_rhel6/Dockerfile  .
       - name: Generate Package sha256
         working-directory: packages
         run: for file in *.tar.gz; do sha256sum "$file" > "$file.sha256"; done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,6 +249,8 @@ jobs:
         run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/musl_llvm/Dockerfile  .
       - name: Smoketest gnu (gcc)
         run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/gnu/Dockerfile  .
+      - name: Smoketest gnu rhel 6 (gcc)
+        run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/gnu_rhel6/Dockerfile  .
       - name: Generate Package sha256
         working-directory: packages
         run: for file in *.tar.gz; do sha256sum "$file" > "$file.sha256"; done

--- a/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
+++ b/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
@@ -8,6 +8,7 @@ COPY smoketest /smoketest
 RUN yum -y install gcc cmake make
 
 RUN tar -kxf packages/libddwaf-*-${ARCH}-linux-*.tar.gz --strip-components=1
+RUN ln -s /lib/libddwaf.* /lib64/
 
 RUN mkdir build_static && cd build_static && \
     cmake -DCMAKE_C_FLAGS="-I/include" \

--- a/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
+++ b/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
@@ -8,8 +8,7 @@ COPY smoketest /smoketest
 
 RUN yum -y install gcc cmake make
 
-RUN tar -kxf packages/libddwaf-*-${ARCH}-linux-*.tar.gz --strip-components=1
-RUN ln -s /lib/libddwaf.* /lib64/
+RUN tar -kxf packages/libddwaf-*-${ARCH}-linux-*.tar.gz -C /usr --strip-components=1
 
 RUN mkdir build_static && cd build_static && \
     cmake -DCMAKE_C_FLAGS="-I/include" \

--- a/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
+++ b/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
@@ -1,0 +1,21 @@
+FROM quay.io/pypa/manylinux2010_x86_64:latest AS smoketest
+
+ARG ARCH
+
+COPY packages/ /packages
+COPY smoketest /smoketest
+
+RUN yum -y install gcc cmake make
+
+RUN tar -kxf packages/libddwaf-*-${ARCH}-linux-*.tar.gz --strip-components=1
+
+RUN mkdir build_static && cd build_static && \
+    cmake -DCMAKE_C_FLAGS="-I/include" \
+          -DLIBDDWAF_SMOKE_LINK_STATIC=ON /smoketest && \
+    make && ./smoketest
+
+RUN mkdir build_shared && cd build_shared && \
+    cmake -DCMAKE_C_FLAGS="-I/include" \
+          -DLIBDDWAF_SMOKE_LINK_STATIC=OFF /smoketest && \
+    make && ./smoketest
+

--- a/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
+++ b/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/pypa/manylinux2010_x86_64:latest AS smoketest
+ARG MANYLINUX_ARCH=x86_64
+FROM quay.io/pypa/manylinux2010_${MANYLINUX_ARCH}:latest AS smoketest
 
 ARG ARCH
 

--- a/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
+++ b/docker/libddwaf/smoketest/gnu_rhel6/Dockerfile
@@ -1,5 +1,4 @@
-ARG MANYLINUX_ARCH=x86_64
-FROM quay.io/pypa/manylinux2010_${MANYLINUX_ARCH}:latest AS smoketest
+FROM quay.io/pypa/manylinux2010_x86_64:latest AS smoketest
 
 ARG ARCH
 
@@ -8,7 +7,8 @@ COPY smoketest /smoketest
 
 RUN yum -y install gcc cmake make
 
-RUN tar -kxf packages/libddwaf-*-${ARCH}-linux-*.tar.gz -C /usr --strip-components=1
+RUN tar -kxf packages/libddwaf-*-${ARCH}-linux-*.tar.gz --strip-components=1
+RUN ln -s /lib/libddwaf.* /lib64/
 
 RUN mkdir build_static && cd build_static && \
     cmake -DCMAKE_C_FLAGS="-I/include" \

--- a/docker/libddwaf/sysroot/Dockerfile
+++ b/docker/libddwaf/sysroot/Dockerfile
@@ -18,9 +18,9 @@ RUN cd llvm-project-${LLVM_VERSION}.src && mkdir -p build && cd build && \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_C_COMPILER=clang \
-    -DCMAKE_C_FLAGS=-fno-omit-frame-pointer \
+    -DCMAKE_C_FLAGS="-fno-omit-frame-pointer -D_LIBCPP_HAS_NO_C11_ALIGNED_ALLOC=1" \
     -DCMAKE_CXX_COMPILER=clang++ \
-    -DCMAKE_CXX_FLAGS=-fno-omit-frame-pointer \
+    -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer -D_LIBCPP_HAS_NO_C11_ALIGNED_ALLOC=1" \
     -DLIBUNWIND_ENABLE_SHARED=OFF \
     -DLIBUNWIND_ENABLE_STATIC=ON \
     -DLIBUNWIND_USE_COMPILER_RT=ON \


### PR DESCRIPTION
* Add a smoke test for old RHEL 6-based distros.
* Add `-D_LIBCPP_HAS_NO_C11_ALIGNED_ALLOC=1` to libc++ CFLAGS to ensure it doesn't use `aligned_alloc` and use a fallback. This is the only missing symbol on old RHEL 6.