### PR TITLE
Update schemas and tests to include validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,6 +328,8 @@ jobs:
           path: artifacts
       - name: Display structure of downloaded files
         run: find
+      - name: Copy schemas
+        run: for file in ./schema/*.json; do cp "$file" "./artifacts/$(basename $file .json)-schema.json"; done
       - name: Release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
@@ -336,3 +338,4 @@ jobs:
             ./artifacts/**/*.tar.gz
             ./artifacts/**/*.sha256
             ./artifacts/**/*.nupkg
+            ./artifacts/**/*.json

--- a/schema/actions.json
+++ b/schema/actions.json
@@ -1,43 +1,64 @@
 {
-    "title": "WAF Actions Schema",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "schema/actions.json",
-    "type": "object",
-    "description": "Map of unique actions",
-    "properties": {
-        "block_request": {
-            "type": "object",
-            "properties": {
-                "status_code": {"type": "string"},
-                "type": {"type": "string"},
-                "grpc_status_code": {"type": "string"}
-            },
-            "required": ["status_code", "type", "grpc_status_code"],
-            "additionalProperties": true
+  "title": "WAF Actions Schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema/actions.json",
+  "type": "object",
+  "description": "Map of unique actions",
+  "properties": {
+    "block_request": {
+      "type": "object",
+      "properties": {
+        "status_code": {
+          "type": "string"
         },
-        "redirect_request": {
-            "type": "object",
-            "properties": {
-                "status_code": {"type": "string"},
-                "location": {"type": "string"}
-            },
-            "required": ["status_code", "location"],
-            "additionalProperties": true
+        "type": {
+          "type": "string"
         },
-        "generate_stack": {
-            "type": "object",
-            "properties": {
-                "stack_id": {"type": "string"}
-            },
-            "required": ["stack_id"],
-            "additionalProperties": true
-        },
-        "generate_schema": {
-            "type": "object",
-            "properties": {},
-            "required": [],
-            "additionalProperties": true
+        "grpc_status_code": {
+          "type": "string"
         }
+      },
+      "required": [
+        "status_code",
+        "type",
+        "grpc_status_code"
+      ],
+      "additionalProperties": true
     },
-    "additionalProperties": true
+    "redirect_request": {
+      "type": "object",
+      "properties": {
+        "status_code": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status_code",
+        "location"
+      ],
+      "additionalProperties": true
+    },
+    "generate_stack": {
+      "type": "object",
+      "properties": {
+        "stack_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "stack_id"
+      ],
+      "additionalProperties": true
+    },
+    "generate_schema": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
 }

--- a/schema/actions.json
+++ b/schema/actions.json
@@ -2,9 +2,42 @@
     "title": "WAF Actions Schema",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "schema/actions.json",
-    "type": "array",
-    "description": "Array of unique actions",
-    "items": {
-        "type": "string"
-    }
+    "type": "object",
+    "description": "Map of unique actions",
+    "properties": {
+        "block_request": {
+            "type": "object",
+            "properties": {
+                "status_code": {"type": "string"},
+                "type": {"type": "string"},
+                "grpc_status_code": {"type": "string"}
+            },
+            "required": ["status_code", "type", "grpc_status_code"],
+            "additionalProperties": true
+        },
+        "redirect_request": {
+            "type": "object",
+            "properties": {
+                "status_code": {"type": "string"},
+                "location": {"type": "string"}
+            },
+            "required": ["status_code", "location"],
+            "additionalProperties": true
+        },
+        "generate_stack": {
+            "type": "object",
+            "properties": {
+                "stack_id": {"type": "string"}
+            },
+            "required": ["stack_id"],
+            "additionalProperties": true
+        },
+        "generate_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": true
+        }
+    },
+    "additionalProperties": true
 }

--- a/schema/diagnostics.json
+++ b/schema/diagnostics.json
@@ -1,91 +1,102 @@
 {
-    "title": "Ruleset Diagnostics Schema",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "schema/diagnostics.json",
-    "type": "object",
-    "properties": {
-        "ruleset_version": {
-            "type": "string",
-            "description": "The version of the parsed ruleset if available",
-            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+"
-        },
-        "error": {
-            "type": "string",
-            "description": "The single error which prevented parsing the configuration"
-        },
-        "actions": {
-            "$ref": "#/definitions/feature"
-        },
-        "rules": {
-            "$ref": "#/definitions/feature"
-        },
-        "custom_rules": {
-            "$ref": "#/definitions/feature"
-        },
-        "rules_data": {
-            "$ref": "#/definitions/feature"
-        },
-        "rules_override": {
-            "$ref": "#/definitions/feature"
-        },
-        "exclusions": {
-            "$ref": "#/definitions/feature"
-        },
-        "exclusion_data": {
-            "$ref": "#/definitions/feature"
-        },
-        "processors": {
-            "$ref": "#/definitions/feature"
-        },
-        "scanners": {
-            "$ref": "#/definitions/feature"
-        }
+  "title": "Ruleset Diagnostics Schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema/diagnostics.json",
+  "type": "object",
+  "properties": {
+    "ruleset_version": {
+      "type": "string",
+      "description": "The version of the parsed ruleset if available",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+"
     },
-    "additionalProperties": false,
-    "definitions": {
-        "feature": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string",
-                    "description": "The single error which prevented parsing this object"
-                },
-                "loaded": {
-                    "type": "array",
-                    "description": "A list of the unique identifiers from successfully loaded elements",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "failed": {
-                    "type": "array",
-                    "description": "A list of the unique identifiers from the elements which couldn't be loaded",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "skipped": {
-                    "type": "array",
-                    "description": "A list of the unique identifiers from the elements which were skipped due to explicit incompatibility (e.g. min/max version)",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "errors": {
-                    "type": "object",
-                    "description": "Each key corresponds to a parsing error, each value corresponds to a list of the unique identifiers of the elements which failed with said error"
-                },
-                "warnings": {
-                    "type": "object",
-                    "description": "Each key corresponds to a parsing warning, each value corresponds to a list of the unique identifiers of the elements which failed with said warnings"
-                }
-            },
-            "OneOf": [
-                { "required": ["error"] },
-                { "required": ["loaded", "failed", "skipped", "errors", "warnings"] }
-            ],
-            "additionalProperties": false
-        }
+    "error": {
+      "type": "string",
+      "description": "The single error which prevented parsing the configuration"
+    },
+    "actions": {
+      "$ref": "#/definitions/feature"
+    },
+    "rules": {
+      "$ref": "#/definitions/feature"
+    },
+    "custom_rules": {
+      "$ref": "#/definitions/feature"
+    },
+    "rules_data": {
+      "$ref": "#/definitions/feature"
+    },
+    "rules_override": {
+      "$ref": "#/definitions/feature"
+    },
+    "exclusions": {
+      "$ref": "#/definitions/feature"
+    },
+    "exclusion_data": {
+      "$ref": "#/definitions/feature"
+    },
+    "processors": {
+      "$ref": "#/definitions/feature"
+    },
+    "scanners": {
+      "$ref": "#/definitions/feature"
     }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "feature": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "description": "The single error which prevented parsing this object"
+        },
+        "loaded": {
+          "type": "array",
+          "description": "A list of the unique identifiers from successfully loaded elements",
+          "items": {
+            "type": "string"
+          }
+        },
+        "failed": {
+          "type": "array",
+          "description": "A list of the unique identifiers from the elements which couldn't be loaded",
+          "items": {
+            "type": "string"
+          }
+        },
+        "skipped": {
+          "type": "array",
+          "description": "A list of the unique identifiers from the elements which were skipped due to explicit incompatibility (e.g. min/max version)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errors": {
+          "type": "object",
+          "description": "Each key corresponds to a parsing error, each value corresponds to a list of the unique identifiers of the elements which failed with said error"
+        },
+        "warnings": {
+          "type": "object",
+          "description": "Each key corresponds to a parsing warning, each value corresponds to a list of the unique identifiers of the elements which failed with said warnings"
+        }
+      },
+      "OneOf": [
+        {
+          "required": [
+            "error"
+          ]
+        },
+        {
+          "required": [
+            "loaded",
+            "failed",
+            "skipped",
+            "errors",
+            "warnings"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    }
+  }
 }
-

--- a/schema/diagnostics.json
+++ b/schema/diagnostics.json
@@ -2,13 +2,53 @@
     "title": "Ruleset Diagnostics Schema",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "schema/diagnostics.json",
-    "$defs": {
+    "type": "object",
+    "properties": {
+        "ruleset_version": {
+            "type": "string",
+            "description": "The version of the parsed ruleset if available",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+"
+        },
+        "error": {
+            "type": "string",
+            "description": "The single error which prevented parsing the configuration"
+        },
+        "actions": {
+            "$ref": "#/definitions/feature"
+        },
+        "rules": {
+            "$ref": "#/definitions/feature"
+        },
+        "custom_rules": {
+            "$ref": "#/definitions/feature"
+        },
+        "rules_data": {
+            "$ref": "#/definitions/feature"
+        },
+        "rules_override": {
+            "$ref": "#/definitions/feature"
+        },
+        "exclusions": {
+            "$ref": "#/definitions/feature"
+        },
+        "exclusion_data": {
+            "$ref": "#/definitions/feature"
+        },
+        "processors": {
+            "$ref": "#/definitions/feature"
+        },
+        "scanners": {
+            "$ref": "#/definitions/feature"
+        }
+    },
+    "additionalProperties": false,
+    "definitions": {
         "feature": {
             "type": "object",
             "properties": {
                 "error": {
                     "type": "string",
-                    "description": "The single error which prevented parsing this feature"
+                    "description": "The single error which prevented parsing this object"
                 },
                 "loaded": {
                     "type": "array",
@@ -19,8 +59,14 @@
                 },
                 "failed": {
                     "type": "array",
-                    "description": "",
                     "description": "A list of the unique identifiers from the elements which couldn't be loaded",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "skipped": {
+                    "type": "array",
+                    "description": "A list of the unique identifiers from the elements which were skipped due to explicit incompatibility (e.g. min/max version)",
                     "items": {
                         "type": "string"
                     }
@@ -28,34 +74,17 @@
                 "errors": {
                     "type": "object",
                     "description": "Each key corresponds to a parsing error, each value corresponds to a list of the unique identifiers of the elements which failed with said error"
+                },
+                "warnings": {
+                    "type": "object",
+                    "description": "Each key corresponds to a parsing warning, each value corresponds to a list of the unique identifiers of the elements which failed with said warnings"
                 }
             },
-            "required": [],
+            "OneOf": [
+                { "required": ["error"] },
+                { "required": ["loaded", "failed", "skipped", "errors", "warnings"] }
+            ],
             "additionalProperties": false
-        }
-    },
-
-    "type": "object",
-    "properties": {
-        "ruleset_version": {
-            "type": "string",
-            "description": "The version of the parsed ruleset if available",
-            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+"
-        },
-        "rules": {
-            "$ref": "#/$defs/feature"
-        },
-        "custom_rules": {
-            "$ref": "#/$defs/feature"
-        },
-        "exclusions": {
-            "$ref": "#/$defs/feature"
-        },
-        "rules_override": {
-            "$ref": "#/$defs/feature"
-        },
-        "rules_data": {
-            "$ref": "#/$defs/feature"
         }
     }
 }

--- a/schema/events.json
+++ b/schema/events.json
@@ -1,119 +1,122 @@
 {
-    "title": "WAF Events Schema",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "schema/event.json",
-    "type": "array",
-    "items": {
+  "title": "WAF Events Schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema/event.json",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "rule": {
         "type": "object",
         "properties": {
-            "rule": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "The unique identifier of the rule that triggered the event. For example, ``ua-910-xax``."
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "The friendly name of the rule that triggered the event."
-                    },
-                    "tags": {
-                        "type": "object",
-                        "description": "The tags associated to the rule in the event rules file.",
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "description": "The type of the rule as defined in the ruleset"
-                            },
-                            "category": {
-                                "type": "string",
-                                "description": "The category of the rule as defined in the ruleset"
-                            }
-                        },
-                        "required": [
-                            "type"
-                        ]
-                    },
-                    "on_match": {
-                        "type": "array",
-                        "description": "on_match actions as defined in the ruleset.",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "required": [
-                    "id",
-                    "name",
-                    "tags"
-                ],
-                "additionalProperties": false
+          "id": {
+            "type": "string",
+            "description": "The unique identifier of the rule that triggered the event. For example, ``ua-910-xax``."
+          },
+          "name": {
+            "type": "string",
+            "description": "The friendly name of the rule that triggered the event."
+          },
+          "tags": {
+            "type": "object",
+            "description": "The tags associated to the rule in the event rules file.",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "The type of the rule as defined in the ruleset"
+              },
+              "category": {
+                "type": "string",
+                "description": "The category of the rule as defined in the ruleset"
+              }
             },
-            "rule_matches": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "operator": {
-                            "type": "string",
-                            "description": "The rule operator that triggered this event. For example, ``match_regex`` or ``phrase_match``."
-                        },
-                        "operator_value": {
-                            "type": "string",
-                            "description": "The rule operator operand that triggered this event. For example, the word that triggered using the ``phrase_match`` operator."
-                        },
-                        "parameters": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "address": {
-                                        "type": "string",
-                                        "description": "The address containing the value that triggered the rule. For example ``http.server.query``."
-                                    },
-                                    "key_path": {
-                                        "type": "array",
-                                        "description": "The path of the value that triggered the rule. For example ``[\"query\", 0]`` to refer to the value in ``{\"query\": [\"triggering value\"]}``.",
-                                        "items": {
-                                            "anyOf": [
-                                                { "type": "string" },
-                                                { "type": "number" }
-                                            ]
-                                        }
-                                    },
-                                    "value": {
-                                        "type": "string",
-                                        "description": "The value that triggered the rule."
-                                    },
-                                    "highlight": {
-                                        "type": "array",
-                                        "description": "The part of the value that triggered the rule.",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "required": [
-                                    "address",
-                                    "key_path",
-                                    "value",
-                                    "highlight"
-                                ]
-                            }
-                        }
-
-                    },
-                    "required": [
-                        "operator",
-                        "operator_value",
-                        "parameters"
-                    ]
-                }
+            "required": [
+              "type"
+            ]
+          },
+          "on_match": {
+            "type": "array",
+            "description": "on_match actions as defined in the ruleset.",
+            "items": {
+              "type": "string"
             }
+          }
         },
         "required": [
-            "rule",
-            "rule_matches"
-        ]
-    }
+          "id",
+          "name",
+          "tags"
+        ],
+        "additionalProperties": false
+      },
+      "rule_matches": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "operator": {
+              "type": "string",
+              "description": "The rule operator that triggered this event. For example, ``match_regex`` or ``phrase_match``."
+            },
+            "operator_value": {
+              "type": "string",
+              "description": "The rule operator operand that triggered this event. For example, the word that triggered using the ``phrase_match`` operator."
+            },
+            "parameters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "description": "The address containing the value that triggered the rule. For example ``http.server.query``."
+                  },
+                  "key_path": {
+                    "type": "array",
+                    "description": "The path of the value that triggered the rule. For example ``[\"query\", 0]`` to refer to the value in ``{\"query\": [\"triggering value\"]}``.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value that triggered the rule."
+                  },
+                  "highlight": {
+                    "type": "array",
+                    "description": "The part of the value that triggered the rule.",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "address",
+                  "key_path",
+                  "value",
+                  "highlight"
+                ]
+              }
+            }
+          },
+          "required": [
+            "operator",
+            "operator_value",
+            "parameters"
+          ]
+        }
+      }
+    },
+    "required": [
+      "rule",
+      "rule_matches"
+    ]
+  }
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,43 +1,54 @@
 {
-    "title": "Serialized schema for API Security",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "definitions": {
-        "type": {
-            "oneOf": [
-                {
-                    "enum": [0, 1, 2, 4, 8, 16],
-                    "description": "scalar types"
-                },
-                {
-                    "type": "array",
-                    "description": "array of types",
-                    "items": {
-                        "$ref": "#"
-                    },
-                    "minItems": 1
-                },
-                {
-                    "type": "object",
-                    "description": "record type",
-                    "additionalProperties": {
-                        "$ref": "#"
-                    }
-                }
-            ]
+  "title": "Serialized schema for API Security",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "definitions": {
+    "type": {
+      "oneOf": [
+        {
+          "enum": [
+            0,
+            1,
+            2,
+            4,
+            8,
+            16
+          ],
+          "description": "scalar types"
         },
-        "metadata": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "pattern": "^[A-Za-z][A-Za-z0-9\\.\\-\\_:\\/]{0,199}$"
-            },
-            "minItems": 1
+        {
+          "type": "array",
+          "description": "array of types",
+          "items": {
+            "$ref": "#"
+          },
+          "minItems": 1
+        },
+        {
+          "type": "object",
+          "description": "record type",
+          "additionalProperties": {
+            "$ref": "#"
+          }
         }
+      ]
     },
-    "type": "array",
-    "prefixItems": [
-        { "$ref": "#/definitions/type" },
-        { "$ref": "#/definitions/metadata" }
-    ],
-    "minItems": 1
+    "metadata": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z][A-Za-z0-9\\.\\-\\_:\\/]{0,199}$"
+      },
+      "minItems": 1
+    }
+  },
+  "type": "array",
+  "prefixItems": [
+    {
+      "$ref": "#/definitions/type"
+    },
+    {
+      "$ref": "#/definitions/metadata"
+    }
+  ],
+  "minItems": 1
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,7 +1,7 @@
 {
-    "title": "Serialized schema types for API Security",
+    "title": "Serialized schema for API Security",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$defs": {
+    "definitions": {
         "type": {
             "oneOf": [
                 {
@@ -36,8 +36,8 @@
     },
     "type": "array",
     "prefixItems": [
-        { "$ref": "#/$defs/type" },
-        { "$ref": "#/$defs/metadata" }
+        { "$ref": "#/definitions/type" },
+        { "$ref": "#/definitions/metadata" }
     ],
     "minItems": 1
 }

--- a/tests/common/gtest_utils.cpp
+++ b/tests/common/gtest_utils.cpp
@@ -219,7 +219,7 @@ void PrintTo(const ddwaf::test::action_map &actions, ::std::ostream *os) { *os <
 
 ::testing::AssertionResult ValidateSchemaSchema(rapidjson::Document &doc)
 {
-    static schema_validator schema(ddwaf::test::test_directory + "/../schema/types.json");
+    static schema_validator schema(ddwaf::test::test_directory + "/../schema/schema.json");
     auto error = schema.validate(doc);
     if (error) {
         return ::testing::AssertionFailure() << *error;

--- a/tests/common/gtest_utils.cpp
+++ b/tests/common/gtest_utils.cpp
@@ -240,6 +240,17 @@ void PrintTo(const ddwaf::test::action_map &actions, ::std::ostream *os) { *os <
     return ::testing::AssertionSuccess();
 }
 
+::testing::AssertionResult ValidateActionsSchema(const std::string &result)
+{
+    static schema_validator schema(ddwaf::test::test_directory + "/../schema/actions.json");
+    auto error = schema.validate(result.c_str());
+    if (error) {
+        return ::testing::AssertionFailure() << *error;
+    }
+
+    return ::testing::AssertionSuccess();
+}
+
 WafResultActionMatcher::WafResultActionMatcher(
     std::map<std::string, std::map<std::string, std::string>> &&v)
     : expected_(std::move(v))

--- a/tests/common/gtest_utils.cpp
+++ b/tests/common/gtest_utils.cpp
@@ -206,7 +206,7 @@ std::ostream &operator<<(std::ostream &os, const ddwaf::test::action_map &action
 
 void PrintTo(const ddwaf::test::action_map &actions, ::std::ostream *os) { *os << actions; }
 
-::testing::AssertionResult ValidateSchema(const std::string &result)
+::testing::AssertionResult ValidateEventSchema(const std::string &result)
 {
     static schema_validator schema(ddwaf::test::test_directory + "/../schema/events.json");
     auto error = schema.validate(result.c_str());
@@ -220,6 +220,18 @@ void PrintTo(const ddwaf::test::action_map &actions, ::std::ostream *os) { *os <
 ::testing::AssertionResult ValidateSchemaSchema(rapidjson::Document &doc)
 {
     static schema_validator schema(ddwaf::test::test_directory + "/../schema/types.json");
+    auto error = schema.validate(doc);
+    if (error) {
+        return ::testing::AssertionFailure() << *error;
+    }
+
+    return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult ValidateDiagnosticsSchema(const ddwaf_object &diagnostics)
+{
+    static schema_validator schema(ddwaf::test::test_directory + "/../schema/diagnostics.json");
+    auto doc = ddwaf::test::object_to_rapidjson(diagnostics);
     auto error = schema.validate(doc);
     if (error) {
         return ::testing::AssertionFailure() << *error;

--- a/tests/common/gtest_utils.hpp
+++ b/tests/common/gtest_utils.hpp
@@ -87,8 +87,9 @@ template <> struct as_if<ddwaf::test::action_map, void> {
 
 } // namespace YAML
 
-::testing::AssertionResult ValidateSchema(const std::string &result);
+::testing::AssertionResult ValidateEventSchema(const std::string &result);
 ::testing::AssertionResult ValidateSchemaSchema(rapidjson::Document &doc);
+::testing::AssertionResult ValidateDiagnosticsSchema(const ddwaf_object &diagnostics);
 
 class WafResultActionMatcher {
 public:
@@ -172,7 +173,7 @@ std::list<ddwaf::test::event::match> from_matches(
 #define EXPECT_EVENTS(result, ...)                                                                 \
     {                                                                                              \
         auto data = ddwaf::test::object_to_json(result.events);                                    \
-        EXPECT_TRUE(ValidateSchema(data));                                                         \
+        EXPECT_TRUE(ValidateEventSchema(data));                                                    \
         YAML::Node doc = YAML::Load(data.c_str());                                                 \
         auto events = doc.as<std::list<ddwaf::test::event>>();                                     \
         EXPECT_THAT(events, WithEvents({__VA_ARGS__}));                                            \

--- a/tests/common/gtest_utils.hpp
+++ b/tests/common/gtest_utils.hpp
@@ -90,6 +90,7 @@ template <> struct as_if<ddwaf::test::action_map, void> {
 ::testing::AssertionResult ValidateEventSchema(const std::string &result);
 ::testing::AssertionResult ValidateSchemaSchema(rapidjson::Document &doc);
 ::testing::AssertionResult ValidateDiagnosticsSchema(const ddwaf_object &diagnostics);
+::testing::AssertionResult ValidateActionsSchema(const std::string &result);
 
 class WafResultActionMatcher {
 public:
@@ -194,6 +195,7 @@ std::list<ddwaf::test::event::match> from_matches(
 #define EXPECT_ACTIONS(result, ...)                                                                \
     {                                                                                              \
         auto data = ddwaf::test::object_to_json(result.actions);                                   \
+        EXPECT_TRUE(ValidateActionsSchema(data));                                                  \
         YAML::Node doc = YAML::Load(data.c_str());                                                 \
         auto obtained = doc.as<ddwaf::test::action_map>();                                         \
         EXPECT_THAT(obtained, WithActions(__VA_ARGS__));                                           \

--- a/tests/integration/diagnostics/v2/test.cpp
+++ b/tests/integration/diagnostics/v2/test.cpp
@@ -27,6 +27,8 @@ TEST(TestDiagnosticsV2Integration, InvalidConfigType)
     ASSERT_EQ(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
 
@@ -50,6 +52,8 @@ TEST(TestDiagnosticsV2Integration, UnsupportedSchema)
     ASSERT_EQ(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
 
@@ -72,6 +76,8 @@ TEST(TestDiagnosticsV2Integration, NoSchema)
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, &diagnostics);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -108,6 +114,8 @@ TEST(TestDiagnosticsV2Integration, BasicRule)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
 
@@ -143,6 +151,8 @@ TEST(TestDiagnosticsV2Integration, BasicRuleWithUpdate)
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
 
     {
+        EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
         ddwaf::raw_configuration root(diagnostics);
         auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
 
@@ -167,6 +177,8 @@ TEST(TestDiagnosticsV2Integration, BasicRuleWithUpdate)
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
 
     {
+        EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
         ddwaf::raw_configuration root(diagnostics);
         auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
 
@@ -213,6 +225,8 @@ TEST(TestDiagnosticsV2Integration, InvalidRule)
     ASSERT_EQ(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
 
@@ -248,6 +262,8 @@ TEST(TestDiagnosticsV2Integration, MultipleSameInvalidRules)
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, &diagnostics);
     ASSERT_EQ(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -286,6 +302,10 @@ TEST(TestDiagnosticsV2Integration, MultipleDiffInvalidRules)
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, &diagnostics);
     ASSERT_EQ(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
+    std::cout << ddwaf::test::object_to_json(diagnostics) << '\n';
 
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -336,6 +356,8 @@ TEST(TestDiagnosticsV2Integration, MultipleMixInvalidRules)
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, &diagnostics);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -401,6 +423,8 @@ TEST(TestDiagnosticsV2Integration, InvalidDuplicate)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
 
@@ -439,6 +463,8 @@ TEST(TestDiagnosticsV2Integration, InvalidRuleset)
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, &diagnostics);
     ASSERT_EQ(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -481,6 +507,8 @@ TEST(TestDiagnosticsV2Integration, MultipleRules)
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     {
         ddwaf::raw_configuration root = diagnostics;
@@ -526,6 +554,8 @@ TEST(TestDiagnosticsV2Integration, RulesWithMinVersion)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root = diagnostics;
         auto root_map = static_cast<raw_configuration::map>(root);
@@ -567,6 +597,8 @@ TEST(TestDiagnosticsV2Integration, RulesWithMaxVersion)
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     {
         ddwaf::raw_configuration root = diagnostics;
@@ -610,6 +642,8 @@ TEST(TestDiagnosticsV2Integration, RulesWithMinMaxVersion)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root = diagnostics;
         auto root_map = static_cast<raw_configuration::map>(root);
@@ -652,6 +686,8 @@ TEST(TestDiagnosticsV2Integration, RulesWithErrors)
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     {
         ddwaf::raw_configuration root = diagnostics;
@@ -736,6 +772,8 @@ TEST(TestDiagnosticsV2Integration, CustomRules)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root = diagnostics;
         auto root_map = static_cast<raw_configuration::map>(root);
@@ -780,6 +818,8 @@ TEST(TestDiagnosticsV2Integration, InputFilter)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root = diagnostics;
         auto root_map = static_cast<raw_configuration::map>(root);
@@ -817,6 +857,8 @@ TEST(TestDiagnosticsV2Integration, RuleData)
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     {
         ddwaf::raw_configuration root = diagnostics;
@@ -857,6 +899,8 @@ TEST(TestDiagnosticsV2Integration, Processor)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root = diagnostics;
         auto root_map = static_cast<raw_configuration::map>(root);
@@ -895,6 +939,8 @@ TEST(TestDiagnosticsV2Integration, InvalidRulesContainer)
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root(diagnostics);
         auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -924,6 +970,8 @@ TEST(TestDiagnosticsV2Integration, InvalidCustomRulesContainer)
     ddwaf_object diagnostics;
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     {
         ddwaf::raw_configuration root(diagnostics);
@@ -955,6 +1003,8 @@ TEST(TestDiagnosticsV2Integration, InvalidExclusionsContainer)
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root(diagnostics);
         auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -984,6 +1034,8 @@ TEST(TestDiagnosticsV2Integration, InvalidOverridesContainer)
     ddwaf_object diagnostics;
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     {
         ddwaf::raw_configuration root(diagnostics);
@@ -1015,6 +1067,8 @@ TEST(TestDiagnosticsV2Integration, InvalidScannersContainer)
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root(diagnostics);
         auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -1044,6 +1098,8 @@ TEST(TestDiagnosticsV2Integration, InvalidProcessorsContainer)
     ddwaf_object diagnostics;
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     {
         ddwaf::raw_configuration root(diagnostics);
@@ -1075,6 +1131,8 @@ TEST(TestDiagnosticsV2Integration, InvalidActionsContainer)
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root(diagnostics);
         auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -1105,6 +1163,8 @@ TEST(TestDiagnosticsV2Integration, InvalidRuleDataContainer)
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
 
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
     {
         ddwaf::raw_configuration root(diagnostics);
         auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
@@ -1134,6 +1194,8 @@ TEST(TestDiagnosticsV2Integration, InvalidExclusionDataContainer)
     ddwaf_object diagnostics;
     ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, &diagnostics);
     ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
     {
         ddwaf::raw_configuration root(diagnostics);

--- a/tests/integration/diagnostics/v2/test.cpp
+++ b/tests/integration/diagnostics/v2/test.cpp
@@ -305,8 +305,6 @@ TEST(TestDiagnosticsV2Integration, MultipleDiffInvalidRules)
 
     EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
 
-    std::cout << ddwaf::test::object_to_json(diagnostics) << '\n';
-
     ddwaf::raw_configuration root(diagnostics);
     auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
 

--- a/tests/integration/events/schema/test.cpp
+++ b/tests/integration/events/schema/test.cpp
@@ -53,7 +53,7 @@ public:
 
         auto data = ddwaf::test::object_to_json(ret.events);
         if (!HasFailure()) {
-            EXPECT_TRUE(ValidateSchema(data));
+            EXPECT_TRUE(ValidateEventSchema(data));
         }
     }
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-parameter -Wno-shadow")
 endif()
 
-set(RAPIDJSON_COMMIT 22a62fcc2c2fa2418f5d358cdf65c1df73b418ae)
+set(RAPIDJSON_COMMIT 24b5e7a8b27f42fa16b96fc70aade9106cf7102f)
 ExternalProject_Add(proj_rapidjson
     URL               https://github.com/Tencent/rapidjson/archive/${RAPIDJSON_COMMIT}.tar.gz
     INSTALL_DIR       ${INSTALL_DIR}

--- a/tools/validate_schema.cpp
+++ b/tools/validate_schema.cpp
@@ -1,14 +1,11 @@
-#include <fstream>
 #include <iostream>
-#include <stdexcept>
-#include <string>
 #include <string_view>
 
 #include "common/utils.hpp"
 
+#include "rapidjson/error/en.h"
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/schema.h"
-#include "rapidjson/error/en.h"
 
 using namespace rapidjson;
 
@@ -22,29 +19,39 @@ int main(int argc, char* argv[])
     auto schemaJson = read_file(argv[1]);
     Document sd;
     if (sd.Parse(schemaJson).HasParseError()) {
-        std::cout << "Failed to parse schema" << std::endl;
+        std::cout << "Failed to parse schema\n";
         return EXIT_FAILURE;
     }
+
     SchemaDocument schema(sd);
 
     auto inputJson = read_file(argv[2]);
     Document d;
-    rapidjson::ParseResult result = d.Parse(inputJson);
-    if (result == nullptr) {
-        std::cout << "Failed to parse input json: " 
-                  << rapidjson::GetParseError_En(result.Code())
-                  << result.Offset() << std::endl;
+    if (d.Parse(inputJson).HasParseError()) {
+        std::cout << "Failed to parse input json\n";
         return EXIT_FAILURE;
     }
 
     SchemaValidator validator(schema);
+
     if (!d.Accept(validator)) {
         StringBuffer sb;
+        validator.GetInvalidSchemaPointer().StringifyUriFragment(sb);
+        std::cout << "Invalid schema: " << sb.GetString() << '\n';
+        std::cout << "Invalid keyword: " << validator.GetInvalidSchemaKeyword() << '\n';
+
+        sb.Clear();
+        validator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
+        std::cout << "Invalid document: " << sb.GetString() << '\n';
+
+
+        sb.Clear();
         PrettyWriter<StringBuffer> w(sb);
         validator.GetError().Accept(w);
-        std::cout << "Validation error: " << sb.GetString() << std::endl;
+        std::cout << "Validation error: " << sb.GetString() << '\n';
         return EXIT_FAILURE;
     }
 
+    std::cout << "Validation success\n";
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR updates the output object schemas and validates them on integration tests. In addition, it also adds all schemas to the release artifacts so they can be easily referenced by external repositories.

Related Jira: [APPSEC-57250]

[APPSEC-57250]: https://datadoghq.atlassian.net/browse/APPSEC-57250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