### PR TITLE
SHA256 hash based on OpenSSL

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -86,6 +86,8 @@ jobs:
             params: "--dialect=sqlite"
           - fuzzer: sqli_detector
             params: "--dialect=standard"
+          - fuzzer: sha256
+            params: ""
 
     steps:
       - uses: actions/checkout@v4

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -8,5 +8,6 @@ core,https://github.com/llvm/llvm-project/libcxxabi,Apache-2.0,"Copyright (c) 20
 core,https://github.com/llvm/llvm-project/libunwind,Apache-2.0,"Copyright (c) 2009-2019 by the contributors listed in CREDITS.TXT"
 core,https://github.com/JuliaStrings/utf8proc,MIT,"Copyright (c) 2014-2021 by Steven G. Johnson, Jiahao Chen, Tony Kelman, Jonas Fonseca, and other contributors listed in the git history"
 core,https://github.com/fmtlib/fmt,MIT,"Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors"
+core,https://github.com/openssl/openssl,Apache-2.0,"Copyright © 1999-2024, OpenSSL Project Authors. All Rights Reserved."
 dev,https://github.com/jbeder/yaml-cpp,MIT,Copyright (c) 2008-2015 Jesse Beder
 dev,https://github.com/Tencent/rapidjson,MIT,"Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip"

--- a/cmake/objects.cmake
+++ b/cmake/objects.cmake
@@ -19,6 +19,7 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/utils.cpp
     ${libddwaf_SOURCE_DIR}/src/waf.cpp
     ${libddwaf_SOURCE_DIR}/src/platform.cpp
+    ${libddwaf_SOURCE_DIR}/src/sha256.cpp
     ${libddwaf_SOURCE_DIR}/src/uuid.cpp
     ${libddwaf_SOURCE_DIR}/src/action_mapper.cpp
     ${libddwaf_SOURCE_DIR}/src/builder/processor_builder.cpp

--- a/fuzzer/sha256/corpus/.gitignore
+++ b/fuzzer/sha256/corpus/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/fuzzer/sha256/src/main.cpp
+++ b/fuzzer/sha256/src/main.cpp
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include <cstdint>
+
+#include "sha256.hpp"
+
+extern "C" int LLVMFuzzerInitialize(const int * /*argc*/, char *** /*argv*/) { return 0; }
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
+{
+    ddwaf::sha256_hash hasher;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    hasher << std::string_view{reinterpret_cast<const char *>(bytes), size};
+    auto str = hasher.digest();
+
+    // Force the compiler to not optimize away str
+    // NOLINTNEXTLINE(hicpp-no-assembler)
+    asm volatile("" : "+m"(str) : : "memory");
+
+    return 0;
+}

