### PR TITLE
Fix mishandling invalid actions key type

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrading libddwaf
 
-## Upgrading from `1.16.x` to `1.17.0`
+## Upgrading from `1.16.x` to `1.17.x
 
 ### Action semantics
 
@@ -18,12 +18,12 @@ The first change introduced is that users must now provide action definitions du
 }
 ```
 
-Secondly, since the definition of each action is now available internally, the schema of `ddwaf_result.actions` has been updated from an array of IDs to a map of action types, each containing its own set of parameters:
+Secondly, since the definition of each action is now available internally, the schema of `ddwaf_result.actions` has been updated from an array of IDs to a map of action types, each containing its own set of parameters in string format:
 
 ```json
 {
   "block_request": {
-   "status_code": 403,
+   "status_code": "403",
    "type":  "auto"
   }
 }

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrading libddwaf
 
-## Upgrading from `1.16.x` to `1.17.x
+## Upgrading from `1.16.x` to `1.17.x`
 
 ### Action semantics
 

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -231,7 +231,9 @@ ruleset_builder::change_state ruleset_builder::load(parameter::map &root, base_r
             DDWAF_WARN("Failed to parse actions: {}", e.what());
             section.set_error(e.what());
         }
-    } else if (!actions_) {
+    }
+
+    if (!actions_) {
         actions_ = action_mapper_builder().build_shared();
     }
 

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -234,6 +234,8 @@ ruleset_builder::change_state ruleset_builder::load(parameter::map &root, base_r
     }
 
     if (!actions_) {
+        // Ensure that the actions mapper is never invalid
+        state = state | change_state::actions;
         actions_ = action_mapper_builder().build_shared();
     }
 

--- a/tests/integration/actions/test.cpp
+++ b/tests/integration/actions/test.cpp
@@ -317,32 +317,32 @@ TEST(TestActionsIntegration, EmptyOrInvalidActions)
     ddwaf_object_free(&rule);
 
     ddwaf_object tmp;
-        ddwaf_object parameter = DDWAF_OBJECT_MAP;
-        ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "block"));
+    ddwaf_object parameter = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "block"));
 
-        ddwaf_context context = ddwaf_context_init(handle);
-        ASSERT_NE(context, nullptr);
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
 
-        ddwaf_result res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+    ddwaf_result res;
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
-        EXPECT_EVENTS(res, {.id = "block-rule",
-                               .name = "block-rule",
-                               .tags = {{"type", "flow1"}, {"category", "category1"}},
-                               .actions = {"block"},
-                               .matches = {{.op = "match_regex",
-                                   .op_value = "^block",
-                                   .highlight = "block",
-                                   .args = {{
-                                       .value = "block",
-                                       .address = "value",
-                                   }}}}});
+    EXPECT_EVENTS(res, {.id = "block-rule",
+                           .name = "block-rule",
+                           .tags = {{"type", "flow1"}, {"category", "category1"}},
+                           .actions = {"block"},
+                           .matches = {{.op = "match_regex",
+                               .op_value = "^block",
+                               .highlight = "block",
+                               .args = {{
+                                   .value = "block",
+                                   .address = "value",
+                               }}}}});
 
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
-        ddwaf_result_free(&res);
+    EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
+                                               {"type", "auto"}}}});
+    ddwaf_result_free(&res);
 
-        ddwaf_context_destroy(context);
+    ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 

--- a/tests/integration/actions/yaml/invalid_actions.yaml
+++ b/tests/integration/actions/yaml/invalid_actions.yaml
@@ -1,0 +1,18 @@
+version: '2.1'
+rules:
+  - id: block-rule
+    name: block-rule
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value
+          regex: ^block
+          options:
+            case_sensitive: true
+    on_match: [ block ]
+
+actions: {}


### PR DESCRIPTION
If the `actions` is provided with an incompatible type (i.e. anything but an array), the resulting action mapper is a `nullptr` rather than a valid structure. This later on can cause a segmentation fault on `ddwaf_run`.