### PR TITLE
Pass object limits at evaluation time rather than parsing

### DIFF
--- a/fuzzer/cmdi_detector/src/main.cpp
+++ b/fuzzer/cmdi_detector/src/main.cpp
@@ -206,7 +206,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    (void)cond.eval(cache, store, {}, {}, deadline);
+    (void)cond.eval(cache, store, {}, {}, {}, deadline);
 
     return 0;
 }

--- a/fuzzer/lfi_detector/src/main.cpp
+++ b/fuzzer/lfi_detector/src/main.cpp
@@ -125,7 +125,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    (void)cond.eval(cache, store, {}, {}, deadline);
+    (void)cond.eval(cache, store, {}, {}, {}, deadline);
 
     return 0;
 }

--- a/fuzzer/shi_detector_array/src/main.cpp
+++ b/fuzzer/shi_detector_array/src/main.cpp
@@ -206,7 +206,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    (void)cond.eval(cache, store, {}, {}, deadline);
+    (void)cond.eval(cache, store, {}, {}, {}, deadline);
 
     return 0;
 }

--- a/fuzzer/shi_detector_string/src/main.cpp
+++ b/fuzzer/shi_detector_string/src/main.cpp
@@ -123,7 +123,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    (void)cond.eval(cache, store, {}, {}, deadline);
+    (void)cond.eval(cache, store, {}, {}, {}, deadline);
 
     return 0;
 }

--- a/fuzzer/sqli_detector/src/main.cpp
+++ b/fuzzer/sqli_detector/src/main.cpp
@@ -141,7 +141,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    (void)cond.eval(cache, store, {}, {}, deadline);
+    (void)cond.eval(cache, store, {}, {}, {}, deadline);
 
     return 0;
 }

--- a/fuzzer/ssrf_detector/src/main.cpp
+++ b/fuzzer/ssrf_detector/src/main.cpp
@@ -125,7 +125,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    (void)cond.eval(cache, store, {}, {}, deadline);
+    (void)cond.eval(cache, store, {}, {}, {}, deadline);
 
     return 0;
 }

--- a/src/builder/ruleset_builder.cpp
+++ b/src/builder/ruleset_builder.cpp
@@ -221,6 +221,7 @@ std::shared_ptr<ruleset> ruleset_builder::build(
     rs->actions = actions_;
     rs->free_fn = free_fn_;
     rs->event_obfuscator = event_obfuscator_;
+    rs->limits = limits_;
 
     // An instance is valid if it contains primitives with side-effects, such as
     // rules or postprocessors.

--- a/src/condition/base.hpp
+++ b/src/condition/base.hpp
@@ -81,7 +81,7 @@ public:
 
     virtual eval_result eval(condition_cache &cache, const object_store &store,
         const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-        ddwaf::timer &deadline) const = 0;
+        const object_limits &limits, ddwaf::timer &deadline) const = 0;
 
     virtual void get_addresses(std::unordered_map<target_index, std::string> &addresses) const = 0;
 };

--- a/src/condition/cmdi_detector.cpp
+++ b/src/condition/cmdi_detector.cpp
@@ -436,13 +436,15 @@ std::string generate_string_resource(const ddwaf_object &root)
 
 } // namespace
 