--- a/src/sha256.cpp
+++ b/src/sha256.cpp
@@ -1,0 +1,245 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+//
+// This code has been adapter from OpenSSL.
+//
+// Copyright 2004-2023 The OpenSSL Project Authors. All Rights Reserved.
+//
+// Licensed under the Apache License 2.0 (the "License").  You may not use
+// this file except in compliance with the License.  You can obtain a copy
+// in the file LICENSE in the source distribution or at
+// https://www.openssl.org/source/license.html
+//
+
+#include "sha256.hpp"
+#include "log.hpp"
+#include <iomanip>
+#include <sstream>
+
+namespace ddwaf {
+namespace {
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+/*
+ * Note that FIPS180-2 discusses "Truncation of the Hash Function Output."
+ * default: case below covers for it. It's not clear however if it's
+ * permitted to truncate to amount of bytes not divisible by 4. I bet not,
+ * but if it is, then default: case shall be extended. For reference.
+ * Idea behind separate cases for pre-defined lengths is to let the
+ * compiler decide if it's appropriate to unroll small loops.
+ */
+#define ROTATE(a, n) (((a) << (n)) | (((a) & 0xffffffff) >> (32 - (n))))
+
+#define HOST_c2l(c, l)                                                                             \
+    ((l) = ((static_cast<uint32_t>(*((c)++))) << 24),                                              \
+        (l) |= ((static_cast<uint32_t>(*((c)++))) << 16),                                          \
+        (l) |= ((static_cast<uint32_t>(*((c)++))) << 8),                                           \
+        (l) |= ((static_cast<uint32_t>(*((c)++)))))
+
+#define HOST_l2c(l, c)                                                                             \
+    (*((c)++) = static_cast<uint8_t>(((l) >> 24) & 0xff),                                          \
+        *((c)++) = static_cast<uint8_t>(((l) >> 16) & 0xff),                                       \
+        *((c)++) = static_cast<uint8_t>(((l) >> 8) & 0xff),                                        \
+        *((c)++) = static_cast<uint8_t>(((l)) & 0xff), l)
+
+/*
+ * FIPS specification refers to right rotations, while our ROTATE macro
+ * is left one. This is why you might notice that rotation coefficients
+ * differ from those observed in FIPS document by 32-N...
+ */
+#define Sigma0(x) (ROTATE((x), 30) ^ ROTATE((x), 19) ^ ROTATE((x), 10))
+#define Sigma1(x) (ROTATE((x), 26) ^ ROTATE((x), 21) ^ ROTATE((x), 7))
+#define sigma0(x) (ROTATE((x), 25) ^ ROTATE((x), 14) ^ ((x) >> 3))
+#define sigma1(x) (ROTATE((x), 15) ^ ROTATE((x), 13) ^ ((x) >> 10))
+#define Ch(x, y, z) (((x) & (y)) ^ ((~(x)) & (z)))
+#define Maj(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+constexpr std::array<uint32_t, 64> K256 = {0x428a2f98UL, 0x71374491UL, 0xb5c0fbcfUL, 0xe9b5dba5UL,
+    0x3956c25bUL, 0x59f111f1UL, 0x923f82a4UL, 0xab1c5ed5UL, 0xd807aa98UL, 0x12835b01UL,
+    0x243185beUL, 0x550c7dc3UL, 0x72be5d74UL, 0x80deb1feUL, 0x9bdc06a7UL, 0xc19bf174UL,
+    0xe49b69c1UL, 0xefbe4786UL, 0x0fc19dc6UL, 0x240ca1ccUL, 0x2de92c6fUL, 0x4a7484aaUL,
+    0x5cb0a9dcUL, 0x76f988daUL, 0x983e5152UL, 0xa831c66dUL, 0xb00327c8UL, 0xbf597fc7UL,
+    0xc6e00bf3UL, 0xd5a79147UL, 0x06ca6351UL, 0x14292967UL, 0x27b70a85UL, 0x2e1b2138UL,
+    0x4d2c6dfcUL, 0x53380d13UL, 0x650a7354UL, 0x766a0abbUL, 0x81c2c92eUL, 0x92722c85UL,
+    0xa2bfe8a1UL, 0xa81a664bUL, 0xc24b8b70UL, 0xc76c51a3UL, 0xd192e819UL, 0xd6990624UL,
+    0xf40e3585UL, 0x106aa070UL, 0x19a4c116UL, 0x1e376c08UL, 0x2748774cUL, 0x34b0bcb5UL,
+    0x391c0cb3UL, 0x4ed8aa4aUL, 0x5b9cca4fUL, 0x682e6ff3UL, 0x748f82eeUL, 0x78a5636fUL,
+    0x84c87814UL, 0x8cc70208UL, 0x90befffaUL, 0xa4506cebUL, 0xbef9a3f7UL, 0xc67178f2UL};
+
+constexpr std::size_t sha_digest_length = 32;
+constexpr std::size_t sha_block_size = 64;
+
+} // namespace
+
+sha256_hash &sha256_hash::operator<<(std::string_view str)
+{
+    unsigned char *p;
+    uint32_t l;
+    size_t n;
+
+    if (str.length() == 0) {
+        return *this;
+    }
+    auto len = static_cast<uint32_t>(str.length());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    const auto *data = reinterpret_cast<const unsigned char *>(str.data());
+
+    l = (length_low + (((uint32_t)len) << 3)) & 0xffffffffUL;
+    if (l < length_low) { /* overflow */
+        length_high++;
+    }
+    length_high += (len >> 29); /* might cause compiler warning on
+                                 * 16-bit */
+    length_low = l;
+
+    n = num;
+    if (n != 0) {
+        p = buffer.data();
+
+        if (len >= sha_block_size || len + n >= sha_block_size) {
+            memcpy(p + n, data, sha_block_size - n);
+            sha_block_data_order(p, 1);
+            n = sha_block_size - n;
+            data += n;
+            len -= n;
+            num = 0;
+            memset(p, 0, sha_block_size); /* keep it zeroed */
+        } else {
+            memcpy(p + n, data, len);
+            num += len;
+            return *this;
+        }
+    }
+
+    n = len / sha_block_size;
+    if (n > 0) {
+        sha_block_data_order(data, n);
+        n *= sha_block_size;
+        data += n;
+        len -= n;
+    }
+
+    if (len != 0) {
+        p = buffer.data();
+        num = len;
+        memcpy(p, data, len);
+    }
+    return *this;
+}
+
+std::string sha256_hash::digest()
+{
+    auto *p = buffer.data();
+    size_t n = num;
+
+    p[n] = 0x80; /* there is always room for one */
+    n++;
+
+    if (n > (sha_block_size - 8)) {
+        memset(p + n, 0, sha_block_size - n);
+        n = 0;
+        sha_block_data_order(p, 1);
+    }
+    memset(p + n, 0, sha_block_size - 8 - n);
+
+    p += sha_block_size - 8;
+    (void)HOST_l2c(length_high, p);
+    (void)HOST_l2c(length_low, p);
+    p -= sha_block_size;
+    sha_block_data_order(p, 1);
+    num = 0;
+    memset(p, 0, sha_block_size);
+
+    std::array<uint8_t, sha_digest_length> digest_buffer{0};
+    auto *digest_ptr = digest_buffer.data();
+    for (unsigned int nn = 0; nn < sha_digest_length / 4; nn++) {
+        uint32_t ll = hash[nn];
+        (void)HOST_l2c(ll, digest_ptr);
+    }
+
+    std::stringstream ss;
+    for (unsigned char &uc : digest_buffer) {
+        ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<unsigned>(uc);
+    }
+    return ss.str();
+}
+
+void sha256_hash::sha_block_data_order(const uint8_t *data, size_t len)
+{
+    unsigned int a;
+    unsigned int b;
+    unsigned int c;
+    unsigned int d;
+    unsigned int e;
+    unsigned int f;
+    unsigned int g;
+    unsigned int h;
+    unsigned int s0;
+    unsigned int s1;
+    unsigned int T1;
+    unsigned int T2;
+    std::array<uint32_t, 16> X{};
+    uint32_t l;
+    int i;
+
+    while ((len--) != 0) {
+
+        a = hash[0];
+        b = hash[1];
+        c = hash[2];
+        d = hash[3];
+        e = hash[4];
+        f = hash[5];
+        g = hash[6];
+        h = hash[7];
+
+        for (i = 0; i < 16; i++) {
+            (void)HOST_c2l(data, l);
+            T1 = X[i] = l;
+            T1 += h + Sigma1(e) + Ch(e, f, g) + K256[i];
+            T2 = Sigma0(a) + Maj(a, b, c);
+            h = g;
+            g = f;
+            f = e;
+            e = d + T1;
+            d = c;
+            c = b;
+            b = a;
+            a = T1 + T2;
+        }
+
+        for (; i < 64; i++) {
+            s0 = X[(i + 1) & 0x0f];
+            s0 = sigma0(s0);
+            s1 = X[(i + 14) & 0x0f];
+            s1 = sigma1(s1);
+
+            T1 = X[i & 0xf] += s0 + s1 + X[(i + 9) & 0xf];
+            T1 += h + Sigma1(e) + Ch(e, f, g) + K256[i];
+            T2 = Sigma0(a) + Maj(a, b, c);
+            h = g;
+            g = f;
+            f = e;
+            e = d + T1;
+            d = c;
+            c = b;
+            b = a;
+            a = T1 + T2;
+        }
+
+        hash[0] += a;
+        hash[1] += b;
+        hash[2] += c;
+        hash[3] += d;
+        hash[4] += e;
+        hash[5] += f;
+        hash[6] += g;
+        hash[7] += h;
+    }
+}
+
+} // namespace ddwaf

