### PR TITLE
Support for basic processor overrides

### DIFF
--- a/cmake/objects.cmake
+++ b/cmake/objects.cmake
@@ -42,6 +42,7 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/configuration/data_parser.cpp
     ${libddwaf_SOURCE_DIR}/src/configuration/exclusion_parser.cpp
     ${libddwaf_SOURCE_DIR}/src/configuration/processor_parser.cpp
+    ${libddwaf_SOURCE_DIR}/src/configuration/processor_override_parser.cpp
     ${libddwaf_SOURCE_DIR}/src/configuration/rule_override_parser.cpp
     ${libddwaf_SOURCE_DIR}/src/configuration/rule_parser.cpp
     ${libddwaf_SOURCE_DIR}/src/configuration/legacy_rule_parser.cpp

--- a/src/builder/processor_builder.cpp
+++ b/src/builder/processor_builder.cpp
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <set>
-#include <string>
 #include <vector>
 
 #include "builder/processor_builder.hpp"
@@ -105,20 +104,19 @@ template <typename T>
 } // namespace
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-std::unique_ptr<base_processor> processor_builder::build(
-    const std::string &id, const processor_spec &spec, const indexer<const scanner> &scanners)
+std::unique_ptr<base_processor> processor_builder::build(const indexer<const scanner> &scanners)
 {
-    switch (spec.type) {
+    switch (spec_.type) {
     case processor_type::extract_schema:
-        return build_with_type<extract_schema>(id, spec, scanners);
+        return build_with_type<extract_schema>(id_, spec_, scanners);
     case processor_type::http_endpoint_fingerprint:
-        return build_with_type<http_endpoint_fingerprint>(id, spec, scanners);
+        return build_with_type<http_endpoint_fingerprint>(id_, spec_, scanners);
     case processor_type::http_header_fingerprint:
-        return build_with_type<http_header_fingerprint>(id, spec, scanners);
+        return build_with_type<http_header_fingerprint>(id_, spec_, scanners);
     case processor_type::http_network_fingerprint:
-        return build_with_type<http_network_fingerprint>(id, spec, scanners);
+        return build_with_type<http_network_fingerprint>(id_, spec_, scanners);
     case processor_type::session_fingerprint:
-        return build_with_type<session_fingerprint>(id, spec, scanners);
+        return build_with_type<session_fingerprint>(id_, spec_, scanners);
     default:
         break;
     }

--- a/src/builder/processor_builder.hpp
+++ b/src/builder/processor_builder.hpp
@@ -14,9 +14,24 @@
 
 namespace ddwaf {
 
-struct processor_builder {
-    static std::unique_ptr<base_processor> build(
-        const std::string &id, const processor_spec &spec, const indexer<const scanner> &scanners);
+class processor_builder {
+public:
+    processor_builder(std::string id, processor_spec spec)
+        : id_(std::move(id)), spec_(std::move(spec))
+    {}
+
+    std::unique_ptr<base_processor> build(const indexer<const scanner> &scanners);
+
+    bool apply_override(const processor_override_spec &ovrd)
+    {
+        // TODO error if processor doesn't support scanners
+        spec_.scanners = ovrd.scanners;
+        return true;
+    }
+
+protected:
+    std::string id_;
+    processor_spec spec_;
 };
 
 } // namespace ddwaf

--- a/src/builder/processor_builder.hpp
+++ b/src/builder/processor_builder.hpp
@@ -29,6 +29,8 @@ public:
         return true;
     }
 
+    [[nodiscard]] std::string_view get_id() const { return id_; }
+
 protected:
     std::string id_;
     processor_spec spec_;

--- a/src/builder/rule_builder.hpp
+++ b/src/builder/rule_builder.hpp
@@ -26,7 +26,7 @@ public:
     const std::unordered_map<std::string, std::string> &get_tags() const { return spec_.tags; }
     [[nodiscard]] bool is_enabled() const { return spec_.enabled; }
 
-    bool apply_override(const override_spec &ovrd)
+    bool apply_override(const rule_override_spec &ovrd)
     {
         if (ovrd.enabled.has_value()) {
             spec_.enabled = *ovrd.enabled;

--- a/src/configuration/common/configuration.hpp
+++ b/src/configuration/common/configuration.hpp
@@ -30,7 +30,7 @@ struct rule_spec {
     std::vector<std::string> actions;
 };
 
-enum class reference_type { none, id, tags };
+enum class reference_type : uint8_t { none, id, tags };
 
 struct reference_spec {
     reference_type type;
@@ -38,7 +38,7 @@ struct reference_spec {
     std::unordered_map<std::string, std::string> tags;
 };
 
-struct override_spec {
+struct rule_override_spec {
     reference_type type;
     std::optional<bool> enabled;
     std::optional<std::vector<std::string>> actions;
@@ -59,7 +59,7 @@ struct input_filter_spec {
     std::vector<reference_spec> targets;
 };
 
-enum class processor_type : unsigned {
+enum class processor_type : uint8_t {
     extract_schema,
     http_endpoint_fingerprint,
     http_network_fingerprint,
@@ -74,6 +74,11 @@ struct processor_spec {
     std::vector<reference_spec> scanners;
     bool evaluate{false};
     bool output{true};
+};
+
+struct processor_override_spec {
+    std::vector<reference_spec> targets;
+    std::vector<reference_spec> scanners;
 };
 
 enum class data_type : uint8_t { unknown, data_with_expiration, ip_with_expiration };
@@ -94,13 +99,14 @@ enum class change_set : uint16_t {
     none = 0,
     rules = 1,
     custom_rules = 2,
-    overrides = 4,
+    rule_overrides = 4,
     filters = 8,
     rule_data = 16,
     processors = 32,
-    scanners = 64,
-    actions = 128,
-    exclusion_data = 256,
+    processor_overrides = 64,
+    scanners = 128,
+    actions = 256,
+    exclusion_data = 512,
 };
 
 // NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
@@ -137,9 +143,9 @@ struct configuration_change_spec {
     // Rule data IDs consist of a pair containing the data ID and a given unique
     // ID for the given data spec.
     std::vector<std::pair<std::string, std::string>> rule_data;
-    // Override IDs consisting of a unique ID auto-generated for each override
-    std::unordered_set<std::string> overrides_by_id;
-    std::unordered_set<std::string> overrides_by_tags;
+    // Rule override IDs consisting of a unique ID auto-generated for each override
+    std::unordered_set<std::string> rule_overrides_by_id;
+    std::unordered_set<std::string> rule_overrides_by_tags;
     // Filter IDs
     std::unordered_set<std::string> rule_filters;
     std::unordered_set<std::string> input_filters;
@@ -148,6 +154,8 @@ struct configuration_change_spec {
     std::vector<std::pair<std::string, std::string>> exclusion_data;
     // Processor IDs
     std::unordered_set<std::string> processors;
+    // Processor  override IDs consisting of a unique ID auto-generated for each override
+    std::unordered_set<std::string> processor_overrides;
     // Scanner IDs
     std::unordered_set<std::string> scanners;
     // Action IDs
@@ -168,8 +176,8 @@ struct configuration_spec {
     // Obtained from 'rules_override'
     // The distinction is only necessary due to the restriction that
     // overrides by ID are to be considered a priority over overrides by tags
-    std::unordered_map<std::string, override_spec> overrides_by_id;
-    std::unordered_map<std::string, override_spec> overrides_by_tags;
+    std::unordered_map<std::string, rule_override_spec> rule_overrides_by_id;
+    std::unordered_map<std::string, rule_override_spec> rule_overrides_by_tags;
     // Obtained from 'exclusions'
     std::unordered_map<std::string, rule_filter_spec> rule_filters;
     std::unordered_map<std::string, input_filter_spec> input_filters;
@@ -177,6 +185,8 @@ struct configuration_spec {
     std::unordered_map<std::string, data_spec> exclusion_data;
     // Obtained from 'processors'
     std::unordered_map<std::string, processor_spec> processors;
+    // Obtained from 'processor_override'
+    std::unordered_map<std::string, processor_override_spec> processor_overrides;
     // Obtained from 'scanners'
     // Scanners are stored directly in an indexer to simplify their use
     std::unordered_map<std::string, scanner> scanners;

--- a/src/configuration/common/configuration_collector.hpp
+++ b/src/configuration/common/configuration_collector.hpp
@@ -60,16 +60,16 @@ public:
         }
     }
 
-    void emplace_override(std::string id, override_spec spec)
+    void emplace_rule_override(std::string id, rule_override_spec spec)
     {
-        change_.content |= change_set::overrides;
+        change_.content |= change_set::rule_overrides;
 
         if (spec.type == reference_type::id) {
-            change_.overrides_by_id.emplace(id);
-            config_.overrides_by_id.emplace(std::move(id), std::move(spec));
+            change_.rule_overrides_by_id.emplace(id);
+            config_.rule_overrides_by_id.emplace(std::move(id), std::move(spec));
         } else if (spec.type == reference_type::tags) {
-            change_.overrides_by_tags.emplace(id);
-            config_.overrides_by_tags.emplace(std::move(id), std::move(spec));
+            change_.rule_overrides_by_tags.emplace(id);
+            config_.rule_overrides_by_tags.emplace(std::move(id), std::move(spec));
         }
     }
 
@@ -95,6 +95,14 @@ public:
 
         change_.processors.emplace(id);
         config_.processors.emplace(std::move(id), std::move(spec));
+    }
+
+    void emplace_processor_override(std::string id, processor_override_spec spec)
+    {
+        change_.content |= change_set::processor_overrides;
+
+        change_.processor_overrides.emplace(id);
+        config_.processor_overrides.emplace(std::move(id), std::move(spec));
     }
 
     void emplace_scanner(std::string id, scanner scnr)

--- a/src/configuration/configuration_manager.cpp
+++ b/src/configuration/configuration_manager.cpp
@@ -142,10 +142,10 @@ void configuration_manager::load(
         }
     }
 
-    it = root.find("processor_override");
+    it = root.find("processor_overrides");
     if (it != root.end()) {
         DDWAF_DEBUG("Parsing processor overrides");
-        auto &section = info.add_section("processor_override");
+        auto &section = info.add_section("processor_overrides");
         try {
             auto overrides = static_cast<raw_configuration::vector>(it->second);
             if (!overrides.empty()) {

--- a/src/configuration/processor_override_parser.cpp
+++ b/src/configuration/processor_override_parser.cpp
@@ -38,7 +38,9 @@ processor_override_spec parse_override(const raw_configuration::map &node)
         }
     } else {
         // Since the target array is empty, the ID is mandatory
-        current.targets.emplace_back(reference_type::id, at<std::string>(node, "id"), decltype(reference_spec::tags){});
+        // NOLINTNEXTLINE(hicpp-use-emplace,modernize-use-emplace)
+        current.targets.emplace_back(reference_spec{
+            .type = reference_type::id, .ref_id = at<std::string>(node, "id"), .tags = {}});
     }
 
     auto scanners_target_array = at<raw_configuration::vector>(node, "scanners", {});

--- a/src/configuration/processor_override_parser.cpp
+++ b/src/configuration/processor_override_parser.cpp
@@ -43,10 +43,6 @@ processor_override_spec parse_override(const raw_configuration::map &node)
     }
 
     auto scanners_target_array = at<raw_configuration::vector>(node, "scanners");
-    if (scanners_target_array.empty()) {
-        throw ddwaf::parsing_error("processor override without side-effects");
-    }
-
     current.scanners.reserve(scanners_target_array.size());
     for (const auto &target : scanners_target_array) {
         auto target_spec = parse_reference(static_cast<raw_configuration::map>(target));

--- a/src/configuration/processor_override_parser.cpp
+++ b/src/configuration/processor_override_parser.cpp
@@ -38,8 +38,7 @@ processor_override_spec parse_override(const raw_configuration::map &node)
         }
     } else {
         // Since the target array is empty, the ID is mandatory
-        current.targets.emplace_back(reference_spec{
-            .type = reference_type::id, .ref_id = at<std::string>(node, "id"), .tags = {}});
+        current.targets.emplace_back(reference_type::id, at<std::string>(node, "id"), decltype(reference_spec::tags){});
     }
 
     auto scanners_target_array = at<raw_configuration::vector>(node, "scanners", {});

--- a/src/configuration/processor_override_parser.cpp
+++ b/src/configuration/processor_override_parser.cpp
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+#include <exception>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "configuration/common/common.hpp"
+#include "configuration/common/configuration.hpp"
+#include "configuration/common/configuration_collector.hpp"
+#include "configuration/common/parser_exception.hpp"
+#include "configuration/common/raw_configuration.hpp"
+#include "configuration/common/reference_parser.hpp"
+#include "configuration/processor_override_parser.hpp"
+#include "log.hpp"
+#include "ruleset_info.hpp"
+#include "uuid.hpp"
+
+namespace ddwaf {
+
+namespace {
+
+processor_override_spec parse_override(const raw_configuration::map &node)
+{
+    // Note that ID is a duplicate field and will be deprecated at some point
+    processor_override_spec current;
+
+    auto target_array = at<raw_configuration::vector>(node, "target", {});
+    if (!target_array.empty()) {
+        current.targets.reserve(target_array.size());
+
+        for (const auto &target : target_array) {
+            auto target_spec = parse_reference(static_cast<raw_configuration::map>(target));
+            current.targets.emplace_back(std::move(target_spec));
+        }
+    } else {
+        // Since the target array is empty, the ID is mandatory
+        current.targets.emplace_back(reference_spec{
+            .type = reference_type::id, .ref_id = at<std::string>(node, "id"), .tags = {}});
+    }
+
+    auto scanners_target_array = at<raw_configuration::vector>(node, "scanners", {});
+    if (!scanners_target_array.empty()) {
+        for (const auto &target : scanners_target_array) {
+            auto target_spec = parse_reference(static_cast<raw_configuration::map>(target));
+            current.scanners.emplace_back(std::move(target_spec));
+        }
+    }
+
+    if (current.targets.empty() && current.scanners.empty()) {
+        throw ddwaf::parsing_error("processor override without side-effects");
+    }
+
+    return current;
+}
+
+} // namespace
+
+void parse_processor_overrides(const raw_configuration::vector &override_array,
+    configuration_collector &cfg, ruleset_info::base_section_info &info)
+{
+    for (unsigned i = 0; i < override_array.size(); ++i) {
+        const auto &node_param = override_array[i];
+        auto node = static_cast<raw_configuration::map>(node_param);
+        try {
+            auto spec = parse_override(node);
+            DDWAF_DEBUG("Parsed processor override index:{}", i);
+            info.add_loaded(i);
+            // We use a UUID since we want to have a unique identifier across
+            // all configurations
+            cfg.emplace_processor_override(uuidv4_generate_pseudo(), std::move(spec));
+        } catch (const parsing_exception &e) {
+            DDWAF_WARN("Failed to parse processor override: {}", e.what());
+            info.add_failed(i, e.severity(), e.what());
+        } catch (const std::exception &e) {
+            DDWAF_WARN("Failed to parse processor override: {}", e.what());
+            info.add_failed(i, parser_error_severity::error, e.what());
+        }
+    }
+}
+
+} // namespace ddwaf

--- a/src/configuration/processor_override_parser.hpp
+++ b/src/configuration/processor_override_parser.hpp
@@ -2,7 +2,7 @@
 // dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2021 Datadog, Inc.
+// Copyright 2025 Datadog, Inc.
 
 #pragma once
 
@@ -12,7 +12,7 @@
 
 namespace ddwaf {
 
-void parse_rule_overrides(const raw_configuration::vector &override_array,
+void parse_processor_overrides(const raw_configuration::vector &override_array,
     configuration_collector &cfg, ruleset_info::base_section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/rule_override_parser.cpp
+++ b/src/configuration/rule_override_parser.cpp
@@ -24,10 +24,10 @@ namespace ddwaf {
 
 namespace {
 
-override_spec parse_override(const raw_configuration::map &node)
+rule_override_spec parse_override(const raw_configuration::map &node)
 {
     // Note that ID is a duplicate field and will be deprecated at some point
-    override_spec current;
+    rule_override_spec current;
     current.type = reference_type::none;
 
     auto it = node.find("enabled");
@@ -78,8 +78,8 @@ override_spec parse_override(const raw_configuration::map &node)
 
 } // namespace
 
-void parse_overrides(const raw_configuration::vector &override_array, configuration_collector &cfg,
-    ruleset_info::base_section_info &info)
+void parse_rule_overrides(const raw_configuration::vector &override_array,
+    configuration_collector &cfg, ruleset_info::base_section_info &info)
 {
     for (unsigned i = 0; i < override_array.size(); ++i) {
         const auto &node_param = override_array[i];
@@ -88,16 +88,16 @@ void parse_overrides(const raw_configuration::vector &override_array, configurat
             auto spec = parse_override(node);
             if (spec.type == reference_type::none) {
                 // This code is likely unreachable
-                DDWAF_WARN("Rule override with no targets");
+                DDWAF_WARN("Rule rule override with no targets");
                 info.add_failed(i, parser_error_severity::error, "rule override with no targets");
                 continue;
             }
 
-            DDWAF_DEBUG("Parsed override index:{}", i);
+            DDWAF_DEBUG("Parsed rule override index:{}", i);
             info.add_loaded(i);
             // We use a UUID since we want to have a unique identifier across
             // all configurations
-            cfg.emplace_override(uuidv4_generate_pseudo(), std::move(spec));
+            cfg.emplace_rule_override(uuidv4_generate_pseudo(), std::move(spec));
         } catch (const parsing_exception &e) {
             DDWAF_WARN("Failed to parse rule override: {}", e.what());
             info.add_failed(i, e.severity(), e.what());

--- a/tests/integration/processors/overrides/ruleset/processors.json
+++ b/tests/integration/processors/overrides/ruleset/processors.json
@@ -1,0 +1,54 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.99.99"
+  },
+  "processors": [
+    {
+      "id": "extract-content",
+      "generator": "extract_schema",
+      "conditions": [],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "output": "server.request.body.schema"
+          }
+        ],
+        "scanners": []
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "extract-headers",
+      "generator": "extract_schema",
+      "conditions": [],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.headers"
+              }
+            ],
+            "output": "server.request.headers.schema"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "credential"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    }
+  ]
+}

--- a/tests/integration/processors/overrides/ruleset/scanners.json
+++ b/tests/integration/processors/overrides/ruleset/scanners.json
@@ -1,0 +1,55 @@
+{
+  "scanners": [
+    {
+      "id": "scanner-001",
+      "key": {
+          "operator": "match_regex",
+          "parameters": {
+            "regex": "(?:email|mail)",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          }
+      },
+      "value": {
+          "operator": "match_regex",
+          "parameters": {
+            "regex": "\\b[\\w!#$%&'*+\\/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+\\/=?`{|}~^-]+)*(%40|@)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}\\b",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          }
+      },
+      "tags": { "type": "email", "category": "pii" }
+    },
+    {
+      "id": "scanner-002",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": ".*",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 5
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+          "parameters": {
+            "regex": "\\b[\\w!#$%&'*+\\/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+\\/=?`{|}~^-]+)*(%40|@)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}\\b",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          }
+      },
+      "tags": {
+        "type": "token",
+        "category": "credential"
+      }
+    }
+  ]
+}

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -56,7 +56,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersById)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_override": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -137,7 +137,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersByTags)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_override": [{"target":[{"id":"extract-content"}], "scanners": [{"tags": {"type":"email"}}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": [{"tags": {"type":"email"}}]}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -219,7 +219,7 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_override": [{"target":[{"id":"extract-headers"}], "scanners": [{"id": "scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": [{"id": "scanner-001"}]}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -255,7 +255,7 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
     ddwaf_destroy(handle);
 
     ovrd = json_to_object(
-        R"({"processor_override": [{"target":[{"id":"extract-headers"}], "scanners": []}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": []}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -336,7 +336,7 @@ TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_override": [{"target":[{"id":"extract-headers"}], "scanners": []}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": []}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -416,7 +416,7 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_override": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -528,7 +528,7 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_override": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -649,7 +649,7 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_override": [{"target":[{"id":"extract-content"},{"id":"extract-headers"}], "scanners": [{"id":"scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"},{"id":"extract-headers"}], "scanners": [{"id":"scanner-001"}]}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -1,0 +1,293 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "common/gtest_utils.hpp"
+
+using namespace ddwaf;
+
+namespace {
+constexpr std::string_view base_dir = "integration/processors/overrides";
+
+TEST(TestProcessorOverridesIntegration, AddScannersById)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    auto ovrd = json_to_object(
+        R"({"processor_override": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestProcessorOverridesIntegration, AddScannersByTags)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    auto ovrd = json_to_object(
+        R"({"processor_override": [{"target":[{"id":"extract-content"}], "scanners": [{"tags": {"type":"email"}}]}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.headers.schema":[{"email":[8,{"type":"token","category":"credential"}]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    auto ovrd = json_to_object(
+        R"({"processor_override": [{"target":[{"id":"extract-headers"}], "scanners": [{"id": "scanner-001"}]}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.headers.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    ovrd = json_to_object(
+        R"({"processor_override": [{"target":[{"id":"extract-headers"}], "scanners": []}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema, R"({"server.request.headers.schema":[{"email":[8]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+} // namespace

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -595,4 +595,92 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
     ddwaf_builder_destroy(builder);
 }
 
+TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 2);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.headers.schema":[{"email":[8,{"type":"token","category":"credential"}]}],"server.request.body.schema":[{"email":[8]}]})");
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    auto ovrd = json_to_object(
+        R"({"processor_override": [{"target":[{"id":"extract-content"},{"id":"extract-headers"}], "scanners": [{"id":"scanner-001"}]}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 2);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.headers.schema":[{"email":[8,{"type":"email","category":"pii"}]}],"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
 } // namespace

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -290,4 +290,309 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
     ddwaf_builder_destroy(builder);
 }
 
+TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.headers.schema":[{"email":[8,{"type":"token","category":"credential"}]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    auto ovrd = json_to_object(
+        R"({"processor_override": [{"target":[{"id":"extract-headers"}], "scanners": []}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema, R"({"server.request.headers.schema":[{"email":[8]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    auto ovrd = json_to_object(
+        R"({"processor_override": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_remove_config(builder, LSTRARG("scanners"));
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestProcessorOverridesIntegration, RemoveOverride)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    auto ovrd = json_to_object(
+        R"({"processor_override": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema,
+            R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_remove_config(builder, LSTRARG("override"));
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_result out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_FALSE(out.timeout);
+
+        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+
+        auto schema = test::object_to_json(out.derivatives);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_result_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
 } // namespace

--- a/tests/unit/configuration/action_parser_test.cpp
+++ b/tests/unit/configuration/action_parser_test.cpp
@@ -38,8 +38,8 @@ TEST(TestActionParser, EmptyActions)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -50,8 +50,8 @@ TEST(TestActionParser, EmptyActions)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestActionParser, SingleAction)
@@ -101,8 +101,8 @@ TEST(TestActionParser, SingleAction)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.base_rules.empty());
     EXPECT_TRUE(cfg.user_rules.empty());
@@ -112,8 +112,8 @@ TEST(TestActionParser, SingleAction)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestActionParser, RedirectAction)
@@ -196,8 +196,8 @@ TEST(TestActionParser, RedirectAction)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.base_rules.empty());
     EXPECT_TRUE(cfg.user_rules.empty());
@@ -207,8 +207,8 @@ TEST(TestActionParser, RedirectAction)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestActionParser, RedirectActionInvalidStatusCode)

--- a/tests/unit/configuration/base_rule_parser_test.cpp
+++ b/tests/unit/configuration/base_rule_parser_test.cpp
@@ -73,8 +73,8 @@ TEST(TestBaseRuleParser, ParseRule)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.user_rules.empty());
@@ -84,8 +84,8 @@ TEST(TestBaseRuleParser, ParseRule)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, ParseRuleWithoutType)
@@ -138,8 +138,8 @@ TEST(TestBaseRuleParser, ParseRuleWithoutType)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -150,8 +150,8 @@ TEST(TestBaseRuleParser, ParseRuleWithoutType)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, ParseRuleWithoutConditions)
@@ -206,8 +206,8 @@ TEST(TestBaseRuleParser, ParseRuleWithoutConditions)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -218,8 +218,8 @@ TEST(TestBaseRuleParser, ParseRuleWithoutConditions)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, ParseRuleInvalidTransformer)
@@ -275,8 +275,8 @@ TEST(TestBaseRuleParser, ParseRuleInvalidTransformer)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -287,8 +287,8 @@ TEST(TestBaseRuleParser, ParseRuleInvalidTransformer)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, ParseRuleWithoutID)
@@ -341,8 +341,8 @@ TEST(TestBaseRuleParser, ParseRuleWithoutID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -353,8 +353,8 @@ TEST(TestBaseRuleParser, ParseRuleWithoutID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, ParseMultipleRules)
@@ -622,8 +622,8 @@ TEST(TestBaseRuleParser, KeyPathTooLong)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -634,8 +634,8 @@ TEST(TestBaseRuleParser, KeyPathTooLong)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, NegatedMatcherTooManyParameters)
@@ -690,8 +690,8 @@ TEST(TestBaseRuleParser, NegatedMatcherTooManyParameters)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -702,8 +702,8 @@ TEST(TestBaseRuleParser, NegatedMatcherTooManyParameters)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, SupportedVersionedOperator)
@@ -800,8 +800,8 @@ TEST(TestBaseRuleParser, UnsupportedVersionedOperator)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -812,8 +812,8 @@ TEST(TestBaseRuleParser, UnsupportedVersionedOperator)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, IncompatibleMinVersion)
@@ -865,8 +865,8 @@ TEST(TestBaseRuleParser, IncompatibleMinVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -877,8 +877,8 @@ TEST(TestBaseRuleParser, IncompatibleMinVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, IncompatibleMaxVersion)
@@ -930,8 +930,8 @@ TEST(TestBaseRuleParser, IncompatibleMaxVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -942,8 +942,8 @@ TEST(TestBaseRuleParser, IncompatibleMaxVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestBaseRuleParser, CompatibleVersion)

--- a/tests/unit/configuration/exclusion_data_parser_test.cpp
+++ b/tests/unit/configuration/exclusion_data_parser_test.cpp
@@ -238,8 +238,8 @@ TEST(TestExclusionDataParser, ParseUnsupportedTypes)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -250,8 +250,8 @@ TEST(TestExclusionDataParser, ParseUnsupportedTypes)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestExclusionDataParser, ParseUnknownDataIDWithUnsupportedType)
@@ -302,8 +302,8 @@ TEST(TestExclusionDataParser, ParseUnknownDataIDWithUnsupportedType)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -314,8 +314,8 @@ TEST(TestExclusionDataParser, ParseUnknownDataIDWithUnsupportedType)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestExclusionDataParser, ParseMissingType)
@@ -366,8 +366,8 @@ TEST(TestExclusionDataParser, ParseMissingType)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -378,8 +378,8 @@ TEST(TestExclusionDataParser, ParseMissingType)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestExclusionDataParser, ParseMissingID)
@@ -430,8 +430,8 @@ TEST(TestExclusionDataParser, ParseMissingID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -442,8 +442,8 @@ TEST(TestExclusionDataParser, ParseMissingID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestExclusionDataParser, ParseMissingData)
@@ -493,8 +493,8 @@ TEST(TestExclusionDataParser, ParseMissingData)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -505,8 +505,8 @@ TEST(TestExclusionDataParser, ParseMissingData)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 } // namespace

--- a/tests/unit/configuration/input_filter_parser_test.cpp
+++ b/tests/unit/configuration/input_filter_parser_test.cpp
@@ -61,8 +61,8 @@ TEST(TestInputFilterParser, ParseEmpty)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -73,8 +73,8 @@ TEST(TestInputFilterParser, ParseEmpty)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestInputFilterParser, ParseFilterWithoutID)
@@ -124,8 +124,8 @@ TEST(TestInputFilterParser, ParseFilterWithoutID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -136,8 +136,8 @@ TEST(TestInputFilterParser, ParseFilterWithoutID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestInputFilterParser, ParseDuplicateFilters)
@@ -690,8 +690,8 @@ TEST(TestInputFilterParser, IncompatibleMinVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -702,8 +702,8 @@ TEST(TestInputFilterParser, IncompatibleMinVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestInputFilterParser, IncompatibleMaxVersion)
@@ -751,8 +751,8 @@ TEST(TestInputFilterParser, IncompatibleMaxVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -763,8 +763,8 @@ TEST(TestInputFilterParser, IncompatibleMaxVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestInputFilterParser, CompatibleVersion)

--- a/tests/unit/configuration/processor_override_parser_test.cpp
+++ b/tests/unit/configuration/processor_override_parser_test.cpp
@@ -183,6 +183,10 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithoutScanners)
     EXPECT_EQ(change.processor_overrides.size(), 1);
     EXPECT_EQ(cfg.processor_overrides.size(), 1);
 
+    auto &ovrd = cfg.processor_overrides.begin()->second;
+    EXPECT_EQ(ovrd.targets.size(), 1);
+    EXPECT_EQ(ovrd.scanners.size(), 0);
+
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());
     EXPECT_TRUE(change.user_rules.empty());
@@ -246,6 +250,10 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerById)
     EXPECT_EQ(change.processor_overrides.size(), 1);
     EXPECT_EQ(cfg.processor_overrides.size(), 1);
 
+    auto &ovrd = cfg.processor_overrides.begin()->second;
+    EXPECT_EQ(ovrd.targets.size(), 1);
+    EXPECT_EQ(ovrd.scanners.size(), 1);
+
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());
     EXPECT_TRUE(change.user_rules.empty());
@@ -308,6 +316,142 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerByTags)
 
     EXPECT_EQ(change.processor_overrides.size(), 1);
     EXPECT_EQ(cfg.processor_overrides.size(), 1);
+
+    auto &ovrd = cfg.processor_overrides.begin()->second;
+    EXPECT_EQ(ovrd.targets.size(), 1);
+    EXPECT_EQ(ovrd.scanners.size(), 1);
+
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+}
+
+TEST(TestProcessorOverrideParser, ParseOverrideWithMultipleTargets)
+{
+    auto object = yaml_to_object(
+        R"([{"target":[{"id":"extract-content"}, {"id": "something-else"}, {"id": "extract-headers"}], "scanners": [{"id": "scanner-001"}]}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::processor_overrides);
+
+    EXPECT_EQ(change.processor_overrides.size(), 1);
+    EXPECT_EQ(cfg.processor_overrides.size(), 1);
+
+    auto &ovrd = cfg.processor_overrides.begin()->second;
+    EXPECT_EQ(ovrd.targets.size(), 3);
+    EXPECT_EQ(ovrd.scanners.size(), 1);
+
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+}
+
+TEST(TestProcessorOverrideParser, ParseOverrideWithMultipleTargetsAndScanners)
+{
+    auto object = yaml_to_object(
+        R"([{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]},{"target":[{"id": "something-else"}], "scanners": [{"tags": {"type": "value"}}]},{"target":[{"id": "extract-headers"}], "scanners": [{"id": "scanner-002"}]}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 3);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
+        EXPECT_NE(loaded.find("index:1"), loaded.end());
+        EXPECT_NE(loaded.find("index:2"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::processor_overrides);
+
+    EXPECT_EQ(change.processor_overrides.size(), 3);
+    EXPECT_EQ(cfg.processor_overrides.size(), 3);
 
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());

--- a/tests/unit/configuration/processor_override_parser_test.cpp
+++ b/tests/unit/configuration/processor_override_parser_test.cpp
@@ -165,26 +165,24 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithoutScanners)
         auto root_map = static_cast<raw_configuration::map>(root);
 
         auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
-        EXPECT_EQ(loaded.size(), 0);
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
 
         auto failed = at<raw_configuration::string_set>(root_map, "failed");
-        EXPECT_EQ(failed.size(), 1);
-        EXPECT_NE(failed.find("index:0"), failed.end());
+        EXPECT_EQ(failed.size(), 0);
 
         auto errors = at<raw_configuration::map>(root_map, "errors");
-        EXPECT_EQ(errors.size(), 1);
-
-        auto it = errors.find("processor override without side-effects");
-        EXPECT_NE(it, errors.end());
-
-        auto error_rules = static_cast<raw_configuration::string_set>(it->second);
-        EXPECT_EQ(error_rules.size(), 1);
-        EXPECT_NE(error_rules.find("index:0"), error_rules.end());
+        EXPECT_EQ(errors.size(), 0);
 
         ddwaf_object_free(&root);
     }
 
-    EXPECT_TRUE(change.empty());
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::processor_overrides);
+
+    EXPECT_EQ(change.processor_overrides.size(), 1);
+    EXPECT_EQ(cfg.processor_overrides.size(), 1);
+
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());
     EXPECT_TRUE(change.user_rules.empty());
@@ -196,7 +194,6 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithoutScanners)
     EXPECT_TRUE(change.scanners.empty());
     EXPECT_TRUE(change.rule_overrides_by_id.empty());
     EXPECT_TRUE(change.rule_overrides_by_tags.empty());
-    EXPECT_TRUE(change.processor_overrides.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -209,7 +206,6 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithoutScanners)
     EXPECT_TRUE(cfg.scanners.empty());
     EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
     EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
-    EXPECT_TRUE(cfg.processor_overrides.empty());
 }
 
 TEST(TestProcessorOverrideParser, ParseOverrideWithScannerById)
@@ -245,6 +241,7 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerById)
     }
 
     EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::processor_overrides);
 
     EXPECT_EQ(change.processor_overrides.size(), 1);
     EXPECT_EQ(cfg.processor_overrides.size(), 1);
