### PR TITLE
Validate redirection location and restrict status codes

### DIFF
--- a/src/uri_utils.cpp
+++ b/src/uri_utils.cpp
@@ -14,6 +14,11 @@
                  / path-absolute
                  / path-rootless
                  / path-empty
+   relative-ref  = relative-part [ "?" query ] [ "#" fragment ]
+   relative-part = "//" authority path-abempty
+                 / path-absolute
+                 / path-noscheme -> Not supported
+                 / path-empty -> Not supported
    scheme        = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
    authority     = [ userinfo "@" ] host [ ":" port ]
    userinfo      = *( unreserved / pct-encoded / sub-delims / ":" )
@@ -68,7 +73,6 @@ enum class token_type {
     ipv6address,
     regname_or_ipv4address,
     path,
-    path_no_authority,
     query,
     fragment,
 };
@@ -172,25 +176,9 @@ std::optional<uri_decomposed> uri_parse(std::string_view uri)
                 i += 2;
             } else {
                 // Otherwise we expect a path (path-absolute, path-rootless, path-empty)
-                expected_token = token_type::path_no_authority;
+                expected_token = token_type::path;
             }
             break;
-        }
-        case token_type::path_no_authority: {
-            auto token_begin = i;
-            // The path can be empty but we wouldn't be here...
-            while (i < uri.size()) {
-                const auto c = uri[i++];
-                if (!is_path_char(c) && c != '/') {
-                    return std::nullopt;
-                }
-            }
-
-            decomposed.path_index = token_begin;
-            decomposed.path = uri.substr(token_begin, i - token_begin);
-
-            // We're done, nothing else to parse
-            return decomposed;
         }
         case token_type::authority: {
             auto token_begin = i;

--- a/tests/uri_utils_test.cpp
+++ b/tests/uri_utils_test.cpp
@@ -488,4 +488,118 @@ TEST(TestURI, Complete)
     }
 }
 
+TEST(TestURI, RelativeRefHostPortQuery)
+{
+    auto uri = ddwaf::uri_parse("//authority:123?query");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "authority");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_STRV(uri->authority.port, "123");
+    EXPECT_STRV(uri->query, "query");
+}
+
+TEST(TestURI, RelativeRefHostPortPath)
+{
+    auto uri = ddwaf::uri_parse("//authority:12/path");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "authority");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_STRV(uri->authority.port, "12");
+    EXPECT_STRV(uri->path, "/path");
+}
+
+TEST(TestURI, RelativeRefHostPortFragment)
+{
+    auto uri = ddwaf::uri_parse("//authority:1#f");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "authority");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_STRV(uri->authority.port, "1");
+    EXPECT_STRV(uri->fragment, "f");
+}
+
+TEST(TestURI, RelativeRefUserHostQuery)
+{
+    auto uri = ddwaf::uri_parse("//user@authority?query");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "authority");
+    EXPECT_STRV(uri->authority.userinfo, "user");
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->query, "query");
+}
+
+TEST(TestURI, RelativeRefUserHostPath)
+{
+    auto uri = ddwaf::uri_parse("//us@authority/path");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "authority");
+    EXPECT_STRV(uri->authority.userinfo, "us");
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->path, "/path");
+}
+
+TEST(TestURI, RelativeRefUserHostFragment)
+{
+    auto uri = ddwaf::uri_parse("//u@authority#f");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "authority");
+    EXPECT_STRV(uri->authority.userinfo, "u");
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->fragment, "f");
+}
+
+TEST(TestURI, RelativeRefAbsolutePath)
+{
+    auto uri = ddwaf::uri_parse("/path");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_STRV(uri->authority.port, "");
+    EXPECT_STRV(uri->path, "/path");
+}
+
+TEST(TestURI, RelativeRefAbsolutePathFragment)
+{
+    auto uri = ddwaf::uri_parse("/path#f");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_STRV(uri->authority.port, "");
+    EXPECT_STRV(uri->path, "/path");
+    EXPECT_STRV(uri->fragment, "f");
+}
+
+TEST(TestURI, RelativeRefAbsolutePathQuery)
+{
+    auto uri = ddwaf::uri_parse("/path?query");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_STRV(uri->authority.port, "");
+    EXPECT_STRV(uri->path, "/path");
+    EXPECT_STRV(uri->query, "query");
+}
+
+TEST(TestURI, RelativeRefAbsolutePathQueryFragment)
+{
+    auto uri = ddwaf::uri_parse("/path?query#f");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_STRV(uri->authority.port, "");
+    EXPECT_STRV(uri->path, "/path");
+    EXPECT_STRV(uri->query, "query");
+    EXPECT_STRV(uri->fragment, "f");
+}
+
 } // namespace

