### PR TITLE
Prevent scheme matches in isolation

### DIFF
--- a/src/condition/ssrf_detector.cpp
+++ b/src/condition/ssrf_detector.cpp
@@ -215,11 +215,13 @@ ssrf_result ssrf_impl(const uri_decomposed &uri, const ddwaf_object &params,
             }
         }
 
-        // If the injection includes the scheme check if it's still a valid one
+        // If the injection includes the scheme and beyond, check if the
+        // potentially injected scheme is still a valid one
         //
         //  scheme://userinfo@host:port/path?query#fragment
-        //  ───────────────────>
-        if (param_index == 0 && !authorised_scheme_set.contains(uri.scheme)) {
+        //  ───────>
+        if (!uri.scheme.empty() && param_index == 0 && param.size() > uri.scheme.size() &&
+            !authorised_scheme_set.contains(uri.scheme)) {
             return {{std::string(param), it.get_current_path()}};
         }
 

--- a/src/condition/ssrf_detector.hpp
+++ b/src/condition/ssrf_detector.hpp
@@ -13,7 +13,7 @@ namespace ddwaf {
 
 class ssrf_detector : public base_impl<ssrf_detector> {
 public:
-    static constexpr unsigned version = 1;
+    static constexpr unsigned version = 2;
     static constexpr std::array<std::string_view, 2> param_names{"resource", "params"};
 
     explicit ssrf_detector(std::vector<condition_parameter> args, const object_limits &limits = {});

--- a/tests/unit/condition/ssrf_detector_test.cpp
+++ b/tests/unit/condition/ssrf_detector_test.cpp
@@ -74,7 +74,9 @@ void match_path_and_input(
 TEST(TestSSRFDetector, MatchScheme)
 {
     match_path_and_input({
-        {"gopher://blabla.com/path", {.yaml = "gopher"}},
+        {"gopher://blabla.com/path", {.yaml = R"("gopher:")", .resolved = "gopher:"}},
+        {"data://blabla.com/path",
+            {.yaml = R"(data://blabla.com)", .resolved = "data://blabla.com"}},
     });
 }
 
@@ -208,6 +210,8 @@ TEST(TestSSRFDetector, NoMatchPotentialFalsePositives)
             {"http://google.com/batch", {.yaml = R"({query: {param: "batch"}})"}},
             {"http://google.com/batch", {.yaml = R"({query: {param: "/batch"}})"}},
             {"file/blabla/metadata", {.yaml = R"({query: {param: "blabla"}})"}},
+            {"gopher://blabla.com/path", {.yaml = "gopher"}},
+            {"data://blabla.com/path", {.yaml = "data"}},
             /*            {"http://scrapper-proxy.awsregion.bla.iohttps://images.bla.com/whatever",*/
             /*{.yaml = R"({url: "https://images.bla.com/whatever"})"}},*/
         },


### PR DESCRIPTION
This PR adds extra checks to the SSRF heuristic to prevent matching the scheme when it's the only injection performed, as it's not a likely injection and the match itself is prone to false positives. 

Related Jira: [APPSEC-55879]

[APPSEC-55879]: https://datadoghq.atlassian.net/browse/APPSEC-55879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