### PR TITLE
Expand detections per parameter

### DIFF
--- a/src/condition/match_iterator.hpp
+++ b/src/condition/match_iterator.hpp
@@ -8,18 +8,17 @@
 
 #include "iterator.hpp"
 
-
 namespace ddwaf {
 
-template <std::size_t MinLength = 2, typename Iterator = object::kv_iterator>
-class match_iterator
-{
+template <std::size_t MinLength = 2, typename Iterator = object::kv_iterator> class match_iterator {
 public:
     static constexpr std::size_t npos = std::string_view::npos;
 
     explicit match_iterator(std::string_view resource, const ddwaf_object *obj,
-        const exclusion::object_set_ref &exclude, const object_limits &limits = object_limits()): resource_(resource), it_(obj, {}, exclude, limits) {
-        for (; it_ ; ++it_) {
+        const exclusion::object_set_ref &exclude, const object_limits &limits = object_limits())
+        : resource_(resource), it_(obj, {}, exclude, limits)
+    {
+        for (; it_; ++it_) {
             const auto *current_obj = *it_;
             if (current_obj->type == DDWAF_OBJ_STRING && current_obj->nbEntries >= MinLength) {
                 current_param_ = std::string_view{current_obj->stringValue, current_obj->nbEntries};
@@ -37,12 +36,18 @@ public:
     match_iterator &operator=(const match_iterator &) = delete;
     match_iterator &operator=(match_iterator &&) = delete;
 
-    [[nodiscard]] std::pair<std::string_view, std::size_t> operator*() { return {current_param_, current_index_}; }
+    [[nodiscard]] std::pair<std::string_view, std::size_t> operator*()
+    {
+        return {current_param_, current_index_};
+    }
 
-    bool operator++() {
+    bool operator++()
+    {
         if (current_index_ != npos) {
             current_index_ = resource_.find(current_param_, current_index_ + 1);
-            if (current_index_ != npos) { return true; }
+            if (current_index_ != npos) {
+                return true;
+            }
         }
 
         while (++it_) {
@@ -59,7 +64,8 @@ public:
 
     [[nodiscard]] explicit operator bool() const { return static_cast<bool>(it_); }
 
-    [[nodiscard]] std::vector<std::string> get_current_path() const {
+    [[nodiscard]] std::vector<std::string> get_current_path() const
+    {
         return it_.get_current_path();
     }
 
@@ -69,6 +75,5 @@ protected:
     std::size_t current_index_{npos};
     Iterator it_;
 };
-
 
 } // namespace ddwaf

--- a/src/condition/match_iterator.hpp
+++ b/src/condition/match_iterator.hpp
@@ -21,9 +21,12 @@ public:
         for (; it_; ++it_) {
             const auto *current_obj = *it_;
             if (current_obj->type == DDWAF_OBJ_STRING && current_obj->nbEntries >= MinLength) {
-                current_param_ = std::string_view{current_obj->stringValue, current_obj->nbEntries};
+                current_param_ = std::string_view{
+                    current_obj->stringValue, static_cast<std::size_t>(current_obj->nbEntries)};
                 current_index_ = resource_.find(current_param_, 0);
-                break;
+                if (current_index_ != npos) {
+                    break;
+                }
             }
         }
     }
@@ -53,9 +56,12 @@ public:
         while (++it_) {
             const auto *current_obj = *it_;
             if (current_obj->type == DDWAF_OBJ_STRING && current_obj->nbEntries >= MinLength) {
-                current_param_ = std::string_view{current_obj->stringValue, current_obj->nbEntries};
+                current_param_ = std::string_view{
+                    current_obj->stringValue, static_cast<std::size_t>(current_obj->nbEntries)};
                 current_index_ = resource_.find(current_param_, 0);
-                return true;
+                if (current_index_ != npos) {
+                    return true;
+                }
             }
         }
 

--- a/src/condition/match_iterator.hpp
+++ b/src/condition/match_iterator.hpp
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#pragma once
+
+#include "iterator.hpp"
+
+
+namespace ddwaf {
+
+template <std::size_t MinLength = 2, typename Iterator = object::kv_iterator>
+class match_iterator
+{
+public:
+    static constexpr std::size_t npos = std::string_view::npos;
+
+    explicit match_iterator(std::string_view resource, const ddwaf_object *obj,
+        const exclusion::object_set_ref &exclude, const object_limits &limits = object_limits()): resource_(resource), it_(obj, {}, exclude, limits) {
+        for (; it_ ; ++it_) {
+            const auto *current_obj = *it_;
+            if (current_obj->type == DDWAF_OBJ_STRING && current_obj->nbEntries >= MinLength) {
+                current_param_ = std::string_view{current_obj->stringValue, current_obj->nbEntries};
+                current_index_ = resource_.find(current_param_, 0);
+                break;
+            }
+        }
+    }
+
+    ~match_iterator() = default;
+
+    match_iterator(const match_iterator &) = default;
+    match_iterator(match_iterator &&) = delete;
+
+    match_iterator &operator=(const match_iterator &) = delete;
+    match_iterator &operator=(match_iterator &&) = delete;
+
+    [[nodiscard]] std::pair<std::string_view, std::size_t> operator*() { return {current_param_, current_index_}; }
+
+    bool operator++() {
+        if (current_index_ != npos) {
+            current_index_ = resource_.find(current_param_, current_index_ + 1);
+            if (current_index_ != npos) { return true; }
+        }
+
+        while (++it_) {
+            const auto *current_obj = *it_;
+            if (current_obj->type == DDWAF_OBJ_STRING && current_obj->nbEntries >= MinLength) {
+                current_param_ = std::string_view{current_obj->stringValue, current_obj->nbEntries};
+                current_index_ = resource_.find(current_param_, 0);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    [[nodiscard]] explicit operator bool() const { return static_cast<bool>(it_); }
+
+    [[nodiscard]] std::vector<std::string> get_current_path() const {
+        return it_.get_current_path();
+    }
+
+protected:
+    std::string_view resource_;
+    std::string_view current_param_{};
+    std::size_t current_index_{npos};
+    Iterator it_;
+};
+
+
+} // namespace ddwaf

--- a/tests/condition/lfi_detector_test.cpp
+++ b/tests/condition/lfi_detector_test.cpp
@@ -4,9 +4,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "../test_utils.hpp"
 #include "condition/lfi_detector.hpp"
 #include "platform.hpp"
-#include "test_utils.hpp"
 
 using namespace ddwaf;
 using namespace std::literals;

--- a/tests/condition/match_iterator_test.cpp
+++ b/tests/condition/match_iterator_test.cpp
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "../test_utils.hpp"
+#include "condition/match_iterator.hpp"
+
+using namespace ddwaf;
+
+namespace {
+
+TEST(TestMatchIterator, InvalidIterator)
+{
+    ddwaf_object object;
+    ddwaf_object_invalid(&object);
+
+    std::string resource = "this is the resource";
+    exclusion::object_set_ref exclude;
+    ddwaf::match_iterator it(resource, &object, exclude);
+    EXPECT_FALSE((bool)it);
+
+    auto path = it.get_current_path();
+    EXPECT_EQ(path.size(), 0);
+
+    EXPECT_FALSE(++it);
+}
+
+TEST(TestMatchIterator, NoMatch)
+{
+    ddwaf_object object;
+    ddwaf_object_string(&object, "no match");
+
+    std::string resource = "this is the resource";
+    exclusion::object_set_ref exclude;
+    ddwaf::match_iterator it(resource, &object, exclude);
+    EXPECT_FALSE((bool)it);
+
+    auto path = it.get_current_path();
+    EXPECT_EQ(path.size(), 0);
+
+    EXPECT_FALSE(++it);
+
+    ddwaf_object_free(&object);
+}
+
+TEST(TestMatchIterator, SingleMatch)
+{
+    ddwaf_object object;
+    ddwaf_object_string(&object, "resource");
+
+    std::string resource = "this is the resource";
+    exclusion::object_set_ref exclude;
+    ddwaf::match_iterator it(resource, &object, exclude);
+    EXPECT_TRUE((bool)it);
+
+    auto [param, index] = *it;
+    EXPECT_STRV(param, "resource");
+    EXPECT_EQ(index, 12);
+
+    auto path = it.get_current_path();
+    EXPECT_EQ(path.size(), 0);
+
+    EXPECT_FALSE(++it);
+
+    ddwaf_object_free(&object);
+}
+
+TEST(TestMatchIterator, MultipleMatches)
+{
+    ddwaf_object object;
+    ddwaf_object_string(&object, "resource");
+
+    std::string resource = "resource resource resource resource";
+    exclusion::object_set_ref exclude;
+    ddwaf::match_iterator it(resource, &object, exclude);
+
+    for (std::size_t i = 0; i < 4; ++i) {
+        EXPECT_TRUE((bool)it);
+        auto [param, index] = *it;
+        EXPECT_STRV(param, "resource");
+        EXPECT_EQ(index, i * 9);
+
+        auto path = it.get_current_path();
+        EXPECT_EQ(path.size(), 0);
+
+        ++it;
+    }
+
+    EXPECT_FALSE(++it);
+
+    ddwaf_object_free(&object);
+}
+
+TEST(TestMatchIterator, OverlappingMatches)
+{
+    ddwaf_object object;
+    ddwaf_object_string(&object, "ee");
+
+    std::string resource = "eeeeeeeeee";
+    exclusion::object_set_ref exclude;
+    ddwaf::match_iterator it(resource, &object, exclude);
+    EXPECT_TRUE((bool)it);
+
+    for (std::size_t i = 0; i < 9; ++i) {
+        auto [param, index] = *it;
+        EXPECT_STRV(param, "ee");
+        EXPECT_EQ(index, i);
+
+        auto path = it.get_current_path();
+        EXPECT_EQ(path.size(), 0);
+
+        ++it;
+    }
+
+    EXPECT_FALSE(++it);
+
+    ddwaf_object_free(&object);
+}
+
+} // namespace

--- a/tests/condition/shi_detector_test.cpp
+++ b/tests/condition/shi_detector_test.cpp
@@ -68,6 +68,8 @@ TEST(TestSHIDetector, ExecutablesAndRedirections)
         {"ls 2> file; echo hello", "2> file"},
         {"ls &> file; echo hello", "&> file"},
         {"$(<file) -l", "$(<file) -l"},
+        {"ls injection ls; injection ls", "injection ls"},
+        {"ls $(<file) -l ; $(<file) -l", "$(<file) -l"},
     };
 
     for (const auto &[resource, param] : samples) {

--- a/tests/condition/shi_detector_test.cpp
+++ b/tests/condition/shi_detector_test.cpp
@@ -4,8 +4,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "../test_utils.hpp"
 #include "condition/shi_detector.hpp"
-#include "test_utils.hpp"
 
 using namespace ddwaf;
 using namespace std::literals;

--- a/tests/condition/sqli_detector_internals_test.cpp
+++ b/tests/condition/sqli_detector_internals_test.cpp
@@ -4,8 +4,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "../test_utils.hpp"
 #include "condition/sqli_detector.hpp"
-#include "test_utils.hpp"
 #include "tokenizer/generic_sql.hpp"
 #include "utils.hpp"
 

--- a/tests/condition/sqli_detector_test.cpp
+++ b/tests/condition/sqli_detector_test.cpp
@@ -233,6 +233,13 @@ TEST_P(DialectTestFixture, Tautologies)
             "SELECT x FROM t WHERE id = ? or (?) = (?)", "(1) = ('1')"},
         {R"(SELECT * FROM ships WHERE name LIKE '%neb%' OR 1=1)",
             R"(SELECT * FROM ships WHERE name LIKE ? OR ?=?)", R"(neb%' OR 1=1)"},
+        {
+            R"(-- 'something' OR 1=1; --
+            SELECT * FROM table WHERE id='' OR 1=1; --)",
+            R"(-- 'something' OR 1=1; --
+            SELECT * FROM table WHERE id=? OR ?=?; --)",
+            "' OR 1=1; --",
+        },
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {

--- a/tests/condition/sqli_detector_test.cpp
+++ b/tests/condition/sqli_detector_test.cpp
@@ -4,8 +4,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "../test_utils.hpp"
 #include "condition/sqli_detector.hpp"
-#include "test_utils.hpp"
 
 using namespace ddwaf;
 using namespace std::literals;

--- a/tests/condition/ssrf_detector_test.cpp
+++ b/tests/condition/ssrf_detector_test.cpp
@@ -4,8 +4,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "../test_utils.hpp"
 #include "condition/ssrf_detector.hpp"
-#include "test_utils.hpp"
 
 using namespace ddwaf;
 using namespace std::literals;


### PR DESCRIPTION
This PR introduces an iterator to iterate through all possible matches of a parameter within a given resource. This expands the number of detections that one could perform on a single resource. This is now being used in SQLi, SHi and SSRF.