--- a/src/sha256.cpp
+++ b/src/sha256.cpp
@@ -4,7 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 //
-// This code has been adapter from OpenSSL.
+// This code has been adapted from OpenSSL.
 //
 // Copyright 2004-2023 The OpenSSL Project Authors. All Rights Reserved.
 //

--- a/src/sha256.hpp
+++ b/src/sha256.hpp
@@ -17,12 +17,22 @@ public:
     sha256_hash() = default;
     sha256_hash &operator<<(std::string_view str);
     std::string digest();
+    void reset()
+    {
+        hash = initial_hash_values;
+        length_low = 0;
+        length_high = 0;
+        buffer = {0};
+        num = {0};
+    }
 
 protected:
+    static constexpr std::array<uint32_t, 8> initial_hash_values{0x6a09e667, 0xbb67ae85, 0x3c6ef372,
+        0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+
     void sha_block_data_order(const uint8_t *data, size_t len);
 
-    std::array<uint32_t, 8> hash{0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f,
-        0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+    std::array<uint32_t, 8> hash{initial_hash_values};
     uint32_t length_low{0};
     uint32_t length_high{0};
     std::array<uint8_t, 128> buffer{0};

--- a/src/sha256.hpp
+++ b/src/sha256.hpp
@@ -15,8 +15,15 @@ namespace ddwaf {
 class sha256_hash {
 public:
     sha256_hash() = default;
+    ~sha256_hash() = default;
+    sha256_hash(const sha256_hash &) = delete;
+    sha256_hash(sha256_hash &&) = delete;
+    sha256_hash &operator=(const sha256_hash &) = delete;
+    sha256_hash &operator=(sha256_hash &&) noexcept = delete;
+
     sha256_hash &operator<<(std::string_view str);
-    std::string digest();
+    [[nodiscard]] std::string digest();
+
     void reset()
     {
         hash = initial_hash_values;

--- a/src/sha256.hpp
+++ b/src/sha256.hpp
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+namespace ddwaf {
+
+class sha256_hash {
+public:
+    sha256_hash() = default;
+    sha256_hash &operator<<(std::string_view str);
+    std::string digest();
+
+protected:
+    void sha_block_data_order(const uint8_t *data, size_t len);
+
+    std::array<uint32_t, 8> hash{0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f,
+        0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+    uint32_t length_low{0};
+    uint32_t length_high{0};
+    std::array<uint8_t, 128> buffer{0};
+    uint32_t num{0};
+};
+
+} // namespace ddwaf

--- a/src/sha256.hpp
+++ b/src/sha256.hpp
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <cstring>
-#include <iostream>
 #include <string>
 #include <string_view>
 
@@ -34,6 +33,7 @@ public:
     }
 
 protected:
+    static constexpr std::size_t block_size = 64;
     static constexpr std::array<uint32_t, 8> initial_hash_values{0x6a09e667, 0xbb67ae85, 0x3c6ef372,
         0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
 
@@ -42,7 +42,7 @@ protected:
     std::array<uint32_t, 8> hash{initial_hash_values};
     uint32_t length_low{0};
     uint32_t length_high{0};
-    std::array<uint8_t, 128> buffer{0};
+    std::array<uint8_t, block_size> buffer{0};
     uint32_t num{0};
 };
 

--- a/tests/sha256_test.cpp
+++ b/tests/sha256_test.cpp
@@ -7,9 +7,12 @@
 #include "sha256.hpp"
 #include "test.hpp"
 
+#include <utility>
+#include <vector>
+
 TEST(TestSha256, RandomInputTest)
 {
-    std::unordered_map<std::string, std::string> samples{
+    std::vector<std::pair<std::string, std::string>> samples{
         {"YqJwhSIzGlqqehMom6Z3Ok4bqLFN2Kpn",
             "403b62faf37de5e5e6e02a300a2ed1a42e2dbf9d83951ec8b288bf026b6f79a2"},
         {"3f3qLGvqHleNTAWS7MxB0QGXLoS1IMk1",
@@ -50,6 +53,16 @@ TEST(TestSha256, RandomInputTest)
             "48f76b330cf0d34a1942956af302f6b85d6806eb52f8a736a057744298be58e2"},
         {"uVF4yUAufiREPkPFwlUOrEsQ10duGD0L",
             "e61c936a0d8c85f4bc9d22e25bca6cea9ac6b2097fd567f60d5efa38c34cfb30"},
+        {"JaoF4myRTg4TCMm", "a1f9adb16b52ef2c845e85bc552a86c6426cb2780bb061e34c8982e41c2e36af"},
+        {"1sj5xeZxRF623qV", "97cc8c0f72ed810be1f3d9653372926e6e5884f341e58f4edfb2f875b097655e"},
+        {"ipsEfuH3nmPqzcp", "32adf694cb470c2ffd50b26fb684510510b0d4b227f89bd2ae5ba49d2a6e4c3a"},
+        {"Biy1I5idi5TQK9e", "76d42814fecde876121bbf8c73721893578077092eb30aa072a78679f80a48a8"},
+        {"dE8BpndRLevSL81", "6d7218b399480aed8afb21194f57daf1767c4ac20ff5edcd2c757e7c214d9ef7"},
+        {"92eB4V0FBDivRwB", "ff7e8ec21651f29cfeb692318b506db7b09be207765ff4eae000a8a2f9b579cc"},
+        {"we37ZqY2Swj5hrf", "da1134a980af5aa6a74d2cd09f6478ada8cfd69e4385a66bf8393345629db865"},
+        {"YmmkJi9JmR5F4uK", "6eb6206a23058f0c8c945b79dab52e374a7cccfde17928312d7dd1156ec0b013"},
+        {"xVdC0kucB0ykKd3", "065093b4389e81c2235ccf57c4f7d9916e478ece5209aac5d850ae82d7c1106b"},
+        {"kovdtReY2LmgFn8", "d51e607c19b019efe4d3768bb9e0202c0b439c0c556bd4ba87e2e05417f54c3f"},
     };
 
     for (auto &[original, hash] : samples) {

--- a/tests/sha256_test.cpp
+++ b/tests/sha256_test.cpp
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "sha256.hpp"
+#include "test.hpp"
+
+TEST(TestSha256, RandomInputTest)
+{
+    std::unordered_map<std::string, std::string> samples{
+        {"YqJwhSIzGlqqehMom6Z3Ok4bqLFN2Kpn",
+            "403b62faf37de5e5e6e02a300a2ed1a42e2dbf9d83951ec8b288bf026b6f79a2"},
+        {"3f3qLGvqHleNTAWS7MxB0QGXLoS1IMk1",
+            "535a34d235d1a0914d49abd6d9e6ceb8cd55ce4948214e7805e5d829616c1a3b"},
+        {"QZly1PUSiJ5sxknDjzh5ZKOmam9gGSnl",
+            "2af42b61fc7b75cbfcc2fb7aaee9ba287e0fcdcae284f8498cdcf97bdfa8ad6c"},
+        {"np1WXOU7JTH1zd3N3eEEVpojfCSG07qN",
+            "3fadb64fe82e69e500aeba66aaa4042dcf1e33f7636b3f826bb13651de8c3c6e"},
+        {"kZCS8KnHLcBGyJvqXKVMTYZyQvKdXONI",
+            "34990ff286e09cb6c88ca4db69143de0ef495820ecbc1b874e1171ce3038015c"},
+        {"zmZO2KUR3KKa2llyA8vdQuLSjEIHRGDx",
+            "4ce5dcf2b57e70660cae49d5e9747f0b6e6f3d0a43173858ced3543735474a37"},
+        {"xcd5YpxGerWhw6B0lR4G7duiMftNSu8V",
+            "06784e3810f127b2e1cb1c37b184ed7723a19cd4ba5f3afc01730646b20db89a"},
+        {"PAIbUxTu9WiHNUXxlzwrb6E4oEkJqwM8",
+            "87a5aefe7cc55c91f556d2e37b0c3871b0792db570ec57abe6b07a0d96b9ca94"},
+        {"tFUFGUSS6GXa6IQwTXHULFPt4GeeaKnR",
+            "505349119e977eefdd0cb24715a9133e0c4b93597cb4e94f953f3b4eadd63725"},
+        {"WfUaDo5mEMZIH15gfIxBh3mwfJDGNL6h",
+            "dce8225f0559d76a1928c004a6a55887293761c40623cdbbe7d31c97326d8c8b"},
+        {"auTy0yqqU9QvVGjhCGCx2C7Zx5wCE61P",
+            "5af6e6fbaf3a551abb60c0a366668581a42584dd1c3ae5756d25172e6f0a8554"},
+        {"ue30YmBaXqXejTRwWHOPABDVo0NCOydy",
+            "0002bef6617f034614d9444f6a74b86136037534a162837639d8c4d8d81844ac"},
+        {"m7UkVhIDVOtqXaVvkFbGoc6WUwG4s8D6",
+            "4e9d3107abf6d9128de5a12d9ce2bbd5c61a12e993c01832ce531f728ee5c21a"},
+        {"PqT7NuFLaTlHQulpoccYzAgvDRJHbp3M",
+            "37187a7c80428feb5c0976b3f32d44616a52799ebfc7f31f95613f4e5d938678"},
+        {"RgbxLhrZFbrYv5XykdSBlU537fDYkW1g",
+            "34144fc83c319f8ceff879d67531d7b9aed67bc81a2ec02f9ad401b52fe217b6"},
+        {"wngyajXn1cSOaczvTomAAItUXwGZOEoz",
+            "4a1e660e9b4f63fa28d489f025f04deed37045a051b590e8ab36617bcc307e81"},
+        {"Esyl9moe4yShgxayVGaGTP4nP0cZCoVC",
+            "a4d0f3b09d6ade659061fb1d21a5a5ef07d9b71bdc0ca2f389466d8a4ac53527"},
+        {"qkXBYY4xnD1dGLthAYZCo2me3c5MG58q",
+            "ab5af4c9a196e775fd25e84e33a118d422d8ed983f6bb4b9e676fc028723648b"},
+        {"XPhl2droso1w5qdf9kt7ztzuL0a3T8zi",
+            "48f76b330cf0d34a1942956af302f6b85d6806eb52f8a736a057744298be58e2"},
+        {"uVF4yUAufiREPkPFwlUOrEsQ10duGD0L",
+            "e61c936a0d8c85f4bc9d22e25bca6cea9ac6b2097fd567f60d5efa38c34cfb30"},
+    };
+
+    for (auto &[original, hash] : samples) {
+        ddwaf::sha256_hash hasher;
+        hasher << original;
+
+        EXPECT_STR(hasher.digest(), hash.c_str());
+    }
+}

--- a/tests/sha256_test.cpp
+++ b/tests/sha256_test.cpp
@@ -72,3 +72,78 @@ TEST(TestSha256, RandomInputTest)
         EXPECT_STR(hasher.digest(), hash.c_str());
     }
 }
+
+TEST(TestSha256, StreamedTest)
+{
+    std::string blob = "Ai2KO2HKBOXdwJRlrxbNrDXQus8Slx9G"
+                       "DW7DU9Uptyr1TLZM4msEuP0qRXZqbIcl"
+                       "9IdxP1H909eeH09vC7fM6zGY5OGh9oIZ"
+                       "hlHjjC2cLC47vOpthrUQTwKaEs06uwnt"
+                       "4haHvH3Y9znnEkFz9iEVMtvpO3Apxtyh"
+                       "lwXNcvrj56UKTz2KHPHQV2GdrRRrDDWt"
+                       "4mjiQTX8ozDyQO1mN8WZapm1F16Fj538"
+                       "IenCvtermrzDYIFXsBe1tovNIatThxVS"
+                       "euVkn2oijl7XgT1dmOnWkaFGjer8Ic38"
+                       "itIcWeNzqID6mUQxoYual6Qkl7OqD8jb"
+                       "WpkOshSHB2y1hkRUnSub5rCFwh2nTvsp"
+                       "F0oH1FOIn7gU6OI24DWgPsxJrz18Teht"
+                       "EhGQUBcVxBZiNaVV87VniRbUT6kkGKKN"
+                       "F1pGrWGSDSwTL1AEXuhpSXv1Q705kGzi"
+                       "TExoakd2wOUsordxOv3bF2Um1EKfFGHN"
+                       "FTFTph7B49WdhxTXDF0JLHdHYCkNS6oc"
+                       "MB6D2hmZAEuNPp3sO7YDXnGCI0lk2mEK"
+                       "IHk17j3jBIEI6KJOHHErtZiE3i2g2j9a"
+                       "dWetVl6ElvfTewSHByuLSAkYjfEhtAct"
+                       "EmHBedfeQ8mLiKd2fcRzItB4DtZRlRGw"
+                       "1eHlCZFFciwxTPxUL30ornn1sDdHa7N7"
+                       "TewPCQiljeRilUK4rzl24toKBrF3FheK"
+                       "JPfUlmOV8T6rrqpq8iDX4fMVwkHcyyNZ"
+                       "JD6n3TIfDnZcsurqjywtp9PbWuvB0FxP"
+                       "Ujm4U3Nn68kIQs326iLrpy1tDwu1e7Io"
+                       "iRyA3xpLIKvnIAabgXggUzL6hTd2QbRZ"
+                       "4QwRvJoHwZjjei08baJqrAL5CiytVsMW"
+                       "gIqWp8Wq4HmlOhJpLxuLHn6xPoCsuaPh"
+                       "0yFqjZ33cmZJ3M2jAG2Fwnx7kObsOO2E"
+                       "ENUR6iVXLUQJeDGep1JA7tupGQtynAmL"
+                       "kmM82VgKlKx3tMsWEU1xZXM6oJeeRKPm"
+                       "KSfe8ivjQBb9YaLfcuidxhmoWCu0vn9H"
+                       "hGQaeHhqlbZ0CVDR1R4wPeF4cGr1AaFJ"
+                       "E10KDeGJaMiagBMOT5o8h4K7PvkBpnDv"
+                       "U1a55iWhxPf9w952Si0EsFLRJBjb5QYn"
+                       "sqdhqeCe3DyPQbCOGRITYdKuxQBcBL7W"
+                       "PdtHrWSqEkwOL6Mc1HLmEQALr3uSgvA7"
+                       "wxP6WN3A05T0v9w6UkEWlwspX4nd96Xj"
+                       "zZKgKEwsEjJ7bL2Lo0T0BokSjA2n5pTn"
+                       "1iw0quvM9wiPk2FKmXV0IMWI9oHBlwmu"
+                       "FVzE023CSNiN0UQ4fOklUPwOZ2ugdNeI"
+                       "AGPppJa6LYPdR1vg7G1BbDg7gR74XjxU"
+                       "eKQFDGMTELYhloXFC9J5U9oAwxKwcSWK"
+                       "wjIKFWazNYXDVKJWN4BlutUOE6MqvPaD"
+                       "COk1r4LiWCI88CvvoTleQMtDbeO4dYHp"
+                       "cLiXmG57FrGEu9NhaPkFPe9Qn4CaBmq8"
+                       "Ivq7RDYnQnbEnvuQXsiL9bXnL8gwR5Ws"
+                       "y9OqKZSeuDfiwUAgWXbFNI7QTxsPzy12"
+                       "L2CyAIGsYvwEpzIBKu2ZrD7eKTBUnjhZ"
+                       "w5jZADzh4dO79PZ5kyzPEyK56TF2KSb6"
+                       "aAs29";
+
+    // Test whole blob first
+    {
+        ddwaf::sha256_hash hasher;
+        hasher << blob;
+        EXPECT_STR(
+            hasher.digest(), "83f6f81ae50bad3f221a494ee4e79be65b51283c0fa19c99923e0c8827ca484a");
+    }
+
+    {
+        ddwaf::sha256_hash hasher;
+
+        for (std::size_t i = 0, bytes = 1; i < blob.size(); i += bytes, ++bytes) {
+            auto sub = blob.substr(i, (i + bytes) >= blob.size() ? std::string::npos : bytes);
+            hasher << sub;
+        }
+
+        EXPECT_STR(
+            hasher.digest(), "83f6f81ae50bad3f221a494ee4e79be65b51283c0fa19c99923e0c8827ca484a");
+    }
+}

--- a/tests/sha256_test.cpp
+++ b/tests/sha256_test.cpp
@@ -125,14 +125,37 @@ TEST(TestSha256, StreamedTest)
                        "y9OqKZSeuDfiwUAgWXbFNI7QTxsPzy12"
                        "L2CyAIGsYvwEpzIBKu2ZrD7eKTBUnjhZ"
                        "w5jZADzh4dO79PZ5kyzPEyK56TF2KSb6"
-                       "aAs29";
+                       "ZT3bZhnruaHMnQnOG8bk"
+                       "WPFXaHtDusILTT6xrv4S"
+                       "1GGIuIloQRt7CwM7aA5i"
+                       "uSLS8ZwmeVW9nyHhKPEF"
+                       "ERH0zHH7Camp2sZ621Sz"
+                       "DcDZQkxGoixYaFqemYpD"
+                       "zxo0s1rNTYzUWtDIxfFK"
+                       "UkX9j8XOTepq0s9PmBks"
+                       "lAGJhcPvO8kFojBJyubu"
+                       "Kq72twgeJpablacHOtfD"
+                       "JKfkR8ALfqaEI7ubAv9C"
+                       "AuiUMCcOuNdAqWNbjybN"
+                       "XM7ScXx9yvPvdiMeY1ma"
+                       "XZXPw6yL3V6ufx20ZLVT"
+                       "VKoYSrCVLGpEyRLaMz3e"
+                       "RAGX5eKp6S6XBKUe0iwx"
+                       "D22oOuVl6R78MgvGWsoS"
+                       "YG1qxg4dJayp5O4IRAUy"
+                       "KNWlAmcXjspkFDYOFRk2"
+                       "cxvLG2mrBgXZkBe7tqVw"
+                       "FkNsRWwswSJvT7aP1MpI"
+                       "t6k4rhJLholcpQCTN2Vi"
+                       "50fM7yVWNBCIOrdyF0R9"
+                       "HE2Zd3BDVPl9dhb5oYDN";
 
     // Test whole blob first
     {
         ddwaf::sha256_hash hasher;
         hasher << blob;
         EXPECT_STR(
-            hasher.digest(), "83f6f81ae50bad3f221a494ee4e79be65b51283c0fa19c99923e0c8827ca484a");
+            hasher.digest(), "a198619280b5107d1fde448e4098d5b527a216a4bc41df70d24ae33fc2dac2da");
     }
 
     {
@@ -144,6 +167,6 @@ TEST(TestSha256, StreamedTest)
         }
 
         EXPECT_STR(
-            hasher.digest(), "83f6f81ae50bad3f221a494ee4e79be65b51283c0fa19c99923e0c8827ca484a");
+            hasher.digest(), "a198619280b5107d1fde448e4098d5b527a216a4bc41df70d24ae33fc2dac2da");
     }
 }


### PR DESCRIPTION
This PR introduces a class to compute the sha256 digest, the code is based on the [openssl](https://github.com/openssl/openssl/blob/140540189c67ba94188165b1144fdfb5b248bc02/crypto/sha/sha256.c#L124) implementation. At first, the objective is to use this hash for request fingerprinting purposes, however it could be used for other purposes:

- As a processor generator, in order to produce a hash of part of the request, in a similar fashion to a fingerprint although more targeted.
- As a transformer, to match obfuscated data.