### PR TITLE
Add function to get list of loaded configuration paths

### DIFF
--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -415,6 +415,27 @@ bool ddwaf_builder_remove_config(ddwaf_builder builder, const char *path, uint32
 ddwaf_handle ddwaf_builder_build_instance(ddwaf_builder builder);
 
 /**
+ * ddwaf_builder_get_config_paths
+ *
+ * Provides an array of the currently loaded paths, optionally matching the
+ * regex provided in filter. In addition, the count is provided as the return
+ * value, allowing paths to be nullptr.
+ *
+ * @param builder Builder to perform the operation on. (nonnull)
+ * @param paths The object in which paths will be returned, as an array of
+ *        strings. If NULL, only the count is provided. (nullable)
+ * @param filter An optional string type regex to filter the provided paths. (nullable).
+ * @oaran filter_len The length of the filter string (or 0 otherwise).
+ *
+ * @return The total number of configurations loaded or, if provided, the number
+ *         of those matching the filter.
+ *
+ * @note This function is not thread-safe and the memory of the paths object must
+ *       be freed by the caller.
+ **/
+uint32_t ddwaf_builder_get_config_paths(ddwaf_builder builder, ddwaf_object *paths, const char *filter, uint32_t filter_len);
+
+/**
  * ddwaf_builder_destroy
  *
  * Destroy an instance of the builder.

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -424,7 +424,10 @@ ddwaf_handle ddwaf_builder_build_instance(ddwaf_builder builder);
  * @param builder Builder to perform the operation on. (nonnull)
  * @param paths The object in which paths will be returned, as an array of
  *        strings. If NULL, only the count is provided. (nullable)
- * @param filter An optional string type regex to filter the provided paths. (nullable).
+ * @param filter An optional string regex to filter the provided paths. The
+ *        provided regular expression is used unanchored so matches can be found
+ *        at any point within the path, any necessary anchors must be explicitly
+ *        added to the regex. (nullable).
  * @oaran filter_len The length of the filter string (or 0 otherwise).
  *
  * @return The total number of configurations loaded or, if provided, the number

--- a/src/builder/waf_builder.hpp
+++ b/src/builder/waf_builder.hpp
@@ -42,6 +42,13 @@ public:
         return waf{std::move(ruleset)};
     }
 
+    std::vector<std::string_view> get_filtered_config_paths(re2::RE2 &filter) const
+    {
+        return cfg_mgr_.get_filtered_config_paths(filter);
+    }
+
+    std::vector<std::string_view> get_config_paths() const { return cfg_mgr_.get_config_paths(); }
+
 protected:
     configuration_manager cfg_mgr_;
     ruleset_builder rbuilder_;

--- a/src/configuration/configuration_manager.hpp
+++ b/src/configuration/configuration_manager.hpp
@@ -30,6 +30,28 @@ public:
 
     std::pair<const configuration_spec &, change_set> consolidate();
 
+    std::vector<std::string_view> get_config_paths() const
+    {
+        std::vector<std::string_view> paths;
+        paths.reserve(configs_.size());
+        for (const auto &[path, _] : configs_) { paths.emplace_back(path); }
+        return paths;
+    }
+
+    std::vector<std::string_view> get_filtered_config_paths(re2::RE2 &filter) const
+    {
+        std::vector<std::string_view> paths;
+        paths.reserve(configs_.size());
+        for (const auto &[path, _] : configs_) {
+            const re2::StringPiece ref(path.data(), path.size());
+            if (!filter.Match(ref, 0, path.size(), re2::RE2::UNANCHORED, nullptr, 0)) {
+                continue;
+            }
+            paths.emplace_back(path);
+        }
+        return paths;
+    }
+
 protected:
     void remove_config(const configuration_change_spec &cfg);
 

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -6,12 +6,14 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <string_view>
+#include <vector>
 
 #include "builder/waf_builder.hpp"
 #include "configuration/common/raw_configuration.hpp"
@@ -19,6 +21,7 @@
 #include "ddwaf.h"
 #include "log.hpp"
 #include "obfuscator.hpp"
+#include "re2.h"
 #include "ruleset_info.hpp"
 #include "utils.hpp"
 #include "version.hpp"
@@ -337,6 +340,44 @@ ddwaf_handle ddwaf_builder_build_instance(ddwaf::waf_builder *builder)
     }
 
     return nullptr;
+}
+
+uint32_t ddwaf_builder_get_config_paths(
+    ddwaf_builder builder, ddwaf_object *paths, const char *filter, uint32_t filter_len)
+{
+    if (builder == nullptr) {
+        return 0;
+    }
+
+    try {
+        std::vector<std::string_view> config_paths;
+        if (filter != nullptr) {
+            re2::RE2::Options options;
+            options.set_log_errors(false);
+            options.set_case_sensitive(true);
+
+            re2::RE2 regex_filter{{filter, static_cast<std::size_t>(filter_len)}, options};
+            config_paths = builder->get_filtered_config_paths(regex_filter);
+        } else {
+            config_paths = builder->get_config_paths();
+        }
+
+        if (paths != nullptr) {
+            ddwaf_object_array(paths);
+            for (const auto &value : config_paths) {
+                ddwaf_object tmp;
+                ddwaf_object_array_add(
+                    paths, ddwaf_object_stringl(&tmp, value.data(), value.size()));
+            }
+        }
+        return config_paths.size();
+    } catch (const std::exception &e) {
+        DDWAF_ERROR("{}", e.what());
+    } catch (...) {
+        DDWAF_ERROR("unknown exception");
+    }
+
+    return 0;
 }
 
 void ddwaf_builder_destroy(ddwaf_builder builder) { delete builder; }

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -2637,6 +2637,17 @@ TEST(TestWafIntegration, KnownActionsNullHandle)
     EXPECT_EQ(actions, nullptr);
 }
 
+std::unordered_set<std::string_view> object_to_string_set(const ddwaf_object *array)
+{
+    std::unordered_set<std::string_view> set;
+    for (std::size_t i = 0; i < ddwaf_object_size(array); ++i) {
+        const ddwaf_object *child = ddwaf_object_get_index(array, i);
+        EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
+        set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
+    }
+    return set;
+}
+
 TEST(TestWafIntegration, GetConfigPathSingleConfig)
 {
     auto rule = read_file("interface.yaml", base_dir);
@@ -2654,11 +2665,8 @@ TEST(TestWafIntegration, GetConfigPathSingleConfig)
         EXPECT_EQ(ddwaf_object_size(&paths), 1);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        const auto *first = ddwaf_object_get_index(&paths, 0);
-        EXPECT_EQ(ddwaf_object_type(first), DDWAF_OBJ_STRING);
-
-        std::string_view value{first->stringValue, static_cast<std::size_t>(first->nbEntries)};
-        EXPECT_STRV(value, "ASM_DD/default");
+        auto path_set = object_to_string_set(&paths);
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
 
         ddwaf_object_free(&paths);
     }
@@ -2702,13 +2710,7 @@ TEST(TestWafIntegration, GetConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 3);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        std::unordered_set<std::string_view> path_set;
-        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
-            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
-            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
-            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
-        }
-
+        auto path_set = object_to_string_set(&paths);
         EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
         EXPECT_TRUE(path_set.contains("ASM/overrides"));
         EXPECT_TRUE(path_set.contains("ASM_DD/default"));
@@ -2730,13 +2732,7 @@ TEST(TestWafIntegration, GetConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 2);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        std::unordered_set<std::string_view> path_set;
-        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
-            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
-            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
-            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
-        }
-
+        auto path_set = object_to_string_set(&paths);
         EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
         EXPECT_TRUE(path_set.contains("ASM_DD/default"));
 
@@ -2757,11 +2753,8 @@ TEST(TestWafIntegration, GetConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 1);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        const auto *first = ddwaf_object_get_index(&paths, 0);
-        EXPECT_EQ(ddwaf_object_type(first), DDWAF_OBJ_STRING);
-
-        std::string_view value{first->stringValue, static_cast<std::size_t>(first->nbEntries)};
-        EXPECT_STRV(value, "ASM_DD/default");
+        auto path_set = object_to_string_set(&paths);
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
 
         ddwaf_object_free(&paths);
     }
@@ -2807,11 +2800,8 @@ TEST(TestWafIntegration, GetFilteredConfigPathSingleConfig)
         EXPECT_EQ(ddwaf_object_size(&paths), 1);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        const auto *first = ddwaf_object_get_index(&paths, 0);
-        EXPECT_EQ(ddwaf_object_type(first), DDWAF_OBJ_STRING);
-
-        std::string_view value{first->stringValue, static_cast<std::size_t>(first->nbEntries)};
-        EXPECT_STRV(value, "ASM_DD/default");
+        auto path_set = object_to_string_set(&paths);
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
 
         ddwaf_object_free(&paths);
     }
@@ -2887,13 +2877,7 @@ TEST(TestWafIntegration, GetFilteredConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 3);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        std::unordered_set<std::string_view> path_set;
-        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
-            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
-            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
-            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
-        }
-
+        auto path_set = object_to_string_set(&paths);
         EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
         EXPECT_TRUE(path_set.contains("ASM/overrides"));
         EXPECT_TRUE(path_set.contains("ASM_DD/default"));
@@ -2914,13 +2898,7 @@ TEST(TestWafIntegration, GetFilteredConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 1);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        std::unordered_set<std::string_view> path_set;
-        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
-            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
-            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
-            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
-        }
-
+        auto path_set = object_to_string_set(&paths);
         EXPECT_TRUE(path_set.contains("ASM_DD/default"));
 
         ddwaf_object_free(&paths);
@@ -2939,13 +2917,7 @@ TEST(TestWafIntegration, GetFilteredConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 2);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        std::unordered_set<std::string_view> path_set;
-        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
-            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
-            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
-            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
-        }
-
+        auto path_set = object_to_string_set(&paths);
         EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
         EXPECT_TRUE(path_set.contains("ASM_DD/default"));
 
@@ -2965,13 +2937,7 @@ TEST(TestWafIntegration, GetFilteredConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 1);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        std::unordered_set<std::string_view> path_set;
-        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
-            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
-            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
-            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
-        }
-
+        auto path_set = object_to_string_set(&paths);
         EXPECT_TRUE(path_set.contains("ASM/overrides"));
 
         ddwaf_object_free(&paths);
@@ -2992,13 +2958,7 @@ TEST(TestWafIntegration, GetFilteredConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 2);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        std::unordered_set<std::string_view> path_set;
-        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
-            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
-            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
-            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
-        }
-
+        auto path_set = object_to_string_set(&paths);
         EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
         EXPECT_TRUE(path_set.contains("ASM_DD/default"));
 
@@ -3019,11 +2979,8 @@ TEST(TestWafIntegration, GetFilteredConfigPathMultipleConfigs)
         EXPECT_EQ(ddwaf_object_size(&paths), 1);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
 
-        const auto *first = ddwaf_object_get_index(&paths, 0);
-        EXPECT_EQ(ddwaf_object_type(first), DDWAF_OBJ_STRING);
-
-        std::string_view value{first->stringValue, static_cast<std::size_t>(first->nbEntries)};
-        EXPECT_STRV(value, "ASM_DD/default");
+        auto path_set = object_to_string_set(&paths);
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
 
         ddwaf_object_free(&paths);
     }

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -2637,47 +2637,19 @@ TEST(TestWafIntegration, KnownActionsNullHandle)
     EXPECT_EQ(actions, nullptr);
 }
 
-TEST(TestWafIntegration, GetConfigPath)
+TEST(TestWafIntegration, GetConfigPathSingleConfig)
 {
     auto rule = read_file("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_builder builder = ddwaf_builder_init(nullptr);
-    ddwaf_builder_add_or_update_config(
-        builder, "ASM_DD/default", sizeof("ASM_DD/default") - 1, &rule, nullptr);
-    ddwaf_object_free(&rule);
-
-    ddwaf_object paths;
-    auto count = ddwaf_builder_get_config_paths(builder, &paths, nullptr, 0);
-
-    EXPECT_EQ(count, 1);
-    EXPECT_EQ(ddwaf_object_size(&paths), 1);
-    EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
-
-    const auto *first = ddwaf_object_get_index(&paths, 0);
-    EXPECT_EQ(ddwaf_object_type(first), DDWAF_OBJ_STRING);
-
-    std::string_view value{first->stringValue, static_cast<std::size_t>(first->nbEntries)};
-    EXPECT_STRV(value, "ASM_DD/default");
-
-    ddwaf_object_free(&paths);
-    ddwaf_builder_destroy(builder);
-}
-
-TEST(TestWafIntegration, GetFilteredConfigPath)
-{
-    auto rule = read_file("interface.yaml", base_dir);
-    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
-
-    ddwaf_builder builder = ddwaf_builder_init(nullptr);
-    ddwaf_builder_add_or_update_config(
-        builder, "ASM_DD/default", sizeof("ASM_DD/default") - 1, &rule, nullptr);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("ASM_DD/default"), &rule, nullptr);
     ddwaf_object_free(&rule);
 
     {
         ddwaf_object paths;
-        auto count =
-            ddwaf_builder_get_config_paths(builder, &paths, "^ASM_DD/.*", sizeof("^ASM_DD/.*") - 1);
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, nullptr, 0);
+
         EXPECT_EQ(count, 1);
         EXPECT_EQ(ddwaf_object_size(&paths), 1);
         EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
@@ -2692,9 +2664,117 @@ TEST(TestWafIntegration, GetFilteredConfigPath)
     }
 
     {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, nullptr, 0);
+        EXPECT_EQ(count, 1);
+    }
+
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestWafIntegration, GetConfigPathMultipleConfigs)
+{
+
+    ddwaf_builder builder = ddwaf_builder_init(nullptr);
+    {
+        auto rule = read_file("interface.yaml", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("ASM_DD/default"), &rule, nullptr);
+        ddwaf_object_free(&rule);
+    }
+
+    {
+        auto overrides = yaml_to_object(
+            R"({rules_override: [{rules_target: [{rule_id: id-rule-1}], enabled: false}]})");
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("ASM/overrides"), &overrides, nullptr);
+        ddwaf_object_free(&overrides);
+    }
+
+    {
+        auto data = read_file("rule_data.yaml", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("ASM_DATA/blocked"), &data, nullptr);
+        ddwaf_object_free(&data);
+    }
+
+    {
         ddwaf_object paths;
-        auto count =
-            ddwaf_builder_get_config_paths(builder, &paths, "^ASM/.*", sizeof("^ASM/.*") - 1);
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, nullptr, 0);
+
+        EXPECT_EQ(count, 3);
+        EXPECT_EQ(ddwaf_object_size(&paths), 3);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        std::unordered_set<std::string_view> path_set;
+        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
+            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
+            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
+            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
+        }
+
+        EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
+        EXPECT_TRUE(path_set.contains("ASM/overrides"));
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, nullptr, 0);
+        EXPECT_EQ(count, 3);
+    }
+
+    ddwaf_builder_remove_config(builder, LSTRARG("ASM/overrides"));
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, nullptr, 0);
+
+        EXPECT_EQ(count, 2);
+        EXPECT_EQ(ddwaf_object_size(&paths), 2);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        std::unordered_set<std::string_view> path_set;
+        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
+            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
+            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
+            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
+        }
+
+        EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, nullptr, 0);
+        EXPECT_EQ(count, 2);
+    }
+
+    ddwaf_builder_remove_config(builder, LSTRARG("ASM_DATA/blocked"));
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, nullptr, 0);
+
+        EXPECT_EQ(count, 1);
+        EXPECT_EQ(ddwaf_object_size(&paths), 1);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        const auto *first = ddwaf_object_get_index(&paths, 0);
+        EXPECT_EQ(ddwaf_object_type(first), DDWAF_OBJ_STRING);
+
+        std::string_view value{first->stringValue, static_cast<std::size_t>(first->nbEntries)};
+        EXPECT_STRV(value, "ASM_DD/default");
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, nullptr, 0);
+        EXPECT_EQ(count, 1);
+    }
+
+    ddwaf_builder_remove_config(builder, LSTRARG("ASM_DD/default"));
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, nullptr, 0);
 
         EXPECT_EQ(count, 0);
         EXPECT_EQ(ddwaf_object_size(&paths), 0);
@@ -2703,6 +2783,290 @@ TEST(TestWafIntegration, GetFilteredConfigPath)
         ddwaf_object_free(&paths);
     }
 
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, nullptr, 0);
+        EXPECT_EQ(count, 0);
+    }
+
     ddwaf_builder_destroy(builder);
 }
+
+TEST(TestWafIntegration, GetFilteredConfigPathSingleConfig)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_builder builder = ddwaf_builder_init(nullptr);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("ASM_DD/default"), &rule, nullptr);
+    ddwaf_object_free(&rule);
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM_DD/.*"));
+        EXPECT_EQ(count, 1);
+        EXPECT_EQ(ddwaf_object_size(&paths), 1);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        const auto *first = ddwaf_object_get_index(&paths, 0);
+        EXPECT_EQ(ddwaf_object_type(first), DDWAF_OBJ_STRING);
+
+        std::string_view value{first->stringValue, static_cast<std::size_t>(first->nbEntries)};
+        EXPECT_STRV(value, "ASM_DD/default");
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM_DD/.*"));
+        EXPECT_EQ(count, 1);
+    }
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM/.*"));
+
+        EXPECT_EQ(count, 0);
+        EXPECT_EQ(ddwaf_object_size(&paths), 0);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM/.*"));
+        EXPECT_EQ(count, 0);
+    }
+
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestWafIntegration, GetFilteredConfigPathMultipleConfigs)
+{
+
+    ddwaf_builder builder = ddwaf_builder_init(nullptr);
+    {
+        auto rule = read_file("interface.yaml", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("ASM_DD/default"), &rule, nullptr);
+        ddwaf_object_free(&rule);
+    }
+
+    {
+        auto overrides = yaml_to_object(
+            R"({rules_override: [{rules_target: [{rule_id: id-rule-1}], enabled: false}]})");
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("ASM/overrides"), &overrides, nullptr);
+        ddwaf_object_free(&overrides);
+    }
+
+    {
+        auto data = read_file("rule_data.yaml", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("ASM_DATA/blocked"), &data, nullptr);
+        ddwaf_object_free(&data);
+    }
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^random"));
+
+        EXPECT_EQ(count, 0);
+        EXPECT_EQ(ddwaf_object_size(&paths), 0);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^random"));
+        EXPECT_EQ(count, 0);
+    }
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM.*"));
+
+        EXPECT_EQ(count, 3);
+        EXPECT_EQ(ddwaf_object_size(&paths), 3);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        std::unordered_set<std::string_view> path_set;
+        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
+            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
+            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
+            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
+        }
+
+        EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
+        EXPECT_TRUE(path_set.contains("ASM/overrides"));
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM.*"));
+        EXPECT_EQ(count, 3);
+    }
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM_DD/.*"));
+
+        EXPECT_EQ(count, 1);
+        EXPECT_EQ(ddwaf_object_size(&paths), 1);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        std::unordered_set<std::string_view> path_set;
+        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
+            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
+            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
+            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
+        }
+
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM_DD/.*"));
+        EXPECT_EQ(count, 1);
+    }
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM_D.*"));
+
+        EXPECT_EQ(count, 2);
+        EXPECT_EQ(ddwaf_object_size(&paths), 2);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        std::unordered_set<std::string_view> path_set;
+        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
+            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
+            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
+            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
+        }
+
+        EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM_D.*"));
+        EXPECT_EQ(count, 2);
+    }
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM/.*"));
+
+        EXPECT_EQ(count, 1);
+        EXPECT_EQ(ddwaf_object_size(&paths), 1);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        std::unordered_set<std::string_view> path_set;
+        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
+            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
+            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
+            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
+        }
+
+        EXPECT_TRUE(path_set.contains("ASM/overrides"));
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM/.*"));
+        EXPECT_EQ(count, 1);
+    }
+
+    ddwaf_builder_remove_config(builder, LSTRARG("ASM/overrides"));
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM_D.*"));
+
+        EXPECT_EQ(count, 2);
+        EXPECT_EQ(ddwaf_object_size(&paths), 2);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        std::unordered_set<std::string_view> path_set;
+        for (std::size_t i = 0; i < ddwaf_object_size(&paths); ++i) {
+            const ddwaf_object *child = ddwaf_object_get_index(&paths, i);
+            EXPECT_EQ(ddwaf_object_type(child), DDWAF_OBJ_STRING);
+            path_set.emplace(child->stringValue, static_cast<std::size_t>(child->nbEntries));
+        }
+
+        EXPECT_TRUE(path_set.contains("ASM_DATA/blocked"));
+        EXPECT_TRUE(path_set.contains("ASM_DD/default"));
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM_D.*"));
+        EXPECT_EQ(count, 2);
+    }
+
+    ddwaf_builder_remove_config(builder, LSTRARG("ASM_DATA/blocked"));
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM_DD/.*"));
+
+        EXPECT_EQ(count, 1);
+        EXPECT_EQ(ddwaf_object_size(&paths), 1);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        const auto *first = ddwaf_object_get_index(&paths, 0);
+        EXPECT_EQ(ddwaf_object_type(first), DDWAF_OBJ_STRING);
+
+        std::string_view value{first->stringValue, static_cast<std::size_t>(first->nbEntries)};
+        EXPECT_STRV(value, "ASM_DD/default");
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM_DD/.*"));
+        EXPECT_EQ(count, 1);
+    }
+
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^random"));
+
+        EXPECT_EQ(count, 0);
+        EXPECT_EQ(ddwaf_object_size(&paths), 0);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^random"));
+        EXPECT_EQ(count, 0);
+    }
+
+    ddwaf_builder_remove_config(builder, LSTRARG("ASM_DD/default"));
+    {
+        ddwaf_object paths;
+        auto count = ddwaf_builder_get_config_paths(builder, &paths, LSTRARG("^ASM.*"));
+
+        EXPECT_EQ(count, 0);
+        EXPECT_EQ(ddwaf_object_size(&paths), 0);
+        EXPECT_EQ(ddwaf_object_type(&paths), DDWAF_OBJ_ARRAY);
+
+        ddwaf_object_free(&paths);
+    }
+
+    {
+        auto count = ddwaf_builder_get_config_paths(builder, nullptr, LSTRARG("^ASM.*"));
+        EXPECT_EQ(count, 0);
+    }
+
+    ddwaf_builder_destroy(builder);
+}
+
 } // namespace


### PR DESCRIPTION
This PR adds a new builder function to retrieve all loaded paths, either as a complete list or filtered based on a given regex, the signature of this function is as follows:

```c
uint32_t ddwaf_builder_get_config_paths(ddwaf_builder builder, ddwaf_object *paths, const char *filter, uint32_t filter_len);
```

This function allows the builder user to determine the available set of configurations in order to determine if the default one needs to be added.