--- a/tests/uri_utils_test.cpp
+++ b/tests/uri_utils_test.cpp
@@ -140,12 +140,7 @@ TEST(TestURI, SchemeAndPath)
     }
 }
 
-TEST(TestURI, SchemeMalformedPath)
-{
-    EXPECT_FALSE(ddwaf::uri_parse("file:[][][]"));
-    EXPECT_FALSE(ddwaf::uri_parse("file:?query"));
-    EXPECT_FALSE(ddwaf::uri_parse("file:#fragment"));
-}
+TEST(TestURI, SchemeMalformedPath) { EXPECT_FALSE(ddwaf::uri_parse("file:[][][]")); }
 
 TEST(TestURI, SchemeHost)
 {
@@ -176,6 +171,40 @@ TEST(TestURI, SchemeHost)
         EXPECT_TRUE(uri->authority.userinfo.empty());
         EXPECT_TRUE(uri->authority.port.empty());
     }
+}
+
+TEST(TestURI, SchemeQuery)
+{
+    auto uri = ddwaf::uri_parse("http:?hello");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "http");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->query, "hello");
+}
+
+TEST(TestURI, SchemeFragment)
+{
+    auto uri = ddwaf::uri_parse("http:#hello");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "http");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->fragment, "hello");
+}
+
+TEST(TestURI, SchemeQueryFragment)
+{
+    auto uri = ddwaf::uri_parse("http:?hello#bye");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "http");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->query, "hello");
+    EXPECT_STRV(uri->fragment, "bye");
 }
 
 TEST(TestURI, SchemeIPv4Host)
@@ -600,6 +629,43 @@ TEST(TestURI, RelativeRefAbsolutePathQueryFragment)
     EXPECT_STRV(uri->path, "/path");
     EXPECT_STRV(uri->query, "query");
     EXPECT_STRV(uri->fragment, "f");
+}
+
+TEST(TestURI, RelativeRefQuery)
+{
+    auto uri = ddwaf::uri_parse("/?hello");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->path, "/");
+    EXPECT_STRV(uri->query, "hello");
+}
+
+TEST(TestURI, RelativeRefFragment)
+{
+    auto uri = ddwaf::uri_parse("/#hello");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->path, "/");
+    EXPECT_STRV(uri->fragment, "hello");
+}
+
+TEST(TestURI, RelativeRefQueryFragment)
+{
+    auto uri = ddwaf::uri_parse("/?hello#bye");
+    ASSERT_TRUE(uri);
+    EXPECT_STRV(uri->scheme, "");
+    EXPECT_STRV(uri->authority.host, "");
+    EXPECT_TRUE(uri->authority.userinfo.empty());
+    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_STRV(uri->path, "/");
+    EXPECT_STRV(uri->query, "hello");
+    EXPECT_STRV(uri->fragment, "bye");
 }
 
 } // namespace


### PR DESCRIPTION
Extra validations for redirect actions:

- Valid status codes are now 301, 302, 303 or 307
- The `location` must now:
  -  Be a valid URL
  - If it contains a scheme, it must be either `http` or `https`
  - if it doesn't, it must be an absolute-path reference starting with `/`

The URI parser has been updated to support:
- Fragments and query on URLs without authority 
- Network-path references
- Absolute-path references
- Relative-path references are not yet supported

Related Jira: [APPSEC-53568]

[APPSEC-53568]: https://datadoghq.atlassian.net/browse/APPSEC-53568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