-cmdi_detector::cmdi_detector(std::vector<condition_parameter> args, const object_limits &limits)
-    : base_impl<cmdi_detector>(std::move(args), limits)
+cmdi_detector::cmdi_detector(std::vector<condition_parameter> args)
+    : base_impl<cmdi_detector>(std::move(args))
 {}
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 eval_result cmdi_detector::eval_impl(const unary_argument<const ddwaf_object *> &resource,
     const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-    const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+    ddwaf::timer &deadline) const
 {
     if (resource.value->type != DDWAF_OBJ_ARRAY || resource.value->nbEntries == 0) {
         return {};
@@ -451,7 +453,7 @@ eval_result cmdi_detector::eval_impl(const unary_argument<const ddwaf_object *> 
     std::vector<shell_token> resource_tokens;
     for (const auto &param : params) {
         auto res = cmdi_impl(
-            *resource.value, resource_tokens, *param.value, objects_excluded, limits_, deadline);
+            *resource.value, resource_tokens, *param.value, objects_excluded, limits, deadline);
         if (res.has_value()) {
             const std::vector<std::string> resource_kp{
                 resource.key_path.begin(), resource.key_path.end()};

--- a/src/condition/cmdi_detector.hpp
+++ b/src/condition/cmdi_detector.hpp
@@ -15,12 +15,13 @@ public:
     static constexpr unsigned version = 1;
     static constexpr std::array<std::string_view, 2> param_names{"resource", "params"};
 
-    explicit cmdi_detector(std::vector<condition_parameter> args, const object_limits &limits = {});
+    explicit cmdi_detector(std::vector<condition_parameter> args);
 
 protected:
     [[nodiscard]] eval_result eval_impl(const unary_argument<const ddwaf_object *> &resource,
         const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-        const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const;
+        const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+        ddwaf::timer &deadline) const;
 
     friend class base_impl<cmdi_detector>;
 };

--- a/src/condition/exists.hpp
+++ b/src/condition/exists.hpp
@@ -16,15 +16,14 @@ class exists_condition : public base_impl<exists_condition> {
 public:
     static constexpr std::array<std::string_view, 1> param_names{"inputs"};
 
-    explicit exists_condition(
-        std::vector<condition_parameter> args, const object_limits &limits = {})
-        : base_impl<exists_condition>(std::move(args), limits)
+    explicit exists_condition(std::vector<condition_parameter> args)
+        : base_impl<exists_condition>(std::move(args))
     {}
 
 protected:
     [[nodiscard]] eval_result eval_impl(const variadic_argument<const ddwaf_object *> &inputs,
         condition_cache &cache, const exclusion::object_set_ref &objects_excluded,
-        ddwaf::timer &deadline) const;
+        const object_limits &limits, ddwaf::timer &deadline) const;
 
     friend class base_impl<exists_condition>;
 };
@@ -33,15 +32,14 @@ class exists_negated_condition : public base_impl<exists_negated_condition> {
 public:
     static constexpr std::array<std::string_view, 1> param_names{"inputs"};
 
-    explicit exists_negated_condition(
-        std::vector<condition_parameter> args, const object_limits &limits = {})
-        : base_impl<exists_negated_condition>(std::move(args), limits)
+    explicit exists_negated_condition(std::vector<condition_parameter> args)
+        : base_impl<exists_negated_condition>(std::move(args))
     {}
 
 protected:
     [[nodiscard]] eval_result eval_impl(const unary_argument<const ddwaf_object *> &input,
         condition_cache &cache, const exclusion::object_set_ref &objects_excluded,
-        ddwaf::timer & /*deadline*/) const;
+        const object_limits &limits, ddwaf::timer & /*deadline*/) const;
 
     friend class base_impl<exists_negated_condition>;
 };

--- a/src/condition/lfi_detector.cpp
+++ b/src/condition/lfi_detector.cpp
@@ -122,12 +122,14 @@ lfi_result lfi_impl(std::string_view path, const ddwaf_object &params,
 }
 } // namespace
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 eval_result lfi_detector::eval_impl(const unary_argument<std::string_view> &path,
     const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-    const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+    ddwaf::timer &deadline) const
 {
     for (const auto &param : params) {
-        auto res = lfi_impl(path.value, *param.value, objects_excluded, limits_, deadline);
+        auto res = lfi_impl(path.value, *param.value, objects_excluded, limits, deadline);
         if (res.has_value()) {
             const std::vector<std::string> path_kp{path.key_path.begin(), path.key_path.end()};
             const bool ephemeral = path.ephemeral || param.ephemeral;

--- a/src/condition/lfi_detector.hpp
+++ b/src/condition/lfi_detector.hpp
@@ -15,14 +15,15 @@ public:
     static constexpr unsigned version = 2;
     static constexpr std::array<std::string_view, 2> param_names{"resource", "params"};
 
-    explicit lfi_detector(std::vector<condition_parameter> args, const object_limits &limits = {})
-        : base_impl<lfi_detector>(std::move(args), limits)
+    explicit lfi_detector(std::vector<condition_parameter> args)
+        : base_impl<lfi_detector>(std::move(args))
     {}
 
 protected:
     [[nodiscard]] eval_result eval_impl(const unary_argument<std::string_view> &path,
         const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-        const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const;
+        const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+        ddwaf::timer &deadline) const;
 
     friend class base_impl<lfi_detector>;
 };

--- a/src/condition/match_iterator.hpp
+++ b/src/condition/match_iterator.hpp
@@ -17,7 +17,7 @@ public:
     static constexpr std::size_t npos = std::string_view::npos;
 
     explicit match_iterator(ResourceType resource, const ddwaf_object *obj,
-        const exclusion::object_set_ref &exclude, const object_limits &limits = object_limits())
+        const exclusion::object_set_ref &exclude, const object_limits &limits = {})
         : resource_(resource), it_(obj, {}, exclude, limits)
     {
         for (; it_; ++it_) {

--- a/src/condition/scalar_condition.cpp
+++ b/src/condition/scalar_condition.cpp
@@ -131,7 +131,7 @@ const matcher::base *get_matcher(const std::unique_ptr<matcher::base> &matcher,
 
 eval_result scalar_condition::eval(condition_cache &cache, const object_store &store,
     const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-    ddwaf::timer &deadline) const
+    const object_limits &limits, ddwaf::timer &deadline) const
 {
     const auto *matcher = get_matcher(matcher_, data_id_, dynamic_matchers);
     if (matcher == nullptr) {
@@ -161,13 +161,13 @@ eval_result scalar_condition::eval(condition_cache &cache, const object_store &s
         std::optional<condition_match> match;
         // TODO: iterators could be cached to avoid reinitialisation
         if (target.source == data_source::keys) {
-            object::key_iterator it(object, target.key_path, objects_excluded, limits_);
+            object::key_iterator it(object, target.key_path, objects_excluded, limits);
             match = eval_target<std::optional<condition_match>>(
-                it, target.name, ephemeral, *matcher, target.transformers, limits_, deadline);
+                it, target.name, ephemeral, *matcher, target.transformers, limits, deadline);
         } else {
-            object::value_iterator it(object, target.key_path, objects_excluded, limits_);
+            object::value_iterator it(object, target.key_path, objects_excluded, limits);
             match = eval_target<std::optional<condition_match>>(
-                it, target.name, ephemeral, *matcher, target.transformers, limits_, deadline);
+                it, target.name, ephemeral, *matcher, target.transformers, limits, deadline);
         }
 
         if (match.has_value()) {
@@ -181,7 +181,7 @@ eval_result scalar_condition::eval(condition_cache &cache, const object_store &s
 
 eval_result scalar_negated_condition::eval(condition_cache &cache, const object_store &store,
     const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-    ddwaf::timer &deadline) const
+    const object_limits &limits, ddwaf::timer &deadline) const
 {
     if (deadline.expired()) {
         throw ddwaf::timeout_exception();
@@ -208,13 +208,13 @@ eval_result scalar_negated_condition::eval(condition_cache &cache, const object_
 
     bool match = false;
     if (target_.source == data_source::keys) {
-        object::key_iterator it(object, target_.key_path, objects_excluded, limits_);
+        object::key_iterator it(object, target_.key_path, objects_excluded, limits);
         match = eval_target<bool>(
-            it, target_.name, ephemeral, *matcher, target_.transformers, limits_, deadline);
+            it, target_.name, ephemeral, *matcher, target_.transformers, limits, deadline);
     } else {
-        object::value_iterator it(object, target_.key_path, objects_excluded, limits_);
+        object::value_iterator it(object, target_.key_path, objects_excluded, limits);
         match = eval_target<bool>(
-            it, target_.name, ephemeral, *matcher, target_.transformers, limits_, deadline);
+            it, target_.name, ephemeral, *matcher, target_.transformers, limits, deadline);
     }
 
     if (!match) {

--- a/src/condition/scalar_condition.hpp
+++ b/src/condition/scalar_condition.hpp
@@ -13,8 +13,8 @@ namespace ddwaf {
 class scalar_condition : public base_condition {
 public:
     scalar_condition(std::unique_ptr<matcher::base> &&matcher, std::string data_id,
-        std::vector<condition_parameter> args, const object_limits &limits = {})
-        : matcher_(std::move(matcher)), data_id_(std::move(data_id)), limits_(limits)
+        std::vector<condition_parameter> args)
+        : matcher_(std::move(matcher)), data_id_(std::move(data_id))
     {
         if (args.size() > 1) {
             throw std::invalid_argument("matcher initialised with more than one argument");
@@ -29,7 +29,7 @@ public:
 
     eval_result eval(condition_cache &cache, const object_store &store,
         const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-        ddwaf::timer &deadline) const override;
+        const object_limits &limits, ddwaf::timer &deadline) const override;
 
     void get_addresses(std::unordered_map<target_index, std::string> &addresses) const override
     {
@@ -46,14 +46,13 @@ protected:
     std::unique_ptr<matcher::base> matcher_;
     std::string data_id_;
     std::vector<condition_target> targets_;
-    object_limits limits_;
 };
 
 class scalar_negated_condition : public base_condition {
 public:
     scalar_negated_condition(std::unique_ptr<matcher::base> &&matcher, std::string data_id,
-        std::vector<condition_parameter> args, const object_limits &limits = {})
-        : matcher_(std::move(matcher)), data_id_(std::move(data_id)), limits_(limits)
+        std::vector<condition_parameter> args)
+        : matcher_(std::move(matcher)), data_id_(std::move(data_id))
     {
         if (args.size() > 1) {
             throw std::invalid_argument("matcher initialised with more than one argument");
@@ -72,7 +71,7 @@ public:
 
     eval_result eval(condition_cache &cache, const object_store &store,
         const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-        ddwaf::timer &deadline) const override;
+        const object_limits &limits, ddwaf::timer &deadline) const override;
 
     void get_addresses(std::unordered_map<target_index, std::string> &addresses) const override
     {
@@ -89,7 +88,6 @@ protected:
     std::unique_ptr<matcher::base> matcher_;
     std::string data_id_;
     condition_target target_;
-    object_limits limits_;
 };
 
 } // namespace ddwaf

--- a/src/condition/shi_detector.cpp
+++ b/src/condition/shi_detector.cpp
@@ -28,7 +28,8 @@ namespace ddwaf {
 
 eval_result shi_detector::eval_string(const unary_argument<const ddwaf_object *> &resource,
     const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-    const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+    ddwaf::timer &deadline)
 {
     if (resource.value->nbEntries == 0 || resource.value->stringValue == nullptr) {
         return {};
@@ -41,7 +42,7 @@ eval_result shi_detector::eval_string(const unary_argument<const ddwaf_object *>
     std::vector<shell_token> resource_tokens;
     for (const auto &param : params) {
         auto res = find_shi_from_params(
-            resource_sv, resource_tokens, *param.value, objects_excluded, limits_, deadline);
+            resource_sv, resource_tokens, *param.value, objects_excluded, limits, deadline);
         if (res.has_value()) {
             const std::vector<std::string> resource_kp{
                 resource.key_path.begin(), resource.key_path.end()};
@@ -73,7 +74,8 @@ eval_result shi_detector::eval_string(const unary_argument<const ddwaf_object *>
 
 eval_result shi_detector::eval_array(const unary_argument<const ddwaf_object *> &resource,
     const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-    const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+    ddwaf::timer &deadline)
 {
     shell_argument_array arguments{*resource.value};
     if (arguments.empty()) {
@@ -83,7 +85,7 @@ eval_result shi_detector::eval_array(const unary_argument<const ddwaf_object *> 
     std::vector<shell_token> resource_tokens;
     for (const auto &param : params) {
         auto res = find_shi_from_params(
-            arguments, resource_tokens, *param.value, objects_excluded, limits_, deadline);
+            arguments, resource_tokens, *param.value, objects_excluded, limits, deadline);
         if (res.has_value()) {
             const std::vector<std::string> resource_kp{
                 resource.key_path.begin(), resource.key_path.end()};
@@ -113,20 +115,22 @@ eval_result shi_detector::eval_array(const unary_argument<const ddwaf_object *> 
     return {};
 }
 
-shi_detector::shi_detector(std::vector<condition_parameter> args, const object_limits &limits)
-    : base_impl<shi_detector>(std::move(args), limits)
+shi_detector::shi_detector(std::vector<condition_parameter> args)
+    : base_impl<shi_detector>(std::move(args))
 {}
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 eval_result shi_detector::eval_impl(const unary_argument<const ddwaf_object *> &resource,
     const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-    const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+    ddwaf::timer &deadline) const
 {
     if (resource.value->type == DDWAF_OBJ_STRING) {
-        return eval_string(resource, params, cache, objects_excluded, deadline);
+        return eval_string(resource, params, cache, objects_excluded, limits, deadline);
     }
 
     if (resource.value->type == DDWAF_OBJ_ARRAY) {
-        return eval_array(resource, params, cache, objects_excluded, deadline);
+        return eval_array(resource, params, cache, objects_excluded, limits, deadline);
     }
 
     return {};

--- a/src/condition/shi_detector.hpp
+++ b/src/condition/shi_detector.hpp
@@ -16,20 +16,25 @@ public:
     static constexpr unsigned version = 1;
     static constexpr std::array<std::string_view, 2> param_names{"resource", "params"};
 
-    explicit shi_detector(std::vector<condition_parameter> args, const object_limits &limits = {});
+    explicit shi_detector(std::vector<condition_parameter> args);
 
 protected:
     [[nodiscard]] eval_result eval_impl(const unary_argument<const ddwaf_object *> &resource,
         const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-        const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const;
+        const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+        ddwaf::timer &deadline) const;
 
-    [[nodiscard]] eval_result eval_string(const unary_argument<const ddwaf_object *> &resource,
+    [[nodiscard]] static eval_result eval_string(
+        const unary_argument<const ddwaf_object *> &resource,
         const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-        const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const;
+        const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+        ddwaf::timer &deadline);
 
-    [[nodiscard]] eval_result eval_array(const unary_argument<const ddwaf_object *> &resource,
+    [[nodiscard]] static eval_result eval_array(
+        const unary_argument<const ddwaf_object *> &resource,
         const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-        const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const;
+        const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+        ddwaf::timer &deadline);
 
     friend class base_impl<shi_detector>;
 };

--- a/src/condition/sqli_detector.cpp
+++ b/src/condition/sqli_detector.cpp
@@ -507,10 +507,12 @@ sqli_result sqli_impl(std::string_view resource, std::vector<sql_token> &resourc
 
 } // namespace internal
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 [[nodiscard]] eval_result sqli_detector::eval_impl(const unary_argument<std::string_view> &sql,
     const variadic_argument<const ddwaf_object *> &params,
     const unary_argument<std::string_view> &db_type, condition_cache &cache,
-    const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+    ddwaf::timer &deadline) const
 {
     auto dialect = sql_dialect_from_type(db_type.value);
 
@@ -518,7 +520,7 @@ sqli_result sqli_impl(std::string_view resource, std::vector<sql_token> &resourc
 
     for (const auto &param : params) {
         auto res = internal::sqli_impl(
-            sql.value, resource_tokens, *param.value, dialect, objects_excluded, limits_, deadline);
+            sql.value, resource_tokens, *param.value, dialect, objects_excluded, limits, deadline);
         if (std::holds_alternative<internal::matched_param>(res)) {
             const std::vector<std::string> sql_kp{sql.key_path.begin(), sql.key_path.end()};
             const bool ephemeral = sql.ephemeral || param.ephemeral;

--- a/src/condition/sqli_detector.hpp
+++ b/src/condition/sqli_detector.hpp
@@ -16,15 +16,16 @@ public:
     static constexpr unsigned version = 3;
     static constexpr std::array<std::string_view, 3> param_names{"resource", "params", "db_type"};
 
-    explicit sqli_detector(std::vector<condition_parameter> args, const object_limits &limits = {})
-        : base_impl<sqli_detector>(std::move(args), limits)
+    explicit sqli_detector(std::vector<condition_parameter> args)
+        : base_impl<sqli_detector>(std::move(args))
     {}
 
 protected:
     [[nodiscard]] eval_result eval_impl(const unary_argument<std::string_view> &sql,
         const variadic_argument<const ddwaf_object *> &params,
         const unary_argument<std::string_view> &db_type, condition_cache &cache,
-        const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const;
+        const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+        ddwaf::timer &deadline) const;
 
     friend class base_impl<sqli_detector>;
 };

--- a/src/condition/ssrf_detector.cpp
+++ b/src/condition/ssrf_detector.cpp
@@ -250,15 +250,16 @@ ssrf_result ssrf_impl(const uri_decomposed &uri, const ddwaf_object &params,
 
 } // namespace
 
-ssrf_detector::ssrf_detector(std::vector<condition_parameter> args, const object_limits &limits)
-    : base_impl<ssrf_detector>(std::move(args), limits),
+ssrf_detector::ssrf_detector(std::vector<condition_parameter> args)
+    : base_impl<ssrf_detector>(std::move(args)),
       dangerous_ip_matcher_(std::make_unique<matcher::ip_match>(dangerous_ips)),
       authorised_schemes_(authorised_schemes.begin(), authorised_schemes.end())
 {}
 
 eval_result ssrf_detector::eval_impl(const unary_argument<std::string_view> &uri,
     const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-    const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+    ddwaf::timer &deadline) const
 {
     auto decomposed = uri_parse(uri.value);
     if (!decomposed.has_value()) {
@@ -266,7 +267,7 @@ eval_result ssrf_detector::eval_impl(const unary_argument<std::string_view> &uri
     }
 
     for (const auto &param : params) {
-        auto res = ssrf_impl(*decomposed, *param.value, objects_excluded, limits_,
+        auto res = ssrf_impl(*decomposed, *param.value, objects_excluded, limits,
             dangerous_ip_matcher_, authorised_schemes_, deadline);
         if (res.has_value()) {
             const std::vector<std::string> uri_kp{uri.key_path.begin(), uri.key_path.end()};

--- a/src/condition/ssrf_detector.hpp
+++ b/src/condition/ssrf_detector.hpp
@@ -16,12 +16,13 @@ public:
     static constexpr unsigned version = 2;
     static constexpr std::array<std::string_view, 2> param_names{"resource", "params"};
 
-    explicit ssrf_detector(std::vector<condition_parameter> args, const object_limits &limits = {});
+    explicit ssrf_detector(std::vector<condition_parameter> args);
 
 protected:
     [[nodiscard]] eval_result eval_impl(const unary_argument<std::string_view> &uri,
         const variadic_argument<const ddwaf_object *> &params, condition_cache &cache,
-        const exclusion::object_set_ref &objects_excluded, ddwaf::timer &deadline) const;
+        const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
+        ddwaf::timer &deadline) const;
 
     std::unique_ptr<matcher::ip_match> dangerous_ip_matcher_;
     std::unordered_set<std::string_view> authorised_schemes_;

--- a/src/condition/structured_condition.hpp
+++ b/src/condition/structured_condition.hpp
@@ -26,9 +26,7 @@ function_traits<Class::param_names.size(), Class, Args...> make_eval_traits(
 
 template <typename Self> class base_impl : public base_condition {
 public:
-    explicit base_impl(std::vector<condition_parameter> args, const object_limits &limits)
-        : arguments_(std::move(args)), limits_(limits)
-    {}
+    explicit base_impl(std::vector<condition_parameter> args) : arguments_(std::move(args)) {}
     ~base_impl() override = default;
     base_impl(const base_impl &) = default;
     base_impl &operator=(const base_impl &) = default;
@@ -37,7 +35,7 @@ public:
 
     [[nodiscard]] eval_result eval(condition_cache &cache, const object_store &store,
         const exclusion::object_set_ref &objects_excluded, const matcher_mapper & /*unused*/,
-        ddwaf::timer &deadline) const override
+        const object_limits &limits, ddwaf::timer &deadline) const override
     {
 
         using func_traits = decltype(make_eval_traits(&Self::eval_impl));
@@ -53,7 +51,8 @@ public:
         return std::apply(
             [&](auto &&...args) {
                 return static_cast<const Self *>(this)->eval_impl(
-                    std::forward<decltype(args)>(args)..., cache, objects_excluded, deadline);
+                    std::forward<decltype(args)>(args)..., cache, objects_excluded, limits,
+                    deadline);
             },
             std::move(args));
     }
@@ -154,7 +153,6 @@ protected:
     }
 
     std::vector<condition_parameter> arguments_;
-    const object_limits limits_;
 };
 
 } // namespace ddwaf

--- a/src/configuration/common/expression_parser.hpp
+++ b/src/configuration/common/expression_parser.hpp
@@ -14,10 +14,9 @@ namespace ddwaf {
 
 // TODO: merge these and use default arguments
 std::shared_ptr<expression> parse_expression(const raw_configuration::vector &conditions_array,
-    data_source source, const std::vector<transformer_id> &transformers,
-    const object_limits &limits);
+    data_source source, const std::vector<transformer_id> &transformers);
 
 std::shared_ptr<expression> parse_simplified_expression(
-    const raw_configuration::vector &conditions_array, const object_limits &limits);
+    const raw_configuration::vector &conditions_array);
 
 } // namespace ddwaf

--- a/src/configuration/configuration_manager.cpp
+++ b/src/configuration/configuration_manager.cpp
@@ -55,7 +55,7 @@ void configuration_manager::load(
             try {
                 auto rules = static_cast<raw_configuration::vector>(it->second);
                 if (!rules.empty()) {
-                    parse_legacy_rules(rules, collector, section, limits_);
+                    parse_legacy_rules(rules, collector, section);
                 }
             } catch (const std::exception &e) {
                 DDWAF_WARN("Failed to parse rules: {}", e.what());
@@ -88,7 +88,7 @@ void configuration_manager::load(
         try {
             auto rules = static_cast<raw_configuration::vector>(it->second);
             if (!rules.empty()) {
-                parse_base_rules(rules, collector, section, limits_);
+                parse_base_rules(rules, collector, section);
             }
         } catch (const std::exception &e) {
             DDWAF_WARN("Failed to parse rules: {}", e.what());
@@ -103,7 +103,7 @@ void configuration_manager::load(
         try {
             auto rules = static_cast<raw_configuration::vector>(it->second);
             if (!rules.empty()) {
-                parse_user_rules(rules, collector, section, limits_);
+                parse_user_rules(rules, collector, section);
             }
         } catch (const std::exception &e) {
             DDWAF_WARN("Failed to parse custom rules: {}", e.what());
@@ -148,7 +148,7 @@ void configuration_manager::load(
         try {
             auto exclusions = static_cast<raw_configuration::vector>(it->second);
             if (!exclusions.empty()) {
-                parse_filters(exclusions, collector, section, limits_);
+                parse_filters(exclusions, collector, section);
             }
         } catch (const std::exception &e) {
             DDWAF_WARN("Failed to parse exclusions: {}", e.what());
@@ -178,7 +178,7 @@ void configuration_manager::load(
         try {
             auto processors = static_cast<raw_configuration::vector>(it->second);
             if (!processors.empty()) {
-                parse_processors(processors, collector, section, limits_);
+                parse_processors(processors, collector, section);
             }
         } catch (const std::exception &e) {
             DDWAF_WARN("Failed to parse processors: {}", e.what());

--- a/src/configuration/configuration_manager.hpp
+++ b/src/configuration/configuration_manager.hpp
@@ -33,13 +33,12 @@ public:
 protected:
     void remove_config(const configuration_change_spec &cfg);
 
-    void load(
+    static void load(
         raw_configuration::map &root, configuration_collector &collector, base_ruleset_info &info);
 
     std::unordered_map<std::string, configuration_change_spec> configs_;
     configuration_spec global_config_;
     change_set changes_{change_set::none};
-    object_limits limits_;
 };
 
 } // namespace ddwaf

--- a/src/configuration/exclusion_parser.hpp
+++ b/src/configuration/exclusion_parser.hpp
@@ -13,6 +13,6 @@
 namespace ddwaf {
 
 void parse_filters(const raw_configuration::vector &filter_array, configuration_collector &cfg,
-    ruleset_info::base_section_info &info, const object_limits &limits);
+    ruleset_info::base_section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/legacy_rule_parser.cpp
+++ b/src/configuration/legacy_rule_parser.cpp
@@ -40,8 +40,8 @@ namespace ddwaf {
 
 namespace {
 
-std::shared_ptr<expression> parse_expression(raw_configuration::vector &conditions_array,
-    const std::vector<transformer_id> &transformers, ddwaf::object_limits limits)
+std::shared_ptr<expression> parse_expression(
+    raw_configuration::vector &conditions_array, const std::vector<transformer_id> &transformers)
 {
     std::vector<std::unique_ptr<base_condition>> conditions;
 
@@ -120,7 +120,7 @@ std::shared_ptr<expression> parse_expression(raw_configuration::vector &conditio
         }
 
         conditions.emplace_back(std::make_unique<scalar_condition>(
-            std::move(matcher), std::string{}, std::move(definitions), limits));
+            std::move(matcher), std::string{}, std::move(definitions)));
     }
 
     return std::make_shared<expression>(std::move(conditions));
@@ -129,7 +129,7 @@ std::shared_ptr<expression> parse_expression(raw_configuration::vector &conditio
 } // namespace
 
 void parse_legacy_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info, object_limits limits)
+    base_section_info &info)
 {
     for (unsigned i = 0; i < rule_array.size(); ++i) {
         std::string id;
@@ -147,7 +147,7 @@ void parse_legacy_rules(const raw_configuration::vector &rule_array, configurati
             std::vector<transformer_id> rule_transformers;
             auto transformers =
                 at<raw_configuration::vector>(node, "transformers", raw_configuration::vector());
-            if (transformers.size() > limits.max_transformers_per_address) {
+            if (transformers.size() > object_limits::max_transformers_per_address) {
                 throw ddwaf::parsing_error("number of transformers beyond allowed limit");
             }
 
@@ -162,7 +162,7 @@ void parse_legacy_rules(const raw_configuration::vector &rule_array, configurati
             }
 
             auto conditions_array = at<raw_configuration::vector>(node, "conditions");
-            auto expression = parse_expression(conditions_array, rule_transformers, limits);
+            auto expression = parse_expression(conditions_array, rule_transformers);
 
             std::unordered_map<std::string, std::string> tags;
             for (auto &[key, value] : at<raw_configuration::map>(node, "tags")) {

--- a/src/configuration/legacy_rule_parser.hpp
+++ b/src/configuration/legacy_rule_parser.hpp
@@ -13,6 +13,6 @@
 namespace ddwaf {
 
 void parse_legacy_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info, object_limits limits);
+    base_section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/processor_parser.cpp
+++ b/src/configuration/processor_parser.cpp
@@ -24,7 +24,6 @@
 #include "ruleset_info.hpp"
 #include "semver.hpp"
 #include "target_address.hpp"
-#include "utils.hpp"
 #include "version.hpp"
 
 namespace ddwaf {
@@ -69,8 +68,7 @@ std::vector<processor_mapping> parse_processor_mappings(
 } // namespace
 
 void parse_processors(const raw_configuration::vector &processor_array,
-    configuration_collector &cfg, ruleset_info::base_section_info &info,
-    const object_limits &limits)
+    configuration_collector &cfg, ruleset_info::base_section_info &info)
 {
     for (unsigned i = 0; i < processor_array.size(); i++) {
         const auto &node_param = processor_array[i];
@@ -112,7 +110,7 @@ void parse_processors(const raw_configuration::vector &processor_array,
             }
 
             auto conditions_array = at<raw_configuration::vector>(node, "conditions", {});
-            auto expr = parse_simplified_expression(conditions_array, limits);
+            auto expr = parse_simplified_expression(conditions_array);
 
             auto params = at<raw_configuration::map>(node, "parameters");
             auto mappings_vec = at<raw_configuration::vector>(params, "mappings");

--- a/src/configuration/processor_parser.hpp
+++ b/src/configuration/processor_parser.hpp
@@ -14,7 +14,6 @@
 namespace ddwaf {
 
 void parse_processors(const raw_configuration::vector &processor_array,
-    configuration_collector &cfg, ruleset_info::base_section_info &info,
-    const object_limits &limits);
+    configuration_collector &cfg, ruleset_info::base_section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/rule_parser.hpp
+++ b/src/configuration/rule_parser.hpp
@@ -13,9 +13,9 @@
 namespace ddwaf {
 
 void parse_base_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info, const object_limits &limits);
+    base_section_info &info);
 
 void parse_user_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info, const object_limits &limits);
+    base_section_info &info);
 
 } // namespace ddwaf

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -143,7 +143,7 @@ void context::eval_preprocessors(optional_ref<ddwaf_object> &derived, ddwaf::tim
             it = new_it;
         }
 
-        preproc->eval(store_, derived, it->second, deadline);
+        preproc->eval(store_, derived, it->second, limits_, deadline);
     }
 }
 
@@ -163,7 +163,7 @@ void context::eval_postprocessors(optional_ref<ddwaf_object> &derived, ddwaf::ti
             it = new_it;
         }
 
-        postproc->eval(store_, derived, it->second, deadline);
+        postproc->eval(store_, derived, it->second, limits_, deadline);
     }
 }
 
@@ -184,7 +184,7 @@ exclusion::context_policy &context::eval_filters(ddwaf::timer &deadline)
         }
 
         rule_filter::cache_type &cache = it->second;
-        auto exclusion = filter.match(store_, cache, exclusion_matchers_, deadline);
+        auto exclusion = filter.match(store_, cache, exclusion_matchers_, limits_, deadline);
         if (exclusion.has_value()) {
             for (const auto &rule : exclusion->rules) {
                 exclusion_policy_.add_rule_exclusion(
@@ -208,7 +208,7 @@ exclusion::context_policy &context::eval_filters(ddwaf::timer &deadline)
         }
 
         input_filter::cache_type &cache = it->second;
-        auto exclusion = filter.match(store_, cache, exclusion_matchers_, deadline);
+        auto exclusion = filter.match(store_, cache, exclusion_matchers_, limits_, deadline);
         if (exclusion.has_value()) {
             for (const auto &rule : exclusion->rules) {
                 exclusion_policy_.add_input_exclusion(rule, exclusion->objects);
@@ -228,7 +228,7 @@ std::vector<event> context::eval_rules(
         const auto &mod = ruleset_->rule_modules[i];
         auto &cache = rule_module_cache_[i];
 
-        auto verdict = mod.eval(events, store_, cache, policy, rule_matchers_, deadline);
+        auto verdict = mod.eval(events, store_, cache, policy, rule_matchers_, limits_, deadline);
         if (verdict == rule_module::verdict_type::block) {
             break;
         }

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -34,7 +34,7 @@ public:
           postprocessors_(*ruleset_->postprocessors), rule_filters_(*ruleset_->rule_filters),
           input_filters_(*ruleset_->input_filters), rule_matchers_(*ruleset_->rule_matchers),
           exclusion_matchers_(*ruleset_->exclusion_matchers), actions_(*ruleset_->actions),
-          event_obfuscator_(*ruleset_->event_obfuscator)
+          limits_(ruleset_->limits), event_obfuscator_(*ruleset_->event_obfuscator)
     {
         processor_cache_.reserve(
             ruleset_->preprocessors->size() + ruleset_->postprocessors->size());
@@ -100,6 +100,7 @@ protected:
 
     const action_mapper &actions_;
 
+    const object_limits &limits_;
     const obfuscator &event_obfuscator_;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 

--- a/src/exclusion/input_filter.cpp
+++ b/src/exclusion/input_filter.cpp
@@ -19,6 +19,7 @@
 #include "matcher/base.hpp"
 #include "object_store.hpp"
 #include "rule.hpp"
+#include "utils.hpp"
 
 namespace ddwaf::exclusion {
 
@@ -35,18 +36,20 @@ input_filter::input_filter(std::string id, std::shared_ptr<expression> expr,
 }
 
 std::optional<excluded_set> input_filter::match(const object_store &store, cache_type &cache,
-    const matcher_mapper &dynamic_matchers, ddwaf::timer &deadline) const
+    const matcher_mapper &dynamic_matchers, const object_limits &limits,
+    ddwaf::timer &deadline) const
 {
     DDWAF_DEBUG("Evaluating input filter '{}'", id_);
 
     // An event was already produced, so we skip the rule
     // Note that conditions in a filter are optional
-    auto res = expr_->eval(cache.expr_cache, store, {}, dynamic_matchers, deadline);
+    auto res = expr_->eval(cache.expr_cache, store, {}, dynamic_matchers, limits, deadline);
     if (!res.outcome) {
         return std::nullopt;
     }
 
-    auto objects = filter_->match(store, cache.object_filter_cache, res.ephemeral, deadline);
+    auto objects =
+        filter_->match(store, cache.object_filter_cache, res.ephemeral, limits, deadline);
     if (objects.empty()) {
         return std::nullopt;
     }

--- a/src/exclusion/input_filter.hpp
+++ b/src/exclusion/input_filter.hpp
@@ -38,7 +38,8 @@ public:
     virtual ~input_filter() = default;
 
     virtual std::optional<excluded_set> match(const object_store &store, cache_type &cache,
-        const matcher_mapper &dynamic_matchers, ddwaf::timer &deadline) const;
+        const matcher_mapper &dynamic_matchers, const object_limits &limits,
+        ddwaf::timer &deadline) const;
 
     std::string_view get_id() { return id_; }
 

--- a/src/exclusion/object_filter.cpp
+++ b/src/exclusion/object_filter.cpp
@@ -101,8 +101,8 @@ void iterate_object(const path_trie::traverser &filter, const ddwaf_object *obje
 
 } // namespace
 
-object_set object_filter::match(
-    const object_store &store, cache_type &cache, bool ephemeral, ddwaf::timer &deadline) const
+object_set object_filter::match(const object_store &store, cache_type &cache, bool ephemeral,
+    const object_limits &limits, ddwaf::timer &deadline) const
 {
     object_set objects_to_exclude;
     for (const auto &[target, filter] : target_paths_) {
@@ -117,9 +117,9 @@ object_set object_filter::match(
 
         if (!ephemeral && attr != object_store::attribute::ephemeral) {
             cache.emplace(object);
-            iterate_object(filter.get_traverser(), object, objects_to_exclude.persistent, limits_);
+            iterate_object(filter.get_traverser(), object, objects_to_exclude.persistent, limits);
         } else {
-            iterate_object(filter.get_traverser(), object, objects_to_exclude.ephemeral, limits_);
+            iterate_object(filter.get_traverser(), object, objects_to_exclude.ephemeral, limits);
         }
     }
 

--- a/src/exclusion/object_filter.hpp
+++ b/src/exclusion/object_filter.hpp
@@ -239,7 +239,7 @@ class object_filter {
 public:
     using cache_type = memory::unordered_set<ddwaf_object *>;
 
-    explicit object_filter(const ddwaf::object_limits &limits = {}) : limits_(limits) {}
+    object_filter() = default;
 
     void insert(
         target_index target, std::string name, const std::vector<std::string_view> &key_path = {})
@@ -250,8 +250,8 @@ public:
 
     [[nodiscard]] bool empty() const { return target_paths_.empty(); }
 
-    object_set match(
-        const object_store &store, cache_type &cache, bool ephemeral, ddwaf::timer &deadline) const;
+    object_set match(const object_store &store, cache_type &cache, bool ephemeral,
+        const object_limits &limits, ddwaf::timer &deadline) const;
 
     void get_addresses(std::unordered_map<target_index, std::string> &addresses) const
     {
@@ -259,7 +259,6 @@ public:
     }
 
 protected:
-    object_limits limits_;
     std::unordered_map<target_index, path_trie> target_paths_;
     std::unordered_map<target_index, std::string> targets_;
 };

--- a/src/exclusion/rule_filter.cpp
+++ b/src/exclusion/rule_filter.cpp
@@ -18,6 +18,7 @@
 #include "matcher/base.hpp"
 #include "object_store.hpp"
 #include "rule.hpp"
+#include "utils.hpp"
 
 namespace ddwaf::exclusion {
 
@@ -38,7 +39,8 @@ rule_filter::rule_filter(std::string id, std::shared_ptr<expression> expr,
 }
 
 std::optional<excluded_set> rule_filter::match(const object_store &store, cache_type &cache,
-    const matcher_mapper &dynamic_matchers, ddwaf::timer &deadline) const
+    const matcher_mapper &dynamic_matchers, const object_limits &limits,
+    ddwaf::timer &deadline) const
 {
     DDWAF_DEBUG("Evaluating rule filter '{}'", id_);
 
@@ -47,7 +49,7 @@ std::optional<excluded_set> rule_filter::match(const object_store &store, cache_
         return std::nullopt;
     }
 
-    auto res = expr_->eval(cache, store, {}, dynamic_matchers, deadline);
+    auto res = expr_->eval(cache, store, {}, dynamic_matchers, limits, deadline);
     if (!res.outcome) {
         return std::nullopt;
     }

--- a/src/exclusion/rule_filter.hpp
+++ b/src/exclusion/rule_filter.hpp
@@ -38,7 +38,8 @@ public:
     virtual ~rule_filter() = default;
 
     virtual std::optional<excluded_set> match(const object_store &store, cache_type &cache,
-        const matcher_mapper &dynamic_matchers, ddwaf::timer &deadline) const;
+        const matcher_mapper &dynamic_matchers, const object_limits &limits,
+        ddwaf::timer &deadline) const;
 
     std::string_view get_id() const { return id_; }
 

--- a/src/expression.cpp
+++ b/src/expression.cpp
@@ -18,7 +18,7 @@ namespace ddwaf {
 
 eval_result expression::eval(cache_type &cache, const object_store &store,
     const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-    ddwaf::timer &deadline) const
+    const object_limits &limits, ddwaf::timer &deadline) const
 {
     if (cache.result || conditions_.empty()) {
         return {.outcome = true, .ephemeral = false};
@@ -38,7 +38,7 @@ eval_result expression::eval(cache_type &cache, const object_store &store,
         }
 
         auto [res, ephemeral] =
-            cond->eval(cond_cache, store, objects_excluded, dynamic_matchers, deadline);
+            cond->eval(cond_cache, store, objects_excluded, dynamic_matchers, limits, deadline);
         if (!res) {
             return {.outcome = false, .ephemeral = false};
         }

--- a/src/expression.hpp
+++ b/src/expression.hpp
@@ -37,7 +37,7 @@ public:
 
     eval_result eval(cache_type &cache, const object_store &store,
         const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-        ddwaf::timer &deadline) const;
+        const object_limits &limits, ddwaf::timer &deadline) const;
 
     void get_addresses(std::unordered_map<target_index, std::string> &addresses) const
     {

--- a/src/module.hpp
+++ b/src/module.hpp
@@ -53,12 +53,13 @@ public:
 
     verdict_type eval(std::vector<event> &events, object_store &store, cache_type &cache,
         const exclusion::context_policy &exclusion, const matcher_mapper &dynamic_matchers,
-        ddwaf::timer &deadline) const;
+        const object_limits &limits, ddwaf::timer &deadline) const;
 
 protected:
     verdict_type eval_with_collections(std::vector<event> &events, object_store &store,
         cache_type &cache, const exclusion::context_policy &exclusion,
-        const matcher_mapper &dynamic_matchers, ddwaf::timer &deadline) const;
+        const matcher_mapper &dynamic_matchers, const object_limits &limits,
+        ddwaf::timer &deadline) const;
 
     ddwaf::timer &get_deadline(ddwaf::timer &deadline) const;
 

--- a/src/processor/base.hpp
+++ b/src/processor/base.hpp
@@ -80,7 +80,7 @@ public:
     virtual ~base_processor() = default;
 
     virtual void eval(object_store &store, optional_ref<ddwaf_object> &derived,
-        processor_cache &cache, ddwaf::timer &deadline) const = 0;
+        processor_cache &cache, const object_limits &limits, ddwaf::timer &deadline) const = 0;
 
     virtual void get_addresses(std::unordered_map<target_index, std::string> &addresses) const = 0;
 
@@ -103,7 +103,7 @@ public:
     ~structured_processor() override = default;
 
     void eval(object_store &store, optional_ref<ddwaf_object> &derived, processor_cache &cache,
-        ddwaf::timer &deadline) const override
+        const object_limits &limits, ddwaf::timer &deadline) const override
     {
         // No result structure, but this processor only produces derived objects
         // so it makes no sense to evaluate.
@@ -113,7 +113,7 @@ public:
 
         DDWAF_DEBUG("Evaluating processor '{}'", id_);
 
-        if (!expr_->eval(cache.expr_cache, store, {}, {}, deadline).outcome) {
+        if (!expr_->eval(cache.expr_cache, store, {}, {}, limits, deadline).outcome) {
             return;
         }
 

--- a/src/rule.hpp
+++ b/src/rule.hpp
@@ -60,14 +60,14 @@ public:
 
     virtual std::optional<event> match(const object_store &store, cache_type &cache,
         const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-        ddwaf::timer &deadline) const
+        const object_limits &limits, ddwaf::timer &deadline) const
     {
         if (expression::get_result(cache)) {
             // An event was already produced, so we skip the rule
             return std::nullopt;
         }
 
-        auto res = expr_->eval(cache, store, objects_excluded, dynamic_matchers, deadline);
+        auto res = expr_->eval(cache, store, objects_excluded, dynamic_matchers, limits, deadline);
         if (!res.outcome) {
             return std::nullopt;
         }

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -128,6 +128,7 @@ struct ruleset {
     }
 
     ddwaf_object_free_fn free_fn{ddwaf_object_free};
+    object_limits limits{};
     std::shared_ptr<const ddwaf::obfuscator> event_obfuscator;
 
     std::shared_ptr<const std::vector<std::unique_ptr<base_processor>>> preprocessors;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -50,10 +50,14 @@ struct object_limits {
     static constexpr uint32_t default_max_container_size{DDWAF_MAX_CONTAINER_SIZE};
     static constexpr uint32_t default_max_string_length{DDWAF_MAX_STRING_LENGTH};
 
+    // Non-overridable limits
+    static constexpr uint32_t max_transformers_per_address{10};
+    static constexpr uint32_t max_key_path_depth{DDWAF_MAX_CONTAINER_DEPTH};
+
+    // User provided limits
     uint32_t max_container_depth{DDWAF_MAX_CONTAINER_DEPTH};
     uint32_t max_container_size{DDWAF_MAX_CONTAINER_SIZE};
     uint32_t max_string_length{DDWAF_MAX_STRING_LENGTH};
-    uint32_t max_transformers_per_address{10}; // can't be overridden for now
 };
 
 inline size_t find_string_cutoff(const char *str, size_t length, object_limits limits = {})

--- a/tests/unit/condition/cmdi_detector_test.cpp
+++ b/tests/unit/condition/cmdi_detector_test.cpp
@@ -49,7 +49,7 @@ TEST(TestCmdiDetector, InvalidType)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -69,7 +69,7 @@ TEST(TestCmdiDetector, EmptyResource)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -126,7 +126,7 @@ TEST(TestCmdiDetector, NoInjection)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
     }
@@ -174,7 +174,7 @@ TEST(TestCmdiDetector, NoExecutableInjection)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
     }
@@ -239,7 +239,7 @@ TEST(TestCmdiDetector, NoShellInjection)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << resource_str;
         EXPECT_FALSE(res.ephemeral);
     }
@@ -283,7 +283,7 @@ TEST(TestCmdiDetector, ExecutableInjectionLinux)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
 
@@ -341,7 +341,7 @@ TEST(TestCmdiDetector, ExecutableInjectionWindows)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
 
@@ -394,7 +394,7 @@ TEST(TestCmdiDetector, ExecutableWithSpacesInjection)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
 
@@ -630,7 +630,7 @@ TEST(TestCmdiDetector, LinuxShellInjection)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << resource_str;
         EXPECT_FALSE(res.ephemeral);
 
@@ -727,7 +727,7 @@ TEST(TestCmdiDetector, WindowsShellInjection)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << resource_str;
         EXPECT_FALSE(res.ephemeral);
 
@@ -775,7 +775,7 @@ TEST(TestCmdiDetector, ExecutableInjectionMultipleArguments)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome) << resource[0];
     EXPECT_FALSE(res.ephemeral);
 
@@ -822,7 +822,7 @@ TEST(TestCmdiDetector, EmptyExecutable)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome) << resource[0];
     EXPECT_FALSE(res.ephemeral);
 }
@@ -858,7 +858,7 @@ TEST(TestCmdiDetector, ShellInjectionMultipleArguments)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome) << resource[0];
     EXPECT_FALSE(res.ephemeral);
 

--- a/tests/unit/condition/exists_condition_test.cpp
+++ b/tests/unit/condition/exists_condition_test.cpp
@@ -33,7 +33,7 @@ TEST(TestExistsCondition, AddressAvailable)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome);
 }
 
@@ -65,7 +65,7 @@ TEST(TestExistsCondition, KeyPathAvailable)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome);
 }
 
@@ -83,7 +83,7 @@ TEST(TestExistsCondition, AddressNotAvaialble)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -111,7 +111,7 @@ TEST(TestExistsCondition, KeyPathNotAvailable)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -152,7 +152,7 @@ TEST(TestExistsCondition, KeyPathAvailableButExcluded)
     // While the key path is present, since part of the path was excluded
     // the evaluation fails to determine the presence of the full key path,
     // for that reason, no match is generated.
-    auto res = cond.eval(cache, store, excluded_ref, {}, deadline);
+    auto res = cond.eval(cache, store, excluded_ref, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -172,7 +172,7 @@ TEST(TestExistsCondition, MultipleAddresses)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_EQ(res.outcome, expected);
     };
 
@@ -213,7 +213,7 @@ TEST(TestExistsCondition, MultipleAddressesAndKeyPaths)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_EQ(res.outcome, expected);
     };
 
@@ -257,7 +257,7 @@ TEST(TestExistsNegatedCondition, KeyPathAvailable)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -285,7 +285,7 @@ TEST(TestExistsNegatedCondition, KeyPathNotAvailable)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome);
 }
 
@@ -322,7 +322,7 @@ TEST(TestExistsNegatedCondition, KeyPathAvailableButExcluded)
     // While the key path is not present, since part of the path was excluded
     // the evaluation fails to determine the presence of the full key path,
     // for that reason, no match is generated.
-    auto res = cond.eval(cache, store, excluded_ref, {}, deadline);
+    auto res = cond.eval(cache, store, excluded_ref, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 

--- a/tests/unit/condition/lfi_detector_test.cpp
+++ b/tests/unit/condition/lfi_detector_test.cpp
@@ -47,7 +47,7 @@ TEST(TestLFIDetector, MatchBasicUnix)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         EXPECT_TRUE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
 
@@ -116,7 +116,7 @@ TEST(TestLFIDetector, MatchBasicWindows)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         EXPECT_TRUE(res.outcome) << path;
         EXPECT_FALSE(res.ephemeral);
 
@@ -146,7 +146,7 @@ TEST(TestLFIDetector, MatchWithKeyPath)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     EXPECT_TRUE(res.outcome);
     EXPECT_FALSE(res.ephemeral);
 
@@ -187,7 +187,7 @@ TEST(TestLFIDetector, PartiallyEphemeralMatch)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     EXPECT_TRUE(res.outcome);
     EXPECT_TRUE(res.ephemeral);
 
@@ -221,7 +221,7 @@ TEST(TestLFIDetector, EphemeralMatch)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     EXPECT_TRUE(res.outcome);
     EXPECT_TRUE(res.ephemeral);
 
@@ -265,7 +265,7 @@ TEST(TestLFIDetector, NoMatchUnix)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         EXPECT_FALSE(res.outcome) << path;
         EXPECT_FALSE(res.ephemeral) << path;
         EXPECT_FALSE(cache.match);
@@ -309,7 +309,7 @@ TEST(TestLFIDetector, NoMatchWindows)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         EXPECT_FALSE(res.outcome) << path;
         EXPECT_FALSE(res.ephemeral) << path;
         EXPECT_FALSE(cache.match);
@@ -340,7 +340,7 @@ TEST(TestLFIDetector, NoMatchExcludedPath)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, exclusion, {}, deadline);
+    auto res = cond.eval(cache, store, exclusion, {}, {}, deadline);
     EXPECT_FALSE(res.outcome);
     EXPECT_FALSE(res.ephemeral);
     EXPECT_FALSE(cache.match);
@@ -370,7 +370,7 @@ TEST(TestLFIDetector, NoMatchExcludedAddress)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, exclusion, {}, deadline);
+    auto res = cond.eval(cache, store, exclusion, {}, {}, deadline);
     EXPECT_FALSE(res.outcome);
     EXPECT_FALSE(res.ephemeral);
     EXPECT_FALSE(cache.match);
@@ -400,7 +400,7 @@ TEST(TestLFIDetector, Timeout)
 
     ddwaf::timer deadline{0s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, exclusion, {}, deadline);
+    auto res = cond.eval(cache, store, exclusion, {}, {}, deadline);
     EXPECT_FALSE(res.outcome);
     EXPECT_FALSE(res.ephemeral);
     EXPECT_FALSE(cache.match);
@@ -425,7 +425,7 @@ TEST(TestLFIDetector, NoParams)
 
     ddwaf::timer deadline{0s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, exclusion, {}, deadline);
+    auto res = cond.eval(cache, store, exclusion, {}, {}, deadline);
     EXPECT_FALSE(res.outcome);
     EXPECT_FALSE(res.ephemeral);
     EXPECT_FALSE(cache.match);

--- a/tests/unit/condition/scalar_condition_test.cpp
+++ b/tests/unit/condition/scalar_condition_test.cpp
@@ -50,7 +50,7 @@ TEST(TestScalarCondition, NoMatch)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
     ASSERT_FALSE(res.ephemeral);
 }
@@ -70,7 +70,7 @@ TEST(TestScalarCondition, Timeout)
 
     ddwaf::timer deadline{0s};
     condition_cache cache;
-    EXPECT_THROW(cond.eval(cache, store, {}, {}, deadline), ddwaf::timeout_exception);
+    EXPECT_THROW(cond.eval(cache, store, {}, {}, {}, deadline), ddwaf::timeout_exception);
 }
 
 TEST(TestScalarCondition, SimpleMatch)
@@ -88,7 +88,7 @@ TEST(TestScalarCondition, SimpleMatch)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome);
     ASSERT_FALSE(res.ephemeral);
 }
@@ -96,7 +96,7 @@ TEST(TestScalarCondition, SimpleMatch)
 TEST(TestScalarCondition, CachedMatch)
 {
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
-        {gen_variadic_param("server.request.uri.raw")}, {}};
+        {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
@@ -110,7 +110,7 @@ TEST(TestScalarCondition, CachedMatch)
         object_store store;
         store.insert(root, object_store::attribute::none, nullptr);
 
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome);
         ASSERT_FALSE(res.ephemeral);
     }
@@ -119,7 +119,7 @@ TEST(TestScalarCondition, CachedMatch)
         object_store store;
         store.insert(root, object_store::attribute::none, nullptr);
 
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome);
         ASSERT_FALSE(res.ephemeral);
     }
@@ -148,7 +148,7 @@ TEST(TestScalarCondition, SimpleMatchOnKeys)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome);
     ASSERT_FALSE(res.ephemeral);
 }
@@ -171,7 +171,7 @@ TEST(TestScalarCondition, SimpleEphemeralMatch)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome);
         ASSERT_TRUE(res.ephemeral);
     }
@@ -183,7 +183,7 @@ TEST(TestScalarCondition, SimpleEphemeralMatch)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome);
         ASSERT_TRUE(res.ephemeral);
     }

--- a/tests/unit/condition/scalar_negated_condition_test.cpp
+++ b/tests/unit/condition/scalar_negated_condition_test.cpp
@@ -23,9 +23,8 @@ template <typename... Args> condition_parameter gen_variadic_param(Args... addre
 
 TEST(TestScalarNegatedCondition, VariadicTargetInConstructor)
 {
-    EXPECT_THROW(
-        (scalar_negated_condition{std::make_unique<matcher::regex_match>(".*", 0, true), {},
-            {gen_variadic_param("server.request.uri.raw", "server.request.query")}, {}}),
+    EXPECT_THROW((scalar_negated_condition{std::make_unique<matcher::regex_match>(".*", 0, true),
+                     {}, {gen_variadic_param("server.request.uri.raw", "server.request.query")}}),
         std::invalid_argument);
 }
 
@@ -34,22 +33,21 @@ TEST(TestScalarNegatedCondition, TooManyAddressesInConstructor)
     EXPECT_THROW(
         (scalar_negated_condition{std::make_unique<matcher::regex_match>(".*", 0, true), {},
             {gen_variadic_param("server.request.uri.raw"),
-                gen_variadic_param("server.request.query")},
-            {}}),
+                gen_variadic_param("server.request.query")}}),
         std::invalid_argument);
 }
 
 TEST(TestScalarNegatedCondition, NoAddressesInConstructor)
 {
-    EXPECT_THROW((scalar_negated_condition{
-                     std::make_unique<matcher::regex_match>(".*", 0, true), {}, {}, {}}),
+    EXPECT_THROW(
+        (scalar_negated_condition{std::make_unique<matcher::regex_match>(".*", 0, true), {}, {}}),
         std::invalid_argument);
 }
 
 TEST(TestScalarNegatedCondition, NoMatch)
 {
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
-        {gen_variadic_param("server.request.uri.raw")}, {}};
+        {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf_object tmp;
     ddwaf_object root;
@@ -61,7 +59,7 @@ TEST(TestScalarNegatedCondition, NoMatch)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
     ASSERT_FALSE(res.ephemeral);
 }
@@ -69,7 +67,7 @@ TEST(TestScalarNegatedCondition, NoMatch)
 TEST(TestScalarNegatedCondition, Timeout)
 {
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
-        {gen_variadic_param("server.request.uri.raw")}, {}};
+        {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf_object tmp;
     ddwaf_object root;
@@ -81,13 +79,13 @@ TEST(TestScalarNegatedCondition, Timeout)
 
     ddwaf::timer deadline{0s};
     condition_cache cache;
-    EXPECT_THROW(cond.eval(cache, store, {}, {}, deadline), ddwaf::timeout_exception);
+    EXPECT_THROW(cond.eval(cache, store, {}, {}, {}, deadline), ddwaf::timeout_exception);
 }
 
 TEST(TestScalarNegatedCondition, SimpleMatch)
 {
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
-        {gen_variadic_param("server.request.uri.raw")}, {}};
+        {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf_object tmp;
     ddwaf_object root;
@@ -99,7 +97,7 @@ TEST(TestScalarNegatedCondition, SimpleMatch)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome);
     ASSERT_FALSE(res.ephemeral);
 }
@@ -107,7 +105,7 @@ TEST(TestScalarNegatedCondition, SimpleMatch)
 TEST(TestScalarNegatedCondition, CachedMatch)
 {
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
-        {gen_variadic_param("server.request.uri.raw")}, {}};
+        {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
@@ -121,7 +119,7 @@ TEST(TestScalarNegatedCondition, CachedMatch)
         object_store store;
         store.insert(root, object_store::attribute::none, nullptr);
 
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome);
         ASSERT_FALSE(res.ephemeral);
     }
@@ -130,7 +128,7 @@ TEST(TestScalarNegatedCondition, CachedMatch)
         object_store store;
         store.insert(root, object_store::attribute::none, nullptr);
 
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome);
         ASSERT_FALSE(res.ephemeral);
     }
@@ -144,7 +142,7 @@ TEST(TestScalarNegatedCondition, SimpleMatchOnKeys)
     target.targets[0].source = data_source::keys;
 
     scalar_negated_condition cond{
-        std::make_unique<matcher::regex_match>("hello", 0, true), {}, {std::move(target)}, {}};
+        std::make_unique<matcher::regex_match>("hello", 0, true), {}, {std::move(target)}};
 
     ddwaf_object tmp;
     ddwaf_object root;
@@ -159,7 +157,7 @@ TEST(TestScalarNegatedCondition, SimpleMatchOnKeys)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome);
     ASSERT_FALSE(res.ephemeral);
 }
@@ -167,7 +165,7 @@ TEST(TestScalarNegatedCondition, SimpleMatchOnKeys)
 TEST(TestScalarNegatedCondition, SimpleEphemeralMatch)
 {
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
-        {gen_variadic_param("server.request.uri.raw")}, {}};
+        {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf_object tmp;
     ddwaf_object root;
@@ -182,7 +180,7 @@ TEST(TestScalarNegatedCondition, SimpleEphemeralMatch)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome);
         ASSERT_TRUE(res.ephemeral);
     }
