### PR TITLE
Set `content:write` permissions on release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,6 +320,8 @@ jobs:
     needs: [ windows-builds, macos-build, macos-cross-build, docker-builds, linux-musl-build, package-nuget]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Workflow token permissions have been reduced, so the release job permissions have been updated to allow generating releases.