@@ -307,6 +304,7 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerByTags)
     }
 
     EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::processor_overrides);
 
     EXPECT_EQ(change.processor_overrides.size(), 1);
     EXPECT_EQ(cfg.processor_overrides.size(), 1);

--- a/tests/unit/configuration/processor_override_parser_test.cpp
+++ b/tests/unit/configuration/processor_override_parser_test.cpp
@@ -1,0 +1,339 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+
+#include "common/gtest_utils.hpp"
+#include "configuration/common/common.hpp"
+#include "configuration/common/configuration.hpp"
+#include "configuration/common/raw_configuration.hpp"
+#include "configuration/processor_override_parser.hpp"
+
+using namespace ddwaf;
+
+namespace {
+
+TEST(TestProcessorOverrideParser, ParseOverrideWithoutTargets)
+{
+    auto object = yaml_to_object(R"([{"target":[], "scanners":[]}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("index:0"), failed.end());
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+
+        auto it = errors.find("processor override without targets");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<raw_configuration::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("index:0"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_TRUE(change.empty());
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+    EXPECT_TRUE(change.processor_overrides.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.processor_overrides.empty());
+}
+
+TEST(TestProcessorOverrideParser, ParseOverrideWithTargetByTags)
+{
+    auto object = yaml_to_object(R"([{"target":[{"tags": {"type": "value"}}], "scanners":[]}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("index:0"), failed.end());
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+
+        auto it = errors.find("processor override with target by tags not supported");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<raw_configuration::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("index:0"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_TRUE(change.empty());
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+    EXPECT_TRUE(change.processor_overrides.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.processor_overrides.empty());
+}
+
+TEST(TestProcessorOverrideParser, ParseOverrideWithoutScanners)
+{
+    auto object = yaml_to_object(R"([{"target":[{"id":"extract-content"}], "scanners":[]}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("index:0"), failed.end());
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+
+        auto it = errors.find("processor override without side-effects");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<raw_configuration::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("index:0"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_TRUE(change.empty());
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+    EXPECT_TRUE(change.processor_overrides.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.processor_overrides.empty());
+}
+
+TEST(TestProcessorOverrideParser, ParseOverrideWithScannerById)
+{
+    auto object = yaml_to_object(
+        R"([{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+
+    EXPECT_EQ(change.processor_overrides.size(), 1);
+    EXPECT_EQ(cfg.processor_overrides.size(), 1);
+
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+}
+
+TEST(TestProcessorOverrideParser, ParseOverrideWithScannerByTags)
+{
+    auto object = yaml_to_object(
+        R"([{"target":[{"id":"extract-content"}], "scanners": [{"tags": {"type":"email"}}]}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+
+    EXPECT_EQ(change.processor_overrides.size(), 1);
+    EXPECT_EQ(cfg.processor_overrides.size(), 1);
+
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+}
+
+} // namespace

--- a/tests/unit/configuration/processor_parser_test.cpp
+++ b/tests/unit/configuration/processor_parser_test.cpp
@@ -61,8 +61,8 @@ TEST(TestProcessorParser, ParseNoGenerator)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -73,8 +73,8 @@ TEST(TestProcessorParser, ParseNoGenerator)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -126,8 +126,8 @@ TEST(TestProcessorParser, ParseNoID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -138,8 +138,8 @@ TEST(TestProcessorParser, ParseNoID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -191,8 +191,8 @@ TEST(TestProcessorParser, ParseNoParameters)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -203,8 +203,8 @@ TEST(TestProcessorParser, ParseNoParameters)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -256,8 +256,8 @@ TEST(TestProcessorParser, ParseNoMappings)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -268,8 +268,8 @@ TEST(TestProcessorParser, ParseNoMappings)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -322,8 +322,8 @@ TEST(TestProcessorParser, ParseEmptyMappings)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -334,8 +334,8 @@ TEST(TestProcessorParser, ParseEmptyMappings)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -388,8 +388,8 @@ TEST(TestProcessorParser, ParseNoInput)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -400,8 +400,8 @@ TEST(TestProcessorParser, ParseNoInput)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -454,8 +454,8 @@ TEST(TestProcessorParser, ParseEmptyInput)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -466,8 +466,8 @@ TEST(TestProcessorParser, ParseEmptyInput)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -520,8 +520,8 @@ TEST(TestProcessorParser, ParseNoOutput)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -532,8 +532,8 @@ TEST(TestProcessorParser, ParseNoOutput)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -630,8 +630,8 @@ TEST(TestProcessorParser, ParseUseless)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -642,8 +642,8 @@ TEST(TestProcessorParser, ParseUseless)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     EXPECT_EQ(cfg.processors.size(), 0);
 }
@@ -777,8 +777,8 @@ TEST(TestProcessorParser, IncompatibleMinVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -789,8 +789,8 @@ TEST(TestProcessorParser, IncompatibleMinVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     {
         raw_configuration root;
@@ -838,8 +838,8 @@ TEST(TestProcessorParser, IncompatibleMaxVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -850,8 +850,8 @@ TEST(TestProcessorParser, IncompatibleMaxVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 
     {
         raw_configuration root;

--- a/tests/unit/configuration/rule_data_parser_test.cpp
+++ b/tests/unit/configuration/rule_data_parser_test.cpp
@@ -238,8 +238,8 @@ TEST(TestRuleDataParser, ParseUnsupportedTypes)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -250,8 +250,8 @@ TEST(TestRuleDataParser, ParseUnsupportedTypes)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleDataParser, ParseUnknownDataIDWithUnsupportedType)
@@ -302,8 +302,8 @@ TEST(TestRuleDataParser, ParseUnknownDataIDWithUnsupportedType)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -314,8 +314,8 @@ TEST(TestRuleDataParser, ParseUnknownDataIDWithUnsupportedType)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleDataParser, ParseMissingType)
@@ -366,8 +366,8 @@ TEST(TestRuleDataParser, ParseMissingType)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -378,8 +378,8 @@ TEST(TestRuleDataParser, ParseMissingType)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleDataParser, ParseMissingID)
@@ -430,8 +430,8 @@ TEST(TestRuleDataParser, ParseMissingID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -442,8 +442,8 @@ TEST(TestRuleDataParser, ParseMissingID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleDataParser, ParseMissingData)
@@ -493,8 +493,8 @@ TEST(TestRuleDataParser, ParseMissingData)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -505,8 +505,8 @@ TEST(TestRuleDataParser, ParseMissingData)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 } // namespace

--- a/tests/unit/configuration/rule_filter_parser_test.cpp
+++ b/tests/unit/configuration/rule_filter_parser_test.cpp
@@ -61,8 +61,8 @@ TEST(TestRuleFilterParser, ParseEmptyFilter)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -73,8 +73,8 @@ TEST(TestRuleFilterParser, ParseEmptyFilter)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleFilterParser, ParseFilterWithoutID)
@@ -124,8 +124,8 @@ TEST(TestRuleFilterParser, ParseFilterWithoutID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -136,8 +136,8 @@ TEST(TestRuleFilterParser, ParseFilterWithoutID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleFilterParser, ParseDuplicateUnconditional)
@@ -843,8 +843,8 @@ TEST(TestRuleFilterParser, ParseInvalidOnMatch)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -855,8 +855,8 @@ TEST(TestRuleFilterParser, ParseInvalidOnMatch)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleFilterParser, IncompatibleMinVersion)
@@ -904,8 +904,8 @@ TEST(TestRuleFilterParser, IncompatibleMinVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -916,8 +916,8 @@ TEST(TestRuleFilterParser, IncompatibleMinVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleFilterParser, IncompatibleMaxVersion)
@@ -965,8 +965,8 @@ TEST(TestRuleFilterParser, IncompatibleMaxVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -977,8 +977,8 @@ TEST(TestRuleFilterParser, IncompatibleMaxVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleFilterParser, CompatibleVersion)

--- a/tests/unit/configuration/rule_override_parser_test.cpp
+++ b/tests/unit/configuration/rule_override_parser_test.cpp
@@ -23,7 +23,7 @@ TEST(TestRuleOverrideParser, ParseRuleOverrideWithoutSideEffects)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_overrides(override_array, collector, section);
+    parse_rule_overrides(override_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -62,8 +62,8 @@ TEST(TestRuleOverrideParser, ParseRuleOverrideWithoutSideEffects)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -74,8 +74,8 @@ TEST(TestRuleOverrideParser, ParseRuleOverrideWithoutSideEffects)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleOverrideParser, ParseRuleOverrideWithoutTargets)
@@ -87,7 +87,7 @@ TEST(TestRuleOverrideParser, ParseRuleOverrideWithoutTargets)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_overrides(override_array, collector, section);
+    parse_rule_overrides(override_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -126,8 +126,8 @@ TEST(TestRuleOverrideParser, ParseRuleOverrideWithoutTargets)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -138,8 +138,8 @@ TEST(TestRuleOverrideParser, ParseRuleOverrideWithoutTargets)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleOverrideParser, ParseRuleOverride)
@@ -152,7 +152,7 @@ TEST(TestRuleOverrideParser, ParseRuleOverride)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_overrides(override_array, collector, section);
+    parse_rule_overrides(override_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -174,13 +174,13 @@ TEST(TestRuleOverrideParser, ParseRuleOverride)
         ddwaf_object_free(&root);
     }
 
-    EXPECT_EQ(change.overrides_by_id.size(), 0);
-    EXPECT_EQ(change.overrides_by_tags.size(), 1);
+    EXPECT_EQ(change.rule_overrides_by_id.size(), 0);
+    EXPECT_EQ(change.rule_overrides_by_tags.size(), 1);
 
-    EXPECT_EQ(cfg.overrides_by_id.size(), 0);
-    EXPECT_EQ(cfg.overrides_by_tags.size(), 1);
+    EXPECT_EQ(cfg.rule_overrides_by_id.size(), 0);
+    EXPECT_EQ(cfg.rule_overrides_by_tags.size(), 1);
 
-    auto &ovrd = cfg.overrides_by_tags.begin()->second;
+    auto &ovrd = cfg.rule_overrides_by_tags.begin()->second;
     EXPECT_FALSE(ovrd.enabled.has_value());
     EXPECT_TRUE(ovrd.actions.has_value());
     EXPECT_EQ(ovrd.actions->size(), 1);
@@ -204,7 +204,7 @@ TEST(TestRuleOverrideParser, ParseMultipleRuleOverrides)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_overrides(override_array, collector, section);
+    parse_rule_overrides(override_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -227,14 +227,14 @@ TEST(TestRuleOverrideParser, ParseMultipleRuleOverrides)
         ddwaf_object_free(&root);
     }
 
-    EXPECT_EQ(change.overrides_by_id.size(), 1);
-    EXPECT_EQ(change.overrides_by_tags.size(), 1);
+    EXPECT_EQ(change.rule_overrides_by_id.size(), 1);
+    EXPECT_EQ(change.rule_overrides_by_tags.size(), 1);
 
-    EXPECT_EQ(cfg.overrides_by_id.size(), 1);
-    EXPECT_EQ(cfg.overrides_by_tags.size(), 1);
+    EXPECT_EQ(cfg.rule_overrides_by_id.size(), 1);
+    EXPECT_EQ(cfg.rule_overrides_by_tags.size(), 1);
 
     {
-        auto &ovrd = cfg.overrides_by_tags.begin()->second;
+        auto &ovrd = cfg.rule_overrides_by_tags.begin()->second;
         EXPECT_FALSE(ovrd.enabled.has_value());
         EXPECT_TRUE(ovrd.actions.has_value());
         EXPECT_EQ(ovrd.actions->size(), 1);
@@ -249,7 +249,7 @@ TEST(TestRuleOverrideParser, ParseMultipleRuleOverrides)
     }
 
     {
-        auto &ovrd = cfg.overrides_by_id.begin()->second;
+        auto &ovrd = cfg.rule_overrides_by_id.begin()->second;
         EXPECT_TRUE(ovrd.enabled.has_value());
         EXPECT_FALSE(*ovrd.enabled);
         EXPECT_FALSE(ovrd.actions.has_value());
@@ -272,7 +272,7 @@ TEST(TestRuleOverrideParser, ParseInconsistentRuleOverride)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_overrides(override_array, collector, section);
+    parse_rule_overrides(override_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -311,8 +311,8 @@ TEST(TestRuleOverrideParser, ParseInconsistentRuleOverride)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -323,8 +323,8 @@ TEST(TestRuleOverrideParser, ParseInconsistentRuleOverride)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestRuleOverrideParser, ParseRuleOverrideForTags)
@@ -337,7 +337,7 @@ TEST(TestRuleOverrideParser, ParseRuleOverrideForTags)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_overrides(override_array, collector, section);
+    parse_rule_overrides(override_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -359,13 +359,13 @@ TEST(TestRuleOverrideParser, ParseRuleOverrideForTags)
         ddwaf_object_free(&root);
     }
 
-    EXPECT_EQ(change.overrides_by_id.size(), 0);
-    EXPECT_EQ(change.overrides_by_tags.size(), 1);
+    EXPECT_EQ(change.rule_overrides_by_id.size(), 0);
+    EXPECT_EQ(change.rule_overrides_by_tags.size(), 1);
 
-    EXPECT_EQ(cfg.overrides_by_id.size(), 0);
-    EXPECT_EQ(cfg.overrides_by_tags.size(), 1);
+    EXPECT_EQ(cfg.rule_overrides_by_id.size(), 0);
+    EXPECT_EQ(cfg.rule_overrides_by_tags.size(), 1);
 
-    auto &ovrd = cfg.overrides_by_tags.begin()->second;
+    auto &ovrd = cfg.rule_overrides_by_tags.begin()->second;
     EXPECT_FALSE(ovrd.enabled.has_value());
     EXPECT_TRUE(ovrd.actions.has_value());
     EXPECT_EQ(ovrd.actions->size(), 1);
@@ -392,7 +392,7 @@ TEST(TestRuleOverrideParser, ParseInvalidTagsField)
     configuration_collector collector{change, cfg};
     ruleset_info::section_info section;
     auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
-    parse_overrides(override_array, collector, section);
+    parse_rule_overrides(override_array, collector, section);
     ddwaf_object_free(&object);
 
     {
@@ -431,8 +431,8 @@ TEST(TestRuleOverrideParser, ParseInvalidTagsField)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -443,8 +443,8 @@ TEST(TestRuleOverrideParser, ParseInvalidTagsField)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 } // namespace

--- a/tests/unit/configuration/scanner_parser_test.cpp
+++ b/tests/unit/configuration/scanner_parser_test.cpp
@@ -224,8 +224,8 @@ TEST(TestScannerParser, ParseNoID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -236,8 +236,8 @@ TEST(TestScannerParser, ParseNoID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, ParseNoTags)
@@ -288,8 +288,8 @@ TEST(TestScannerParser, ParseNoTags)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -300,8 +300,8 @@ TEST(TestScannerParser, ParseNoTags)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, ParseNoKeyValue)
@@ -352,8 +352,8 @@ TEST(TestScannerParser, ParseNoKeyValue)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -364,8 +364,8 @@ TEST(TestScannerParser, ParseNoKeyValue)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, ParseDuplicate)
@@ -463,8 +463,8 @@ TEST(TestScannerParser, ParseKeyNoOperator)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -475,8 +475,8 @@ TEST(TestScannerParser, ParseKeyNoOperator)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, ParseKeyNoParameters)
@@ -527,8 +527,8 @@ TEST(TestScannerParser, ParseKeyNoParameters)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -539,8 +539,8 @@ TEST(TestScannerParser, ParseKeyNoParameters)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, ParseValueNoOperator)
@@ -591,8 +591,8 @@ TEST(TestScannerParser, ParseValueNoOperator)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -603,8 +603,8 @@ TEST(TestScannerParser, ParseValueNoOperator)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, ParseValueNoParameters)
@@ -655,8 +655,8 @@ TEST(TestScannerParser, ParseValueNoParameters)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -667,8 +667,8 @@ TEST(TestScannerParser, ParseValueNoParameters)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, ParseUnknownMatcher)
@@ -723,8 +723,8 @@ TEST(TestScannerParser, ParseUnknownMatcher)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -735,8 +735,8 @@ TEST(TestScannerParser, ParseUnknownMatcher)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, ParseRuleDataID)
@@ -788,8 +788,8 @@ TEST(TestScannerParser, ParseRuleDataID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -800,8 +800,8 @@ TEST(TestScannerParser, ParseRuleDataID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, IncompatibleMinVersion)
@@ -850,8 +850,8 @@ TEST(TestScannerParser, IncompatibleMinVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -862,8 +862,8 @@ TEST(TestScannerParser, IncompatibleMinVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, IncompatibleMaxVersion)
@@ -912,8 +912,8 @@ TEST(TestScannerParser, IncompatibleMaxVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -924,8 +924,8 @@ TEST(TestScannerParser, IncompatibleMaxVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestScannerParser, CompatibleVersion)

--- a/tests/unit/configuration/user_rule_parser_test.cpp
+++ b/tests/unit/configuration/user_rule_parser_test.cpp
@@ -116,8 +116,8 @@ TEST(TestUserRuleParser, ParseRuleWithoutType)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -128,8 +128,8 @@ TEST(TestUserRuleParser, ParseRuleWithoutType)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, ParseRuleWithoutConditions)
@@ -184,8 +184,8 @@ TEST(TestUserRuleParser, ParseRuleWithoutConditions)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -196,8 +196,8 @@ TEST(TestUserRuleParser, ParseRuleWithoutConditions)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, ParseRuleInvalidTransformer)
@@ -253,8 +253,8 @@ TEST(TestUserRuleParser, ParseRuleInvalidTransformer)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -265,8 +265,8 @@ TEST(TestUserRuleParser, ParseRuleInvalidTransformer)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, ParseRuleWithoutID)
@@ -319,8 +319,8 @@ TEST(TestUserRuleParser, ParseRuleWithoutID)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -331,8 +331,8 @@ TEST(TestUserRuleParser, ParseRuleWithoutID)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, ParseMultipleRules)
@@ -600,8 +600,8 @@ TEST(TestUserRuleParser, KeyPathTooLong)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -612,8 +612,8 @@ TEST(TestUserRuleParser, KeyPathTooLong)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, NegatedMatcherTooManyParameters)
@@ -668,8 +668,8 @@ TEST(TestUserRuleParser, NegatedMatcherTooManyParameters)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -680,8 +680,8 @@ TEST(TestUserRuleParser, NegatedMatcherTooManyParameters)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, SupportedVersionedOperator)
@@ -778,8 +778,8 @@ TEST(TestUserRuleParser, UnsupportedVersionedOperator)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -790,8 +790,8 @@ TEST(TestUserRuleParser, UnsupportedVersionedOperator)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, IncompatibleMinVersion)
@@ -843,8 +843,8 @@ TEST(TestUserRuleParser, IncompatibleMinVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -855,8 +855,8 @@ TEST(TestUserRuleParser, IncompatibleMinVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, IncompatibleMaxVersion)
@@ -908,8 +908,8 @@ TEST(TestUserRuleParser, IncompatibleMaxVersion)
     EXPECT_TRUE(change.input_filters.empty());
     EXPECT_TRUE(change.processors.empty());
     EXPECT_TRUE(change.scanners.empty());
-    EXPECT_TRUE(change.overrides_by_id.empty());
-    EXPECT_TRUE(change.overrides_by_tags.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
 
     EXPECT_TRUE(cfg.actions.empty());
     EXPECT_TRUE(cfg.base_rules.empty());
@@ -920,8 +920,8 @@ TEST(TestUserRuleParser, IncompatibleMaxVersion)
     EXPECT_TRUE(cfg.input_filters.empty());
     EXPECT_TRUE(cfg.processors.empty());
     EXPECT_TRUE(cfg.scanners.empty());
-    EXPECT_TRUE(cfg.overrides_by_id.empty());
-    EXPECT_TRUE(cfg.overrides_by_tags.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
 TEST(TestUserRuleParser, CompatibleVersion)


### PR DESCRIPTION
This PR adds support for processor overrides with the goal of allowing changes to the list of scanners used by the schema extraction processor. Processor overrides have two fields, one specifying the processors on which to apply the override and another one specifying the scanners to be used. An example override can be seen below

```json
{
  "processor_overrides": [
    {
      "target": [
        {
          "id": "extract-headers"
        },
        {
          "id": "extract-content"
        }
      ],
      "scanners": [
        {
          "tags": {
            "category": "pii"
          }
        },
        {
          "id": "my_scanner"
        }
      ]
    }
  ]
}
```

Related Jira: [APPSEC-57296]

[APPSEC-57296]: https://datadoghq.atlassian.net/browse/APPSEC-57296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