@@ -194,7 +192,7 @@ TEST(TestScalarNegatedCondition, SimpleEphemeralMatch)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome);
         ASSERT_TRUE(res.ephemeral);
     }

--- a/tests/unit/condition/shi_detector_array_test.cpp
+++ b/tests/unit/condition/shi_detector_array_test.cpp
@@ -33,7 +33,7 @@ TEST(TestShiDetectorArray, InvalidType)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -53,7 +53,7 @@ TEST(TestShiDetectorArray, EmptyResource)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -82,7 +82,7 @@ TEST(TestShiDetectorArray, InvalidTypeWithinArray)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_TRUE(res.outcome);
     EXPECT_FALSE(res.ephemeral);
 
@@ -148,7 +148,7 @@ TEST(TestShiDetectorArray, NoMatchAndFalsePositives)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << param;
     }
 }
@@ -199,7 +199,7 @@ TEST(TestShiDetectorArray, ExecutablesAndRedirections)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
 
@@ -260,7 +260,7 @@ TEST(TestShiDetectorArray, OverlappingInjections)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << param;
     }
 }
@@ -306,7 +306,7 @@ TEST(TestShiDetectorArray, InjectionsWithinCommandSubstitution)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
 
@@ -357,7 +357,7 @@ TEST(TestShiDetectorArray, InjectionsWithinProcessSubstitution)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
 
