### PR TITLE
[v2] Remove mingw builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,33 +166,6 @@ jobs:
             ${{ github.workspace }}/packages/*.tar.gz
             ${{ github.workspace }}/packages/*.sha256
 
-  docker-builds:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - name: mingw64
-            dockerfile: docker/libddwaf/gcc/mingw64/Dockerfile
-            package: libddwaf-linux-mingw64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - run: docker build -f ${{ matrix.target.dockerfile }} -o /tmp/packages .
-      - run: ${{ matrix.target.check_script }}
-        if: matrix.target.check_script
-        name: Invoke check script
-      - name: Generate Package sha256
-        working-directory: /tmp/packages
-        run: for file in *.tar.gz; do sha256sum "$file" > "$file.sha256"; done
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.target.package }}
-          path: |
-            /tmp/packages/*.tar.gz
-            /tmp/packages/*.sha256
-
   linux-musl-build:
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,7 @@ jobs:
           path: ${{ github.workspace }}/output-packages
 
   release:
-    needs: [ windows-builds, macos-build, docker-builds, linux-musl-build, package-nuget]
+    needs: [ windows-builds, macos-build, linux-musl-build, package-nuget]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:


### PR DESCRIPTION
MinGW-64 builds have been supported for a long time now, however they are currently unused (and have been for 3+ years). Consequently they are being deprecated in v2.