### PR TITLE
Make SQL comment injection check stricter

### DIFF
--- a/src/condition/sqli_detector.hpp
+++ b/src/condition/sqli_detector.hpp
@@ -50,6 +50,9 @@ bool is_where_tautology(const std::vector<sql_token> &resource_tokens,
 bool is_query_comment(const std::vector<sql_token> &resource_tokens,
     std::span<sql_token> param_tokens, std::size_t param_index, std::size_t param_tokens_begin);
 
+bool is_query_comment(
+    std::string_view resource, std::span<sql_token> param_tokens, std::size_t param_end);
+
 } // namespace internal
 
 } // namespace ddwaf

--- a/tests/integration/context/test.cpp
+++ b/tests/integration/context/test.cpp
@@ -757,6 +757,43 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
     ddwaf_destroy(handle);
 }
 
+TEST(TestContextIntegration, ReplaceEphemeral)
+{
+    auto rule = read_file("processor7.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    {
+        ddwaf_object tmp;
+        ddwaf_object ephemeral = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
+        ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
+
+        ddwaf_result ret;
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EVENTS(ret, {.id = "1",
+                               .name = "rule1",
+                               .tags = {{"type", "flow1"}, {"category", "category1"}},
+                               .matches = {{.op = "match_regex",
+                                   .op_value = "^string.*",
+                                   .highlight = "string 1",
+                                   .args = {{
+                                       .value = "string 1",
+                                       .address = "arg1",
+                                   }}}}});
+        ddwaf_result_free(&ret);
+    }
+
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
 TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
 {
     auto rule = read_file("processor7.yaml", base_dir);

--- a/tests/unit/condition/sqli_detector_internals_test.cpp
+++ b/tests/unit/condition/sqli_detector_internals_test.cpp
@@ -255,6 +255,7 @@ TEST(TestSqliDetectorInternals, IsQueryCommentFailure)
         1 OR 1)",
             R"(#  )"},
         {"SELECT * FROM ships WHERE id=-- \n1", "-- \n1"},
+        {"SELECT * FROM ships WHERE id=input -", "input -"},
     };
 
     for (const auto &[statement, param] : samples) {

--- a/tests/unit/condition/sqli_detector_internals_test.cpp
+++ b/tests/unit/condition/sqli_detector_internals_test.cpp
@@ -228,6 +228,7 @@ TEST(TestSqliDetectorInternals, IsQueryCommentSuccess)
         {R"(SELECT x FROM t WHERE id=''-- AND pwd='pwd'''--)", R"('--)"},
         {R"(SELECT * FROM ships WHERE id= 1 # AND password=HASH('str') 1 # )", R"( 1 # )"},
         {"SELECT * FROM users WHERE user = 'admin'--' AND password = '' LIMIT 1", "admin'--'"},
+        {"SELECT * FROM ships WHERE id='a' --smh", "' --"},
     };
 
     for (const auto &[statement, param] : samples) {
@@ -257,7 +258,6 @@ TEST(TestSqliDetectorInternals, IsQueryCommentFailure)
         {"SELECT * FROM ships WHERE id=-- \n1", "-- \n1"},
         {"SELECT * FROM ships WHERE id=input -", "input -"},
         {"SELECT * FROM ships WHERE id='a' --smh", "' -"},
-        {"SELECT * FROM ships WHERE id='a' --smh", "' --"},
         {"SELECT * FROM ships WHERE id='a' --smh", "--s"},
     };
 

--- a/tests/unit/condition/sqli_detector_internals_test.cpp
+++ b/tests/unit/condition/sqli_detector_internals_test.cpp
@@ -256,6 +256,9 @@ TEST(TestSqliDetectorInternals, IsQueryCommentFailure)
             R"(#  )"},
         {"SELECT * FROM ships WHERE id=-- \n1", "-- \n1"},
         {"SELECT * FROM ships WHERE id=input -", "input -"},
+        {"SELECT * FROM ships WHERE id='a' --smh", "' -"},
+        {"SELECT * FROM ships WHERE id='a' --smh", "' --"},
+        {"SELECT * FROM ships WHERE id='a' --smh", "--s"},
     };
 
     for (const auto &[statement, param] : samples) {

--- a/tests/unit/condition/sqli_detector_test.cpp
+++ b/tests/unit/condition/sqli_detector_test.cpp
@@ -289,11 +289,8 @@ TEST_P(DialectTestFixture, Comments)
             R"(SELECT x FROM t WHERE id=?-- AND pwd='pwd'''--)", R"('--)"},
         {R"(SELECT * FROM ships WHERE id= 1 -- AND password=HASH('str') 1 --)",
             R"(SELECT * FROM ships WHERE id= ? -- AND password=HASH('str') 1 --)", R"( 1 --)"},
-        {R"(SELECT * FROM ships WHERE id=-- AND password=HASH('str')
-        1 OR 1)",
-            R"(SELECT * FROM ships WHERE id=-- AND password=HASH('str')
-        ? OR ?)",
-            R"(-- AND)"},
+        {"SELECT * FROM ships WHERE id=-- \n1 OR 1", "SELECT * FROM ships WHERE id=-- \n? OR ?",
+            "-- \n1 OR 1"},
     };
 
     sqli_detector cond{
@@ -331,7 +328,7 @@ TEST_P(DialectTestFixture, Comments)
     }
 }
 