@@ -414,7 +414,7 @@ TEST(TestShiDetectorArray, OffByOnePayloadsMatch)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << param;
         EXPECT_FALSE(res.ephemeral);
 

--- a/tests/unit/condition/shi_detector_string_test.cpp
+++ b/tests/unit/condition/shi_detector_string_test.cpp
@@ -33,7 +33,7 @@ TEST(TestShiDetectorString, InvalidType)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -53,7 +53,7 @@ TEST(TestShiDetectorString, EmptyResource)
 
     ddwaf::timer deadline{2s};
     condition_cache cache;
-    auto res = cond.eval(cache, store, {}, {}, deadline);
+    auto res = cond.eval(cache, store, {}, {}, {}, deadline);
     ASSERT_FALSE(res.outcome);
 }
 
@@ -98,7 +98,7 @@ TEST(TestShiDetectorString, NoMatchAndFalsePositives)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << resource;
     }
 }
@@ -133,7 +133,7 @@ TEST(TestShiDetectorString, ExecutablesAndRedirections)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << resource;
         EXPECT_FALSE(res.ephemeral);
 
@@ -181,7 +181,7 @@ TEST(TestShiDetectorString, InjectionsWithinCommandSubstitution)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << resource;
         EXPECT_FALSE(res.ephemeral);
 
@@ -222,7 +222,7 @@ TEST(TestShiDetectorString, InjectionsWithinProcessSubstitution)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << resource;
         EXPECT_FALSE(res.ephemeral);
 
@@ -265,7 +265,7 @@ TEST(TestShiDetectorString, OffByOnePayloadsMatch)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << resource;
         EXPECT_FALSE(res.ephemeral);
 
@@ -331,7 +331,7 @@ TEST(TestShiDetectorString, MultipleArgumentsMatch)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << resource;
         EXPECT_FALSE(res.ephemeral);
 

--- a/tests/unit/condition/sqli_detector_test.cpp
+++ b/tests/unit/condition/sqli_detector_test.cpp
@@ -49,7 +49,7 @@ TEST_P(DialectTestFixture, InvalidSql)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << statement;
     }
 }
@@ -81,7 +81,7 @@ TEST_P(DialectTestFixture, InjectionWithoutTokens)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << statement;
     }
 }
@@ -124,7 +124,7 @@ TEST_P(DialectTestFixture, BenignInjections)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_FALSE(res.outcome) << statement;
     }
 }
@@ -181,7 +181,7 @@ TEST_P(DialectTestFixture, MaliciousInjections)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << statement;
         EXPECT_FALSE(res.ephemeral);
 
@@ -259,7 +259,7 @@ TEST_P(DialectTestFixture, Tautologies)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << statement;
         EXPECT_FALSE(res.ephemeral);
 
@@ -314,7 +314,7 @@ TEST_P(DialectTestFixture, Comments)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << statement;
         EXPECT_FALSE(res.ephemeral);
 
@@ -366,7 +366,7 @@ TEST(TestSQLiDetectorMySql, Comments)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << statement;
         EXPECT_FALSE(res.ephemeral);
 
@@ -418,7 +418,7 @@ TEST(TestSQLiDetectorMySql, Tautologies)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << statement;
         EXPECT_FALSE(res.ephemeral);
 
@@ -473,7 +473,7 @@ TEST(TestSQLiDetectorPgSql, Tautologies)
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         ASSERT_TRUE(res.outcome) << statement;
         EXPECT_FALSE(res.ephemeral);
 

