### PR TITLE
Fix LFI logic error on windows check

### DIFF
--- a/src/condition/lfi_detector.cpp
+++ b/src/condition/lfi_detector.cpp
@@ -71,7 +71,7 @@ bool lfi_impl_windows(std::string_view path, std::string_view param)
 {
     static constexpr std::size_t min_str_len = 2;
 
-    if (param.size() < min_str_len && !path.ends_with(param)) {
+    if (param.size() < min_str_len || !path.ends_with(param)) {
         return false;
     }
 

--- a/src/condition/lfi_detector.hpp
+++ b/src/condition/lfi_detector.hpp
@@ -12,7 +12,7 @@ namespace ddwaf {
 
 class lfi_detector : public base_impl<lfi_detector> {
 public:
-    static constexpr unsigned version = 1;
+    static constexpr unsigned version = 2;
     static constexpr std::array<std::string_view, 2> param_names{"resource", "params"};
 
     explicit lfi_detector(std::vector<condition_parameter> args, const object_limits &limits = {})

--- a/tests/condition/lfi_detector_test.cpp
+++ b/tests/condition/lfi_detector_test.cpp
@@ -273,6 +273,8 @@ TEST(TestLFIDetector, NoMatchUnix)
 
 TEST(TestLFIDetector, NoMatchWindows)
 {
+    system_platform_override spo{platform::windows};
+
     lfi_detector cond{{gen_param_def("server.io.fs.file", "server.request.query")}};
 
     std::vector<std::pair<std::string, std::string>> samples{
@@ -282,6 +284,9 @@ TEST(TestLFIDetector, NoMatchWindows)
         {R"(documents\pony.txt)", R"(my\documents\pony.txt)"},
         {R"(XXX\YYY\documents\pony.txt)", R"(documents\pony.txt)"},
         {R"(C:\XXX\YYY\documents\pony.txt)", R"(documents\pony.txt)"},
+        {R"(C:\XXX\YYY\documents\pony.txt)", R"(documents/../pony.txt)"},
+        {R"(C:\XXX\YYY\documents\pony.txt)", R"(documents\..\pony.txt)"},
+        {R"(C:\XXX\YYY\documents\pony.txt)", R"(C:\YYY\XXX\file.txt)"},
         {R"(documents\unicorn)", R"(pony.txt)"},
         {R"(documents\unicorn.jp)", R"(pony.jp)"},
         {R"(C:\documents\unicorn.jp)", R"(pony.jp)"},

--- a/validator/tests/rules/structured/ruleset.yaml
+++ b/validator/tests/rules/structured/ruleset.yaml
@@ -19,7 +19,7 @@ rules:
             - address: grpc.server.request.message
             - address: graphql.server.all_resolvers
             - address: graphql.server.resolver
-        operator: lfi_detector@v1
+        operator: lfi_detector@v2
   - id: rsp-930-002
     name: SSRF Exploit detection
     tags:


### PR DESCRIPTION
This PR fixes a logic error when checking if the parameter of the LFI satisfies the condition for analysis. Specifically on the windows heuristic. The version of lfi_detector has been increased to v2, `lfi_detector@v2`.