### PR TITLE
Split collections by module

### DIFF
--- a/src/rule.hpp
+++ b/src/rule.hpp
@@ -78,6 +78,12 @@ public:
         return it == tags_.end() ? std::string_view() : it->second;
     }
 
+    std::string_view get_tag_or(const std::string &tag, std::string_view or_value) const
+    {
+        auto it = tags_.find(tag);
+        return it == tags_.end() ? or_value : it->second;
+    }
+
     const std::unordered_map<std::string, std::string> &get_tags() const { return tags_; }
     const std::unordered_map<std::string, std::string> &get_ancillary_tags() const
     {

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -26,18 +26,21 @@ struct ruleset {
     {
         rules.emplace_back(rule);
         std::string_view type = rule->get_tag("type");
-        collection_types.emplace(type);
+        std::string_view mod = rule->get_tag_or("module", "waf");
+
+        auto [it, res] = collection_types.emplace(ddwaf::fmt::format("{}.{}", mod, type));
+        const auto &collection = *it;
         if (rule->get_actions().empty()) {
             if (rule->get_source() == rule::source_type::user) {
-                user_collections[type].insert(rule);
+                user_collections[collection].insert(rule);
             } else {
-                base_collections[type].insert(rule);
+                base_collections[collection].insert(rule);
             }
         } else {
             if (rule->get_source() == rule::source_type::user) {
-                user_priority_collections[type].insert(rule);
+                user_priority_collections[collection].insert(rule);
             } else {
-                base_priority_collections[type].insert(rule);
+                base_priority_collections[collection].insert(rule);
             }
         }
         rule->get_addresses(rule_addresses);
@@ -169,7 +172,7 @@ struct ruleset {
     std::shared_ptr<action_mapper> actions;
 
     // The key used to organise collections is rule.type
-    std::unordered_set<std::string_view> collection_types;
+    std::unordered_set<std::string> collection_types;
     std::unordered_map<std::string_view, priority_collection> user_priority_collections;
     std::unordered_map<std::string_view, priority_collection> base_priority_collections;
     std::unordered_map<std::string_view, collection> user_collections;

--- a/tests/integration/context/yaml/same-type-different-module.yaml
+++ b/tests/integration/context/yaml/same-type-different-module.yaml
@@ -1,0 +1,25 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+      module: rasp
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: param1
+          regex: Sqreen
+  - id: 2
+    name: rule2
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: param1
+          regex: Sqreen


### PR DESCRIPTION
This PR introduces a very small change to ensure two rules with different `module` but same `type` aren't grouped in the same collection. This ensures that `type` collisions don't prevent RASP rules from being evaluated.