--- a/tests/unit/condition/ssrf_detector_test.cpp
+++ b/tests/unit/condition/ssrf_detector_test.cpp
@@ -43,7 +43,7 @@ void match_path_and_input(
 
         ddwaf::timer deadline{2s};
         condition_cache cache;
-        auto res = cond.eval(cache, store, {}, {}, deadline);
+        auto res = cond.eval(cache, store, {}, {}, {}, deadline);
         if (match) {
             ASSERT_TRUE(res.outcome) << path;
             EXPECT_FALSE(res.ephemeral);

--- a/tests/unit/configuration/base_rule_parser_test.cpp
+++ b/tests/unit/configuration/base_rule_parser_test.cpp
@@ -16,7 +16,6 @@ namespace {
 
 TEST(TestBaseRuleParser, ParseRule)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -26,7 +25,7 @@ TEST(TestBaseRuleParser, ParseRule)
         R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -91,7 +90,6 @@ TEST(TestBaseRuleParser, ParseRule)
 
 TEST(TestBaseRuleParser, ParseRuleWithoutType)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -101,7 +99,7 @@ TEST(TestBaseRuleParser, ParseRuleWithoutType)
         R"([{id: 1, name: rule1, tags: {category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -158,7 +156,6 @@ TEST(TestBaseRuleParser, ParseRuleWithoutType)
 
 TEST(TestBaseRuleParser, ParseRuleWithoutConditions)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -168,7 +165,7 @@ TEST(TestBaseRuleParser, ParseRuleWithoutConditions)
         R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: []}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
     {
@@ -227,7 +224,6 @@ TEST(TestBaseRuleParser, ParseRuleWithoutConditions)
 
 TEST(TestBaseRuleParser, ParseRuleInvalidTransformer)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -237,7 +233,7 @@ TEST(TestBaseRuleParser, ParseRuleInvalidTransformer)
         R"([{id: 1, name: rule1, tags: {category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y], transformers: [unknown]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -297,7 +293,6 @@ TEST(TestBaseRuleParser, ParseRuleInvalidTransformer)
 
 TEST(TestBaseRuleParser, ParseRuleWithoutID)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -307,7 +302,7 @@ TEST(TestBaseRuleParser, ParseRuleWithoutID)
         R"([{name: rule1, tags: {type: type1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -364,7 +359,6 @@ TEST(TestBaseRuleParser, ParseRuleWithoutID)
 
 TEST(TestBaseRuleParser, ParseMultipleRules)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -376,7 +370,7 @@ TEST(TestBaseRuleParser, ParseMultipleRules)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 2);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -437,7 +431,6 @@ TEST(TestBaseRuleParser, ParseMultipleRules)
 
 TEST(TestBaseRuleParser, ParseMultipleRulesOneInvalid)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -448,7 +441,7 @@ TEST(TestBaseRuleParser, ParseMultipleRulesOneInvalid)
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -516,7 +509,6 @@ TEST(TestBaseRuleParser, ParseMultipleRulesOneInvalid)
 
 TEST(TestBaseRuleParser, ParseMultipleRulesOneDuplicate)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -528,7 +520,7 @@ TEST(TestBaseRuleParser, ParseMultipleRulesOneDuplicate)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 2);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -580,20 +572,18 @@ TEST(TestBaseRuleParser, ParseMultipleRulesOneDuplicate)
 
 TEST(TestBaseRuleParser, KeyPathTooLong)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
 
     auto rule_object = yaml_to_object(
-        R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x, y, z]}], regex: .*}}]}])");
+        R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -650,8 +640,6 @@ TEST(TestBaseRuleParser, KeyPathTooLong)
 
 TEST(TestBaseRuleParser, NegatedMatcherTooManyParameters)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -663,7 +651,7 @@ TEST(TestBaseRuleParser, NegatedMatcherTooManyParameters)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -720,8 +708,6 @@ TEST(TestBaseRuleParser, NegatedMatcherTooManyParameters)
 
 TEST(TestBaseRuleParser, SupportedVersionedOperator)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -733,7 +719,7 @@ TEST(TestBaseRuleParser, SupportedVersionedOperator)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -767,8 +753,6 @@ TEST(TestBaseRuleParser, SupportedVersionedOperator)
 
 TEST(TestBaseRuleParser, UnsupportedVersionedOperator)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -780,7 +764,7 @@ TEST(TestBaseRuleParser, UnsupportedVersionedOperator)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -834,8 +818,6 @@ TEST(TestBaseRuleParser, UnsupportedVersionedOperator)
 
 TEST(TestBaseRuleParser, IncompatibleMinVersion)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -847,7 +829,7 @@ TEST(TestBaseRuleParser, IncompatibleMinVersion)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -901,8 +883,6 @@ TEST(TestBaseRuleParser, IncompatibleMinVersion)
 
 TEST(TestBaseRuleParser, IncompatibleMaxVersion)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -914,7 +894,7 @@ TEST(TestBaseRuleParser, IncompatibleMaxVersion)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -968,8 +948,6 @@ TEST(TestBaseRuleParser, IncompatibleMaxVersion)
 
 TEST(TestBaseRuleParser, CompatibleVersion)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -981,7 +959,7 @@ TEST(TestBaseRuleParser, CompatibleVersion)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_base_rules(rule_array, collector, section, limits);
+    parse_base_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 

--- a/tests/unit/configuration/input_filter_parser_test.cpp
+++ b/tests/unit/configuration/input_filter_parser_test.cpp
@@ -16,7 +16,6 @@ namespace {
 
 TEST(TestInputFilterParser, ParseEmpty)
 {
-    object_limits limits;
     auto object = yaml_to_object(R"([{id: 1, inputs: []}])");
 
     configuration_spec cfg;
@@ -24,7 +23,7 @@ TEST(TestInputFilterParser, ParseEmpty)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -80,8 +79,6 @@ TEST(TestInputFilterParser, ParseEmpty)
 
 TEST(TestInputFilterParser, ParseFilterWithoutID)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{inputs: [{address: http.client_ip}]}])");
 
     configuration_spec cfg;
@@ -89,7 +86,7 @@ TEST(TestInputFilterParser, ParseFilterWithoutID)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -145,8 +142,6 @@ TEST(TestInputFilterParser, ParseFilterWithoutID)
 
 TEST(TestInputFilterParser, ParseDuplicateFilters)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}]}, {id: 1, inputs: [{address: usr.id}]}])");
 
@@ -155,7 +150,7 @@ TEST(TestInputFilterParser, ParseDuplicateFilters)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -197,8 +192,6 @@ TEST(TestInputFilterParser, ParseDuplicateFilters)
 
 TEST(TestInputFilterParser, ParseUnconditionalNoTargets)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{id: 1, inputs: [{address: http.client_ip}]}])");
 
     configuration_spec cfg;
@@ -206,7 +199,7 @@ TEST(TestInputFilterParser, ParseUnconditionalNoTargets)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -241,8 +234,6 @@ TEST(TestInputFilterParser, ParseUnconditionalNoTargets)
 
 TEST(TestInputFilterParser, ParseUnconditionalTargetID)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}], rules_target: [{rule_id: 2939}]}])");
 
@@ -251,7 +242,7 @@ TEST(TestInputFilterParser, ParseUnconditionalTargetID)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -298,8 +289,6 @@ TEST(TestInputFilterParser, ParseUnconditionalTargetID)
 
 TEST(TestInputFilterParser, ParseUnconditionalTargetTags)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}], rules_target: [{tags: {type: rule, category: unknown}}]}])");
 
@@ -308,7 +297,7 @@ TEST(TestInputFilterParser, ParseUnconditionalTargetTags)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -356,8 +345,6 @@ TEST(TestInputFilterParser, ParseUnconditionalTargetTags)
 
 TEST(TestInputFilterParser, ParseUnconditionalTargetPriority)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}], rules_target: [{rule_id: 2939, tags: {type: rule, category: unknown}}]}])");
 
@@ -366,7 +353,7 @@ TEST(TestInputFilterParser, ParseUnconditionalTargetPriority)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -412,7 +399,6 @@ TEST(TestInputFilterParser, ParseUnconditionalTargetPriority)
 
 TEST(TestInputFilterParser, ParseUnconditionalMultipleTargets)
 {
-    object_limits limits;
 
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}], rules_target: [{rule_id: 2939}, {tags: {type: rule, category: unknown}}]}])");
@@ -422,7 +408,7 @@ TEST(TestInputFilterParser, ParseUnconditionalMultipleTargets)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -479,8 +465,6 @@ TEST(TestInputFilterParser, ParseUnconditionalMultipleTargets)
 
 TEST(TestInputFilterParser, ParseMultipleUnconditional)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}], rules_target: [{rule_id: 2939}]}, {id: 2, inputs: [{address: usr.id}], rules_target: [{tags: {type: rule, category: unknown}}]}])");
 
@@ -489,7 +473,7 @@ TEST(TestInputFilterParser, ParseMultipleUnconditional)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -555,8 +539,6 @@ TEST(TestInputFilterParser, ParseMultipleUnconditional)
 
 TEST(TestInputFilterParser, ParseConditionalSingleCondition)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}], rules_target: [{rule_id: 2939}], conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}]}])");
 
@@ -565,7 +547,7 @@ TEST(TestInputFilterParser, ParseConditionalSingleCondition)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -611,7 +593,6 @@ TEST(TestInputFilterParser, ParseConditionalSingleCondition)
 
 TEST(TestInputFilterParser, ParseConditionalMultipleConditions)
 {
-    object_limits limits;
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}], rules_target: [{rule_id: 2939}], conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y]}], regex: .*}}]}])");
 
@@ -620,7 +601,7 @@ TEST(TestInputFilterParser, ParseConditionalMultipleConditions)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -666,8 +647,6 @@ TEST(TestInputFilterParser, ParseConditionalMultipleConditions)
 
 TEST(TestInputFilterParser, IncompatibleMinVersion)
 {
-    object_limits limits;
-
     auto object =
         yaml_to_object(R"([{id: 1, inputs: [{address: http.client_ip}], min_version: 99.0.0}])");
 
@@ -676,7 +655,7 @@ TEST(TestInputFilterParser, IncompatibleMinVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -729,8 +708,6 @@ TEST(TestInputFilterParser, IncompatibleMinVersion)
 
 TEST(TestInputFilterParser, IncompatibleMaxVersion)
 {
-    object_limits limits;
-
     auto object =
         yaml_to_object(R"([{id: 1, inputs: [{address: http.client_ip}], max_version: 0.0.99}])");
 
@@ -739,7 +716,7 @@ TEST(TestInputFilterParser, IncompatibleMaxVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -792,8 +769,6 @@ TEST(TestInputFilterParser, IncompatibleMaxVersion)
 
 TEST(TestInputFilterParser, CompatibleVersion)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, inputs: [{address: http.client_ip}], min_version: 0.0.99, max_version: 2.0.0}])");
 
@@ -802,7 +777,7 @@ TEST(TestInputFilterParser, CompatibleVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {

--- a/tests/unit/configuration/processor_parser_test.cpp
+++ b/tests/unit/configuration/processor_parser_test.cpp
@@ -16,8 +16,6 @@ namespace {
 
 TEST(TestProcessorParser, ParseNoGenerator)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{id: 1}])");
 
     configuration_spec cfg;
@@ -25,7 +23,7 @@ TEST(TestProcessorParser, ParseNoGenerator)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -83,8 +81,6 @@ TEST(TestProcessorParser, ParseNoGenerator)
 
 TEST(TestProcessorParser, ParseNoID)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{}])");
 
     configuration_spec cfg;
@@ -92,7 +88,7 @@ TEST(TestProcessorParser, ParseNoID)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -150,8 +146,6 @@ TEST(TestProcessorParser, ParseNoID)
 
 TEST(TestProcessorParser, ParseNoParameters)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{id: 1, generator: extract_schema}])");
 
     configuration_spec cfg;
@@ -159,7 +153,7 @@ TEST(TestProcessorParser, ParseNoParameters)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -217,8 +211,6 @@ TEST(TestProcessorParser, ParseNoParameters)
 
 TEST(TestProcessorParser, ParseNoMappings)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{id: 1, generator: extract_schema, parameters: {}}])");
 
     configuration_spec cfg;
@@ -226,7 +218,7 @@ TEST(TestProcessorParser, ParseNoMappings)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -284,8 +276,6 @@ TEST(TestProcessorParser, ParseNoMappings)
 
 TEST(TestProcessorParser, ParseEmptyMappings)
 {
-    object_limits limits;
-
     auto object =
         yaml_to_object(R"([{id: 1, generator: extract_schema, parameters: {mappings: []}}])");
 
@@ -294,7 +284,7 @@ TEST(TestProcessorParser, ParseEmptyMappings)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -352,8 +342,6 @@ TEST(TestProcessorParser, ParseEmptyMappings)
 
 TEST(TestProcessorParser, ParseNoInput)
 {
-    object_limits limits;
-
     auto object =
         yaml_to_object(R"([{id: 1, generator: extract_schema, parameters: {mappings: [{}]}}])");
 
@@ -362,7 +350,7 @@ TEST(TestProcessorParser, ParseNoInput)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -420,8 +408,6 @@ TEST(TestProcessorParser, ParseNoInput)
 
 TEST(TestProcessorParser, ParseEmptyInput)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [], output: out}]}}])");
 
@@ -430,7 +416,7 @@ TEST(TestProcessorParser, ParseEmptyInput)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -488,8 +474,6 @@ TEST(TestProcessorParser, ParseEmptyInput)
 
 TEST(TestProcessorParser, ParseNoOutput)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}]}]}}])");
 
@@ -498,7 +482,7 @@ TEST(TestProcessorParser, ParseNoOutput)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -556,8 +540,6 @@ TEST(TestProcessorParser, ParseNoOutput)
 
 TEST(TestProcessorParser, ParseUnknownGenerator)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: unknown, parameters: {mappings: [{inputs: [{address: in}], output: out}]}}])");
 
@@ -566,7 +548,7 @@ TEST(TestProcessorParser, ParseUnknownGenerator)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -602,8 +584,6 @@ TEST(TestProcessorParser, ParseUnknownGenerator)
 
 TEST(TestProcessorParser, ParseUseless)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, evaluate: false, output: false}])");
 
@@ -612,7 +592,7 @@ TEST(TestProcessorParser, ParseUseless)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -670,8 +650,6 @@ TEST(TestProcessorParser, ParseUseless)
 
 TEST(TestProcessorParser, ParsePreprocessor)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, evaluate: true, output: false}])");
 
@@ -680,7 +658,7 @@ TEST(TestProcessorParser, ParsePreprocessor)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     EXPECT_EQ(change.content, change_set::processors);
@@ -692,8 +670,6 @@ TEST(TestProcessorParser, ParsePreprocessor)
 
 TEST(TestProcessorParser, ParsePreprocessorWithOutput)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, evaluate: true, output: true}])");
 
@@ -702,7 +678,7 @@ TEST(TestProcessorParser, ParsePreprocessorWithOutput)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     EXPECT_EQ(change.content, change_set::processors);
@@ -714,8 +690,6 @@ TEST(TestProcessorParser, ParsePreprocessorWithOutput)
 
 TEST(TestProcessorParser, ParsePostprocessor)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, evaluate: false, output: true}])");
 
@@ -724,7 +698,7 @@ TEST(TestProcessorParser, ParsePostprocessor)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     EXPECT_EQ(change.content, change_set::processors);
@@ -736,8 +710,6 @@ TEST(TestProcessorParser, ParsePostprocessor)
 
 TEST(TestProcessorParser, ParseDuplicate)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, evaluate: false, output: true},{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, evaluate: true, output: false}])");
 
@@ -746,7 +718,7 @@ TEST(TestProcessorParser, ParseDuplicate)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     EXPECT_EQ(change.content, change_set::processors);
@@ -784,8 +756,6 @@ TEST(TestProcessorParser, ParseDuplicate)
 
 TEST(TestProcessorParser, IncompatibleMinVersion)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, min_version: 99.0.0, evaluate: false, output: true}])");
 
@@ -794,7 +764,7 @@ TEST(TestProcessorParser, IncompatibleMinVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     EXPECT_TRUE(change.empty());
@@ -847,8 +817,6 @@ TEST(TestProcessorParser, IncompatibleMinVersion)
 
 TEST(TestProcessorParser, IncompatibleMaxVersion)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, max_version: 0.0.99, evaluate: false, output: true}])");
 
@@ -857,7 +825,7 @@ TEST(TestProcessorParser, IncompatibleMaxVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     EXPECT_TRUE(change.empty());
@@ -910,8 +878,6 @@ TEST(TestProcessorParser, IncompatibleMaxVersion)
 
 TEST(TestProcessorParser, CompatibleVersion)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, generator: extract_schema, parameters: {mappings: [{inputs: [{address: in}], output: out}]}, min_version: 0.0.99, max_version: 2.0.0, evaluate: false, output: true}])");
 
@@ -920,7 +886,7 @@ TEST(TestProcessorParser, CompatibleVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_processors(array, collector, section, limits);
+    parse_processors(array, collector, section);
     ddwaf_object_free(&object);
 
     EXPECT_EQ(change.content, change_set::processors);

--- a/tests/unit/configuration/rule_filter_parser_test.cpp
+++ b/tests/unit/configuration/rule_filter_parser_test.cpp
@@ -16,8 +16,6 @@ namespace {
 
 TEST(TestRuleFilterParser, ParseEmptyFilter)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{id: 1}])");
 
     configuration_spec cfg;
@@ -25,7 +23,7 @@ TEST(TestRuleFilterParser, ParseEmptyFilter)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -81,8 +79,6 @@ TEST(TestRuleFilterParser, ParseEmptyFilter)
 
 TEST(TestRuleFilterParser, ParseFilterWithoutID)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{rules_target: [{rule_id: 2939}]}])");
 
     configuration_spec cfg;
@@ -90,7 +86,7 @@ TEST(TestRuleFilterParser, ParseFilterWithoutID)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -146,8 +142,6 @@ TEST(TestRuleFilterParser, ParseFilterWithoutID)
 
 TEST(TestRuleFilterParser, ParseDuplicateUnconditional)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939}]},{id: 1, rules_target: [{tags: {type: rule, category: unknown}}]}])");
 
