### PR TITLE
Attempt to build libddwaf on arm64 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,17 +206,12 @@ jobs:
             /tmp/packages/*.tar.gz
             /tmp/packages/*.sha256
 
-  linux-musl-build:
+  linux-musl-build-amd64:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         target:
-          - name: aarch64
-            arch: aarch64
-            qemu_action_arch: arm64
-            platform: linux/arm64
-            package: libddwaf-aarch64-linux-musl
           - name: x86_64
             arch: x86_64
             qemu_action_arch: amd64
@@ -227,11 +222,6 @@ jobs:
             qemu_action_arch: i386
             platform: linux/386
             package: libddwaf-i386-linux-musl
-          - name: armv7
-            arch: armv7
-            qemu_action_arch: arm
-            platform: linux/arm/v7
-            package: libddwaf-armv7-linux-musl
     steps:
       - uses: actions/checkout@v4
         with:
@@ -240,10 +230,6 @@ jobs:
         id: buildx
         with:
           install: true
-      - uses: docker/setup-qemu-action@v3
-        if: matrix.target.qemu_action_arch == 'arm64'
-        with:
-          platforms: ${{ matrix.target.qemu_action_arch }}
       - run: docker build --progress=plain --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/build/Dockerfile -o packages .
       - name: Smoketest musl (gcc)
         run: docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/musl/Dockerfile  .
@@ -264,8 +250,49 @@ jobs:
             packages/*.tar.gz
             packages/*.sha256
 
+  linux-musl-build-arm64:
+    runs-on: arm-4core-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - name: aarch64
+            arch: aarch64
+            qemu_action_arch: arm64
+            platform: linux/arm64
+            package: libddwaf-aarch64-linux-musl
+          - name: armv7
+            arch: armv7
+            qemu_action_arch: arm
+            platform: linux/arm/v7
+            package: libddwaf-armv7-linux-musl
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install docker
+        run: |
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh get-docker.sh
+      - run: sudo docker build --progress=plain --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/build/Dockerfile -o packages .
+      - name: Smoketest musl (gcc)
+        run: sudo docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/musl/Dockerfile  .
+      - name: Smoketest musl (clang)
+        run: sudo docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/musl_llvm/Dockerfile  .
+      - name: Smoketest gnu (gcc)
+        run: sudo docker build --progress=plain --platform ${{ matrix.target.platform }} --build-arg "ARCH=${{ matrix.target.arch }}" -f docker/libddwaf/smoketest/gnu/Dockerfile  .
+      - name: Generate Package sha256
+        working-directory: packages
+        run: for file in *.tar.gz; do sha256sum "$file" > "$file.sha256"; done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target.package }}
+          path: |
+            packages/*.tar.gz
+            packages/*.sha256
+
   package-nuget:
-    needs: [ windows-builds, macos-universal-package, linux-musl-build]
+    needs: [ windows-builds, macos-universal-package, linux-musl-build-amd64 linux-musl-build-arm64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -321,7 +348,7 @@ jobs:
           path: ${{ github.workspace }}/output-packages
 
   release:
-    needs: [ windows-builds, macos-build, macos-cross-build, docker-builds, linux-musl-build, package-nuget]
+    needs: [ windows-builds, macos-build, macos-cross-build, docker-builds, linux-musl-build-amd64, linux-musl-build-arm64, package-nuget]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
             packages/*.sha256
 
   package-nuget:
-    needs: [ windows-builds, macos-universal-package, linux-musl-build-amd64 linux-musl-build-arm64]
+    needs: [ windows-builds, macos-universal-package, linux-musl-build-amd64, linux-musl-build-arm64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Use new arm64 runners for aarch64 and armv7 builds, this doesn't provide much currently since we are using cross-compilation toolchains, however the slowest smoke test went from 2 minutes to 20 seconds so it's still valuable.