### PR TITLE
Generate coverage at multiple log levels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,7 @@ jobs:
 
       - name: Package Nuget
         run: |
-          sudo apt-get update && sudo apt-get install -y libarchive-tools
+          sudo apt-get update && sudo apt-get install -y libarchive-tools mono-complete
           function extract_file {
             local -r arch=$1 filepat=$2 dest=$3
             local -r file_in_arch=$(bsdtar -tf "$arch" | grep "$filepat" | head -1)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,37 +156,37 @@ jobs:
         run: VERBOSE=1 make -j $(nproc) waf_test waf_validator
         working-directory: Debug
 
-      - name: Test (level: trace)
+      - name: "Test (level: trace)"
         run: make test
         env:
           DDWAF_TEST_LOG_LEVEL: trace
         working-directory: Debug
 
-      - name: Test (level: debug)
+      - name: "Test (level: debug)"
         run: make test
         env:
           DDWAF_TEST_LOG_LEVEL: debug
         working-directory: Debug
 
-      - name: Test (level: error)
+      - name: "Test (level: error)"
         run: make test
         env:
           DDWAF_TEST_LOG_LEVEL: error
         working-directory: Debug
 
-      - name: Test (level: warn)
+      - name: "Test (level: warn)"
         run: make test
         env:
           DDWAF_TEST_LOG_LEVEL: warn
         working-directory: Debug
 
-      - name: Test (level: info)
+      - name: "Test (level: info)"
         run: make test
         env:
           DDWAF_TEST_LOG_LEVEL: info
         working-directory: Debug
 
-      - name: Test (level: off)
+      - name: "Test (level: off)"
         run: make test
         env:
           DDWAF_TEST_LOG_LEVEL: off

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,8 +156,40 @@ jobs:
         run: VERBOSE=1 make -j $(nproc) waf_test waf_validator
         working-directory: Debug
 
-      - name: Test
+      - name: Test (level: trace)
         run: make test
+        env:
+          DDWAF_TEST_LOG_LEVEL: trace
+        working-directory: Debug
+
+      - name: Test (level: debug)
+        run: make test
+        env:
+          DDWAF_TEST_LOG_LEVEL: debug
+        working-directory: Debug
+
+      - name: Test (level: error)
+        run: make test
+        env:
+          DDWAF_TEST_LOG_LEVEL: error
+        working-directory: Debug
+
+      - name: Test (level: warn)
+        run: make test
+        env:
+          DDWAF_TEST_LOG_LEVEL: warn
+        working-directory: Debug
+
+      - name: Test (level: info)
+        run: make test
+        env:
+          DDWAF_TEST_LOG_LEVEL: info
+        working-directory: Debug
+
+      - name: Test (level: off)
+        run: make test
+        env:
+          DDWAF_TEST_LOG_LEVEL: off
         working-directory: Debug
 
       - name: Validate

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -64,15 +64,6 @@ DDWAF_RET_CODE context::run(optional_ref<ddwaf_object> persistent,
         output = DDWAF_RESULT_INITIALISER;
     }
 
-    {
-        if (ddwaf::logger::valid(DDWAF_LOG_INFO)) {
-            constexpr const char *filename = base_name(__FILE__);
-            auto message = ddwaf::fmt::format("this is a test message");
-            ddwaf::logger::log(
-                DDWAF_LOG_INFO, __FUNCTION__, filename, __LINE__, message.c_str(), message.size());
-        }
-    }
-
     auto *free_fn = ruleset_->free_fn;
     if (persistent.has_value() && !store_.insert(*persistent, attribute::none, free_fn)) {
         DDWAF_WARN("Illegal WAF call: parameter structure invalid!");

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -64,6 +64,15 @@ DDWAF_RET_CODE context::run(optional_ref<ddwaf_object> persistent,
         output = DDWAF_RESULT_INITIALISER;
     }
 
+    {
+        if (ddwaf::logger::valid(DDWAF_LOG_INFO)) {
+            constexpr const char *filename = base_name(__FILE__);
+            auto message = ddwaf::fmt::format("this is a test message");
+            ddwaf::logger::log(
+                DDWAF_LOG_INFO, __FUNCTION__, filename, __LINE__, message.c_str(), message.size());
+        }
+    }
+
     auto *free_fn = ruleset_->free_fn;
     if (persistent.has_value() && !store_.insert(*persistent, attribute::none, free_fn)) {
         DDWAF_WARN("Illegal WAF call: parameter structure invalid!");

--- a/src/sha256.hpp
+++ b/src/sha256.hpp
@@ -5,6 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <span>
 #include <string>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -9,6 +9,10 @@
 
 #include "common/gtest_utils.hpp"
 
+#include <string_view>
+
+using namespace std::literals;
+
 const char *level_to_str(DDWAF_LOG_LEVEL level)
 {
     switch (level) {
@@ -29,15 +33,61 @@ const char *level_to_str(DDWAF_LOG_LEVEL level)
     return "off";
 }
 
+DDWAF_LOG_LEVEL str_to_level(std::string_view str)
+{
+    if (str == "trace"sv || str == "TRACE"sv) {
+        return DDWAF_LOG_TRACE;
+    }
+
+    if (str == "debug"sv || str == "DEBUG"sv) {
+        return DDWAF_LOG_DEBUG;
+    }
+
+    if (str == "error"sv || str == "ERROR"sv) {
+        return DDWAF_LOG_ERROR;
+    }
+
+    if (str == "warn"sv || str == "WARN"sv) {
+        return DDWAF_LOG_WARN;
+    }
+
+    if (str == "info"sv || str == "INFO"sv) {
+        return DDWAF_LOG_INFO;
+    }
+
+    return DDWAF_LOG_OFF;
+}
+
 void log_cb(DDWAF_LOG_LEVEL level, const char *function, const char *file, unsigned line,
     const char *message, [[maybe_unused]] uint64_t len)
 {
     ddwaf::fmt::print("[{}][{}:{}:{}]: {}\n", level_to_str(level), file, function, line, message);
 }
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+DDWAF_LOG_LEVEL find_log_level(int argc, char *argv[])
+{
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    auto *env_level = getenv("DDWAF_TEST_LOG_LEVEL");
+    if (env_level != nullptr) {
+        return str_to_level(env_level);
+    }
+
+    DDWAF_LOG_LEVEL level = DDWAF_LOG_TRACE;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--log_level" || arg == "--log-level") {
+            if (i + 1 < argc) {
+                level = str_to_level(argv[i + 1]);
+            }
+            break;
+        }
+    }
+    return level;
+}
 int main(int argc, char *argv[])
 {
-    ddwaf_set_log_cb(log_cb, DDWAF_LOG_TRACE);
+    ddwaf_set_log_cb(log_cb, find_log_level(argc, argv));
     ddwaf::memory::set_local_memory_resource(std::pmr::new_delete_resource());
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
This PR fixes a few random issues that have appeared and it also adds coverage for all log levels. This is mostly to avoid the coverage noise introduced by adding log messages, perhaps this just needed trace and off but for now all levels are tested.