@@ -156,7 +150,7 @@ TEST(TestRuleFilterParser, ParseDuplicateUnconditional)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -198,8 +192,6 @@ TEST(TestRuleFilterParser, ParseDuplicateUnconditional)
 
 TEST(TestRuleFilterParser, ParseUnconditionalTargetID)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{id: 1, rules_target: [{rule_id: 2939}]}])");
 
     configuration_spec cfg;
@@ -207,7 +199,7 @@ TEST(TestRuleFilterParser, ParseUnconditionalTargetID)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -251,8 +243,6 @@ TEST(TestRuleFilterParser, ParseUnconditionalTargetID)
 
 TEST(TestRuleFilterParser, ParseUnconditionalTargetTags)
 {
-    object_limits limits;
-
     auto object =
         yaml_to_object(R"([{id: 1, rules_target: [{tags: {type: rule, category: unknown}}]}])");
 
@@ -261,7 +251,7 @@ TEST(TestRuleFilterParser, ParseUnconditionalTargetTags)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -307,8 +297,6 @@ TEST(TestRuleFilterParser, ParseUnconditionalTargetTags)
 
 TEST(TestRuleFilterParser, ParseUnconditionalTargetPriority)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939, tags: {type: rule, category: unknown}}]}])");
 
@@ -317,7 +305,7 @@ TEST(TestRuleFilterParser, ParseUnconditionalTargetPriority)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -361,8 +349,6 @@ TEST(TestRuleFilterParser, ParseUnconditionalTargetPriority)
 
 TEST(TestRuleFilterParser, ParseUnconditionalMultipleTargets)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939},{tags: {type: rule, category: unknown}}]}])");
 
@@ -371,7 +357,7 @@ TEST(TestRuleFilterParser, ParseUnconditionalMultipleTargets)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -426,8 +412,6 @@ TEST(TestRuleFilterParser, ParseUnconditionalMultipleTargets)
 
 TEST(TestRuleFilterParser, ParseMultipleUnconditional)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939}]},{id: 2, rules_target: [{tags: {type: rule, category: unknown}}]}])");
 
@@ -436,7 +420,7 @@ TEST(TestRuleFilterParser, ParseMultipleUnconditional)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -500,8 +484,6 @@ TEST(TestRuleFilterParser, ParseMultipleUnconditional)
 
 TEST(TestRuleFilterParser, ParseDuplicateConditional)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939}], conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}]},{id: 1, rules_target: [{tags: {type: rule, category: unknown}}], conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}]}])");
 
@@ -510,7 +492,7 @@ TEST(TestRuleFilterParser, ParseDuplicateConditional)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     EXPECT_FALSE(change.empty());
@@ -525,8 +507,6 @@ TEST(TestRuleFilterParser, ParseDuplicateConditional)
 
 TEST(TestRuleFilterParser, ParseConditionalSingleCondition)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939}], conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}]}])");
 
@@ -535,7 +515,7 @@ TEST(TestRuleFilterParser, ParseConditionalSingleCondition)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -579,8 +559,6 @@ TEST(TestRuleFilterParser, ParseConditionalSingleCondition)
 
 TEST(TestRuleFilterParser, ParseConditionalGlobal)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}]}])");
 
@@ -589,7 +567,7 @@ TEST(TestRuleFilterParser, ParseConditionalGlobal)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -629,8 +607,6 @@ TEST(TestRuleFilterParser, ParseConditionalGlobal)
 
 TEST(TestRuleFilterParser, ParseConditionalMultipleConditions)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939}], conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y]}], regex: .*}}]}])");
 
@@ -639,7 +615,7 @@ TEST(TestRuleFilterParser, ParseConditionalMultipleConditions)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -684,8 +660,6 @@ TEST(TestRuleFilterParser, ParseConditionalMultipleConditions)
 
 TEST(TestRuleFilterParser, ParseOnMatchMonitor)
 {
-    object_limits limits;
-
     auto object =
         yaml_to_object(R"([{id: 1, rules_target: [{rule_id: 2939}], on_match: monitor}])");
 
@@ -694,7 +668,7 @@ TEST(TestRuleFilterParser, ParseOnMatchMonitor)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -732,8 +706,6 @@ TEST(TestRuleFilterParser, ParseOnMatchMonitor)
 
 TEST(TestRuleFilterParser, ParseOnMatchBypass)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{id: 1, rules_target: [{rule_id: 2939}], on_match: bypass}])");
 
     configuration_spec cfg;
@@ -741,7 +713,7 @@ TEST(TestRuleFilterParser, ParseOnMatchBypass)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -779,8 +751,6 @@ TEST(TestRuleFilterParser, ParseOnMatchBypass)
 
 TEST(TestRuleFilterParser, ParseCustomOnMatch)
 {
-    object_limits limits;
-
     auto object =
         yaml_to_object(R"([{id: 1, rules_target: [{rule_id: 2939}], on_match: obliterate}])");
 
@@ -789,7 +759,7 @@ TEST(TestRuleFilterParser, ParseCustomOnMatch)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -828,8 +798,6 @@ TEST(TestRuleFilterParser, ParseCustomOnMatch)
 
 TEST(TestRuleFilterParser, ParseInvalidOnMatch)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(R"([{id: 1, rules_target: [{rule_id: 2939}], on_match: ""}])");
 
     configuration_spec cfg;
@@ -837,7 +805,7 @@ TEST(TestRuleFilterParser, ParseInvalidOnMatch)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -893,8 +861,6 @@ TEST(TestRuleFilterParser, ParseInvalidOnMatch)
 
 TEST(TestRuleFilterParser, IncompatibleMinVersion)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939}], min_version: 99.0.0, on_match: monitor}])");
 
@@ -903,7 +869,7 @@ TEST(TestRuleFilterParser, IncompatibleMinVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -956,8 +922,6 @@ TEST(TestRuleFilterParser, IncompatibleMinVersion)
 
 TEST(TestRuleFilterParser, IncompatibleMaxVersion)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939}], max_version: 0.0.99, on_match: monitor}])");
 
@@ -966,7 +930,7 @@ TEST(TestRuleFilterParser, IncompatibleMaxVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -1019,8 +983,6 @@ TEST(TestRuleFilterParser, IncompatibleMaxVersion)
 
 TEST(TestRuleFilterParser, CompatibleVersion)
 {
-    object_limits limits;
-
     auto object = yaml_to_object(
         R"([{id: 1, rules_target: [{rule_id: 2939}], min_version: 0.0.99, max_version: 2.0.0, on_match: monitor}])");
 
@@ -1029,7 +991,7 @@ TEST(TestRuleFilterParser, CompatibleVersion)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto filters_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_filters(filters_array, collector, section, limits);
+    parse_filters(filters_array, collector, section);
     ddwaf_object_free(&object);
 
     {

--- a/tests/unit/configuration/user_rule_parser_test.cpp
+++ b/tests/unit/configuration/user_rule_parser_test.cpp
@@ -16,7 +16,6 @@ namespace {
 
 TEST(TestUserRuleParser, ParseRule)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -26,7 +25,7 @@ TEST(TestUserRuleParser, ParseRule)
         R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -69,7 +68,6 @@ TEST(TestUserRuleParser, ParseRule)
 
 TEST(TestUserRuleParser, ParseRuleWithoutType)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -79,7 +77,7 @@ TEST(TestUserRuleParser, ParseRuleWithoutType)
         R"([{id: 1, name: rule1, tags: {category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -136,7 +134,6 @@ TEST(TestUserRuleParser, ParseRuleWithoutType)
 
 TEST(TestUserRuleParser, ParseRuleWithoutConditions)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -146,7 +143,7 @@ TEST(TestUserRuleParser, ParseRuleWithoutConditions)
         R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: []}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
     {
@@ -205,7 +202,6 @@ TEST(TestUserRuleParser, ParseRuleWithoutConditions)
 
 TEST(TestUserRuleParser, ParseRuleInvalidTransformer)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -215,7 +211,7 @@ TEST(TestUserRuleParser, ParseRuleInvalidTransformer)
         R"([{id: 1, name: rule1, tags: {category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y], transformers: [unknown]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -275,7 +271,6 @@ TEST(TestUserRuleParser, ParseRuleInvalidTransformer)
 
 TEST(TestUserRuleParser, ParseRuleWithoutID)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -285,7 +280,7 @@ TEST(TestUserRuleParser, ParseRuleWithoutID)
         R"([{name: rule1, tags: {type: type1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x]}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [y]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -342,7 +337,6 @@ TEST(TestUserRuleParser, ParseRuleWithoutID)
 
 TEST(TestUserRuleParser, ParseMultipleRules)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -354,7 +348,7 @@ TEST(TestUserRuleParser, ParseMultipleRules)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 2);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -415,7 +409,6 @@ TEST(TestUserRuleParser, ParseMultipleRules)
 
 TEST(TestUserRuleParser, ParseMultipleRulesOneInvalid)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -426,7 +419,7 @@ TEST(TestUserRuleParser, ParseMultipleRulesOneInvalid)
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -494,7 +487,6 @@ TEST(TestUserRuleParser, ParseMultipleRulesOneInvalid)
 
 TEST(TestUserRuleParser, ParseMultipleRulesOneDuplicate)
 {
-    object_limits limits;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -506,7 +498,7 @@ TEST(TestUserRuleParser, ParseMultipleRulesOneDuplicate)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 2);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -558,20 +550,18 @@ TEST(TestUserRuleParser, ParseMultipleRulesOneDuplicate)
 
 TEST(TestUserRuleParser, KeyPathTooLong)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
 
     auto rule_object = yaml_to_object(
-        R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [x, y, z]}], regex: .*}}]}])");
+        R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: .*}}, {operator: match_regex, parameters: {inputs: [{address: arg2, key_path: [a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z]}], regex: .*}}]}])");
 
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -628,8 +618,6 @@ TEST(TestUserRuleParser, KeyPathTooLong)
 
 TEST(TestUserRuleParser, NegatedMatcherTooManyParameters)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -641,7 +629,7 @@ TEST(TestUserRuleParser, NegatedMatcherTooManyParameters)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -698,8 +686,6 @@ TEST(TestUserRuleParser, NegatedMatcherTooManyParameters)
 
 TEST(TestUserRuleParser, SupportedVersionedOperator)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -711,7 +697,7 @@ TEST(TestUserRuleParser, SupportedVersionedOperator)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -745,8 +731,6 @@ TEST(TestUserRuleParser, SupportedVersionedOperator)
 
 TEST(TestUserRuleParser, UnsupportedVersionedOperator)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -758,7 +742,7 @@ TEST(TestUserRuleParser, UnsupportedVersionedOperator)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -812,8 +796,6 @@ TEST(TestUserRuleParser, UnsupportedVersionedOperator)
 
 TEST(TestUserRuleParser, IncompatibleMinVersion)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -825,7 +807,7 @@ TEST(TestUserRuleParser, IncompatibleMinVersion)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -879,8 +861,6 @@ TEST(TestUserRuleParser, IncompatibleMinVersion)
 
 TEST(TestUserRuleParser, IncompatibleMaxVersion)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -892,7 +872,7 @@ TEST(TestUserRuleParser, IncompatibleMaxVersion)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 
@@ -946,8 +926,6 @@ TEST(TestUserRuleParser, IncompatibleMaxVersion)
 
 TEST(TestUserRuleParser, CompatibleVersion)
 {
-    object_limits limits;
-    limits.max_container_depth = 2;
     configuration_spec cfg;
     configuration_change_spec change;
     configuration_collector collector{change, cfg};
@@ -959,7 +937,7 @@ TEST(TestUserRuleParser, CompatibleVersion)
     auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
     EXPECT_EQ(rule_array.size(), 1);
 
-    parse_user_rules(rule_array, collector, section, limits);
+    parse_user_rules(rule_array, collector, section);
 
     ddwaf_object_free(&rule_object);
 

--- a/tests/unit/exclusion/input_filter_test.cpp
+++ b/tests/unit/exclusion/input_filter_test.cpp
@@ -33,7 +33,7 @@ TEST(TestInputFilter, InputExclusionNoConditions)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -61,7 +61,7 @@ TEST(TestInputFilter, EphemeralInputExclusionNoConditions)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -94,7 +94,7 @@ TEST(TestInputFilter, ObjectExclusionNoConditions)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -127,7 +127,7 @@ TEST(TestInputFilter, EphemeralObjectExclusionNoConditions)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -160,7 +160,7 @@ TEST(TestInputFilter, PersistentInputExclusionWithPersistentCondition)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -193,7 +193,7 @@ TEST(TestInputFilter, EphemeralInputExclusionWithEphemeralCondition)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -230,7 +230,7 @@ TEST(TestInputFilter, PersistentInputExclusionWithEphemeralCondition)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -267,7 +267,7 @@ TEST(TestInputFilter, EphemeralInputExclusionWithPersistentCondition)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -300,7 +300,7 @@ TEST(TestInputFilter, InputExclusionWithConditionAndTransformers)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -332,7 +332,7 @@ TEST(TestInputFilter, InputExclusionFailedCondition)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_FALSE(opt_spec.has_value());
 }
 
@@ -366,7 +366,7 @@ TEST(TestInputFilter, ObjectExclusionWithCondition)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_TRUE(opt_spec.has_value());
     EXPECT_EQ(opt_spec->rules.size(), 1);
     EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -404,7 +404,7 @@ TEST(TestInputFilter, ObjectExclusionFailedCondition)
     ddwaf::timer deadline{2s};
     input_filter::cache_type cache;
 
-    auto opt_spec = filter.match(store, cache, {}, deadline);
+    auto opt_spec = filter.match(store, cache, {}, {}, deadline);
     ASSERT_FALSE(opt_spec.has_value());
 }
 
@@ -440,7 +440,7 @@ TEST(TestInputFilter, InputValidateCachedMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 
     {
@@ -453,7 +453,7 @@ TEST(TestInputFilter, InputValidateCachedMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -494,7 +494,7 @@ TEST(TestInputFilter, InputValidateCachedEphemeralMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -515,7 +515,7 @@ TEST(TestInputFilter, InputValidateCachedEphemeralMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        ASSERT_FALSE(filter.match(store, cache, {}, deadline));
+        ASSERT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 
     {
@@ -528,7 +528,7 @@ TEST(TestInputFilter, InputValidateCachedEphemeralMatch)
         store.insert(root, object_store::attribute::ephemeral);
 
         ddwaf::timer deadline{2s};
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -568,7 +568,7 @@ TEST(TestInputFilter, InputMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         input_filter::cache_type cache;
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 
     {
@@ -582,7 +582,7 @@ TEST(TestInputFilter, InputMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         input_filter::cache_type cache;
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 }
 
@@ -619,7 +619,7 @@ TEST(TestInputFilter, InputNoMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         input_filter::cache_type cache;
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 
     {
@@ -634,7 +634,7 @@ TEST(TestInputFilter, InputNoMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         input_filter::cache_type cache;
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -679,7 +679,7 @@ TEST(TestInputFilter, InputCachedMatchSecondRun)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -698,7 +698,7 @@ TEST(TestInputFilter, InputCachedMatchSecondRun)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        ASSERT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        ASSERT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 }
 
@@ -739,7 +739,7 @@ TEST(TestInputFilter, ObjectValidateCachedMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 
     {
@@ -757,7 +757,7 @@ TEST(TestInputFilter, ObjectValidateCachedMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -801,7 +801,7 @@ TEST(TestInputFilter, ObjectMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         input_filter::cache_type cache;
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 
     {
@@ -820,7 +820,7 @@ TEST(TestInputFilter, ObjectMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         input_filter::cache_type cache;
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 }
 
@@ -862,7 +862,7 @@ TEST(TestInputFilter, ObjectNoMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         input_filter::cache_type cache;
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 
     {
@@ -875,7 +875,7 @@ TEST(TestInputFilter, ObjectNoMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         input_filter::cache_type cache;
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -924,7 +924,7 @@ TEST(TestInputFilter, ObjectCachedMatchSecondRun)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);
@@ -942,7 +942,7 @@ TEST(TestInputFilter, ObjectCachedMatchSecondRun)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        ASSERT_FALSE(filter.match(store, cache, {}, deadline).has_value());
+        ASSERT_FALSE(filter.match(store, cache, {}, {}, deadline).has_value());
     }
 }
 
@@ -982,7 +982,7 @@ TEST(TestInputFilter, MatchWithDynamicMatcher)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto opt_spec = filter.match(store, cache, {}, deadline);
+        auto opt_spec = filter.match(store, cache, {}, {}, deadline);
         ASSERT_FALSE(opt_spec.has_value());
     }
 
@@ -1008,7 +1008,7 @@ TEST(TestInputFilter, MatchWithDynamicMatcher)
             std::make_unique<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
         ddwaf::timer deadline{2s};
-        auto opt_spec = filter.match(store, cache, matchers, deadline);
+        auto opt_spec = filter.match(store, cache, matchers, {}, deadline);
         ASSERT_TRUE(opt_spec.has_value());
         EXPECT_EQ(opt_spec->rules.size(), 1);
         EXPECT_EQ(opt_spec->objects.size(), 1);

--- a/tests/unit/exclusion/object_filter_test.cpp
+++ b/tests/unit/exclusion/object_filter_test.cpp
@@ -33,7 +33,7 @@ TEST(TestObjectFilter, RootTarget)
 
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
-    auto objects_filtered = filter.match(store, cache, false, deadline);
+    auto objects_filtered = filter.match(store, cache, false, {}, deadline);
 
     ASSERT_EQ(objects_filtered.size(), 1);
     EXPECT_TRUE(objects_filtered.contains(&root.array[0]));
@@ -60,7 +60,7 @@ TEST(TestObjectFilter, DuplicateTarget)
         ddwaf_object_map_add(&root, "query", &child);
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
 
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&root.array[0]));
@@ -75,7 +75,7 @@ TEST(TestObjectFilter, DuplicateTarget)
         ddwaf_object_map_add(&root, "query", &child);
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
 
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&root.array[0]));
@@ -105,13 +105,13 @@ TEST(TestObjectFilter, DuplicateCachedTarget)
     store.insert(root);
 
     {
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&root.array[0]));
     }
 
     {
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
@@ -136,7 +136,7 @@ TEST(TestObjectFilter, SingleTarget)
 
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
-    auto objects_filtered = filter.match(store, cache, false, deadline);
+    auto objects_filtered = filter.match(store, cache, false, {}, deadline);
 
     ASSERT_EQ(objects_filtered.size(), 1);
     EXPECT_TRUE(objects_filtered.contains(&child.array[0]));
@@ -164,7 +164,7 @@ TEST(TestObjectFilter, DuplicateSingleTarget)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&child.array[0]));
     }
@@ -179,7 +179,7 @@ TEST(TestObjectFilter, DuplicateSingleTarget)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&child.array[0]));
     }
@@ -221,7 +221,7 @@ TEST(TestObjectFilter, MultipleTargets)
 
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
-    auto objects_filtered = filter.match(store, cache, false, deadline);
+    auto objects_filtered = filter.match(store, cache, false, {}, deadline);
 
     ASSERT_EQ(objects_filtered.size(), 2);
     EXPECT_TRUE(objects_filtered.contains(&child.array[1]));
@@ -266,7 +266,7 @@ TEST(TestObjectFilter, DuplicateMultipleTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
 
         ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_TRUE(objects_filtered.contains(&child.array[1]));
@@ -295,7 +295,7 @@ TEST(TestObjectFilter, DuplicateMultipleTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
 
         ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_TRUE(objects_filtered.contains(&child.array[1]));
@@ -339,7 +339,7 @@ TEST(TestObjectFilter, MissingTarget)
 
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
-    auto objects_filtered = filter.match(store, cache, false, deadline);
+    auto objects_filtered = filter.match(store, cache, false, {}, deadline);
     ASSERT_EQ(objects_filtered.size(), 0);
 }
 
@@ -364,13 +364,13 @@ TEST(TestObjectFilter, SingleTargetCache)
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
     {
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&child.array[0]));
     }
 
     {
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         EXPECT_TRUE(objects_filtered.empty());
     }
 }
@@ -401,7 +401,7 @@ TEST(TestObjectFilter, MultipleTargetsCache)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&child.array[1]));
     }
