### PR TITLE
Skip disabled rules when generating ruleset

### DIFF
--- a/src/indexer.hpp
+++ b/src/indexer.hpp
@@ -27,6 +27,14 @@ public:
         by_tags_.insert(item->get_tags(), item.get());
     }
 
+    iterator erase(iterator &it)
+    {
+        auto &item = *it;
+        by_tags_.erase(item->get_tags(), item.get());
+        by_id_.erase(item->get_id());
+        return items_.erase(it);
+    }
+
     T *find_by_id(std::string_view id) const
     {
         auto it = by_id_.find(id);
@@ -58,7 +66,7 @@ public:
 protected:
     std::vector<std::shared_ptr<T>> items_;
     std::unordered_map<std::string_view, T *> by_id_;
-    multi_key_map<std::string_view, T *> by_tags_;
+    multi_key_map<std::string, T *> by_tags_;
 };
 
 } // namespace ddwaf

--- a/src/mkmap.hpp
+++ b/src/mkmap.hpp
@@ -27,6 +27,14 @@ public:
         for (const auto &key : keys) { data_[key.first][key.second].emplace(value); }
     }
 
+    template <typename U,
+        typename = typename std::enable_if_t<is_pair<typename U::iterator::value_type>::value,
+            typename U::iterator>>
+    void erase(const U &keys, const T &value)
+    {
+        for (const auto &key : keys) { data_[key.first][key.second].erase(value); }
+    }
+
     template <typename CompatKey> std::set<T> find(const std::pair<CompatKey, CompatKey> &key) const
     {
         auto first_it = data_.find(key.first);

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -24,11 +24,6 @@ namespace ddwaf {
 struct ruleset {
     void insert_rule(const std::shared_ptr<rule> &rule)
     {
-        if (!rule->is_enabled()) {
-            // Skip disabled rules
-            return;
-        }
-
         rules.emplace_back(rule);
         std::string_view type = rule->get_tag("type");
         collection_types.emplace(type);

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -24,6 +24,11 @@ namespace ddwaf {
 struct ruleset {
     void insert_rule(const std::shared_ptr<rule> &rule)
     {
+        if (!rule->is_enabled()) {
+            // Skip disabled rules
+            return;
+        }
+
         rules.emplace_back(rule);
         std::string_view type = rule->get_tag("type");
         collection_types.emplace(type);

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -181,10 +181,8 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
     rs->event_obfuscator = event_obfuscator_;
 
     // Since disabled rules aren't added to the final ruleset, we must check
-    // again that there are rules avialable
+    // again that there are rules available.
     if (rs->rules.empty()) {
-        // If we haven't received rules and our base ruleset is empty, the
-        // WAF can't proceed.
         DDWAF_WARN("No valid rules found");
         throw ddwaf::parsing_error("no valid rules found");
     }

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -112,6 +112,15 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
                 }
             }
         }
+
+        // Remove any disabled rules
+        for (auto it = final_base_rules_.begin(); it != final_base_rules_.end();) {
+            if (!(*it)->is_enabled()) {
+                it = final_base_rules_.erase(it);
+            } else {
+                ++it;
+            }
+        }
     }
 
     if ((state & change_state::custom_rules) != change_state::none) {
@@ -121,6 +130,10 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
         for (const auto &[id, spec] : user_rules_) {
             auto rule_ptr = std::make_shared<ddwaf::rule>(
                 id, spec.name, spec.tags, spec.expr, spec.actions, spec.enabled, spec.source);
+            if (!rule_ptr->is_enabled()) {
+                // Skip disabled rules
+                continue;
+            }
             final_user_rules_.emplace(rule_ptr);
         }
     }

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -184,7 +184,7 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
     // again that there are rules available.
     if (rs->rules.empty()) {
         DDWAF_WARN("No valid rules found");
-        throw ddwaf::parsing_error("no valid rules found");
+        throw ddwaf::parsing_error("no valid or enabled rules found");
     }
 
     return rs;

--- a/src/ruleset_builder.cpp
+++ b/src/ruleset_builder.cpp
@@ -180,6 +180,15 @@ std::shared_ptr<ruleset> ruleset_builder::build(parameter::map &root, base_rules
     rs->free_fn = free_fn_;
     rs->event_obfuscator = event_obfuscator_;
 
+    // Since disabled rules aren't added to the final ruleset, we must check
+    // again that there are rules avialable
+    if (rs->rules.empty()) {
+        // If we haven't received rules and our base ruleset is empty, the
+        // WAF can't proceed.
+        DDWAF_WARN("No valid rules found");
+        throw ddwaf::parsing_error("no valid rules found");
+    }
+
     return rs;
 }
 

--- a/tests/mkmap_test.cpp
+++ b/tests/mkmap_test.cpp
@@ -150,4 +150,162 @@ TEST(TestMultiKeyMap, Multifind)
     }
 }
 
+TEST(TestMultiKeyMap, Erase)
+{
+    rule_tag_map ruledb;
+
+    struct rule_spec {
+        std::string id;
+        std::string type;
+        std::string category;
+        std::unordered_map<std::string, std::string> tags;
+    };
+
+    std::vector<rule_spec> specs{{"id0", "type0", "category0", {{"key", "value0"}}},
+        {"id1", "type0", "category0", {{"key", "value1"}}},
+        {"id2", "type0", "category1", {{"key", "value0"}}},
+        {"id3", "type0", "category1", {{"key", "value1"}}},
+        {"id4", "type1", "category0", {{"key", "value0"}}},
+        {"id5", "type1", "category0", {{"key", "value1"}}},
+        {"id6", "type1", "category1", {{"key", "value0"}}},
+        {"id7", "type1", "category1", {{"key", "value1"}}}};
+
+    std::vector<std::shared_ptr<rule>> rules;
+    for (const auto &spec : specs) {
+        std::unordered_map<std::string, std::string> tags = spec.tags;
+        tags.emplace("type", spec.type);
+        tags.emplace("category", spec.category);
+
+        auto rule_ptr = std::make_shared<ddwaf::rule>(
+            std::string(spec.id), "name", decltype(tags)(tags), std::make_shared<expression>());
+        rules.emplace_back(rule_ptr);
+        ruledb.insert(rule_ptr->get_tags(), rule_ptr.get());
+    }
+
+    using sv_pair = std::pair<std::string_view, std::string_view>;
+    {
+        auto rules = ruledb.find(sv_pair{"type"sv, "type0"});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"category", "category0"});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"key"sv, "value0"sv});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    using s_pair = std::pair<std::string, std::string>;
+    {
+        auto rules = ruledb.find(s_pair{"type"sv, "type1"});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    {
+        auto rules = ruledb.find(s_pair{"category", "category1"});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    {
+        auto rules = ruledb.find(s_pair{"key"sv, "value1"sv});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    ruledb.erase(rules[3]->get_tags(), rules[3].get());
+    {
+        auto rules = ruledb.find(sv_pair{"type"sv, "type0"});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"category", "category0"});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"key"sv, "value0"sv});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"type"sv, "type1"});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"category", "category1"});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"key"sv, "value1"sv});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    ruledb.erase(rules[0]->get_tags(), rules[0].get());
+    {
+        auto rules = ruledb.find(sv_pair{"type"sv, "type0"});
+        EXPECT_EQ(rules.size(), 2);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"category", "category0"});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"key"sv, "value0"sv});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"type"sv, "type1"});
+        EXPECT_EQ(rules.size(), 4);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"category", "category1"});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"key"sv, "value1"sv});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    ruledb.erase(rules[7]->get_tags(), rules[7].get());
+    {
+        auto rules = ruledb.find(sv_pair{"type"sv, "type0"});
+        EXPECT_EQ(rules.size(), 2);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"category", "category0"});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"key"sv, "value0"sv});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"type"sv, "type1"});
+        EXPECT_EQ(rules.size(), 3);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"category", "category1"});
+        EXPECT_EQ(rules.size(), 2);
+    }
+
+    {
+        auto rules = ruledb.find(sv_pair{"key"sv, "value1"sv});
+        EXPECT_EQ(rules.size(), 2);
+    }
+}
+
 } // namespace

