### PR TITLE
Support (min|max)_version on verify_rule utility

### DIFF
--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -312,7 +312,7 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
  * @param result Structure containing the result of the operation. (nullable)
  * @param timeout Maximum time budget in microseconds.
  *
- * @return Return code of the operation, also contained in the result structure.
+ * @return Return code of the operation.
  * @error DDWAF_ERR_INVALID_ARGUMENT The context is invalid, the data will not
  *                                   be freed.
  * @error DDWAF_ERR_INVALID_OBJECT The data provided didn't match the desired

--- a/src/semver.hpp
+++ b/src/semver.hpp
@@ -55,6 +55,11 @@ public:
 
         number_ = major_ * 1000000 + minor_ * 1000 + patch_;
     }
+    semantic_version(semantic_version &&other) = default;
+    semantic_version &operator=(semantic_version &&other) noexcept = default;
+    semantic_version(const semantic_version &other) = default;
+    semantic_version &operator=(const semantic_version &other) noexcept = default;
+    ~semantic_version() = default;
 
     bool operator==(const semantic_version &other) const noexcept
     {

--- a/tools/verify_rule.cpp
+++ b/tools/verify_rule.cpp
@@ -86,27 +86,27 @@ int main(int argc, char *argv[])
         YAML::Node rule = YAML::Load(read_file(argv[fileIndex]));
         rule["enabled"] = true;
 
-        auto max_version = ddwaf::semantic_version::max();
-        auto min_version = ddwaf::semantic_version::min();
-
-        if (rule["max_version"].IsDefined()) {
-            max_version = ddwaf::semantic_version{rule["max_version"].as<std::string>()};
-        }
-
-        if (rule["min_version"].IsDefined()) {
-            min_version = ddwaf::semantic_version{rule["min_version"].as<std::string>()};
-        }
-
-        bool should_skip = ddwaf::current_version < min_version || ddwaf::current_version > max_version;
-
         ddwaf_object convertedRule = convertRuleToRuleset(rule);
         ddwaf_handle handle = ddwaf_init(&convertedRule, nullptr, nullptr);
         ddwaf_object_free(&convertedRule);
 
         if (handle == nullptr) {
-            if (should_skip) { // This rule is expected to fail to load
+            // Verify if the rule should've loaded successfully or not
+            auto max_version = ddwaf::semantic_version::max();
+            auto min_version = ddwaf::semantic_version::min();
+
+            if (rule["max_version"].IsDefined()) {
+                max_version = ddwaf::semantic_version{rule["max_version"].as<std::string>()};
+            }
+
+            if (rule["min_version"].IsDefined()) {
+                min_version = ddwaf::semantic_version{rule["min_version"].as<std::string>()};
+            }
+            if (ddwaf::current_version < min_version || ddwaf::current_version > max_version) {
+                // This rule is expected to fail to load
                 continue;
             }
+
             printf("Failed to load rule %s\n", argv[fileIndex]);
             success = false;
             continue;


### PR DESCRIPTION
The `verify_rule` utility loads a single rule, which means that if the rule is incompatible due to the new versioning mechanism, the resulting WAF instance will be invalid due to a lack of valid rules. This change adds a check for min and max version within the `verify_rule` utility.