@@ -424,13 +424,13 @@ TEST(TestObjectFilter, MultipleTargetsCache)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&object.array[0]));
     }
 
     {
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         EXPECT_TRUE(objects_filtered.empty());
     }
 }
@@ -458,7 +458,7 @@ TEST(TestObjectFilter, SingleGlobTarget)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_TRUE(objects_filtered.contains(&child.array[0]));
         EXPECT_TRUE(objects_filtered.contains(&child.array[1]));
@@ -482,7 +482,7 @@ TEST(TestObjectFilter, SingleGlobTarget)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_TRUE(objects_filtered.contains(&child.array[0]));
         EXPECT_TRUE(objects_filtered.contains(&child.array[1]));
@@ -498,7 +498,7 @@ TEST(TestObjectFilter, SingleGlobTarget)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
@@ -527,7 +527,7 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_TRUE(objects_filtered.contains(&child.array[0]));
         EXPECT_TRUE(objects_filtered.contains(&child.array[1]));
@@ -551,7 +551,7 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_TRUE(objects_filtered.contains(&child.array[0]));
         EXPECT_TRUE(objects_filtered.contains(&child.array[1]));
@@ -567,7 +567,7 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
@@ -603,7 +603,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 1);
         EXPECT_TRUE(objects_filtered.contains(&grandnephew.array[0]));
     }
@@ -629,7 +629,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 2);
         EXPECT_TRUE(objects_filtered.contains(&grandnephew.array[0]));
         EXPECT_TRUE(objects_filtered.contains(&grandchild.array[0]));
@@ -656,7 +656,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 0);
     }
 
@@ -674,7 +674,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
@@ -719,7 +719,7 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 4);
         EXPECT_TRUE(objects_filtered.contains(&greatgrandchild.array[0]));
         EXPECT_TRUE(objects_filtered.contains(&greatgrandchild.array[1]));
@@ -748,7 +748,7 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 0);
     }
 
@@ -767,7 +767,7 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
 
         store.insert(root);
 
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 0);
     }
 }
@@ -804,7 +804,7 @@ TEST(TestObjectFilter, MultipleComponentsMultipleGlobAndKeyTargets)
             store.insert(root);
 
             ddwaf::timer deadline{2s};
-            auto objects_filtered = filter.match(store, cache, false, deadline);
+            auto objects_filtered = filter.match(store, cache, false, {}, deadline);
             ASSERT_EQ(objects_filtered.size(), 1);
             EXPECT_STREQ((*objects_filtered.persistent.begin())->parameterName, result.c_str());
         }
@@ -830,7 +830,7 @@ TEST(TestObjectFilter, MultipleComponentsMultipleGlobAndKeyTargets)
             store.insert(root);
 
             ddwaf::timer deadline{2s};
-            auto objects_filtered = filter.match(store, cache, false, deadline);
+            auto objects_filtered = filter.match(store, cache, false, {}, deadline);
             ASSERT_EQ(objects_filtered.size(), 0);
         }
     }
@@ -867,7 +867,7 @@ TEST(TestObjectFilter, ArrayWithGlobTargets)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto objects_filtered = filter.match(store, cache, false, deadline);
+        auto objects_filtered = filter.match(store, cache, false, {}, deadline);
         ASSERT_EQ(objects_filtered.size(), 1);
     }
 }
@@ -894,7 +894,7 @@ TEST(TestObjectFilter, Timeout)
 
     ddwaf::timer deadline{0s};
     object_filter::cache_type cache;
-    EXPECT_THROW(filter.match(store, cache, false, deadline), ddwaf::timeout_exception);
+    EXPECT_THROW(filter.match(store, cache, false, {}, deadline), ddwaf::timeout_exception);
 }
 
 } // namespace

--- a/tests/unit/exclusion/rule_filter_test.cpp
+++ b/tests/unit/exclusion/rule_filter_test.cpp
@@ -44,7 +44,7 @@ TEST(TestRuleFilter, Match)
     exclusion::rule_filter::excluded_set default_set{{}, true, {}, {}};
 
     ddwaf::exclusion::rule_filter::cache_type cache;
-    auto res = filter.match(store, cache, {}, deadline);
+    auto res = filter.match(store, cache, {}, {}, deadline);
     EXPECT_FALSE(res.value_or(default_set).rules.empty());
     EXPECT_FALSE(res.value_or(default_set).ephemeral);
     EXPECT_EQ(res.value_or(default_set).mode, exclusion::filter_mode::bypass);
@@ -78,7 +78,7 @@ TEST(TestRuleFilter, MatchWithDynamicMatcher)
         ddwaf::timer deadline{2s};
 
         ddwaf::exclusion::rule_filter::cache_type cache;
-        auto res = filter.match(store, cache, {}, deadline);
+        auto res = filter.match(store, cache, {}, {}, deadline);
         EXPECT_FALSE(res.has_value());
     }
 
@@ -101,7 +101,7 @@ TEST(TestRuleFilter, MatchWithDynamicMatcher)
             .rules = {}, .ephemeral = true, .mode = {}, .action = {}};
 
         ddwaf::exclusion::rule_filter::cache_type cache;
-        auto res = filter.match(store, cache, matchers, deadline);
+        auto res = filter.match(store, cache, matchers, {}, deadline);
         EXPECT_FALSE(res.value_or(default_set).rules.empty());
         EXPECT_FALSE(res.value_or(default_set).ephemeral);
         EXPECT_EQ(res.value_or(default_set).mode, exclusion::filter_mode::bypass);
@@ -137,7 +137,7 @@ TEST(TestRuleFilter, EphemeralMatch)
     exclusion::rule_filter::excluded_set default_set{{}, false, {}, {}};
 
     ddwaf::exclusion::rule_filter::cache_type cache;
-    auto res = filter.match(store, cache, {}, deadline);
+    auto res = filter.match(store, cache, {}, {}, deadline);
     EXPECT_FALSE(res.value_or(default_set).rules.empty());
     EXPECT_TRUE(res.value_or(default_set).ephemeral);
     EXPECT_EQ(res.value_or(default_set).mode, exclusion::filter_mode::bypass);
@@ -164,7 +164,7 @@ TEST(TestRuleFilter, NoMatch)
     ddwaf::timer deadline{2s};
 
     ddwaf::exclusion::rule_filter::cache_type cache;
-    EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+    EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
 }
 
 TEST(TestRuleFilter, ValidateCachedMatch)
@@ -199,7 +199,7 @@ TEST(TestRuleFilter, ValidateCachedMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 
     {
@@ -215,7 +215,7 @@ TEST(TestRuleFilter, ValidateCachedMatch)
 
         exclusion::rule_filter::excluded_set default_set{{}, false, {}, {}};
 
-        auto res = filter.match(store, cache, {}, deadline);
+        auto res = filter.match(store, cache, {}, {}, deadline);
         EXPECT_FALSE(res.value_or(default_set).rules.empty());
         EXPECT_FALSE(res.value_or(default_set).ephemeral);
         EXPECT_EQ(res.value_or(default_set).mode, exclusion::filter_mode::bypass);
@@ -256,7 +256,7 @@ TEST(TestRuleFilter, CachedMatchAndEphemeralMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 
     {
@@ -272,7 +272,7 @@ TEST(TestRuleFilter, CachedMatchAndEphemeralMatch)
         ddwaf::timer deadline{2s};
         exclusion::rule_filter::excluded_set default_set{{}, false, {}, {}};
 
-        auto res = filter.match(store, cache, {}, deadline);
+        auto res = filter.match(store, cache, {}, {}, deadline);
         EXPECT_FALSE(res.value_or(default_set).rules.empty());
         EXPECT_TRUE(res.value_or(default_set).ephemeral);
         EXPECT_EQ(res.value_or(default_set).mode, exclusion::filter_mode::bypass);
@@ -313,7 +313,7 @@ TEST(TestRuleFilter, ValidateEphemeralMatchCache)
         store.insert(root, object_store::attribute::ephemeral);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 
     {
@@ -327,7 +327,7 @@ TEST(TestRuleFilter, ValidateEphemeralMatchCache)
         store.insert(root, object_store::attribute::ephemeral);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 }
 
@@ -362,7 +362,7 @@ TEST(TestRuleFilter, MatchWithoutCache)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 
     {
@@ -375,7 +375,7 @@ TEST(TestRuleFilter, MatchWithoutCache)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline)->rules.empty());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline)->rules.empty());
     }
 }
 
@@ -409,7 +409,7 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 
     {
@@ -423,7 +423,7 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 }
 
@@ -459,7 +459,7 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline)->rules.empty());
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline)->rules.empty());
         EXPECT_TRUE(cache.result);
     }
 
@@ -472,7 +472,7 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        EXPECT_FALSE(filter.match(store, cache, {}, deadline));
+        EXPECT_FALSE(filter.match(store, cache, {}, {}, deadline));
     }
 }
 

--- a/tests/unit/expression_test.cpp
+++ b/tests/unit/expression_test.cpp
@@ -33,7 +33,7 @@ TEST(TestExpression, SimpleMatch)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    auto res = expr->eval(cache, store, {}, {}, deadline);
+    auto res = expr->eval(cache, store, {}, {}, {}, deadline);
     EXPECT_TRUE(res.outcome);
     EXPECT_FALSE(res.ephemeral);
 
@@ -70,7 +70,7 @@ TEST(TestExpression, SimpleNegatedMatch)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    auto res = expr->eval(cache, store, {}, {}, deadline);
+    auto res = expr->eval(cache, store, {}, {}, {}, deadline);
     EXPECT_TRUE(res.outcome);
     EXPECT_FALSE(res.ephemeral);
 
@@ -107,7 +107,7 @@ TEST(TestExpression, EphemeralMatch)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    auto res = expr->eval(cache, store, {}, {}, deadline);
+    auto res = expr->eval(cache, store, {}, {}, {}, deadline);
     EXPECT_TRUE(res.outcome);
     EXPECT_TRUE(res.ephemeral);
 
@@ -149,7 +149,7 @@ TEST(TestExpression, MultiInputMatchOnSecondEval)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_FALSE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
     }
@@ -166,7 +166,7 @@ TEST(TestExpression, MultiInputMatchOnSecondEval)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_TRUE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
 
@@ -206,7 +206,7 @@ TEST(TestExpression, EphemeralMatchOnSecondEval)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_FALSE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
     }
@@ -223,7 +223,7 @@ TEST(TestExpression, EphemeralMatchOnSecondEval)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_TRUE(res.outcome);
         EXPECT_TRUE(res.ephemeral);
 
@@ -274,7 +274,7 @@ TEST(TestExpression, EphemeralMatchTwoConditions)
 
     ddwaf::timer deadline{2s};
 
-    auto res = expr->eval(cache, store, {}, {}, deadline);
+    auto res = expr->eval(cache, store, {}, {}, {}, deadline);
     EXPECT_TRUE(res.outcome);
     EXPECT_TRUE(res.ephemeral);
 
@@ -326,7 +326,7 @@ TEST(TestExpression, EphemeralMatchOnFirstConditionFirstEval)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_FALSE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
     }
@@ -343,7 +343,7 @@ TEST(TestExpression, EphemeralMatchOnFirstConditionFirstEval)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_FALSE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
     }
@@ -379,7 +379,7 @@ TEST(TestExpression, EphemeralMatchOnFirstConditionSecondEval)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_FALSE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
     }
@@ -396,7 +396,7 @@ TEST(TestExpression, EphemeralMatchOnFirstConditionSecondEval)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_TRUE(res.outcome);
         EXPECT_TRUE(res.ephemeral);
     }
@@ -427,7 +427,7 @@ TEST(TestExpression, DuplicateInput)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_FALSE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
     }
@@ -444,7 +444,7 @@ TEST(TestExpression, DuplicateInput)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_TRUE(res.outcome);
         EXPECT_FALSE(res.ephemeral);
     }
@@ -475,7 +475,7 @@ TEST(TestExpression, DuplicateEphemeralInput)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_TRUE(res.outcome);
         EXPECT_TRUE(res.ephemeral);
     }
@@ -492,7 +492,7 @@ TEST(TestExpression, DuplicateEphemeralInput)
 
         ddwaf::timer deadline{2s};
 
-        auto res = expr->eval(cache, store, {}, {}, deadline);
+        auto res = expr->eval(cache, store, {}, {}, {}, deadline);
         EXPECT_TRUE(res.outcome);
         EXPECT_TRUE(res.ephemeral);
     }
@@ -522,7 +522,7 @@ TEST(TestExpression, MatchDuplicateInputNoCache)
         ddwaf::timer deadline{2s};
 
         expression::cache_type cache;
-        EXPECT_FALSE(expr->eval(cache, store, {}, {}, deadline).outcome);
+        EXPECT_FALSE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     }
 
     {
@@ -538,7 +538,7 @@ TEST(TestExpression, MatchDuplicateInputNoCache)
         ddwaf::timer deadline{2s};
 
         expression::cache_type cache;
-        EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+        EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
 
         auto matches = expr->get_matches(cache);
         EXPECT_EQ(matches.size(), 1);
@@ -583,7 +583,7 @@ TEST(TestExpression, TwoConditionsSingleInputNoMatch)
 
         ddwaf::timer deadline{2s};
 
-        EXPECT_FALSE(expr->eval(cache, store, {}, {}, deadline).outcome);
+        EXPECT_FALSE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     }
 
     {
@@ -598,7 +598,7 @@ TEST(TestExpression, TwoConditionsSingleInputNoMatch)
 
         ddwaf::timer deadline{2s};
 
-        EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+        EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     }
 }
 
@@ -628,7 +628,7 @@ TEST(TestExpression, TwoConditionsSingleInputMatch)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+    EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
 }
 
 TEST(TestExpression, TwoConditionsMultiInputSingleEvalMatch)
