### PR TITLE
Fix false positive on SQLi EOL comments

### DIFF
--- a/src/condition/sqli_detector.cpp
+++ b/src/condition/sqli_detector.cpp
@@ -96,16 +96,15 @@ bool is_query_comment(const std::vector<sql_token> &resource_tokens,
      *                              \---/
      *                            injected string
      */
-    bool is_not_last_token = param_tokens_begin < (resource_tokens.size() - 1);
     for (std::size_t i = 0; i < param_tokens.size(); ++i) {
         if (param_tokens[i].type == sql_token_type::eol_comment) {
-            if (i == 0 && param_tokens.size() == 1 && is_not_last_token) {
+            if (param_tokens.size() == 1 && param_tokens_begin < (resource_tokens.size() - 1)) {
                 // If the first and only token is the comment, ensure that it was introduced
                 // by the injection itself, rather than it being a partial match
                 return param_index <= resource_tokens[param_tokens_begin].index;
             }
 
-            return i > 0 || is_not_last_token;
+            return i > 0;
         }
     }
 

--- a/src/condition/sqli_detector.cpp
+++ b/src/condition/sqli_detector.cpp
@@ -80,6 +80,7 @@ std::string strip_literals(std::string_view statement, std::span<sql_token> toke
 
 bool is_query_comment(const std::vector<sql_token> &resource_tokens,
     std::span<sql_token> param_tokens,
+    std::size_t param_index /* the position of the injection on the resource */,
     std::size_t param_tokens_begin /* first index of param_tokens in resource_tokens */)
 
 {
@@ -95,9 +96,16 @@ bool is_query_comment(const std::vector<sql_token> &resource_tokens,
      *                              \---/
      *                            injected string
      */
+    bool is_not_last_token = param_tokens_begin < (resource_tokens.size() - 1);
     for (std::size_t i = 0; i < param_tokens.size(); ++i) {
         if (param_tokens[i].type == sql_token_type::eol_comment) {
-            return i > 0 || param_tokens_begin < (resource_tokens.size() - 1);
+            if (i == 0 && param_tokens.size() == 1 && is_not_last_token) {
+                // If the first and only token is the comment, ensure that it was introduced
+                // by the injection itself, rather than it being a partial match
+                return param_index <= resource_tokens[param_tokens_begin].index;
+            }
+
+            return i > 0 || is_not_last_token;
         }
     }
 
@@ -482,7 +490,8 @@ sqli_result sqli_impl(std::string_view resource, std::vector<sql_token> &resourc
                 !is_benign_order_by_clause(resource_tokens, param_tokens, param_tokens_begin)) ||
             (param_tokens.size() < min_token_count &&
                 (is_where_tautology(resource_tokens, param_tokens, param_tokens_begin) ||
-                    is_query_comment(resource_tokens, param_tokens, param_tokens_begin)))) {
+                    is_query_comment(
+                        resource_tokens, param_tokens, param_index, param_tokens_begin)))) {
             return matched_param{std::string(value), it.get_current_path()};
         }
     }

--- a/src/condition/sqli_detector.hpp
+++ b/src/condition/sqli_detector.hpp
@@ -46,7 +46,7 @@ bool is_where_tautology(const std::vector<sql_token> &resource_tokens,
     std::span<sql_token> param_tokens, std::size_t param_tokens_begin);
 
 bool is_query_comment(const std::vector<sql_token> &resource_tokens,
-    std::span<sql_token> param_tokens, std::size_t param_tokens_begin);
+    std::span<sql_token> param_tokens, std::size_t param_index, std::size_t param_tokens_begin);
 
 } // namespace internal
 

--- a/tests/sqli_detector_internals_test.cpp
+++ b/tests/sqli_detector_internals_test.cpp
@@ -235,6 +235,7 @@ TEST(TestSqliDetectorInternals, IsQueryCommentSuccess)
             R"(--  )"},
         {"-- thisisacomment\nSELECT * FROM ships WHERE id=paco", "-- thisisacomment"},
         {"SELECT * FROM users WHERE user = 'admin'--' AND password = '' LIMIT 1", "admin'--'"},
+        {"SELECT * FROM Customers WHERE CustomerName = -- AND\nCity = 'Berlin';", "--"},
     };
 
     for (const auto &[statement, param] : samples) {

--- a/tests/sqli_detector_internals_test.cpp
+++ b/tests/sqli_detector_internals_test.cpp
@@ -234,6 +234,7 @@ TEST(TestSqliDetectorInternals, IsQueryCommentSuccess)
         1 OR 1)",
             R"(--  )"},
         {"-- thisisacomment\nSELECT * FROM ships WHERE id=paco", "-- thisisacomment"},
+        {"SELECT * FROM users WHERE user = 'admin'--' AND password = '' LIMIT 1", "admin'--'"},
     };
 
     for (const auto &[statement, param] : samples) {
@@ -255,6 +256,7 @@ TEST(TestSqliDetectorInternals, IsQueryCommentFailure)
 {
     std::vector<std::pair<std::string, std::string>> samples{
         {"-- thisisacomment\nSELECT * FROM ships WHERE id=paco", "thisisacomment"},
+        {"SELECT * FROM user WHERE id = 1 -- thisisacomment", "thisisacomment"},
     };
 
     for (const auto &[statement, param] : samples) {


### PR DESCRIPTION
If an injection is within a comment, it can be matched as a false positive if the comment is not the first or last token in the resource.  To avoid these false positives, we must ensure that the comment itself was part of the injection and / or more than one token was injected.

Related Jiras: [APPSEC-54410]

[APPSEC-54410]: https://datadoghq.atlassian.net/browse/APPSEC-54410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