### PR TITLE
Rule override for adding tags

### DIFF
--- a/src/event.cpp
+++ b/src/event.cpp
@@ -159,6 +159,9 @@ void serialize_rule(const ddwaf::rule &rule, ddwaf_object &rule_map)
     for (const auto &[key, value] : rule.get_tags()) {
         ddwaf_object_map_addl(&tags_map, key.c_str(), key.size(), to_object(tmp, value));
     }
+    for (const auto &[key, value] : rule.get_ancillary_tags()) {
+        ddwaf_object_map_addl(&tags_map, key.c_str(), key.size(), to_object(tmp, value));
+    }
     ddwaf_object_map_add(&rule_map, "tags", &tags_map);
 }
 

--- a/src/parser/rule_override_parser.cpp
+++ b/src/parser/rule_override_parser.cpp
@@ -57,7 +57,7 @@ std::pair<override_spec, reference_type> parse_override(const parameter::map &no
         type = reference_type::id;
     }
 
-    if (!current.actions.has_value() && !current.enabled.has_value()) {
+    if (!current.actions.has_value() && !current.enabled.has_value() && current.tags.empty()) {
         throw ddwaf::parsing_error("rule override without side-effects");
     }
 

--- a/src/parser/rule_override_parser.cpp
+++ b/src/parser/rule_override_parser.cpp
@@ -28,6 +28,12 @@ std::pair<override_spec, reference_type> parse_override(const parameter::map &no
         current.actions = std::move(actions);
     }
 
+    it = node.find("tags");
+    if (it != node.end()) {
+        auto tags = static_cast<std::unordered_map<std::string, std::string>>(it->second);
+        current.tags = std::move(tags);
+    }
+
     reference_type type = reference_type::none;
 
     auto rules_target_array = at<parameter::vector>(node, "rules_target", {});

--- a/src/parser/specification.hpp
+++ b/src/parser/specification.hpp
@@ -40,6 +40,7 @@ struct override_spec {
     std::optional<bool> enabled;
     std::optional<std::vector<std::string>> actions;
     std::vector<reference_spec> targets;
+    std::unordered_map<std::string, std::string> tags;
 };
 
 struct rule_filter_spec {

--- a/src/rule.hpp
+++ b/src/rule.hpp
@@ -43,7 +43,7 @@ public:
     rule &operator=(const rule &) = delete;
 
     rule(rule &&rhs) noexcept = default;
-    rule &operator=(rule &&rhs) noexcept = default;
+    rule &operator=(rule &&rhs) = default;
 
     virtual ~rule() = default;
 

--- a/src/rule.hpp
+++ b/src/rule.hpp
@@ -42,23 +42,8 @@ public:
     rule(const rule &) = delete;
     rule &operator=(const rule &) = delete;
 
-    rule(rule &&rhs) noexcept
-        : enabled_(rhs.enabled_), source_(rhs.source_), id_(std::move(rhs.id_)),
-          name_(std::move(rhs.name_)), tags_(std::move(rhs.tags_)), expr_(std::move(rhs.expr_)),
-          actions_(std::move(rhs.actions_))
-    {}
-
-    rule &operator=(rule &&rhs) noexcept
-    {
-        enabled_ = rhs.enabled_;
-        source_ = rhs.source_;
-        id_ = std::move(rhs.id_);
-        name_ = std::move(rhs.name_);
-        tags_ = std::move(rhs.tags_);
-        expr_ = std::move(rhs.expr_);
-        actions_ = std::move(rhs.actions_);
-        return *this;
-    }
+    rule(rule &&rhs) noexcept = default;
+    rule &operator=(rule &&rhs) noexcept = default;
 
     virtual ~rule() = default;
 
@@ -94,8 +79,18 @@ public:
     }
 
     const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }
+    const std::unordered_map<std::string, std::string> &get_ancillary_tags() const
+    {
+        return ancillary_tags_;
+    }
 
-    void set_tag(const std::string &key, const std::string &value) { tags_[key] = value; }
+    void set_ancillary_tag(const std::string &key, const std::string &value)
+    {
+        // Ancillary tags aren't allowed to overlap with standard tags
+        if (!tags_.contains(key)) {
+            ancillary_tags_[key] = value;
+        }
+    }
 
     const std::vector<std::string> &get_actions() const { return actions_; }
 
@@ -112,6 +107,7 @@ protected:
     std::string id_;
     std::string name_;
     std::unordered_map<std::string, std::string> tags_;
+    std::unordered_map<std::string, std::string> ancillary_tags_;
     std::shared_ptr<expression> expr_;
     std::vector<std::string> actions_;
 };

--- a/src/rule.hpp
+++ b/src/rule.hpp
@@ -95,6 +95,8 @@ public:
 
     const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }
 
+    void set_tag(const std::string &key, const std::string &value) { tags_[key] = value; }
+
     const std::vector<std::string> &get_actions() const { return actions_; }
 
     void get_addresses(std::unordered_map<target_index, std::string> &addresses) const

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -98,7 +98,9 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
                     rule_ptr->set_actions(*ovrd.actions);
                 }
 
