### PR TITLE
Upgrade to macos-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
             ${{ github.workspace }}/packages/*.sha256
 
   macos-build:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,7 +87,7 @@ jobs:
             ${{ github.workspace }}/packages/*.sha256
 
   macos-cross-build:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,7 +117,7 @@ jobs:
             ${{ github.workspace }}/packages/*.sha256
 
   macos-universal-package:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: [macos-build, macos-cross-build]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Upgrade runners to `macos-12` as `macos-11` is being deprecated.