-TEST(TestSQLiDetectorMySql, Comments)
+TEST(TestSqliDetectorMySql, Comments)
 {
     std::vector<std::tuple<std::string, std::string, std::string>> samples{
         {R"(SELECT x FROM t WHERE id='admin'#)", R"(SELECT x FROM t WHERE id=?#)", R"(admin'#)"},
@@ -341,11 +338,8 @@ TEST(TestSQLiDetectorMySql, Comments)
             R"(SELECT x FROM t WHERE id=?# AND pwd='pwd'''# )", R"('# )"},
         {R"(SELECT * FROM ships WHERE id= 1 # AND password=HASH('str') 1 #)",
             R"(SELECT * FROM ships WHERE id= ? # AND password=HASH('str') 1 #)", R"( 1 #)"},
-        {R"(SELECT * FROM ships WHERE id=# AND password=HASH('str')
-        1 OR 1)",
-            R"(SELECT * FROM ships WHERE id=# AND password=HASH('str')
-        ? OR ?)",
-            R"(# AND)"},
+        {"SELECT * FROM ships WHERE id=# \n1 OR 1", "SELECT * FROM ships WHERE id=# \n? OR ?",
+            "# \n1 OR 1"},
     };
 
     sqli_detector cond{
@@ -383,7 +377,7 @@ TEST(TestSQLiDetectorMySql, Comments)
     }
 }
 
-TEST(TestSQLiDetectorMySql, Tautologies)
+TEST(TestSqliDetectorMySql, Tautologies)
 {
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
@@ -435,7 +429,7 @@ TEST(TestSQLiDetectorMySql, Tautologies)
     }
 }
 
-TEST(TestSQLiDetectorPgSql, Tautologies)
+TEST(TestSqliDetectorPgSql, Tautologies)
 {
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};

--- a/tests/unit/condition/sqli_detector_test.cpp
+++ b/tests/unit/condition/sqli_detector_test.cpp
@@ -104,6 +104,7 @@ TEST_P(DialectTestFixture, BenignInjections)
         {R"(SELECT values FROM table WHERE column IN (1, 2, 3, 4, 5);)", "(1, 2, 3, 4, 5)"},
         {R"(SELECT values FROM table WHERE id=-- admin)", "-- admin"},
         {R"(SELECT values FROM table WHERE value IN (-1,-2,+3,+4);)", "-1,-2,+3,+4"},
+        {"SELECT * FROM ships WHERE id=input -", "input -"},
     };
 
     sqli_detector cond{

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -64,24 +64,33 @@ int main(int argc, char *argv[])
 
     const std::vector<std::string> rulesets = args["--ruleset"];
     const std::vector<std::string> inputs = args["--input"];
-    if (rulesets.empty() || rulesets.size() > 1 || inputs.empty()) {
+    if (rulesets.empty() || inputs.empty()) {
         std::cout << "Usage: " << argv[0] << " --ruleset <json/yaml file>"
                   << " --input <json input> [<json input>..]\n";
         return EXIT_FAILURE;
     }
 
-    const auto &ruleset = rulesets[0];
+    const ddwaf_config config{{.max_container_size=0, .max_container_depth=0, .max_string_length=0}, {.key_regex=key_regex, .value_regex=value_regex}, ddwaf_object_free};
+    ddwaf_builder builder = ddwaf_builder_init(&config);
 
-    auto rule = YAML::Load(read_file(ruleset)).as<ddwaf_object>();
-    const ddwaf_config config{{0, 0, 0}, {key_regex, value_regex}, ddwaf_object_free};
-    ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
-    ddwaf_object_free(&rule);
-    if (handle == nullptr) {
-        std::cout << "Failed to load " << ruleset << '\n';
-        return EXIT_FAILURE;
+    std::size_t index = 0;
+    for (const auto & config : rulesets) {
+        auto rule = YAML::Load(read_file(config)).as<ddwaf_object>();
+        auto path = "config/" + std::to_string(index++);
+
+        if (!ddwaf_builder_add_or_update_config(builder, path.data(), path.size(), &rule, nullptr)) {
+            std::cout << "Failed to add configuration: " << config << '\n';
+        }
+
+        ddwaf_object_free(&rule);
     }
 
-    std::cout << "-- Run with " << ruleset << '\n';
+    ddwaf_handle handle = ddwaf_builder_build_instance(builder);
+    ddwaf_builder_destroy(builder);
+    if (handle == nullptr) {
+        std::cout << "Failed to instantiate handle\n";
+        return EXIT_FAILURE;
+    }
 
     ddwaf_context context = ddwaf_context_init(handle);
     if (context == nullptr) {
@@ -158,6 +167,7 @@ int main(int argc, char *argv[])
     }
 
     ddwaf_context_destroy(context);
+
 
     ddwaf_destroy(handle);
 


### PR DESCRIPTION
This PR changes `is_query_comment` to make it more strict by:
- Ensuring that a comment isn't injected in isolation, i.e. there are extra tokens injected.
- When the EOL comment uses `--`, ensuring that the whole `--` token is injected.
- Remove cases for when the injection starts with a comment as those will be covered by other cases.

Related Jiras: [APPSEC-57317]

[APPSEC-57317]: https://datadoghq.atlassian.net/browse/APPSEC-57317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