### PR TITLE
Update default obfuscator regex

### DIFF
--- a/src/obfuscator.hpp
+++ b/src/obfuscator.hpp
@@ -30,7 +30,7 @@ public:
 
 protected:
     static constexpr std::string_view default_key_regex_str{
-        R"((p(ass)?w(or)?d|pass(_?phrase)?|secret|(api_?|private_?|public_?)key)|token|consumer_?(id|key|secret)|sign(ed|ature)|bearer|authorization)"};
+        R"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key)|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\.net[_-]sessionid|sid|jwt)"};
 
     std::unique_ptr<re2::RE2> key_regex{nullptr};
     std::unique_ptr<re2::RE2> value_regex{nullptr};

--- a/src/obfuscator.hpp
+++ b/src/obfuscator.hpp
@@ -28,10 +28,10 @@ public:
 
     static constexpr std::string_view redaction_msg{"<Redacted>"};
 
-protected:
     static constexpr std::string_view default_key_regex_str{
         R"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key)|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\.net[_-]sessionid|sid|jwt)"};
 
+protected:
     std::unique_ptr<re2::RE2> key_regex{nullptr};
     std::unique_ptr<re2::RE2> value_regex{nullptr};
 };

--- a/tests/obfuscator_test.cpp
+++ b/tests/obfuscator_test.cpp
@@ -74,8 +74,7 @@ TEST(TestObfuscator, TestDefaultObfuscator)
         "IDTOKEN", "REFRESH_TOKEN", "REFRESH-TOKEN", "REFRESHTOKEN", "CONSUMER-ID", "CONSUMER_ID",
         "CONSUMERID", "CONSUMER-KEY", "CONSUMER_KEY", "CONSUMERKEY", "CONSUMER-SECRET",
         "CONSUMER_SECRET", "CONSUMERSECRET", "SIGNED", "SIGNATURE", "BEARER", "AUTHORIZATION",
-        "JSESSIONID", "PHPSESSID", "ASP.NET_SESSIONID", "ASP.NET-SESSIONID", "SID", "JWT"
-    };
+        "JSESSIONID", "PHPSESSID", "ASP.NET_SESSIONID", "ASP.NET-SESSIONID", "SID", "JWT"};
 
     ddwaf::obfuscator event_obfuscator{ddwaf::obfuscator::default_key_regex_str, {}};
     for (auto &sample : samples) { EXPECT_TRUE(event_obfuscator.is_sensitive_key(sample)); }

--- a/tests/obfuscator_test.cpp
+++ b/tests/obfuscator_test.cpp
@@ -55,6 +55,32 @@ TEST(TestObfuscator, TestEmptyObfuscator)
     EXPECT_FALSE(event_obfuscator.is_sensitive_value("value"sv));
 }
 
+TEST(TestObfuscator, TestDefaultObfuscator)
+{
+    std::vector<std::string> samples{"password", "pwd", "pword", "passwd", "pass", "passphrase",
+        "pass-phrase", "passphrase", "secret", "api_key", "api-key", "apikey", "private_key",
+        "private-key", "privatekey", "public-key", "public_key", "publickey", "secret_key",
+        "secret-key", "secretkey", "accesskey", "access_key", "access-key", "auth-token",
+        "auth_token", "authtoken", "access-token", "access_token", "accesstoken", "id-token",
+        "id_token", "idtoken", "refresh_token", "refresh-token", "refreshtoken", "consumer-id",
+        "consumer_id", "consumerid", "consumer-key", "consumer_key", "consumerkey",
+        "consumer-secret", "consumer_secret", "consumersecret", "signed", "signature", "bearer",
+        "authorization", "jsessionid", "phpsessid", "asp.net_sessionid", "asp.net-sessionid", "sid",
+        "jwt", "PASSWORD", "PWD", "PWORD", "PASSWD", "PASS", "PASSPHRASE", "PASS-PHRASE",
+        "PASSPHRASE", "SECRET", "API_KEY", "API-KEY", "APIKEY", "PRIVATE_KEY", "PRIVATE-KEY",
+        "PRIVATEKEY", "PUBLIC-KEY", "PUBLIC_KEY", "PUBLICKEY", "SECRET_KEY", "SECRET-KEY",
+        "SECRETKEY", "ACCESSKEY", "ACCESS_KEY", "ACCESS-KEY", "AUTH-TOKEN", "AUTH_TOKEN",
+        "AUTHTOKEN", "ACCESS-TOKEN", "ACCESS_TOKEN", "ACCESSTOKEN", "ID-TOKEN", "ID_TOKEN",
+        "IDTOKEN", "REFRESH_TOKEN", "REFRESH-TOKEN", "REFRESHTOKEN", "CONSUMER-ID", "CONSUMER_ID",
+        "CONSUMERID", "CONSUMER-KEY", "CONSUMER_KEY", "CONSUMERKEY", "CONSUMER-SECRET",
+        "CONSUMER_SECRET", "CONSUMERSECRET", "SIGNED", "SIGNATURE", "BEARER", "AUTHORIZATION",
+        "JSESSIONID", "PHPSESSID", "ASP.NET_SESSIONID", "ASP.NET-SESSIONID", "SID", "JWT"
+    };
+
+    ddwaf::obfuscator event_obfuscator{ddwaf::obfuscator::default_key_regex_str, {}};
+    for (auto &sample : samples) { EXPECT_TRUE(event_obfuscator.is_sensitive_key(sample)); }
+}
+
 TEST(TestObfuscator, TestConfigKeyValue)
 {
     auto rule = read_file("obfuscator.yaml");

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -47,8 +47,9 @@ auto parse_args(int argc, char *argv[])
     }
     return args;
 }
-const char *key_regex = "(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization";
-const char *value_regex = R"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,})";
+const char *key_regex = R"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key)|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\.net[_-]sessionid|sid|jwt)";
+
+const char *value_regex = R"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key(?:[_-]?id)?|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?|jsessionid|phpsessid|asp\.net(?:[_-]|-)sessionid|sid|jwt)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,})";
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
This PR updates the default obfuscator regex, used if the user-provided regexes are unusable. A test has also been added to ensure some expected patterns are detected.

Related Jiras: [APPSEC-53957]

[APPSEC-53957]: https://datadoghq.atlassian.net/browse/APPSEC-53957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