### PR TITLE
Custom rule filter actions

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -40,7 +40,7 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
         DDWAF_DEBUG("Monitoring rule '{}'", id);
         action_override = "monitor";
     } else if (exclusion.mode == exclusion::filter_mode::custom) {
-        action_override = exclusion.action;
+        action_override = exclusion.action_override;
         DDWAF_DEBUG("Evaluating rule '{}' with custom action '{}'", id, action_override);
     } else {
         DDWAF_DEBUG("Evaluating rule '{}'", id);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -58,7 +58,7 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
         event = rule->match(store, rule_cache, exclusion.objects, dynamic_matchers, deadline);
 
         if (event.has_value()) {
-            event->action_override = std::string{action_override};
+            event->action_override = action_override;
         }
 
         return event;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -29,7 +29,7 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
         return std::nullopt;
     }
 
-    action_type action_override = action_type::none;
+    std::string_view action_override;
     auto exclusion = policy.find(rule);
     if (exclusion.mode == exclusion::filter_mode::bypass) {
         DDWAF_DEBUG("Bypassing rule '{}'", id);
@@ -38,10 +38,13 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
 
     if (exclusion.mode == exclusion::filter_mode::monitor) {
         DDWAF_DEBUG("Monitoring rule '{}'", id);
-        action_override = action_type::monitor;
+        action_override = "monitor";
+    } else if (exclusion.mode == exclusion::filter_mode::custom) {
+        action_override = exclusion.action;
+        DDWAF_DEBUG("Evaluating rule '{}' with custom action '{}'", id, action_override);
+    } else {
+        DDWAF_DEBUG("Evaluating rule '{}'", id);
     }
-
-    DDWAF_DEBUG("Evaluating rule '{}'", id);
 
     try {
         auto it = cache.find(rule);
@@ -55,7 +58,7 @@ std::optional<event> match_rule(rule *rule, const object_store &store,
         event = rule->match(store, rule_cache, exclusion.objects, dynamic_matchers, deadline);
 
         if (event.has_value()) {
-            event->action_override = action_override;
+            event->action_override = std::string{action_override};
         }
 
         return event;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -159,7 +159,8 @@ exclusion::context_policy &context::eval_filters(ddwaf::timer &deadline)
         auto exclusion = filter->match(store_, cache, deadline);
         if (exclusion.has_value()) {
             for (const auto &rule : exclusion->rules) {
-                exclusion_policy_.add_rule_exclusion(rule, exclusion->mode, exclusion->ephemeral);
+                exclusion_policy_.add_rule_exclusion(
+                    rule, exclusion->mode, exclusion->action, exclusion->ephemeral);
             }
         }
     }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -178,10 +178,10 @@ void serialize_empty_rule(ddwaf_object &rule_map)
 }
 
 void serialize_and_consolidate_rule_actions(const ddwaf::rule &rule, ddwaf_object &rule_map,
-    action_type action_override, action_tracker &actions, ddwaf_object &stack_id)
+    std::string_view action_override, action_tracker &actions, ddwaf_object &stack_id)
 {
     const auto &rule_actions = rule.get_actions();
-    if (rule_actions.empty()) {
+    if (rule_actions.empty() && action_override.empty()) {
         return;
     }
 
@@ -189,15 +189,20 @@ void serialize_and_consolidate_rule_actions(const ddwaf::rule &rule, ddwaf_objec
     ddwaf_object actions_array;
     ddwaf_object_array(&actions_array);
 
-    if (action_override == action_type::monitor) {
-        ddwaf_object_array_add(&actions_array, to_object(tmp, "monitor"));
+    if (!action_override.empty()) {
+        ddwaf_object_array_add(&actions_array, to_object(tmp, action_override));
+        auto action_it = actions.mapper.find(action_override);
+        if (action_it != actions.mapper.end()) {
+            const auto &[type, type_str, parameters] = action_it->second;
+            add_action_to_tracker(actions, action_override, type);
+        }
     }
 
     for (const auto &action_id : rule_actions) {
         auto action_it = actions.mapper.find(action_id);
         if (action_it != actions.mapper.end()) {
             const auto &[type, type_str, parameters] = action_it->second;
-            if (action_override == action_type::monitor &&
+            if (!action_override.empty() &&
                 (type == action_type::monitor || is_blocking_action(type))) {
                 // If the rule was in monitor mode, ignore blocking and monitor actions
                 continue;

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -21,7 +21,7 @@ struct event {
     const ddwaf::rule *rule{nullptr};
     std::vector<condition_match> matches;
     bool ephemeral{false};
-    std::string action_override;
+    std::string_view action_override;
 };
 
 using optional_event = std::optional<event>;

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -21,7 +21,7 @@ struct event {
     const ddwaf::rule *rule{nullptr};
     std::vector<condition_match> matches;
     bool ephemeral{false};
-    action_type action_override{action_type::none};
+    std::string action_override;
 };
 
 using optional_event = std::optional<event>;

--- a/src/exclusion/common.hpp
+++ b/src/exclusion/common.hpp
@@ -19,7 +19,7 @@ class rule;
 
 namespace exclusion {
 
-enum class filter_mode : uint8_t { none = 0, monitor = 1, bypass = 2 };
+enum class filter_mode : uint8_t { none = 0, custom = 1, monitor = 2, bypass = 3 };
 
 struct object_set {
     std::unordered_set<const ddwaf_object *> persistent;
@@ -35,7 +35,8 @@ struct object_set {
 
 struct rule_policy {
     filter_mode mode{filter_mode::none};
-    std::unordered_set<const ddwaf_object *> objects{};
+    std::string_view action;
+    std::unordered_set<const ddwaf_object *> objects;
 };
 
 struct object_set_ref {
@@ -63,6 +64,7 @@ struct object_set_ref {
 
 struct rule_policy_ref {
     filter_mode mode{filter_mode::none};
+    std::string_view action;
     object_set_ref objects;
 };
 
@@ -86,38 +88,38 @@ struct context_policy {
 
         if (p_it == persistent.end()) {
             if (e_it == ephemeral.end()) {
-                return {filter_mode::none, {std::nullopt, std::nullopt}};
+                return {filter_mode::none, {}, {std::nullopt, std::nullopt}};
             }
 
             const auto &e_policy = e_it->second;
-            return {e_policy.mode, {std::nullopt, e_policy.objects}};
+            return {e_policy.mode, e_policy.action, {std::nullopt, e_policy.objects}};
         }
 
         if (e_it == ephemeral.end()) {
             const auto &p_policy = p_it->second;
             p_policy.objects.size();
-            return {p_policy.mode, {p_policy.objects, std::nullopt}};
+            return {p_policy.mode, p_policy.action, {p_policy.objects, std::nullopt}};
         }
 
         const auto &p_policy = p_it->second;
         const auto &e_policy = e_it->second;
-        auto mode = p_policy.mode > e_policy.mode ? p_policy.mode : e_policy.mode;
 
-        return {mode, {p_policy.objects, e_policy.objects}};
+        if (p_policy.mode > e_policy.mode) {
+            return {p_policy.mode, p_policy.action, {p_policy.objects, e_policy.objects}};
+        }
+        return {e_policy.mode, e_policy.action, {p_policy.objects, e_policy.objects}};
     }
 
-    void add_rule_exclusion(const ddwaf::rule *rule, filter_mode mode, bool ephemeral_exclusion)
+    void add_rule_exclusion(const ddwaf::rule *rule, filter_mode mode, std::string_view action,
+        bool ephemeral_exclusion)
     {
         auto &rule_policy = ephemeral_exclusion ? ephemeral : persistent;
 
-        auto it = rule_policy.find(rule);
+        auto &policy = rule_policy[rule];
         // Bypass has precedence over monitor
-        if (it != rule_policy.end()) {
-            if (it->second.mode < mode) {
-                it->second.mode = mode;
-            }
-        } else {
-            rule_policy[rule].mode = mode;
+        if (policy.mode < mode) {
+            policy.mode = mode;
+            policy.action = action;
         }
     }
 

--- a/src/exclusion/rule_filter.cpp
+++ b/src/exclusion/rule_filter.cpp
@@ -6,14 +6,15 @@
 
 #include <exclusion/rule_filter.hpp>
 #include <log.hpp>
+#include <utility>
 
 namespace ddwaf::exclusion {
 
 using excluded_set = rule_filter::excluded_set;
 
 rule_filter::rule_filter(std::string id, std::shared_ptr<expression> expr,
-    std::set<rule *> rule_targets, filter_mode mode)
-    : id_(std::move(id)), expr_(std::move(expr)), mode_(mode)
+    std::set<rule *> rule_targets, filter_mode mode, std::string action)
+    : id_(std::move(id)), expr_(std::move(expr)), mode_(mode), action_(std::move(action))
 {
     if (!expr_) {
         throw std::invalid_argument("rule filter constructed with null expression");
@@ -40,7 +41,7 @@ std::optional<excluded_set> rule_filter::match(
         return std::nullopt;
     }
 
-    return {{rule_targets_, res.ephemeral, mode_}};
+    return {{rule_targets_, res.ephemeral, mode_, action_}};
 }
 
 } // namespace ddwaf::exclusion

--- a/src/exclusion/rule_filter.hpp
+++ b/src/exclusion/rule_filter.hpp
@@ -23,12 +23,13 @@ public:
         const std::unordered_set<rule *> &rules;
         bool ephemeral{false};
         filter_mode mode{filter_mode::none};
+        std::string_view action;
     };
 
     using cache_type = expression::cache_type;
 
     rule_filter(std::string id, std::shared_ptr<expression> expr, std::set<rule *> rule_targets,
-        filter_mode mode = filter_mode::bypass);
+        filter_mode mode = filter_mode::bypass, std::string action = {});
     rule_filter(const rule_filter &) = delete;
     rule_filter &operator=(const rule_filter &) = delete;
     rule_filter(rule_filter &&) = default;
@@ -50,6 +51,7 @@ protected:
     std::shared_ptr<expression> expr_;
     std::unordered_set<rule *> rule_targets_;
     filter_mode mode_;
+    std::string action_{};
 };
 
 } // namespace ddwaf::exclusion

--- a/src/parser/exclusion_parser.cpp
+++ b/src/parser/exclusion_parser.cpp
@@ -78,9 +78,11 @@ rule_filter_spec parse_rule_filter(
         on_match = exclusion::filter_mode::bypass;
     } else if (on_match_str == "monitor") {
         on_match = exclusion::filter_mode::monitor;
-    } else {
+    } else if (!on_match_str.empty()) {
         on_match = exclusion::filter_mode::custom;
         on_match_id = on_match_str;
+    } else {
+        throw ddwaf::parsing_error("empty on_match value");
     }
 
     if (expr->empty() && rules_target.empty()) {

--- a/src/parser/exclusion_parser.cpp
+++ b/src/parser/exclusion_parser.cpp
@@ -73,19 +73,21 @@ rule_filter_spec parse_rule_filter(
 
     exclusion::filter_mode on_match;
     auto on_match_str = at<std::string_view>(filter, "on_match", "bypass");
+    std::string on_match_id;
     if (on_match_str == "bypass") {
         on_match = exclusion::filter_mode::bypass;
     } else if (on_match_str == "monitor") {
         on_match = exclusion::filter_mode::monitor;
     } else {
-        throw ddwaf::parsing_error("unsupported on_match value: " + std::string(on_match_str));
+        on_match = exclusion::filter_mode::custom;
+        on_match_id = on_match_str;
     }
 
     if (expr->empty() && rules_target.empty()) {
         throw ddwaf::parsing_error("empty exclusion filter");
     }
 
-    return {std::move(expr), std::move(rules_target), on_match};
+    return {std::move(expr), std::move(rules_target), on_match, std::move(on_match_id)};
 }
 
 } // namespace

--- a/src/parser/specification.hpp
+++ b/src/parser/specification.hpp
@@ -46,6 +46,7 @@ struct rule_filter_spec {
     std::shared_ptr<expression> expr;
     std::vector<reference_spec> targets;
     exclusion::filter_mode on_match;
+    std::string custom_action;
 };
 
 struct input_filter_spec {

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -136,7 +136,7 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
             rule_targets.merge(references_to_rules(filter.targets, final_user_rules_));
 
             auto filter_ptr = std::make_shared<exclusion::rule_filter>(
-                id, filter.expr, std::move(rule_targets), filter.on_match);
+                id, filter.expr, std::move(rule_targets), filter.on_match, filter.custom_action);
             rule_filters_.emplace(filter_ptr->get_id(), filter_ptr);
         }
 

--- a/tests/parser_v2_rule_filters_test.cpp
+++ b/tests/parser_v2_rule_filters_test.cpp
@@ -677,4 +677,43 @@ TEST(TestParserV2RuleFilters, ParseCustomOnMatch)
     EXPECT_STR(filter.custom_action, "obliterate");
 }
 
+TEST(TestParserV2RuleFilters, ParseInvalidOnMatch)
+{
+    ddwaf::object_limits limits;
+
+    auto object = yaml_to_object(R"([{id: 1, rules_target: [{rule_id: 2939}], on_match: ""}])");
+
+    ddwaf::ruleset_info::section_info section;
+    auto filters_array = static_cast<parameter::vector>(parameter(object));
+    auto filters = parser::v2::parse_filters(filters_array, section, limits);
+    ddwaf_object_free(&object);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("1"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+        auto it = errors.find("empty on_match value");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("1"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(filters.rule_filters.size(), 0);
+    EXPECT_EQ(filters.input_filters.size(), 0);
+}
 } // namespace

--- a/tests/rule_filter_test.cpp
+++ b/tests/rule_filter_test.cpp
@@ -1212,4 +1212,121 @@ TEST(TestRuleFilter, ConditionalCustomFilterMode)
     ddwaf_destroy(handle);
 }
 
+TEST(TestRuleFilter, CustomFilterModeUnknownAction)
+{
+    auto rule = read_file("exclude_with_unknown_action.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    auto *handle1 = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle1, nullptr);
+    ddwaf_object_free(&rule);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle1);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object root;
+        ddwaf_object tmp;
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+
+        ddwaf_result out;
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EVENTS(out, {.id = "1",
+                               .name = "rule1",
+                               .tags = {{"type", "type1"}, {"category", "category"}},
+                               .matches = {{.op = "ip_match",
+                                   .highlight = "192.168.0.1",
+                                   .args = {{
+                                       .value = "192.168.0.1",
+                                       .address = "http.client_ip",
+                                   }}}}});
+        EXPECT_EQ(out.actions.nbEntries, 0);
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_handle handle2;
+    {
+        auto overrides =
+            yaml_to_object(R"({actions: [{id: block2, type: block_request, parameters: {}}]})");
+        handle2 = ddwaf_update(handle1, &overrides, nullptr);
+        ddwaf_object_free(&overrides);
+        ASSERT_NE(handle2, nullptr);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle2);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object root;
+        ddwaf_object tmp;
+        ddwaf_object_map(&root);
+        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+
+        ddwaf_result out;
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EVENTS(out, {.id = "1",
+                               .name = "rule1",
+                               .tags = {{"type", "type1"}, {"category", "category"}},
+                               .actions = {"block2"},
+                               .matches = {{.op = "ip_match",
+                                   .highlight = "192.168.0.1",
+                                   .args = {{
+                                       .value = "192.168.0.1",
+                                       .address = "http.client_ip",
+                                   }}}}});
+        EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
+                                                   {"type", "auto"}}}})
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle1);
+    ddwaf_destroy(handle2);
+}
+
+TEST(TestRuleFilter, CustomFilterModeNonblockingAction)
+{
+    // In this test, the ruleset contains a rule filter with the action
+    // generate_stack, which is neither a blocking, redirecting or monitoring
+    // action, hence its ignored.
+    auto rule = read_file("exclude_with_nonblocking_action.yaml");
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    auto *handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object tmp;
+    ddwaf_object_map(&root);
+    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+
+    ddwaf_result out;
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EVENTS(out, {.id = "1",
+                           .name = "rule1",
+                           .tags = {{"type", "type1"}, {"category", "category"}},
+                           .actions = {"block"},
+                           .matches = {{.op = "ip_match",
+                               .highlight = "192.168.0.1",
+                               .args = {{
+                                   .value = "192.168.0.1",
+                                   .address = "http.client_ip",
+                               }}}}});
+    EXPECT_ACTIONS(out,
+        {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}})
+
+    ddwaf_result_free(&out);
+    ddwaf_context_destroy(context);
+
+    ddwaf_destroy(handle);
+}
+
 } // namespace

--- a/tests/yaml/bypass_custom_precedence.yaml
+++ b/tests/yaml/bypass_custom_precedence.yaml
@@ -1,0 +1,31 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    on_match: block
+  - id: 2
+    rules_target:
+      - rule_id: 1
+    on_match: bypass
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1
+    on_match: [ redirect ]
+actions:
+  - id: redirect
+    parameters:
+      status_code: 303
+      location: google.com
+    type: redirect_request
+

--- a/tests/yaml/exclude_with_custom_action.yaml
+++ b/tests/yaml/exclude_with_custom_action.yaml
@@ -1,0 +1,19 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    on_match: block
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1

--- a/tests/yaml/exclude_with_custom_action_and_condition.yaml
+++ b/tests/yaml/exclude_with_custom_action_and_condition.yaml
@@ -1,0 +1,27 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1
+    on_match: block
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1
+            - 192.168.0.2

--- a/tests/yaml/exclude_with_nonblocking_action.yaml
+++ b/tests/yaml/exclude_with_nonblocking_action.yaml
@@ -1,0 +1,20 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    on_match: generate_stack
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1
+    on_match: [ block ]

--- a/tests/yaml/exclude_with_unknown_action.yaml
+++ b/tests/yaml/exclude_with_unknown_action.yaml
@@ -1,0 +1,19 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    on_match: block2
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1

--- a/tests/yaml/monitor_custom_precedence.yaml
+++ b/tests/yaml/monitor_custom_precedence.yaml
@@ -1,0 +1,31 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    rules_target:
+      - rule_id: 1
+    on_match: monitor
+  - id: 2
+    rules_target:
+      - rule_id: 1
+    on_match: block
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: type1
+      category: category
+    conditions:
+      - operator: ip_match
+        parameters:
+          inputs:
+            - address: http.client_ip
+          list:
+            - 192.168.0.1
+    on_match: [ redirect ]
+actions:
+  - id: redirect
+    parameters:
+      status_code: 303
+      location: google.com
+    type: redirect_request
+

--- a/validator/tests/exclusions/rule_filter/unconditional/010_rule10_rule_monitored_by_tags.yaml
+++ b/validator/tests/exclusions/rule_filter/unconditional/010_rule10_rule_monitored_by_tags.yaml
@@ -1,5 +1,5 @@
 {
-  name: "Rule monitored by rags",
+  name: "Rule monitored by tags",
   runs: [
     {
       persistent-input: {

--- a/validator/tests/exclusions/rule_filter/unconditional/011_rule11_rule_custom_action_by_id.yaml
+++ b/validator/tests/exclusions/rule_filter/unconditional/011_rule11_rule_custom_action_by_id.yaml
@@ -1,0 +1,22 @@
+{
+  name: "Rule custom action by ID",
+  runs: [
+    {
+      persistent-input: {
+        rule11-input: "rule11"
+      },
+      rules: [
+        {
+          11: [
+            {
+              address: rule11-input,
+              value: rule11,
+              on_match: [ block ]
+            }
+          ]
+        }
+      ],
+      code: match,
+    }
+  ]
+}

--- a/validator/tests/exclusions/rule_filter/unconditional/012_rule11_rule_not_blocking.yaml
+++ b/validator/tests/exclusions/rule_filter/unconditional/012_rule11_rule_not_blocking.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Rule doesn't block due to no match",
+  runs: [
+    {
+      persistent-input: {
+        rule11-input: "rule12"
+      },
+      code: ok,
+    }
+  ]
+}

--- a/validator/tests/exclusions/rule_filter/unconditional/ruleset.yaml
+++ b/validator/tests/exclusions/rule_filter/unconditional/ruleset.yaml
@@ -40,6 +40,17 @@ exclusions:
     rules_target:
       - rule_id: "1"
     on_match: monitor
+  # Test precedence of bypass over custom
+  - id: "9"
+    rules_target:
+      - rule_id: "1"
+      - rule_id: "9"
+    on_match: redirect
+  - id: "10"
+    rules_target:
+      - rule_id: "11"
+    on_match: block
+
 
 rules:
   - id: "1"
@@ -154,3 +165,14 @@ rules:
             - address: rule10-input
           regex: rule10
     on_match: [ block ]
+  - id: "11"
+    name: rule11-custom-by-id
+    tags:
+      type: flow11
+      category: category11
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: rule11-input
+          regex: rule11


### PR DESCRIPTION
This PR introduces support for custom exclusion filter actions, limited to rule filters only. The filter custom action allows overriding the "blocking" (i.e. block, redirect, monitor) action of a rule if the exclusion filter is evaluated positively. For example, when the following filter matches the given IP, `rule 1` is set to `block`:

```yaml
exclusions:
  - id: 1
    rules_target:
      - rule_id: 1
    conditions:
      - operator: ip_match
        parameters:
          inputs:
            - address: http.client_ip
          list:
            - 192.168.0.1
    on_match: block
```

The precedence of rule filter actions is still `bypass > monitor > custom`.

This feature is one of the two required for suspicious attacker blocking.

Related Jira: [APPSEC-53545]

[APPSEC-53545]: https://datadoghq.atlassian.net/browse/APPSEC-53545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