--- a/tests/waf_test.cpp
+++ b/tests/waf_test.cpp
@@ -53,20 +53,11 @@ TEST(TestWaf, RuleDisabledInRuleset)
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf::null_ruleset_info info;
-    ddwaf::waf instance{
-        rule, info, ddwaf::object_limits(), ddwaf_object_free, std::make_shared<obfuscator>()};
+    EXPECT_THROW((ddwaf::waf{rule, info, ddwaf::object_limits(), ddwaf_object_free,
+                     std::make_shared<obfuscator>()}),
+        ddwaf::parsing_error);
+
     ddwaf_object_free(&rule);
-
-    {
-        ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-
-        auto *ctx = instance.create_context();
-        EXPECT_EQ(ctx->run(root, std::nullopt, std::nullopt, LONG_TIME), DDWAF_OK);
-        delete ctx;
-    }
 }
 
 TEST(TestWaf, AddressUniqueness)

--- a/tests/yaml/ruleset_with_disabled_rule.yaml
+++ b/tests/yaml/ruleset_with_disabled_rule.yaml
@@ -1,0 +1,25 @@
+version: '2.1'
+rules:
+  - id: id-rule-1
+    name: rule1
+    enabled: false
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule1
+  - id: id-rule-2
+    name: rule2
+    tags:
+      type: flow2
+      category: category2
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value2
+          regex: rule2


### PR DESCRIPTION
This PR introduces a small change which consists in simply not adding disabled rules to the final ruleset. This reduces the number of rules that need to be iterated and it also helps ensuring that `ddwaf_known_addresses` always returns a list of usable addresses, which in turn can be used to identify enabled / disabled exploit prevention rules given their unique resource address.

Related Jira: [APPSEC-53751]

[APPSEC-53751]: https://datadoghq.atlassian.net/browse/APPSEC-53751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