-                for (const auto &[tag, value] : ovrd.tags) { rule_ptr->set_tag(tag, value); }
+                for (const auto &[tag, value] : ovrd.tags) {
+                    rule_ptr->set_ancillary_tag(tag, value);
+                }
             }
         }
 
@@ -113,7 +115,9 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
                     rule_ptr->set_actions(*ovrd.actions);
                 }
 
-                for (const auto &[tag, value] : ovrd.tags) { rule_ptr->set_tag(tag, value); }
+                for (const auto &[tag, value] : ovrd.tags) {
+                    rule_ptr->set_ancillary_tag(tag, value);
+                }
             }
         }
     }

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -97,6 +97,8 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
                 if (ovrd.actions.has_value()) {
                     rule_ptr->set_actions(*ovrd.actions);
                 }
+
+                for (const auto &[tag, value] : ovrd.tags) { rule_ptr->set_tag(tag, value); }
             }
         }
 
@@ -110,6 +112,8 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
                 if (ovrd.actions.has_value()) {
                     rule_ptr->set_actions(*ovrd.actions);
                 }
+
+                for (const auto &[tag, value] : ovrd.tags) { rule_ptr->set_tag(tag, value); }
             }
         }
     }

--- a/tests/parser_v2_rules_override_test.cpp
+++ b/tests/parser_v2_rules_override_test.cpp
@@ -232,4 +232,93 @@ TEST(TestParserV2RulesOverride, ParseInconsistentRuleOverride)
     EXPECT_EQ(overrides.by_tags.size(), 0);
 }
 
+TEST(TestParserV2RulesOverride, ParseRuleOverrideForTags)
+{
+    auto object = yaml_to_object(
+        R"([{rules_target: [{tags: {confidence: 1}}], on_match: [block], tags: {category: new_category, threshold: 25}}])");
+
+    ddwaf::ruleset_info::section_info section;
+    auto override_array = static_cast<parameter::vector>(parameter(object));
+    auto overrides = parser::v2::parse_overrides(override_array, section);
+    ddwaf_object_free(&object);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(overrides.by_ids.size(), 0);
+    EXPECT_EQ(overrides.by_tags.size(), 1);
+
+    auto &ovrd = overrides.by_tags[0];
+    EXPECT_FALSE(ovrd.enabled.has_value());
+    EXPECT_TRUE(ovrd.actions.has_value());
+    EXPECT_EQ(ovrd.actions->size(), 1);
+    EXPECT_STR((*ovrd.actions)[0], "block");
+    EXPECT_EQ(ovrd.targets.size(), 1);
+    EXPECT_EQ(ovrd.tags.size(), 2);
+    EXPECT_STR(ovrd.tags["category"], "new_category");
+    EXPECT_STR(ovrd.tags["threshold"], "25");
+
+    auto &target = ovrd.targets[0];
+    EXPECT_EQ(target.type, parser::reference_type::tags);
+    EXPECT_TRUE(target.ref_id.empty());
+    EXPECT_EQ(target.tags.size(), 1);
+    EXPECT_STR(target.tags["confidence"], "1");
+}
+
+TEST(TestParserV2RulesOverride, ParseInvalidTagsField)
+{
+    auto object = yaml_to_object(
+        R"([{rules_target: [{tags: {confidence: 1}}], on_match: [block], tags: [{category: new_category}, {threshold: 25}]}])");
+
+    ddwaf::ruleset_info::section_info section;
+    auto override_array = static_cast<parameter::vector>(parameter(object));
+    auto overrides = parser::v2::parse_overrides(override_array, section);
+    ddwaf_object_free(&object);
+
+    {
+        ddwaf::parameter root;
+        section.to_object(root);
+
+        auto root_map = static_cast<parameter::map>(root);
+
+        auto loaded = ddwaf::parser::at<parameter::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::parser::at<parameter::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("index:0"), failed.end());
+
+        auto errors = ddwaf::parser::at<parameter::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+
+        auto it = errors.find("bad cast, expected 'map', obtained 'array'");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::parameter::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("index:0"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_EQ(overrides.by_ids.size(), 0);
+    EXPECT_EQ(overrides.by_tags.size(), 0);
+}
+
 } // namespace


### PR DESCRIPTION
This PR introduces support for adding tags to a rule through rule overrides. The schema of `rules_override` has been updated to support a new `tags` field, which is a map containing the new tags which must be added to a given set of rules. The set of tags to add must not overlap with the set of default tags already available on the rule; any overlapping tag will be ignored. For example:

```json
"rules_override": [
   {
      "rules_target": [
        {
          "tags": {
            "confidence": "1"
          }
        }
      ],
      "tags": {
          "policy": "custom-policy-1"
      }
   }
]
```

Tags will only be used for reporting purposes and won't impact other overrides or exclusion filters targeting a tag set.

Related Jira: [APPSEC-11810]

[APPSEC-11810]: https://datadoghq.atlassian.net/browse/APPSEC-11810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