@@ -659,7 +659,7 @@ TEST(TestExpression, TwoConditionsMultiInputSingleEvalMatch)
 
     ddwaf::timer deadline{2s};
 
-    EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+    EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
 }
 
 TEST(TestExpression, TwoConditionsMultiInputMultiEvalMatch)
@@ -692,7 +692,7 @@ TEST(TestExpression, TwoConditionsMultiInputMultiEvalMatch)
 
         ddwaf::timer deadline{2s};
 
-        EXPECT_FALSE(expr->eval(cache, store, {}, {}, deadline).outcome);
+        EXPECT_FALSE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     }
 
     {
@@ -709,7 +709,7 @@ TEST(TestExpression, TwoConditionsMultiInputMultiEvalMatch)
 
         ddwaf::timer deadline{2s};
 
-        EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+        EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     }
 }
 
@@ -736,7 +736,7 @@ TEST(TestExpression, MatchWithKeyPath)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+    EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = ".*",
@@ -768,7 +768,7 @@ TEST(TestExpression, MatchWithTransformer)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+    EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = "value",
@@ -800,7 +800,7 @@ TEST(TestExpression, MatchWithMultipleTransformers)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+    EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = "^ value $",
@@ -834,7 +834,7 @@ TEST(TestExpression, MatchOnKeys)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+    EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = "value",
@@ -869,7 +869,7 @@ TEST(TestExpression, MatchOnKeysWithTransformer)
     ddwaf::timer deadline{2s};
 
     expression::cache_type cache;
-    EXPECT_TRUE(expr->eval(cache, store, {}, {}, deadline).outcome);
+    EXPECT_TRUE(expr->eval(cache, store, {}, {}, {}, deadline).outcome);
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = "value",
@@ -902,7 +902,7 @@ TEST(TestExpression, ExcludeInput)
     std::unordered_set<const ddwaf_object *> excluded_objects{&root.array[0]};
 
     expression::cache_type cache;
-    EXPECT_FALSE(expr->eval(cache, store, {excluded_objects, {}}, {}, deadline).outcome);
+    EXPECT_FALSE(expr->eval(cache, store, {excluded_objects, {}}, {}, {}, deadline).outcome);
 }
 
 TEST(TestExpression, ExcludeKeyPath)
@@ -930,5 +930,5 @@ TEST(TestExpression, ExcludeKeyPath)
     std::unordered_set<const ddwaf_object *> excluded_objects{&root.array[0]};
 
     expression::cache_type cache;
-    EXPECT_FALSE(expr->eval(cache, store, {excluded_objects, {}}, {}, deadline).outcome);
+    EXPECT_FALSE(expr->eval(cache, store, {excluded_objects, {}}, {}, {}, deadline).outcome);
 }

--- a/tests/unit/module_test.cpp
+++ b/tests/unit/module_test.cpp
@@ -57,7 +57,7 @@ TEST(TestModuleUngrouped, SingleRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 1);
     }
@@ -71,8 +71,8 @@ TEST(TestModuleUngrouped, SingleRuleMatch)
         store.insert(root);
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        mod.eval(events, store, cache, {}, {}, deadline);
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        mod.eval(events, store, cache, {}, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::none);
         EXPECT_EQ(events.size(), 0);
     }
@@ -128,7 +128,7 @@ TEST(TestModuleUngrouped, MultipleMonitoringRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 2);
         EXPECT_TRUE(contains(events, "id1"));
@@ -144,8 +144,8 @@ TEST(TestModuleUngrouped, MultipleMonitoringRuleMatch)
         store.insert(root);
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        mod.eval(events, store, cache, {}, {}, deadline);
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        mod.eval(events, store, cache, {}, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::none);
         EXPECT_EQ(events.size(), 0);
     }
@@ -202,7 +202,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id2"));
@@ -262,7 +262,7 @@ TEST(TestModuleUngrouped, MonitoringRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id1"));
@@ -279,7 +279,7 @@ TEST(TestModuleUngrouped, MonitoringRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
     }
@@ -339,7 +339,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatchBasePrecedence)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id2"));
@@ -402,7 +402,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatchUserPrecedence)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id1"));
@@ -444,7 +444,7 @@ TEST(TestModuleUngrouped, NonExpiringModule)
 
         std::vector<event> events;
         ddwaf::timer deadline{0s};
-        mod.eval(events, store, cache, {}, {}, deadline);
+        mod.eval(events, store, cache, {}, {}, {}, deadline);
 
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id"));
@@ -484,7 +484,8 @@ TEST(TestModuleUngrouped, ExpiringModule)
 
         std::vector<event> events;
         ddwaf::timer deadline{0s};
-        EXPECT_THROW(mod.eval(events, store, cache, {}, {}, deadline), ddwaf::timeout_exception);
+        EXPECT_THROW(
+            mod.eval(events, store, cache, {}, {}, {}, deadline), ddwaf::timeout_exception);
     }
 }
 
@@ -524,7 +525,7 @@ TEST(TestModuleUngrouped, DisabledRules)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::none);
     }
 }
@@ -579,7 +580,7 @@ TEST(TestModuleGrouped, MultipleGroupsMonitoringRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 2);
         EXPECT_TRUE(contains(events, "id1"));
@@ -638,7 +639,7 @@ TEST(TestModuleGrouped, MultipleGroupsBlockingRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id2"));
@@ -696,7 +697,7 @@ TEST(TestModuleGrouped, SingleGroupBlockingRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id2"));
@@ -753,7 +754,7 @@ TEST(TestModuleGrouped, SingleGroupMonitoringRuleMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id1"));
@@ -810,7 +811,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupMonitoringUserMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id2"));
@@ -867,7 +868,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupMonitoringBaseMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id1"));
@@ -925,7 +926,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupBlockingBaseMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id1"));
@@ -984,7 +985,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupBlockingUserMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id2"));
@@ -1042,7 +1043,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupBlockingBaseMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id1"));
@@ -1101,7 +1102,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupBlockingUserMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id2"));
@@ -1158,7 +1159,7 @@ TEST(TestModuleGrouped, UserPrecedenceMultipleGroupsMonitoringMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 2);
         EXPECT_TRUE(contains(events, "id1"));
@@ -1217,7 +1218,7 @@ TEST(TestModuleGrouped, UserPrecedenceMultipleGroupsBlockingMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id2"));
@@ -1274,7 +1275,7 @@ TEST(TestModuleGrouped, BasePrecedenceMultipleGroupsMonitoringMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 2);
         EXPECT_TRUE(contains(events, "id1"));
@@ -1333,7 +1334,7 @@ TEST(TestModuleGrouped, BasePrecedenceMultipleGroupsBlockingMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id1"));
@@ -1479,7 +1480,7 @@ TEST(TestModuleGrouped, MultipleGroupsRulesAndMatches)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 4);
         EXPECT_TRUE(contains(events, "id2"));
@@ -1582,7 +1583,7 @@ TEST(TestModuleGrouped, MultipleGroupsSingleMatchPerGroup)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::monitor);
         EXPECT_EQ(events.size(), 3);
 
@@ -1686,7 +1687,7 @@ TEST(TestModuleGrouped, MultipleGroupsOnlyBlockingMatch)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::block);
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id3"));
@@ -1729,7 +1730,7 @@ TEST(TestModuleGrouped, DisabledRules)
 
         std::vector<event> events;
         ddwaf::timer deadline = endless_timer();
-        auto verdict = mod.eval(events, store, cache, {}, {}, deadline);
+        auto verdict = mod.eval(events, store, cache, {}, {}, {}, deadline);
         EXPECT_EQ(verdict, rule_module::verdict_type::none);
     }
 }
@@ -1767,7 +1768,7 @@ TEST(TestModuleGrouped, NonExpiringModule)
 
         std::vector<event> events;
         ddwaf::timer deadline{0s};
-        mod.eval(events, store, cache, {}, {}, deadline);
+        mod.eval(events, store, cache, {}, {}, {}, deadline);
 
         EXPECT_EQ(events.size(), 1);
         EXPECT_TRUE(contains(events, "id"));
@@ -1807,7 +1808,8 @@ TEST(TestModuleGrouped, ExpiringModule)
 
         std::vector<event> events;
         ddwaf::timer deadline{0s};
-        EXPECT_THROW(mod.eval(events, store, cache, {}, {}, deadline), ddwaf::timeout_exception);
+        EXPECT_THROW(
+            mod.eval(events, store, cache, {}, {}, {}, deadline), ddwaf::timeout_exception);
     }
 }
 

--- a/tests/unit/processor/processor_test.cpp
+++ b/tests/unit/processor/processor_test.cpp
@@ -72,7 +72,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalUnconditional)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 1);
     const auto *obtained = ddwaf_object_get_index(&output_map, 0);
@@ -125,7 +125,7 @@ TEST(TestProcessor, MultiMappingOutputNoEvalUnconditional)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 2);
     {
@@ -185,7 +185,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalTrue)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 1);
     const auto *obtained = ddwaf_object_get_index(&output_map, 0);
@@ -233,7 +233,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
 
     ddwaf_object input;
@@ -245,7 +245,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
     store.insert(input_map);
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
     EXPECT_EQ(ddwaf_object_size(&output_map), 1);
 
     const auto *obtained = ddwaf_object_get_index(&output_map, 0);
@@ -293,7 +293,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalFalse)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
 
@@ -337,7 +337,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
         EXPECT_EQ(obtained, nullptr);
     }
 
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     {
         auto *obtained = store.get_target(get_target_index("output_address")).first;
@@ -387,7 +387,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
 
     EXPECT_EQ(store.get_target(get_target_index("output_address")).first, nullptr);
 
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     {
         auto *obtained = store.get_target(get_target_index("output_address")).first;
@@ -432,7 +432,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalFalse)
     optional_ref<ddwaf_object> derived{std::nullopt};
 
     EXPECT_EQ(store.get_target(get_target_index("output_address")).first, nullptr);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     EXPECT_EQ(store.get_target(get_target_index("output_address")).first, nullptr);
 
@@ -481,7 +481,7 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
     EXPECT_EQ(store.get_target(get_target_index("output_address.first")).first, nullptr);
     EXPECT_EQ(store.get_target(get_target_index("output_address.second")).first, nullptr);
 
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     {
         auto *obtained = store.get_target(get_target_index("output_address.first")).first;
@@ -536,7 +536,7 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
         EXPECT_EQ(ddwaf_object_size(&output_map), 0);
     }
 
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     {
         auto *obtained = store.get_target(get_target_index("output_address")).first;
@@ -583,7 +583,7 @@ TEST(TestProcessor, OutputAlreadyAvailableInStore)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     ddwaf_object_free(&output_map);
 }
@@ -617,8 +617,8 @@ TEST(TestProcessor, OutputAlreadyGenerated)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     ddwaf_object_free(&output_map);
 }
@@ -649,7 +649,7 @@ TEST(TestProcessor, EvalAlreadyAvailableInStore)
     timer deadline{2s};
     optional_ref<ddwaf_object> derived{};
 
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 }
 
 TEST(TestProcessor, OutputWithoutDerivedMap)
@@ -677,7 +677,7 @@ TEST(TestProcessor, OutputWithoutDerivedMap)
     timer deadline{2s};
     optional_ref<ddwaf_object> derived{};
 
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 }
 
 TEST(TestProcessor, OutputEvalWithoutDerivedMap)
@@ -716,7 +716,7 @@ TEST(TestProcessor, OutputEvalWithoutDerivedMap)
         EXPECT_EQ(obtained, nullptr);
     }
 
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     {
         auto *obtained = store.get_target(get_target_index("output_address")).first;
@@ -742,7 +742,7 @@ TEST(TestProcessor, Timeout)
     timer deadline{0s};
     optional_ref<ddwaf_object> derived{};
 
-    EXPECT_THROW(proc.eval(store, derived, cache, deadline), ddwaf::timeout_exception);
+    EXPECT_THROW(proc.eval(store, derived, cache, {}, deadline), ddwaf::timeout_exception);
 }
 
 } // namespace

--- a/tests/unit/processor/structured_processor_test.cpp
+++ b/tests/unit/processor/structured_processor_test.cpp
@@ -81,7 +81,7 @@ TEST(TestStructuredProcessor, AllParametersAvailable)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 1);
     const auto *obtained = ddwaf_object_get_index(&output_map, 0);
@@ -130,7 +130,7 @@ TEST(TestStructuredProcessor, OptionalParametersNotAvailable)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 1);
     const auto *obtained = ddwaf_object_get_index(&output_map, 0);
@@ -174,7 +174,7 @@ TEST(TestStructuredProcessor, RequiredParameterNotAvailable)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
 
     ddwaf_object_free(&output_map);
@@ -213,7 +213,7 @@ TEST(TestStructuredProcessor, NoVariadocParametersAvailable)
     optional_ref<ddwaf_object> derived{output_map};
 
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
-    proc.eval(store, derived, cache, deadline);
+    proc.eval(store, derived, cache, {}, deadline);
     EXPECT_EQ(ddwaf_object_size(&output_map), 0);
 
     ddwaf_object_free(&output_map);

--- a/tests/unit/rule_test.cpp
+++ b/tests/unit/rule_test.cpp
@@ -41,7 +41,7 @@ TEST(TestRule, Match)
         auto scope = store.get_eval_scope();
         store.insert(root, object_store::attribute::none, nullptr);
 
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_TRUE(event.has_value());
 
         EXPECT_STREQ(event->rule->get_id().data(), "id");
@@ -67,7 +67,7 @@ TEST(TestRule, Match)
         auto scope = store.get_eval_scope();
         store.insert(root, object_store::attribute::none, nullptr);
 
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_FALSE(event.has_value());
     }
 
@@ -101,7 +101,7 @@ TEST(TestRule, EphemeralMatch)
         auto scope = store.get_eval_scope();
         store.insert(root, object_store::attribute::ephemeral, nullptr);
 
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         ASSERT_TRUE(event.has_value());
         EXPECT_TRUE(event->ephemeral);
     }
@@ -110,7 +110,7 @@ TEST(TestRule, EphemeralMatch)
         auto scope = store.get_eval_scope();
         store.insert(root, object_store::attribute::ephemeral, nullptr);
 
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         ASSERT_TRUE(event.has_value());
         EXPECT_TRUE(event->ephemeral);
     }
@@ -142,7 +142,7 @@ TEST(TestRule, NoMatch)
     ddwaf::timer deadline{2s};
 
     core_rule::cache_type cache;
-    auto match = rule.match(store, cache, {}, {}, deadline);
+    auto match = rule.match(store, cache, {}, {}, {}, deadline);
     EXPECT_FALSE(match.has_value());
 }
 
@@ -177,7 +177,7 @@ TEST(TestRule, ValidateCachedMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_FALSE(event.has_value());
     }
 
@@ -191,7 +191,7 @@ TEST(TestRule, ValidateCachedMatch)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_TRUE(event.has_value());
         EXPECT_STREQ(event->rule->get_id().data(), "id");
         EXPECT_STREQ(event->rule->get_name().data(), "name");
@@ -251,7 +251,7 @@ TEST(TestRule, MatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         core_rule::cache_type cache;
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_FALSE(event.has_value());
     }
 
@@ -264,7 +264,7 @@ TEST(TestRule, MatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         core_rule::cache_type cache;
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_TRUE(event.has_value());
 
         {
@@ -317,7 +317,7 @@ TEST(TestRule, NoMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         core_rule::cache_type cache;
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_FALSE(event.has_value());
     }
 
@@ -331,7 +331,7 @@ TEST(TestRule, NoMatchWithoutCache)
 
         ddwaf::timer deadline{2s};
         core_rule::cache_type cache;
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_FALSE(event.has_value());
     }
 }
@@ -367,7 +367,7 @@ TEST(TestRule, FullCachedMatchSecondRun)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_TRUE(event.has_value());
     }
 
@@ -381,7 +381,7 @@ TEST(TestRule, FullCachedMatchSecondRun)
         store.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto event = rule.match(store, cache, {}, {}, deadline);
+        auto event = rule.match(store, cache, {}, {}, {}, deadline);
         EXPECT_FALSE(event.has_value());
     }
 }
@@ -409,7 +409,7 @@ TEST(TestRule, ExcludeObject)
 
     std::unordered_set<const ddwaf_object *> excluded_set{&root.array[0]};
     core_rule::cache_type cache;
-    auto event = rule.match(store, cache, {excluded_set, {}}, {}, deadline);
+    auto event = rule.match(store, cache, {excluded_set, {}}, {}, {}, deadline);
     EXPECT_FALSE(event.has_value());
 }
 } // namespace


### PR DESCRIPTION
This PR changes all evaluation primitives by moving the propagation of evaluation limits to the `match` / `eval` function rather than construction. This ensures that limits can be updated through configuration in the future without having to recreate all primitives.