### PR TITLE
Add function to obtain available actions

### DIFF
--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -247,7 +247,8 @@ void ddwaf_destroy(ddwaf_handle handle);
  *             size will be 0 if the return value is NULL.
  * @return NULL if empty, otherwise a pointer to an array with size elements.
  *
- * @Note The returned array should be considered invalid after calling ddwaf_destroy
+ * @note This function is not thread-safe
+ * @note The returned array should be considered invalid after calling ddwaf_destroy
  *       on the handle used to obtain it.
  **/
 const char* const* ddwaf_known_addresses(const ddwaf_handle handle, uint32_t *size);
@@ -264,7 +265,8 @@ const char* const* ddwaf_known_addresses(const ddwaf_handle handle, uint32_t *si
  *             size will be 0 if the return value is NULL.
  * @return NULL if empty, otherwise a pointer to an array with size elements.
  *
- * @Note The returned array should be considered invalid after calling ddwaf_destroy
+ * @note This function is not thread-safe
+ * @note The returned array should be considered invalid after calling ddwaf_destroy
  *       on the handle used to obtain it.
  **/
 const char *const *ddwaf_known_actions(const ddwaf_handle handle, uint32_t *size);

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -251,7 +251,23 @@ void ddwaf_destroy(ddwaf_handle handle);
  *       on the handle used to obtain it.
  **/
 const char* const* ddwaf_known_addresses(const ddwaf_handle handle, uint32_t *size);
-
+/**
+ * ddwaf_known_actions
+ *
+ * Get an array of all the action types which could be triggered as a result of
+ * the current set of rules and exclusion filters.
+ *
+ * The memory is owned by the WAF and should not be freed.
+ *
+ * @param Handle to the WAF instance.
+ * @param size Output parameter in which the size will be returned. The value of
+ *             size will be 0 if the return value is NULL.
+ * @return NULL if empty, otherwise a pointer to an array with size elements.
+ *
+ * @Note The returned array should be considered invalid after calling ddwaf_destroy
+ *       on the handle used to obtain it.
+ **/
+const char *const *ddwaf_known_actions(const ddwaf_handle handle, uint32_t *size);
 /**
  * ddwaf_context_init
  *

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -228,7 +228,7 @@ ddwaf_handle ddwaf_update(ddwaf_handle handle, const ddwaf_object *ruleset,
  *
  * Destroy a WAF instance.
  *
- * @param Handle to the WAF instance.
+ * @param handle Handle to the WAF instance.
  */
 void ddwaf_destroy(ddwaf_handle handle);
 
@@ -242,7 +242,7 @@ void ddwaf_destroy(ddwaf_handle handle);
  *
  * The memory is owned by the WAF and should not be freed.
  *
- * @param Handle to the WAF instance.
+ * @param handle Handle to the WAF instance.
  * @param size Output parameter in which the size will be returned. The value of
  *             size will be 0 if the return value is NULL.
  * @return NULL if empty, otherwise a pointer to an array with size elements.
@@ -259,7 +259,7 @@ const char* const* ddwaf_known_addresses(const ddwaf_handle handle, uint32_t *si
  *
  * The memory is owned by the WAF and should not be freed.
  *
- * @param Handle to the WAF instance.
+ * @param handle Handle to the WAF instance.
  * @param size Output parameter in which the size will be returned. The value of
  *             size will be 0 if the return value is NULL.
  * @return NULL if empty, otherwise a pointer to an array with size elements.

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -38,3 +38,4 @@ EXPORTS
   ddwaf_object_free
   ddwaf_get_version
   ddwaf_set_log_cb
+  ddwaf_known_actions

--- a/smoketest/smoke.c
+++ b/smoketest/smoke.c
@@ -227,6 +227,21 @@ int main() {
         return 1;
     }
 
+    puts("addresses:");
+    uint32_t addrs_size = 0;
+    const char * const* addrs = ddwaf_known_addresses(handle, &addrs_size);
+    for (uint32_t i = 0; i < addrs_size; ++i) {
+        puts(addrs[i]);
+    }
+
+    puts("actions:");
+    uint32_t actions_size = 0;
+    const char * const* actions = ddwaf_known_actions(handle, &actions_size);
+    for (uint32_t i = 0; i < actions_size; ++i) {
+        puts(actions[i]);
+    }
+
+
     ddwaf_context ctx = ddwaf_context_init(handle);
     if (!ctx) {
         puts("ctx is null");

--- a/src/exclusion/rule_filter.hpp
+++ b/src/exclusion/rule_filter.hpp
@@ -47,6 +47,8 @@ public:
         expr_->get_addresses(addresses);
     }
 
+    std::string_view get_action() const { return action_; }
+
 protected:
     std::string id_;
     std::shared_ptr<expression> expr_;

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -168,6 +168,23 @@ const char *const *ddwaf_known_addresses(ddwaf::waf *handle, uint32_t *size)
     return addresses.data();
 }
 
+const char *const *ddwaf_known_actions(ddwaf::waf *handle, uint32_t *size)
+{
+    if (handle == nullptr) {
+        *size = 0;
+        return nullptr;
+    }
+
+    const auto &action_types = handle->get_available_action_types();
+    if (action_types.empty() || action_types.size() > std::numeric_limits<uint32_t>::max()) {
+        *size = 0;
+        return nullptr;
+    }
+
+    *size = (uint32_t)action_types.size();
+    return action_types.data();
+}
+
 ddwaf_context ddwaf_context_init(ddwaf::waf *handle)
 {
     try {

--- a/src/waf.hpp
+++ b/src/waf.hpp
@@ -31,6 +31,11 @@ public:
         return ruleset_->get_root_addresses();
     }
 
+    [[nodiscard]] const std::vector<const char *> &get_available_action_types() const
+    {
+        return ruleset_->get_available_action_types();
+    }
+
 protected:
     waf(std::shared_ptr<ruleset_builder> builder, std::shared_ptr<ruleset> ruleset)
         : builder_(std::move(builder)), ruleset_(std::move(ruleset))

--- a/tests/interface_test.cpp
+++ b/tests/interface_test.cpp
@@ -2503,7 +2503,31 @@ TEST(TestInterface, KnownActions)
         ddwaf_destroy(handle8);
     }
 
-    ddwaf_destroy(handle9);
+    // Disable the rule containing the only action
+    ddwaf_handle handle10;
+    {
+        auto overrides = yaml_to_object(
+            R"({rules_override: [{rules_target: [{rule_id: 1}], on_match: [whatever]}]})");
+        handle10 = ddwaf_update(handle9, &overrides, nullptr);
+        ddwaf_object_free(&overrides);
+
+        uint32_t size;
+        const char *const *actions = ddwaf_known_actions(handle10, &size);
+        EXPECT_EQ(size, 0);
+        EXPECT_EQ(actions, nullptr);
+
+        ddwaf_destroy(handle9);
+    }
+
+    ddwaf_destroy(handle10);
+}
+
+TEST(TestInterface, KnownActionsNullHandle)
+{
+    uint32_t size;
+    const char *const *actions = ddwaf_known_actions(nullptr, &size);
+    EXPECT_EQ(size, 0);
+    EXPECT_EQ(actions, nullptr);
 }
 
 } // namespace


### PR DESCRIPTION
This PR adds a function to report the available action types, based on what can be triggered based on the current set of rules and exclusion filters. The function in question is `ddwaf_known_actions`.

This function has been added as a request from @eliottness 