### PR TITLE
Replace ddwaf_result with ddwaf_object

### DIFF
--- a/BINDING_IMPL_NOTES.md
+++ b/BINDING_IMPL_NOTES.md
@@ -141,7 +141,7 @@ struct ctx_wrapper {
 };
 
 DDWAF_RET_CODE run_waf(
-    ctx_wrapper &wrapper, ddwaf_object *data, ddwaf_result *result, uint64_t timeout)
+    ctx_wrapper &wrapper, ddwaf_object *data, ddwaf_object *result, uint64_t timeout)
 {
     std::lock_guard<std::mutex> lock{wrapper.mutex}; // acquire exclusive lock
     if (wrapper.ctx == nullptr) { /* context already destroyed */ }

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ int main()
     ddwaf_object_map_add(&root, "arg1", ddwaf_object_string(&tmp, "string 1"));
     ddwaf_object_map_add(&root, "arg2", ddwaf_object_string(&tmp, "string 2"));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     auto code = ddwaf_run(context, &root, nullptr, &ret, 1000000 /* microseconds */);
     std::cout << "Output second run: " << code << '\n';
     if (code == DDWAF_MATCH) {
@@ -128,11 +128,10 @@ int main()
         out.SetIndent(2);
         out.SetMapFormat(YAML::Block);
         out.SetSeqFormat(YAML::Block);
-        out << object_to_yaml(ret.events);
-        out << object_to_yaml(ret.actions);
+        out << object_to_yaml(ret);
     }
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);

--- a/benchmark/run_fixture.cpp
+++ b/benchmark/run_fixture.cpp
@@ -42,7 +42,7 @@ void run_fixture::warmup()
             if (i == current->nbEntries) {
                 object_stack.pop();
             } else {
-                object_stack.push({&current->array[i++], 0});
+                object_stack.emplace(&current->array[i++], 0);
             }
         }
     }
@@ -53,18 +53,20 @@ uint64_t run_fixture::test_main()
     uint64_t total_runtime = 0;
 
     for (auto &object : objects_) {
-        ddwaf_result res;
+        ddwaf_object res;
         auto code = ddwaf_run(ctx_, nullptr, &object, &res, std::numeric_limits<uint32_t>::max());
         if (code < 0) {
             throw std::runtime_error("WAF returned " + std::to_string(code));
         }
 
-        if (res.timeout) {
+        const auto *timeout = ddwaf_object_find(&res, "timeout", sizeof("timeout") - 1);
+        if (ddwaf_object_get_bool(timeout)) {
             throw std::runtime_error("WAF timed-out");
         }
 
-        total_runtime += res.total_runtime;
-        ddwaf_result_free(&res);
+        const auto *duration = ddwaf_object_find(&res, "duration", sizeof("duration") - 1);
+        total_runtime += ddwaf_object_get_unsigned(duration);
+        ddwaf_object_free(&res);
     }
 
     return total_runtime;

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -175,7 +175,7 @@ rules:
 
 int main()
 {
-    YAML::Node doc = YAML::Load(waf_rule.data());
+    YAML::Node doc = YAML::Load(waf_rule.data(), waf_rule.size());
 
     auto rule = doc.as<ddwaf_object>(); //= convert_yaml_to_args(doc);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
@@ -190,12 +190,13 @@ int main()
         return EXIT_FAILURE;
     }
 
-    ddwaf_object root, tmp;
+    ddwaf_object root;
+    ddwaf_object tmp;
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "arg1", ddwaf_object_string(&tmp, "string 1"));
     ddwaf_object_map_add(&root, "arg2", ddwaf_object_string(&tmp, "string 2"));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     auto code = ddwaf_run(context, &root, nullptr, &ret, LONG_TIME);
     std::cout << "Output second run: " << code << '\n';
     if (code == DDWAF_MATCH) {
@@ -203,11 +204,10 @@ int main()
         out.SetIndent(2);
         out.SetMapFormat(YAML::Block);
         out.SetSeqFormat(YAML::Block);
-        out << object_to_yaml(ret.events);
-        out << object_to_yaml(ret.actions);
+        out << object_to_yaml(ret);
     }
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);

--- a/fuzzer/global/src/interface.cpp
+++ b/fuzzer/global/src/interface.cpp
@@ -99,7 +99,7 @@ void run_waf(ddwaf_handle handle, ddwaf_object args, bool ephemeral, size_t time
         __builtin_trap();
     }
 
-    ddwaf_result res;
+    ddwaf_object res;
     auto code = DDWAF_OK;
     if (ephemeral) {
         ddwaf_run(context, nullptr, &args, &res, timeLeftInUs);
@@ -113,6 +113,6 @@ void run_waf(ddwaf_handle handle, ddwaf_object args, bool ephemeral, size_t time
         __builtin_trap();
     }
 
-    ddwaf_result_free(&res);
+    ddwaf_object_free(&res);
     ddwaf_context_destroy(context);
 }

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -93,7 +93,6 @@ typedef struct _ddwaf_builder* ddwaf_builder;
 
 typedef struct _ddwaf_object ddwaf_object;
 typedef struct _ddwaf_config ddwaf_config;
-typedef struct _ddwaf_result ddwaf_result;
 /**
  * @struct ddwaf_object
  *
@@ -152,27 +151,6 @@ struct _ddwaf_config
      *  to ddwaf_run. If the value of this function is NULL, the objects will
      *  not be freed. The default value should be ddwaf_object_free. */
     ddwaf_object_free_fn free_fn;
-};
-
-/**
- * @struct ddwaf_result
- *
- * Structure containing the result of a WAF run.
- **/
-struct _ddwaf_result
-{
-    /** Whether there has been a timeout during the operation **/
-    bool timeout;
-    /** Array of events generated, this is guaranteed to be an array **/
-    ddwaf_object events;
-    /** Map of actions generated, this is guaranteed to be a map in the format:
-     * {action type: { <parameter map> }, ...}
-     **/
-    ddwaf_object actions;
-    /** Map containing all derived objects in the format (address, value) **/
-    ddwaf_object derivatives;
-    /** Total WAF runtime in nanoseconds **/
-    uint64_t total_runtime;
 };
 
 /**
@@ -330,7 +308,7 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
  *  recommended and might be explicitly rejected in the future.
  **/
 DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
-    ddwaf_object *ephemeral_data, ddwaf_result *result,  uint64_t timeout);
+    ddwaf_object *ephemeral_data, ddwaf_object *result,  uint64_t timeout);
 
 /**
  * ddwaf_context_destroy
@@ -341,15 +319,6 @@ DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
  * @param context Context to destroy. (nonnull)
  **/
 void ddwaf_context_destroy(ddwaf_context context);
-
-/**
- * ddwaf_result_free
- *
- * Free a ddwaf_result structure.
- *
- * @param result Structure to free. (nonnull)
- **/
-void ddwaf_result_free(ddwaf_result *result);
 
 /**
  * ddwaf_builder_init
@@ -781,6 +750,19 @@ bool ddwaf_object_get_bool(const ddwaf_object *object);
  **/
 const ddwaf_object* ddwaf_object_get_index(const ddwaf_object *object, size_t index);
 
+/**
+ * ddwaf_object_find
+ *
+ * Returns the object within the given map with a key matching the provided one.
+ *
+ * @param object The container from which to extract the object.
+ * @param key A string representing the key to find.
+ * @param length Length of the key.
+ *
+ * @return The requested object or NULL if the key was not found or the
+ *         object is not a container.
+ **/
+const ddwaf_object* ddwaf_object_find(const ddwaf_object *object, const char *key, size_t length);
 
 /**
  * ddwaf_object_free

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -274,7 +274,10 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
  *    can be of an arbitrary type. This parameter can be null if persistent data
  *    is provided.
  *
- * @param result Structure containing the result of the operation. (nullable)
+ * @param result Object map containing all generated events, actions, attributes,
+ *               etc. This structure must be freed by the caller and will
+ *               contain all relevant keys when the result of ddwaf_run is a
+ *               non-error one (e.g. DDWAF_OK, DDWAF_MATCH). (nullable)
  * @param timeout Maximum time budget in microseconds.
  *
  * @return Return code of the operation.

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -274,10 +274,20 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
  *    can be of an arbitrary type. This parameter can be null if persistent data
  *    is provided.
  *
- * @param result Object map containing all generated events, actions, attributes,
- *               etc. This structure must be freed by the caller and will
- *               contain all relevant keys when the result of ddwaf_run is a
- *               non-error one (e.g. DDWAF_OK, DDWAF_MATCH). (nullable)
+ * @param result (nullable) Object map containing the following items:
+ *               - events: an array of the generated events.
+ *               - actions: a map of the generated actions in the format:
+ *                          {action type: { <parameter map> }, ...}
+ *               - duration: an unsigned specifying the total runtime of the
+ *                           call in nanoseconds.
+ *               - timeout: whether there has been a timeout during the call.
+ *               - attributes: a map containing all derived objects in the
+ *                             format: {tag, value}
+ *               - keep: whether the data contained herein must override any
+ *                       transport sampling through the relevant mechanism.
+ *               This structure must be freed by the caller and will contain all
+ *               specified keys when the value returned by ddwaf_run is either
+ *               DDWAF_OK or DDWAF_MATCH and will be empty otherwise.
  * @param timeout Maximum time budget in microseconds.
  *
  * @return Return code of the operation.

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -11,7 +11,6 @@ EXPORTS
   ddwaf_context_init
   ddwaf_run
   ddwaf_context_destroy
-  ddwaf_result_free
   ddwaf_object_invalid
   ddwaf_object_null
   ddwaf_object_string

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -43,3 +43,4 @@ EXPORTS
   ddwaf_get_version
   ddwaf_set_log_cb
   ddwaf_known_actions
+  ddwaf_object_find

--- a/smoketest/smoke.c
+++ b/smoketest/smoke.c
@@ -255,7 +255,9 @@ int main() {
     ddwaf_object result = {0};
     ddwaf_run(ctx, &data, NULL, &result, (uint32_t)-1);
     
-    if (ddwaf_object_size(&result.events) == 0) {
+
+    const ddwaf_object *events = ddwaf_object_find(&result, "events", sizeof("events") - 1);
+    if (ddwaf_object_size(events) == 0) {
         puts("result is empty");
         return 1;
     }

--- a/smoketest/smoke.c
+++ b/smoketest/smoke.c
@@ -252,14 +252,15 @@ int main() {
     ddwaf_object_map(&data);
     ddwaf_object_map_add(&data, "key", DDSTR("Arachni"));
 
-    ddwaf_result result = {0};
+    ddwaf_object result = {0};
     ddwaf_run(ctx, &data, NULL, &result, (uint32_t)-1);
-
+    
     if (ddwaf_object_size(&result.events) == 0) {
         puts("result is empty");
         return 1;
     }
     puts("result is valid");
+    ddwaf_object_free(&result);
 
     return 0;
 }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -52,7 +52,7 @@ void set_context_event_address(object_store &store)
 }
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
-struct result_wrapper {
+struct result_components {
     ddwaf_object &events;
     ddwaf_object &actions;
     ddwaf_object &duration;
@@ -62,7 +62,7 @@ struct result_wrapper {
 };
 // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 
-result_wrapper initialise_result_object(ddwaf_object &object)
+result_components initialise_result_object(ddwaf_object &object)
 {
     ddwaf_object_map(&object);
 
@@ -79,7 +79,7 @@ result_wrapper initialise_result_object(ddwaf_object &object)
         throw std::runtime_error("failed to generate result object");
     }
 
-    result_wrapper res{.events = object.array[0],
+    result_components res{.events = object.array[0],
         .actions = object.array[1],
         .duration = object.array[2],
         .timeout = object.array[3],

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -52,8 +52,8 @@ public:
     context &operator=(context &&) = delete;
     ~context() = default;
 
-    DDWAF_RET_CODE run(optional_ref<ddwaf_object>, optional_ref<ddwaf_object>,
-        optional_ref<ddwaf_result>, uint64_t);
+    std::pair<DDWAF_RET_CODE, ddwaf_object> run(
+        optional_ref<ddwaf_object>, optional_ref<ddwaf_object>, uint64_t);
 
     void eval_preprocessors(optional_ref<ddwaf_object> &derived, ddwaf::timer &deadline);
     void eval_postprocessors(optional_ref<ddwaf_object> &derived, ddwaf::timer &deadline);
@@ -139,11 +139,11 @@ public:
     context_wrapper &operator=(context_wrapper &&) noexcept = delete;
     context_wrapper &operator=(const context_wrapper &) = delete;
 
-    DDWAF_RET_CODE run(optional_ref<ddwaf_object> persistent, optional_ref<ddwaf_object> ephemeral,
-        optional_ref<ddwaf_result> res, uint64_t timeout)
+    std::pair<DDWAF_RET_CODE, ddwaf_object> run(optional_ref<ddwaf_object> persistent,
+        optional_ref<ddwaf_object> ephemeral, uint64_t timeout)
     {
         memory::memory_resource_guard guard(&mr_);
-        return ctx_->run(persistent, ephemeral, res, timeout);
+        return ctx_->run(persistent, ephemeral, timeout);
     }
 
 protected:

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -60,7 +60,8 @@ public:
     // This function below returns a reference to an internal object,
     // however using them this way helps with testing
     exclusion::context_policy &eval_filters(ddwaf::timer &deadline);
-    std::vector<event> eval_rules(const exclusion::context_policy &policy, ddwaf::timer &deadline);
+    void eval_rules(const exclusion::context_policy &policy, std::vector<event> &events,
+        ddwaf::timer &deadline);
 
 protected:
     bool is_first_run() const { return store_.empty(); }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -284,16 +284,12 @@ void serialize_actions(ddwaf_object &action_map, const action_tracker &actions)
 
 } // namespace
 
-void event_serializer::serialize(const std::vector<event> &events, ddwaf_object &output) const
+void event_serializer::serialize(const std::vector<event> &events,
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    ddwaf_object &output_events, ddwaf_object &output_actions) const
 {
     action_tracker actions{
         .blocking_action = {}, .stack_id = {}, .non_blocking_actions = {}, .mapper = actions_};
-
-    ddwaf_object output_events;
-    ddwaf_object output_actions;
-
-    ddwaf_object_array(&output_events);
-    ddwaf_object_map(&output_actions);
 
     for (const auto &event : events) {
         ddwaf_object root_map;
@@ -331,9 +327,6 @@ void event_serializer::serialize(const std::vector<event> &events, ddwaf_object 
     }
 
     serialize_actions(output_actions, actions);
-
-    ddwaf_object_map_addl(&output, "events", sizeof("events") - 1, &output_events);
-    ddwaf_object_map_addl(&output, "actions", sizeof("actions") - 1, &output_actions);
 }
 
 } // namespace ddwaf

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -33,7 +33,8 @@ public:
         : obfuscator_(event_obfuscator), actions_(actions)
     {}
 
-    void serialize(const std::vector<event> &events, ddwaf_object &output) const;
+    void serialize(const std::vector<event> &events, ddwaf_object &output_events,
+        ddwaf_object &output_actions) const;
 
 protected:
     const ddwaf::obfuscator &obfuscator_;

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -33,7 +33,7 @@ public:
         : obfuscator_(event_obfuscator), actions_(actions)
     {}
 
-    void serialize(const std::vector<event> &events, ddwaf_result &output) const;
+    void serialize(const std::vector<event> &events, ddwaf_object &output) const;
 
 protected:
     const ddwaf::obfuscator &obfuscator_;

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -187,24 +187,19 @@ ddwaf_context ddwaf_context_init(ddwaf::waf *handle)
     return nullptr;
 }
 
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
-    ddwaf_object *ephemeral_data, ddwaf_result *result, uint64_t timeout)
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    ddwaf_object *ephemeral_data, ddwaf_object *result, uint64_t timeout)
 {
-    if (result != nullptr) {
-        *result = DDWAF_RESULT_INITIALISER;
-    }
-
     if (context == nullptr || (persistent_data == nullptr && ephemeral_data == nullptr)) {
+        if (result != nullptr) {
+            ddwaf_object_map(result);
+        }
         DDWAF_WARN("Illegal WAF call: context or data was null");
         return DDWAF_ERR_INVALID_ARGUMENT;
     }
-    try {
-        optional_ref<ddwaf_result> res{std::nullopt};
-        if (result != nullptr) {
-            res = *result;
-        }
 
+    try {
         optional_ref<ddwaf_object> persistent{std::nullopt};
         if (persistent_data != nullptr) {
             persistent = *persistent_data;
@@ -220,7 +215,13 @@ DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
         constexpr uint64_t max_timeout_ms = std::chrono::nanoseconds::max().count() / 1000;
         timeout = std::min(timeout, max_timeout_ms);
 
-        return context->run(persistent, ephemeral, res, timeout);
+        auto [code, res] = context->run(persistent, ephemeral, timeout);
+        if (result != nullptr) {
+            *result = res;
+        } else {
+            ddwaf_object_free(&res);
+        }
+        return code;
     } catch (const std::exception &e) {
         // catch-all to avoid std::terminate
         DDWAF_ERROR("{}", e.what());
@@ -254,16 +255,6 @@ bool ddwaf_set_log_cb(ddwaf_log_cb cb, DDWAF_LOG_LEVEL min_level)
     ddwaf::logger::init(cb, min_level);
     DDWAF_INFO("Sending log messages to binding, min level {}", log_level_to_str(min_level));
     return true;
-}
-
-void ddwaf_result_free(ddwaf_result *result)
-{
-    // NOLINTNEXTLINE
-    ddwaf_object_free(&result->events);
-    ddwaf_object_free(&result->actions);
-    ddwaf_object_free(&result->derivatives);
-
-    *result = DDWAF_RESULT_INITIALISER;
 }
 
 ddwaf_builder ddwaf_builder_init(const ddwaf_config *config)

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -192,9 +192,6 @@ DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
     ddwaf_object *ephemeral_data, ddwaf_object *result, uint64_t timeout)
 {
     if (context == nullptr || (persistent_data == nullptr && ephemeral_data == nullptr)) {
-        if (result != nullptr) {
-            ddwaf_object_map(result);
-        }
         DDWAF_WARN("Illegal WAF call: context or data was null");
         return DDWAF_ERR_INVALID_ARGUMENT;
     }
@@ -219,6 +216,7 @@ DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
         if (result != nullptr) {
             *result = res;
         } else {
+            // Nullability of the result structure supported for testing
             ddwaf_object_free(&res);
         }
         return code;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string_view>
 
 #include "ddwaf.h"
 #include "log.hpp"
@@ -457,5 +458,30 @@ const ddwaf_object *ddwaf_object_get_index(const ddwaf_object *object, size_t in
     }
 
     return &object->array[index];
+}
+
+const ddwaf_object *ddwaf_object_find(const ddwaf_object *object, const char *key, size_t length)
+{
+    if (object == nullptr || key == nullptr || length == 0 || !ddwaf::object::is_map(object) ||
+        object->nbEntries == 0) {
+        return nullptr;
+    }
+
+    const std::string_view expected_key{key, length};
+    for (uint64_t i = 0; i < object->nbEntries; ++i) {
+        const auto &child = object->array[i];
+
+        if (child.parameterName == nullptr || child.parameterNameLength == 0) {
+            continue;
+        }
+
+        const std::string_view child_key{
+            child.parameterName, static_cast<std::size_t>(child.parameterNameLength)};
+        if (child_key == expected_key) {
+            return &child;
+        }
+    }
+
+    return nullptr;
 }
 }

--- a/tests/common/gtest_utils.hpp
+++ b/tests/common/gtest_utils.hpp
@@ -173,7 +173,9 @@ std::list<ddwaf::test::event::match> from_matches(
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define EXPECT_EVENTS(result, ...)                                                                 \
     {                                                                                              \
-        auto data = ddwaf::test::object_to_json(result.events);                                    \
+        const auto *object = ddwaf_object_find(&result, STRL("events"));                           \
+        EXPECT_NE(object, nullptr);                                                                \
+        auto data = ddwaf::test::object_to_json(*object);                                          \
         EXPECT_TRUE(ValidateEventSchema(data));                                                    \
         YAML::Node doc = YAML::Load(data.c_str());                                                 \
         auto events = doc.as<std::list<ddwaf::test::event>>();                                     \
@@ -194,7 +196,9 @@ std::list<ddwaf::test::event::match> from_matches(
 
 #define EXPECT_ACTIONS(result, ...)                                                                \
     {                                                                                              \
-        auto data = ddwaf::test::object_to_json(result.actions);                                   \
+        const auto *object = ddwaf_object_find(&result, STRL("actions"));                          \
+        EXPECT_NE(object, nullptr);                                                                \
+        auto data = ddwaf::test::object_to_json(*object);                                          \
         EXPECT_TRUE(ValidateActionsSchema(data));                                                  \
         YAML::Node doc = YAML::Load(data.c_str());                                                 \
         auto obtained = doc.as<ddwaf::test::action_map>();                                         \

--- a/tests/integration/conditions/exists/test.cpp
+++ b/tests/integration/conditions/exists/test.cpp
@@ -26,9 +26,11 @@ TEST(TestConditionExistsIntegration, AddressAvailable)
     ddwaf_object value;
     ddwaf_object_map_add(&map, "input-1", ddwaf_object_invalid(&value));
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1-exists",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -38,7 +40,7 @@ TEST(TestConditionExistsIntegration, AddressAvailable)
                                    .address = "input-1",
                                }}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -58,9 +60,9 @@ TEST(TestConditionExistsIntegration, AddressNotAvailable)
     ddwaf_object value;
     ddwaf_object_map_add(&map, "input", ddwaf_object_invalid(&value));
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -82,9 +84,10 @@ TEST(TestConditionExistsIntegration, KeyPathAvailable)
     ddwaf_object_map_add(&intermediate, "path", ddwaf_object_invalid(&value));
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2-exists-kp",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -92,7 +95,7 @@ TEST(TestConditionExistsIntegration, KeyPathAvailable)
                                .highlight = "",
                                .args = {{.address = "input-2", .path = {"path"}}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -114,10 +117,10 @@ TEST(TestConditionExistsIntegration, KeyPathNotAvailable)
     ddwaf_object_map_add(&intermediate, "poth", ddwaf_object_invalid(&value));
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -137,9 +140,10 @@ TEST(TestConditionExistsIntegration, AddressAvailableVariadicRule)
     ddwaf_object value;
     ddwaf_object_map_add(&map, "input-3-1", ddwaf_object_invalid(&value));
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
                            .name = "rule3-exists-multi",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -149,7 +153,7 @@ TEST(TestConditionExistsIntegration, AddressAvailableVariadicRule)
                                    .address = "input-3-1",
                                }}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -171,9 +175,10 @@ TEST(TestConditionExistsIntegration, KeyPathAvailableVariadicRule)
     ddwaf_object_map_add(&intermediate, "path", ddwaf_object_invalid(&value));
     ddwaf_object_map_add(&map, "input-3-2", &intermediate);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
                            .name = "rule3-exists-multi",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -181,7 +186,7 @@ TEST(TestConditionExistsIntegration, KeyPathAvailableVariadicRule)
                                .highlight = "",
                                .args = {{.address = "input-3-2", .path = {"path"}}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -204,9 +209,10 @@ TEST(TestConditionExistsIntegration, AddressAvailableKeyPathNotAvailableVariadic
     ddwaf_object_map_add(&map, "input-3-2", &intermediate);
     ddwaf_object_map_add(&map, "input-3-1", ddwaf_object_invalid(&value));
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
                            .name = "rule3-exists-multi",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -216,7 +222,7 @@ TEST(TestConditionExistsIntegration, AddressAvailableKeyPathNotAvailableVariadic
                                    .address = "input-3-1",
                                }}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -236,10 +242,10 @@ TEST(TestConditionExistsNegatedIntegration, AddressAvailable)
     ddwaf_object value;
     ddwaf_object_map_add(&map, "input-1", ddwaf_object_invalid(&value));
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -262,10 +268,10 @@ TEST(TestConditionExistsNegatedIntegration, AddressNotAvailable)
     // Even though the address isn't present, this test shouldn't result in a match
     // as the !exists operator only supports address + key path, since we can't
     // assert the absence of an address given that these are provided in stages
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -287,9 +293,10 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathNotAvailable)
     ddwaf_object_map_add(&intermediate, "poth", ddwaf_object_invalid(&value));
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2-not-exists-kp",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -297,7 +304,7 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathNotAvailable)
                                .highlight = "",
                                .args = {{.address = "input-2", .path = {"path"}}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -319,10 +326,10 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathAvailable)
     ddwaf_object_map_add(&intermediate, "path", ddwaf_object_invalid(&value));
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }

--- a/tests/integration/context/test.cpp
+++ b/tests/integration/context/test.cpp
@@ -32,10 +32,11 @@ TEST(TestContextIntegration, Basic)
     ddwaf_object_map_add(&subMap, "key", ddwaf_object_string(&tmp, "rule3"));
     ddwaf_object_map_add(&parameter, "value2", &subMap); // ddwaf_object_string(&,"rule3"));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
 
-    EXPECT_FALSE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -55,7 +56,7 @@ TEST(TestContextIntegration, Basic)
                                        .path = {"key"},
                                    }}}}});
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -79,10 +80,11 @@ TEST(TestContextIntegration, KeyPaths)
     ddwaf_object_map_add(&param, "x", ddwaf_object_string(&tmp, "Sqreen"));
     ddwaf_object_map_add(&root, "param", &param);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
 
-    EXPECT_FALSE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -95,7 +97,7 @@ TEST(TestContextIntegration, KeyPaths)
                                    .path = {"x"},
                                }}}}});
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 
     root = DDWAF_OBJECT_MAP;
     param = DDWAF_OBJECT_MAP;
@@ -104,7 +106,8 @@ TEST(TestContextIntegration, KeyPaths)
 
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
 
-    EXPECT_FALSE(ret.timeout);
+    timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow2"}, {"category", "category2"}},
@@ -116,7 +119,7 @@ TEST(TestContextIntegration, KeyPaths)
                                    .address = "param",
                                    .path = {"z"},
                                }}}}});
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
     ddwaf_context_destroy(context);
 
     context = ddwaf_context_init(handle);
@@ -130,7 +133,8 @@ TEST(TestContextIntegration, KeyPaths)
 
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
 
-    EXPECT_FALSE(ret.timeout);
+    timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -143,7 +147,7 @@ TEST(TestContextIntegration, KeyPaths)
                                    .path = {"y"},
                                }}}}});
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -168,14 +172,17 @@ TEST(TestContextIntegration, MissingParameter)
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
     ddwaf_object_map_add(&param, "param", ddwaf_object_signed(&tmp, 42));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_OK);
 
-    EXPECT_FALSE(ret.timeout);
-    EXPECT_EQ(ddwaf_object_type(&ret.events), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(&ret.events), 0);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-    ddwaf_result_free(&ret);
+    const auto *events = ddwaf_object_find(&ret, STRL("events"));
+    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_size(events), 0);
+
+    ddwaf_object_free(&ret);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -206,16 +213,18 @@ TEST(TestContextIntegration, InvalidUTF8Input)
     ddwaf_object_map_addl(&param, ba1.c_str(), ba1.length(), &mapItem);
     ddwaf_object_map_addl(&param, ba2.c_str(), ba2.length(), ddwaf_object_map(&tmp));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
 
-    EXPECT_FALSE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-    auto data = ddwaf::test::object_to_json(ret.events);
+    const auto *events = ddwaf_object_find(&ret, STRL("events"));
+    auto data = ddwaf::test::object_to_json(*events);
     auto pos = data.find(mapItem.stringValue);
     EXPECT_TRUE(pos != std::string::npos);
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -231,7 +240,7 @@ TEST(TestContextIntegration, SingleCollectionMatch)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
@@ -241,7 +250,8 @@ TEST(TestContextIntegration, SingleCollectionMatch)
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param1, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(ret.timeout);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -252,7 +262,7 @@ TEST(TestContextIntegration, SingleCollectionMatch)
                                        .value = "Sqreen",
                                        .address = "param1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -261,11 +271,14 @@ TEST(TestContextIntegration, SingleCollectionMatch)
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(ret.timeout);
-        EXPECT_EQ(ddwaf_object_type(&ret.events), DDWAF_OBJ_ARRAY);
-        EXPECT_EQ(ddwaf_object_size(&ret.events), 0);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        ddwaf_result_free(&ret);
+        const auto *events = ddwaf_object_find(&ret, STRL("events"));
+        EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+        EXPECT_EQ(ddwaf_object_size(events), 0);
+
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -282,7 +295,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
@@ -292,7 +305,8 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object_map_add(&param, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(ret.timeout);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -303,7 +317,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
                                        .value = "Sqreen",
                                        .address = "param1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -312,11 +326,13 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object_map_add(&param, "param", ddwaf_object_string(&tmp, "Pony"));
 
         EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(ret.timeout);
-        EXPECT_EQ(ddwaf_object_type(&ret.events), DDWAF_OBJ_ARRAY);
-        EXPECT_EQ(ddwaf_object_size(&ret.events), 0);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+        const auto *events = ddwaf_object_find(&ret, STRL("events"));
+        EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+        EXPECT_EQ(ddwaf_object_size(events), 0);
 
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -325,7 +341,8 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
         EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(ret.timeout);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow2"}, {"category", "category2"}},
@@ -336,7 +353,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
                                        .value = "Sqreen",
                                        .address = "param2",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -352,7 +369,7 @@ TEST(TestContextIntegration, Timeout)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
@@ -361,9 +378,10 @@ TEST(TestContextIntegration, Timeout)
     ddwaf_object_map_add(&param, "pm_param", ddwaf_object_string(&tmp, "aaaabbbbbaaa"));
 
     EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, SHORT_TIME), DDWAF_OK);
-    EXPECT_TRUE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_TRUE(ddwaf_object_get_bool(timeout));
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -390,11 +408,12 @@ TEST(TestContextIntegration, ParameterOverride)
 
     // Run with both arg1 and arg2, but arg1 is wrong
     //	// Run with just arg1
-    ddwaf_result ret;
+    ddwaf_object ret;
     auto code = ddwaf_run(context, &param1, nullptr, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_OK);
-    EXPECT_FALSE(ret.timeout);
-    ddwaf_result_free(&ret);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+    ddwaf_object_free(&ret);
 
     // Override `arg1`
     code = ddwaf_run(context, &param2, nullptr, &ret, LONG_TIME);
@@ -417,13 +436,16 @@ TEST(TestContextIntegration, ParameterOverride)
                                        .address = "arg2",
                                    }}}}});
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 
     // Run again without change
     code = ddwaf_run(context, ddwaf_object_map(&tmp), nullptr, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_OK);
-    EXPECT_FALSE(ret.timeout);
-    ddwaf_result_free(&ret);
+
+    timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    ddwaf_object_free(&ret);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
@@ -446,7 +468,7 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
         ddwaf_object param1 = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &param1, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -458,7 +480,7 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
                                        .value = "Sqreen",
                                        .address = "param1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -466,7 +488,7 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
         ddwaf_object param1 = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &param1, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -478,7 +500,7 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
                                        .value = "Sqreen",
                                        .address = "param1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -504,7 +526,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object_map_add(&persistent, "arg1", ddwaf_object_string(&tmp, "string 1"));
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 2"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, &persistent, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -523,7 +545,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
                                            .value = "string 2",
                                            .address = "arg2",
                                        }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -531,7 +553,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object ephemeral = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -550,7 +572,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
                                            .value = "string 8",
                                            .address = "arg2",
                                        }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -558,7 +580,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object ephemeral = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 3"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -577,7 +599,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
                                            .value = "string 3",
                                            .address = "arg2",
                                        }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -601,7 +623,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
         ddwaf_object ephemeral = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -613,7 +635,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
                                        .value = "string 1",
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -622,7 +644,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
@@ -635,7 +657,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
                                        .value = "string 8",
                                        .address = "arg2",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -660,7 +682,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
@@ -673,7 +695,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
                                        .value = "string 8",
                                        .address = "arg2",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -681,7 +703,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
         ddwaf_object ephemeral = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -693,7 +715,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
                                        .value = "string 1",
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -717,7 +739,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
         ddwaf_object ephemeral = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -729,7 +751,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
                                        .value = "string 1",
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -737,7 +759,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
         ddwaf_object persistent = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&persistent, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
@@ -750,7 +772,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
                                        .value = "string 8",
                                        .address = "arg2",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -775,7 +797,7 @@ TEST(TestContextIntegration, ReplaceEphemeral)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -787,7 +809,7 @@ TEST(TestContextIntegration, ReplaceEphemeral)
                                        .value = "string 1",
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -811,7 +833,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
         ddwaf_object ephemeral = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
@@ -824,7 +846,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
                                        .value = "string 8",
                                        .address = "arg2",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -832,7 +854,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
         ddwaf_object persistent = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&persistent, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -845,7 +867,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
                                        .address = "arg1",
                                    }}}}});
 
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -869,7 +891,7 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
         ddwaf_object persistent = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&persistent, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
@@ -882,7 +904,7 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
                                        .value = "string 8",
                                        .address = "arg2",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     {
@@ -890,9 +912,9 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
         ddwaf_object ephemeral = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_OK);
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);
@@ -929,13 +951,15 @@ TEST(TestContextIntegration, WafContextEventAddress)
 
         ddwaf_object_map_add(&map, "waf.trigger", ddwaf_object_string(&tmp, "irrelevant"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 0);
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -959,17 +983,19 @@ TEST(TestContextIntegration, WafContextEventAddress)
 
         ddwaf_object_map_add(&map, "waf.trigger", ddwaf_object_string(&tmp, "rule"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto json = test::object_to_json(out.derivatives);
+        auto json = test::object_to_json(*attributes);
         EXPECT_STR(
             json, R"({"_dd.appsec.fp.http.endpoint":"http-put-729d56c3-2c70e12b-2c70e12b"})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -987,7 +1013,7 @@ TEST(TestContextIntegration, MultipleModuleSingleCollectionMatch)
     ASSERT_NE(handle, nullptr);
     ddwaf_object_free(&rule);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     ddwaf_context context = ddwaf_context_init(handle);
     ASSERT_NE(context, nullptr);
 
@@ -996,7 +1022,8 @@ TEST(TestContextIntegration, MultipleModuleSingleCollectionMatch)
     ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
     EXPECT_EQ(ddwaf_run(context, &param1, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret,
         {.id = "1",
             .name = "rule1",
@@ -1018,7 +1045,7 @@ TEST(TestContextIntegration, MultipleModuleSingleCollectionMatch)
                     .value = "Sqreen",
                     .address = "param1",
                 }}}}});
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
@@ -1045,11 +1072,12 @@ TEST(TestContextIntegration, TimeoutBeyondLimit)
     ddwaf_object_map_add(&subMap, "key", ddwaf_object_string(&tmp, "rule3"));
     ddwaf_object_map_add(&parameter, "value2", &subMap); // ddwaf_object_string(&,"rule3"));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &ret, std::numeric_limits<uint64_t>::max()),
         DDWAF_MATCH);
 
-    EXPECT_FALSE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -1069,7 +1097,7 @@ TEST(TestContextIntegration, TimeoutBeyondLimit)
                                        .path = {"key"},
                                    }}}}});
 
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }

--- a/tests/integration/custom_rules/test.cpp
+++ b/tests/integration/custom_rules/test.cpp
@@ -115,7 +115,7 @@ TEST(TestCustomRulesIntegration, RegularCustomRulesPrecedence)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value3", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule3",
@@ -125,7 +125,7 @@ TEST(TestCustomRulesIntegration, RegularCustomRulesPrecedence)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule",
                                    .args = {{.value = "custom_rule", .address = "value3"}}}}});
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -155,7 +155,7 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -170,7 +170,7 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -200,7 +200,7 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -214,7 +214,7 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -262,7 +262,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
@@ -276,7 +276,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -284,7 +284,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -298,7 +298,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -350,7 +350,7 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -364,7 +364,7 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -372,7 +372,7 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule5",
@@ -383,7 +383,7 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
                                    .highlight = "custom_rule",
                                    .args = {{.value = "custom_rule", .address = "value34"}}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -458,7 +458,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -472,7 +472,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -480,7 +480,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
@@ -494,7 +494,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -546,7 +546,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -560,7 +560,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -568,7 +568,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -582,7 +582,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -648,7 +648,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
@@ -662,7 +662,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -679,7 +679,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -693,7 +693,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -746,7 +746,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
@@ -760,7 +760,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -768,7 +768,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
@@ -782,7 +782,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -848,7 +848,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
@@ -865,7 +865,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -873,7 +873,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule3",
@@ -887,7 +887,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                        .address = "value34",
                                    }}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 
@@ -895,7 +895,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
-        ddwaf_result res;
+        ddwaf_object res;
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule3",
@@ -909,7 +909,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                        .address = "value34",
                                    }}}}});
 
-        ddwaf_result_free(&res);
+        ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
 

--- a/tests/integration/diagnostics/v1/test.cpp
+++ b/tests/integration/diagnostics/v1/test.cpp
@@ -27,12 +27,13 @@ void run_test(ddwaf_handle handle)
     ddwaf_object_map_add(&arg2, "y", ddwaf_object_string(&tmp, "string 3"));
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
 
     // Run with just arg1
     auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
-    EXPECT_FALSE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -60,7 +61,7 @@ void run_test(ddwaf_handle handle)
                                        .address = "arg2",
                                        .path = {"y"},
                                    }}}}});
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 
     ddwaf_context_destroy(context);
 }

--- a/tests/integration/events/obfuscator/test.cpp
+++ b/tests/integration/events/obfuscator/test.cpp
@@ -32,7 +32,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -44,7 +44,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
                                        .value = "rule1",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -56,7 +56,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&inter, "passwordle", ddwaf_object_string(&tmp, "rule1"));
         ddwaf_object_map_add(&parameter, "value", &inter);
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -69,7 +69,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -80,7 +80,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -92,7 +92,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
                                        .value = "<Redacted>",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -104,7 +104,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&inter, "passwordle", ddwaf_object_string(&tmp, "rule1_obf"));
         ddwaf_object_map_add(&parameter, "value", &inter);
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -117,7 +117,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -142,7 +142,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -154,7 +154,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
                                        .value = "rule1",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -166,7 +166,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object_map_add(&inter, "passwordle", ddwaf_object_string(&tmp, "rule1"));
         ddwaf_object_map_add(&parameter, "value", &inter);
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -179,7 +179,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -190,7 +190,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -202,7 +202,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
                                        .value = "rule1_obf",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -227,7 +227,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -239,7 +239,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
                                        .value = "rule1",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -251,7 +251,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object_map_add(&inter, "passwordle", ddwaf_object_string(&tmp, "rule1"));
         ddwaf_object_map_add(&parameter, "value", &inter);
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -264,7 +264,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -275,7 +275,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -287,7 +287,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
                                        .value = "<Redacted>",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -312,7 +312,7 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "badvalue_something"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -323,7 +323,7 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
                                        .value = "<Redacted>",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -334,7 +334,7 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "othervalue_badvalue"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -345,7 +345,7 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
                                        .value = "othervalue_badvalue",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -370,7 +370,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -382,7 +382,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
                                        .value = "rule1",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -394,7 +394,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object_map_add(&inter, "passwordle", ddwaf_object_string(&tmp, "rule1"));
         ddwaf_object_map_add(&parameter, "value", &inter);
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -407,7 +407,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -418,7 +418,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -430,7 +430,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
                                        .value = "rule1_obf",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -455,7 +455,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -467,7 +467,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
                                        .value = "rule1",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -479,7 +479,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object_map_add(&inter, "passwordle", ddwaf_object_string(&tmp, "rule1"));
         ddwaf_object_map_add(&parameter, "value", &inter);
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -492,7 +492,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -503,7 +503,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -515,7 +515,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
                                        .value = "rule1_obf",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -540,7 +540,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -552,7 +552,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
                                        .value = "rule1",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -564,7 +564,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object_map_add(&inter, "passwordle", ddwaf_object_string(&tmp, "rule1"));
         ddwaf_object_map_add(&parameter, "value", &inter);
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -577,7 +577,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -588,7 +588,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object parameter = DDWAF_OBJECT_MAP, tmp;
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -600,7 +600,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
                                        .value = "rule1_obf",
                                        .address = "value",
                                    }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 

--- a/tests/integration/events/schema/test.cpp
+++ b/tests/integration/events/schema/test.cpp
@@ -43,15 +43,19 @@ public:
         context = nullptr;
     }
 
-    void Validate(ddwaf_result ret, DDWAF_RET_CODE code)
+    void Validate(ddwaf_object ret, DDWAF_RET_CODE code)
     {
         Document d;
         EXPECT_EQ(code, DDWAF_MATCH);
-        ASSERT_EQ(ddwaf_object_type(&ret.events), DDWAF_OBJ_ARRAY);
-        ASSERT_GT(ddwaf_object_size(&ret.events), 0);
-        EXPECT_FALSE(ret.timeout);
 
-        auto data = ddwaf::test::object_to_json(ret.events);
+        const auto *events = ddwaf_object_find(&ret, STRL("events"));
+        ASSERT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+        ASSERT_GT(ddwaf_object_size(events), 0);
+
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        auto data = ddwaf::test::object_to_json(*events);
         if (!HasFailure()) {
             EXPECT_TRUE(ValidateEventSchema(data));
         }
@@ -74,10 +78,10 @@ TEST_F(TestSchemaIntegration, SimpleResult)
 
     ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "rule1"));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
     Validate(ret, code);
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 }
 
 TEST_F(TestSchemaIntegration, SimpleResultWithKeyPath)
@@ -88,10 +92,10 @@ TEST_F(TestSchemaIntegration, SimpleResultWithKeyPath)
     ddwaf_object_map_add(&arg2, "key1", ddwaf_object_string(&tmp, "rule2"));
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
     Validate(ret, code);
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 }
 
 TEST_F(TestSchemaIntegration, SimpleResultWithMultiKeyPath)
@@ -105,10 +109,10 @@ TEST_F(TestSchemaIntegration, SimpleResultWithMultiKeyPath)
     ddwaf_object_map_add(&arg2, "key1", &array);
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
     Validate(ret, code);
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 }
 
 TEST_F(TestSchemaIntegration, ResultWithMultiCondition)
@@ -122,10 +126,10 @@ TEST_F(TestSchemaIntegration, ResultWithMultiCondition)
     ddwaf_object_map_add(&arg4, "key1", ddwaf_object_string(&tmp, "rule3"));
     ddwaf_object_map_add(&param, "arg4", &arg4);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
     Validate(ret, code);
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 }
 
 TEST_F(TestSchemaIntegration, MultiResultWithMultiCondition)
@@ -147,10 +151,10 @@ TEST_F(TestSchemaIntegration, MultiResultWithMultiCondition)
     ddwaf_object_map_add(&arg4, "key1", ddwaf_object_string(&tmp, "rule3"));
     ddwaf_object_map_add(&param, "arg4", &arg4);
 
-    ddwaf_result ret;
+    ddwaf_object ret;
     auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
     Validate(ret, code);
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 }
 
 } // namespace

--- a/tests/integration/exclusion/rule_filter/test.cpp
+++ b/tests/integration/exclusion/rule_filter/test.cpp
@@ -30,7 +30,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRule)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -41,7 +41,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRule)
                                    .value = "192.168.0.1",
                                    .address = "http.client_ip",
                                }}}}});
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -63,7 +63,7 @@ TEST(TestRuleFilterIntegration, ExcludeByType)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -74,7 +74,7 @@ TEST(TestRuleFilterIntegration, ExcludeByType)
                                    .value = "192.168.0.1",
                                    .address = "http.client_ip",
                                }}}}});
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -96,10 +96,10 @@ TEST(TestRuleFilterIntegration, ExcludeByCategory)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -121,7 +121,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTags)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
@@ -132,7 +132,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTags)
                                    .value = "192.168.0.1",
                                    .address = "http.client_ip",
                                }}}}});
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -156,10 +156,10 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_OK);
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -172,7 +172,7 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -193,7 +193,7 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
                         .value = "192.168.0.1",
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -218,7 +218,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -230,7 +230,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -243,7 +243,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -264,7 +264,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
                         .value = "192.168.0.1",
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -289,7 +289,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "AD      MIN"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -301,7 +301,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -314,7 +314,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -335,7 +335,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
                         .value = "192.168.0.1",
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -359,7 +359,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -371,7 +371,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -384,7 +384,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -405,7 +405,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
                         .value = "192.168.0.1",
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -430,10 +430,10 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_OK);
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -446,7 +446,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -467,7 +467,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
                         .value = "192.168.0.1",
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -492,7 +492,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -504,7 +504,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -517,7 +517,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -538,7 +538,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
                         .value = "192.168.0.1",
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -561,7 +561,7 @@ TEST(TestRuleFilterIntegration, MonitorSingleRule)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -575,7 +575,7 @@ TEST(TestRuleFilterIntegration, MonitorSingleRule)
                                }}}}});
     EXPECT_ACTIONS(out, {});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -597,7 +597,7 @@ TEST(TestRuleFilterIntegration, AvoidHavingTwoMonitorOnActions)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -611,7 +611,7 @@ TEST(TestRuleFilterIntegration, AvoidHavingTwoMonitorOnActions)
                                }}}}});
     EXPECT_ACTIONS(out, {});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -655,7 +655,7 @@ TEST(TestRuleFilterIntegration, MonitorCustomFilterModePrecedence)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -669,7 +669,7 @@ TEST(TestRuleFilterIntegration, MonitorCustomFilterModePrecedence)
                                }}}}});
     EXPECT_ACTIONS(out, {});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -714,7 +714,7 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -729,7 +729,7 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
     EXPECT_ACTIONS(out,
         {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}})
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -752,7 +752,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -767,7 +767,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}})
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -780,7 +780,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.2"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -793,7 +793,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
                                    }}}}});
         EXPECT_ACTIONS(out, {})
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -822,7 +822,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -833,9 +833,9 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
                                        .value = "192.168.0.1",
                                        .address = "http.client_ip",
                                    }}}}});
-        EXPECT_EQ(out.actions.nbEntries, 0);
+        EXPECT_ACTIONS(out, {});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -858,7 +858,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
@@ -873,7 +873,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}})
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -902,7 +902,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    ddwaf_result out;
+    ddwaf_object out;
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
@@ -917,7 +917,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
     EXPECT_ACTIONS(out,
         {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}})
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
 
     ddwaf_destroy(handle);

--- a/tests/integration/exclusion_data/test.cpp
+++ b/tests/integration/exclusion_data/test.cpp
@@ -36,7 +36,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -58,7 +58,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
                         .address = "http.client_ip",
                     }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -82,7 +82,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -94,7 +94,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -112,7 +112,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -134,7 +134,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
                         .address = "http.client_ip",
                     }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -169,7 +169,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -191,7 +191,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
                         .address = "usr.id",
                     }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -215,7 +215,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -227,7 +227,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
                                        .address = "usr.id",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -245,7 +245,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -266,7 +266,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
                         .value = "admin",
                         .address = "usr.id",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -301,7 +301,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -323,7 +323,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
                         .address = "usr.id",
                     }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -347,7 +347,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -359,7 +359,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
                                        .address = "usr.id",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -383,7 +383,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -404,7 +404,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
                         .value = "admin",
                         .address = "usr.id",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -439,7 +439,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -461,7 +461,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
                         .address = "usr.id",
                     }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -485,7 +485,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
@@ -497,7 +497,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
                                        .address = "usr.id",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -515,7 +515,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
@@ -536,7 +536,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
                         .value = "admin",
                         .address = "usr.id",
                     }}}}});
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 

--- a/tests/integration/interface/context/result/test.cpp
+++ b/tests/integration/interface/context/result/test.cpp
@@ -7,8 +7,6 @@
 #include "common/gtest_utils.hpp"
 #include "ddwaf.h"
 
-#include <memory_resource>
-#include <new>
 using namespace ddwaf;
 
 namespace {

--- a/tests/integration/interface/context/result/test.cpp
+++ b/tests/integration/interface/context/result/test.cpp
@@ -1,0 +1,418 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "common/gtest_utils.hpp"
+#include "ddwaf.h"
+
+#include <memory_resource>
+#include <new>
+using namespace ddwaf;
+
+namespace {
+
+constexpr std::string_view base_dir = "integration/interface/context/result/";
+
+TEST(TestContextResultIntegration, ResultInvalidArgumentNullContext)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_object tmp;
+    ddwaf_object persistent = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&persistent, "value1", ddwaf_object_string(&tmp, "rule1"));
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+
+    EXPECT_EQ(
+        ddwaf_run(nullptr, &persistent, nullptr, &result, LONG_TIME), DDWAF_ERR_INVALID_ARGUMENT);
+
+    // The result object must be unchanged
+    EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
+
+    ddwaf_object_free(&persistent);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestContextResultIntegration, ResultInvalidArgumentNoData)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+
+    EXPECT_EQ(ddwaf_run(context, nullptr, nullptr, &result, LONG_TIME), DDWAF_ERR_INVALID_ARGUMENT);
+
+    // The result object must be unchanged
+    EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
+
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestContextResultIntegration, ResultInvalidObjectInvalidPersistentDataSchema)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object tmp;
+    ddwaf_object persistent = DDWAF_OBJECT_ARRAY;
+    ddwaf_object_array_add(&persistent, ddwaf_object_string(&tmp, "rule1"));
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+
+    EXPECT_EQ(
+        ddwaf_run(context, &persistent, nullptr, &result, LONG_TIME), DDWAF_ERR_INVALID_OBJECT);
+
+    // The result object must be unchanged
+    EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
+
+    // The persistent object, even though invalid, is freed on context destruction
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestContextResultIntegration, ResultInvalidObjectInvalidEphemeralDataSchema)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object tmp;
+    ddwaf_object ephemeral = DDWAF_OBJECT_ARRAY;
+    ddwaf_object_array_add(&ephemeral, ddwaf_object_string(&tmp, "rule1"));
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+
+    EXPECT_EQ(
+        ddwaf_run(context, nullptr, &ephemeral, &result, LONG_TIME), DDWAF_ERR_INVALID_OBJECT);
+
+    // The result object must be unchanged
+    EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
+
+    // The ephemeral object, even though invalid, is freed on context destruction
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestContextResultIntegration, ResultOk)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object tmp;
+    ddwaf_object parameter = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_invalid(&tmp));
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_OK);
+
+    const auto *events = ddwaf_object_find(&result, STRL("events"));
+    ASSERT_NE(events, nullptr);
+    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_size(events), 0);
+
+    const auto *actions = ddwaf_object_find(&result, STRL("actions"));
+    ASSERT_NE(actions, nullptr);
+    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(actions), 0);
+
+    const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
+    ASSERT_NE(timeout, nullptr);
+    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    const auto *duration = ddwaf_object_find(&result, STRL("duration"));
+    ASSERT_NE(duration, nullptr);
+    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
+
+    const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
+    ASSERT_NE(attributes, nullptr);
+    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+
+    const auto *keep = ddwaf_object_find(&result, STRL("keep"));
+    ASSERT_NE(keep, nullptr);
+    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_FALSE(ddwaf_object_get_bool(keep));
+
+    ddwaf_object_free(&result);
+    ddwaf_context_destroy(context);
+}
+
+TEST(TestContextResultIntegration, ResultOkWithAttributes)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object tmp;
+    ddwaf_object parameter = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&parameter, "server.request.body", ddwaf_object_invalid(&tmp));
+
+    ddwaf_object settings;
+    ddwaf_object_map(&settings);
+    ddwaf_object_map_add(&settings, "extract-schema", ddwaf_object_bool(&tmp, true));
+    ddwaf_object_map_add(&parameter, "waf.context.processor", &settings);
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_OK);
+
+    const auto *events = ddwaf_object_find(&result, STRL("events"));
+    ASSERT_NE(events, nullptr);
+    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_size(events), 0);
+
+    const auto *actions = ddwaf_object_find(&result, STRL("actions"));
+    ASSERT_NE(actions, nullptr);
+    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(actions), 0);
+
+    const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
+    ASSERT_NE(timeout, nullptr);
+    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    const auto *duration = ddwaf_object_find(&result, STRL("duration"));
+    ASSERT_NE(duration, nullptr);
+    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
+
+    const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
+    ASSERT_NE(attributes, nullptr);
+    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+    const auto *keep = ddwaf_object_find(&result, STRL("keep"));
+    ASSERT_NE(keep, nullptr);
+    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_FALSE(ddwaf_object_get_bool(keep));
+
+    ddwaf_object_free(&result);
+    ddwaf_context_destroy(context);
+}
+
+TEST(TestContextResultIntegration, ResultOkWithTimeout)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object tmp;
+    ddwaf_object parameter = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_invalid(&tmp));
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, 0), DDWAF_OK);
+
+    const auto *events = ddwaf_object_find(&result, STRL("events"));
+    ASSERT_NE(events, nullptr);
+    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_size(events), 0);
+
+    const auto *actions = ddwaf_object_find(&result, STRL("actions"));
+    ASSERT_NE(actions, nullptr);
+    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(actions), 0);
+
+    const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
+    ASSERT_NE(timeout, nullptr);
+    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_TRUE(ddwaf_object_get_bool(timeout));
+
+    const auto *duration = ddwaf_object_find(&result, STRL("duration"));
+    ASSERT_NE(duration, nullptr);
+    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
+
+    const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
+    ASSERT_NE(attributes, nullptr);
+    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+
+    const auto *keep = ddwaf_object_find(&result, STRL("keep"));
+    ASSERT_NE(keep, nullptr);
+    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_FALSE(ddwaf_object_get_bool(keep));
+
+    ddwaf_object_free(&result);
+    ddwaf_context_destroy(context);
+}
+
+TEST(TestContextResultIntegration, ResultMatch)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object tmp;
+    ddwaf_object parameter = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+
+    const auto *events = ddwaf_object_find(&result, STRL("events"));
+    ASSERT_NE(events, nullptr);
+    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_size(events), 1);
+
+    const auto *actions = ddwaf_object_find(&result, STRL("actions"));
+    ASSERT_NE(actions, nullptr);
+    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(actions), 0);
+
+    const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
+    ASSERT_NE(timeout, nullptr);
+    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    const auto *duration = ddwaf_object_find(&result, STRL("duration"));
+    ASSERT_NE(duration, nullptr);
+    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
+
+    const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
+    ASSERT_NE(attributes, nullptr);
+    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+
+    const auto *keep = ddwaf_object_find(&result, STRL("keep"));
+    ASSERT_NE(keep, nullptr);
+    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_FALSE(ddwaf_object_get_bool(keep));
+
+    ddwaf_object_free(&result);
+    ddwaf_context_destroy(context);
+}
+
+TEST(TestContextResultIntegration, ResultMatchWithTimeout)
+{
+    auto rule = read_file("interface.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object tmp;
+    ddwaf_object parameter = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+
+    ddwaf_object result;
+    ddwaf_object_invalid(&result);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, 0), DDWAF_MATCH);
+
+    const auto *events = ddwaf_object_find(&result, STRL("events"));
+    ASSERT_NE(events, nullptr);
+    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_size(events), 1);
+
+    const auto *actions = ddwaf_object_find(&result, STRL("actions"));
+    ASSERT_NE(actions, nullptr);
+    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(actions), 0);
+
+    const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
+    ASSERT_NE(timeout, nullptr);
+    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_TRUE(ddwaf_object_get_bool(timeout));
+
+    const auto *duration = ddwaf_object_find(&result, STRL("duration"));
+    ASSERT_NE(duration, nullptr);
+    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
+
+    const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
+    ASSERT_NE(attributes, nullptr);
+    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+
+    const auto *keep = ddwaf_object_find(&result, STRL("keep"));
+    ASSERT_NE(keep, nullptr);
+    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_FALSE(ddwaf_object_get_bool(keep));
+
+    ddwaf_object_free(&result);
+    ddwaf_context_destroy(context);
+}
+
+} // namespace

--- a/tests/integration/interface/context/result/yaml/interface.yaml
+++ b/tests/integration/interface/context/result/yaml/interface.yaml
@@ -1,0 +1,59 @@
+version: '2.1'
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+      confidence: 1
+      module: authentication-acl
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+            - address: value2
+          regex: rule1
+  - id: 2
+    name: rule2
+    tags:
+      type: flow2
+      category: category2
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule2
+  - id: 3
+    name: rule3
+    tags:
+      type: flow2
+      category: category3
+      confidence: 1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value2
+          regex: rule3
+processors:
+  - id: processor-001
+    generator: extract_schema
+    conditions:
+      - operator: equals
+        parameters:
+          inputs:
+            - address: waf.context.processor
+              key_path:
+                - extract-schema
+          value: true
+          type: boolean
+    parameters:
+      mappings:
+        - inputs:
+            - address: server.request.body
+          output: server.request.body.schema
+    evaluate: false
+    output: true
+

--- a/tests/integration/interface/object/test.cpp
+++ b/tests/integration/interface/object/test.cpp
@@ -388,4 +388,46 @@ TEST(TestUTF8, TestLongUTF8)
     EXPECT_EQ(find_string_cutoff(buffer, (uint64_t)sizeof(buffer)), DDWAF_MAX_STRING_LENGTH);
 }
 
+TEST(TestObject, FindNullObject) { EXPECT_EQ(ddwaf_object_find(nullptr, STRL("key")), nullptr); }
+
+TEST(TestObject, FindInvalidKey)
+{
+    ddwaf_object tmp;
+    ddwaf_object map;
+    ddwaf_object_map(&map);
+    ddwaf_object_map_add(&map, "key", ddwaf_object_invalid(&tmp));
+
+    EXPECT_EQ(ddwaf_object_find(&map, nullptr, 1), nullptr);
+    EXPECT_EQ(ddwaf_object_find(&map, "", 0), nullptr);
+
+    ddwaf_object_free(&map);
+}
+
+TEST(TestObject, FindNotMap)
+{
+    ddwaf_object tmp;
+    ddwaf_object array;
+    ddwaf_object_array(&array);
+    ddwaf_object_array_add(&array, ddwaf_object_invalid(&tmp));
+
+    EXPECT_EQ(ddwaf_object_find(&array, STRL("key")), nullptr);
+
+    ddwaf_object_free(&array);
+}
+
+TEST(TestObject, FindEmptyMap)
+{
+    ddwaf_object tmp;
+    ddwaf_object map;
+    ddwaf_object_map(&map);
+    ddwaf_object_map_add(&map, "key", ddwaf_object_unsigned(&tmp, 42));
+
+    const auto *object = ddwaf_object_find(&map, STRL("key"));
+    ASSERT_NE(object, nullptr);
+    EXPECT_EQ(ddwaf_object_type(object), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_unsigned(object), 42);
+
+    ddwaf_object_free(&map);
+}
+
 } // namespace

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -31,7 +31,8 @@ TEST(TestWafIntegration, GetWafVersion)
 
 TEST(TestWafIntegration, HandleBad)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, ddwaf_object_free};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, ddwaf_object_free};
 
     ddwaf_object tmp;
     ddwaf_object object = DDWAF_OBJECT_INVALID;
@@ -61,9 +62,13 @@ TEST(TestWafIntegration, HandleBad)
 
     object = DDWAF_OBJECT_MAP;
     ddwaf_object_map_add(&object, "value1", ddwaf_object_string(&tmp, "value"));
-    ddwaf_result res;
+    ddwaf_object res;
     EXPECT_EQ(ddwaf_run(context, &object, nullptr, &res, 0), DDWAF_OK);
-    EXPECT_TRUE(res.timeout);
+
+    const auto *timeout = ddwaf_object_find(&res, STRL("timeout"));
+    EXPECT_TRUE(ddwaf_object_get_bool(timeout));
+
+    ddwaf_object_free(&res);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
@@ -74,7 +79,8 @@ TEST(TestWafIntegration, RootAddresses)
     auto rule = read_file("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -97,7 +103,8 @@ TEST(TestWafIntegration, HandleLifetime)
     auto rule = read_file("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -111,7 +118,8 @@ TEST(TestWafIntegration, HandleLifetime)
 
     ddwaf_object parameter = DDWAF_OBJECT_MAP;
     ddwaf_object tmp;
-    ddwaf_object param_key = DDWAF_OBJECT_ARRAY, param_val = DDWAF_OBJECT_ARRAY;
+    ddwaf_object param_key = DDWAF_OBJECT_ARRAY;
+    ddwaf_object param_val = DDWAF_OBJECT_ARRAY;
 
     ddwaf_object_array_add(&param_key, ddwaf_object_string_from_unsigned(&tmp, 4242));
     ddwaf_object_array_add(&param_key, ddwaf_object_string(&tmp, "randomString"));
@@ -174,7 +182,8 @@ TEST(TestWafIntegration, InvalidVersion)
     auto rule = yaml_to_object("{version: 3.0, rules: []}");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
 
     ddwaf_handle handle1 = ddwaf_init(&rule, &config, nullptr);
     ASSERT_EQ(handle1, nullptr);
@@ -186,7 +195,8 @@ TEST(TestWafIntegration, InvalidVersionNoRules)
     auto rule = yaml_to_object("{version: 3.0}");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
 
     ddwaf_handle handle1 = ddwaf_init(&rule, &config, nullptr);
     ASSERT_EQ(handle1, nullptr);
@@ -291,7 +301,8 @@ TEST(TestWafIntegration, UpdateRules)
     auto rule = read_file("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
 
     ddwaf_builder builder = ddwaf_builder_init(&config);
     ddwaf_builder_add_or_update_config(builder, "default", sizeof("default") - 1, &rule, nullptr);
@@ -420,7 +431,8 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByID)
 
 TEST(TestWafIntegration, UpdateDisableEnableRuleByTags)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -509,7 +521,8 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByTags)
 
 TEST(TestWafIntegration, UpdateActionsByID)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
     ASSERT_NE(builder, nullptr);
 
@@ -557,8 +570,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -570,8 +583,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
             result2, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -588,8 +601,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -599,8 +612,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(result2, {});
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -634,8 +647,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result result2;
-        ddwaf_result result3;
+        ddwaf_object result2;
+        ddwaf_object result3;
 
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
@@ -648,8 +661,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
         EXPECT_ACTIONS(result3,
             {{"redirect_request", {{"status_code", "303"}, {"location", "http://google.com"}}}});
 
-        ddwaf_result_free(&result2);
-        ddwaf_result_free(&result3);
+        ddwaf_object_free(&result2);
+        ddwaf_object_free(&result3);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
@@ -663,7 +676,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
 
 TEST(TestWafIntegration, UpdateActionsByTags)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -710,8 +724,8 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -723,8 +737,8 @@ TEST(TestWafIntegration, UpdateActionsByTags)
             result2, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -741,8 +755,8 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -752,8 +766,8 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(result2, {});
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -767,7 +781,8 @@ TEST(TestWafIntegration, UpdateActionsByTags)
 
 TEST(TestWafIntegration, UpdateTagsByID)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -801,8 +816,8 @@ TEST(TestWafIntegration, UpdateTagsByID)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -830,8 +845,8 @@ TEST(TestWafIntegration, UpdateTagsByID)
 
         ddwaf_object_free(&parameter);
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -851,8 +866,8 @@ TEST(TestWafIntegration, UpdateTagsByID)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result result3;
-        ddwaf_result result2;
+        ddwaf_object result3;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -880,8 +895,8 @@ TEST(TestWafIntegration, UpdateTagsByID)
 
         ddwaf_object_free(&parameter);
 
-        ddwaf_result_free(&result3);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result3);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
@@ -896,7 +911,8 @@ TEST(TestWafIntegration, UpdateTagsByID)
 
 TEST(TestWafIntegration, UpdateTagsByTags)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -931,8 +947,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -960,8 +976,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                     .args = {
                         {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -978,8 +994,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -1006,8 +1022,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                     .args = {
                         {.name = "input", .value = "rule2", .address = "value1", .path = {}}}}}});
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1024,8 +1040,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule3"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -1053,8 +1069,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                     .args = {
                         {.name = "input", .value = "rule3", .address = "value2", .path = {}}}}}});
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1074,8 +1090,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule3"));
 
-        ddwaf_result result3;
-        ddwaf_result result2;
+        ddwaf_object result3;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -1102,8 +1118,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                     .highlight = "rule3",
                     .args = {
                         {.name = "input", .value = "rule3", .address = "value2", .path = {}}}}}});
-        ddwaf_result_free(&result3);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result3);
+        ddwaf_object_free(&result2);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
@@ -1118,7 +1134,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
 
 TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1153,8 +1170,8 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result result1;
-        ddwaf_result result2;
+        ddwaf_object result1;
+        ddwaf_object result2;
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
@@ -1186,8 +1203,8 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
             result2, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result1);
-        ddwaf_result_free(&result2);
+        ddwaf_object_free(&result1);
+        ddwaf_object_free(&result2);
 
         ddwaf_object_free(&parameter);
 
@@ -1217,8 +1234,8 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        ddwaf_result result2;
-        ddwaf_result result3;
+        ddwaf_object result2;
+        ddwaf_object result3;
 
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
@@ -1250,8 +1267,8 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result3, {});
 
-        ddwaf_result_free(&result2);
-        ddwaf_result_free(&result3);
+        ddwaf_object_free(&result2);
+        ddwaf_object_free(&result3);
 
         ddwaf_object_free(&parameter);
 
@@ -1300,7 +1317,8 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
 
 TEST(TestWafIntegration, UpdateInvalidOverrides)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     auto rule = read_file("interface.yaml", base_dir);
@@ -1405,7 +1423,8 @@ TEST(TestWafIntegration, UpdateRuleData)
 
 TEST(TestWafIntegration, UpdateAndRevertRuleData)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1482,7 +1501,8 @@ TEST(TestWafIntegration, UpdateAndRevertRuleData)
 
 TEST(TestWafIntegration, UpdateRuleExclusions)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1579,7 +1599,8 @@ TEST(TestWafIntegration, UpdateRuleExclusions)
 
 TEST(TestWafIntegration, UpdateInputExclusions)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1695,7 +1716,8 @@ TEST(TestWafIntegration, UpdateInputExclusions)
 
 TEST(TestWafIntegration, UpdateEverything)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1789,8 +1811,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.response.status", ddwaf_object_string(&tmp, "rule5"));
 
-        ddwaf_result result2;
-        ddwaf_result result3;
+        ddwaf_object result2;
+        ddwaf_object result3;
 
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
@@ -1802,8 +1824,8 @@ TEST(TestWafIntegration, UpdateEverything)
             result3, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result2);
-        ddwaf_result_free(&result3);
+        ddwaf_object_free(&result2);
+        ddwaf_object_free(&result3);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
@@ -1857,8 +1879,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        ddwaf_result result3;
-        ddwaf_result result4;
+        ddwaf_object result3;
+        ddwaf_object result4;
 
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, &result4, LONG_TIME), DDWAF_MATCH);
@@ -1870,8 +1892,8 @@ TEST(TestWafIntegration, UpdateEverything)
             result4, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result3);
-        ddwaf_result_free(&result4);
+        ddwaf_object_free(&result3);
+        ddwaf_object_free(&result4);
 
         ddwaf_context_destroy(context3);
         ddwaf_context_destroy(context4);
@@ -1920,8 +1942,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        ddwaf_result result4;
-        ddwaf_result result5;
+        ddwaf_object result4;
+        ddwaf_object result5;
 
         EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, &result4, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_MATCH);
@@ -1935,8 +1957,8 @@ TEST(TestWafIntegration, UpdateEverything)
             result5, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result4);
-        ddwaf_result_free(&result5);
+        ddwaf_object_free(&result4);
+        ddwaf_object_free(&result5);
 
         ddwaf_context_destroy(context4);
         ddwaf_context_destroy(context5);
@@ -1974,8 +1996,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.response.status", ddwaf_object_string(&tmp, "rule5"));
 
-        ddwaf_result result4;
-        ddwaf_result result5;
+        ddwaf_object result4;
+        ddwaf_object result5;
 
         EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, &result4, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_OK);
@@ -1987,8 +2009,8 @@ TEST(TestWafIntegration, UpdateEverything)
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result5, {});
 
-        ddwaf_result_free(&result4);
-        ddwaf_result_free(&result5);
+        ddwaf_object_free(&result4);
+        ddwaf_object_free(&result5);
 
         ddwaf_context_destroy(context4);
         ddwaf_context_destroy(context5);
@@ -2021,8 +2043,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.response.status", ddwaf_object_string(&tmp, "rule5"));
 
-        ddwaf_result result5;
-        ddwaf_result result6;
+        ddwaf_object result5;
+        ddwaf_object result6;
 
         EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, &result6, LONG_TIME), DDWAF_MATCH);
@@ -2034,8 +2056,8 @@ TEST(TestWafIntegration, UpdateEverything)
             result6, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result5);
-        ddwaf_result_free(&result6);
+        ddwaf_object_free(&result5);
+        ddwaf_object_free(&result6);
 
         ddwaf_context_destroy(context5);
         ddwaf_context_destroy(context6);
@@ -2053,8 +2075,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        ddwaf_result result5;
-        ddwaf_result result6;
+        ddwaf_object result5;
+        ddwaf_object result6;
 
         EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, &result6, LONG_TIME), DDWAF_MATCH);
@@ -2068,8 +2090,8 @@ TEST(TestWafIntegration, UpdateEverything)
             result6, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result5);
-        ddwaf_result_free(&result6);
+        ddwaf_object_free(&result5);
+        ddwaf_object_free(&result6);
 
         ddwaf_context_destroy(context5);
         ddwaf_context_destroy(context6);
@@ -2110,8 +2132,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        ddwaf_result result6;
-        ddwaf_result result7;
+        ddwaf_object result6;
+        ddwaf_object result7;
 
         EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, &result6, LONG_TIME), DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context7, &parameter, nullptr, &result7, LONG_TIME), DDWAF_MATCH);
@@ -2123,8 +2145,8 @@ TEST(TestWafIntegration, UpdateEverything)
             result7, {{"block_request",
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
 
-        ddwaf_result_free(&result6);
-        ddwaf_result_free(&result7);
+        ddwaf_object_free(&result6);
+        ddwaf_object_free(&result7);
 
         ddwaf_context_destroy(context6);
         ddwaf_context_destroy(context7);
@@ -2150,8 +2172,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        ddwaf_result result7;
-        ddwaf_result result8;
+        ddwaf_object result7;
+        ddwaf_object result8;
 
         EXPECT_EQ(ddwaf_run(context7, &parameter, nullptr, &result7, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
@@ -2163,8 +2185,8 @@ TEST(TestWafIntegration, UpdateEverything)
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result8, {});
 
-        ddwaf_result_free(&result7);
-        ddwaf_result_free(&result8);
+        ddwaf_object_free(&result7);
+        ddwaf_object_free(&result8);
 
         ddwaf_context_destroy(context7);
         ddwaf_context_destroy(context8);
@@ -2182,8 +2204,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        ddwaf_result result7;
-        ddwaf_result result8;
+        ddwaf_object result7;
+        ddwaf_object result8;
 
         EXPECT_EQ(ddwaf_run(context7, &parameter, nullptr, &result7, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
@@ -2195,8 +2217,8 @@ TEST(TestWafIntegration, UpdateEverything)
                          {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result8, {});
 
-        ddwaf_result_free(&result7);
-        ddwaf_result_free(&result8);
+        ddwaf_object_free(&result7);
+        ddwaf_object_free(&result8);
 
         ddwaf_context_destroy(context7);
         ddwaf_context_destroy(context8);
@@ -2219,8 +2241,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        ddwaf_result result8;
-        ddwaf_result result9;
+        ddwaf_object result8;
+        ddwaf_object result9;
 
         EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context9, &parameter, nullptr, &result9, LONG_TIME), DDWAF_MATCH);
@@ -2230,8 +2252,8 @@ TEST(TestWafIntegration, UpdateEverything)
         EXPECT_ACTIONS(result8, {});
         EXPECT_ACTIONS(result9, {});
 
-        ddwaf_result_free(&result8);
-        ddwaf_result_free(&result9);
+        ddwaf_object_free(&result8);
+        ddwaf_object_free(&result9);
 
         ddwaf_context_destroy(context8);
         ddwaf_context_destroy(context9);
@@ -2249,18 +2271,18 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        ddwaf_result result8;
-        ddwaf_result result9;
+        ddwaf_object result8;
+        ddwaf_object result9;
 
         EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context9, &parameter, nullptr, &result9, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_EQ(ddwaf_object_size(&result9.actions), 0);
+        EXPECT_ACTIONS(result9, {});
 
-        ddwaf_result_free(&result8);
-        ddwaf_result_free(&result9);
+        ddwaf_object_free(&result8);
+        ddwaf_object_free(&result9);
 
         ddwaf_context_destroy(context8);
         ddwaf_context_destroy(context9);
@@ -2307,7 +2329,8 @@ TEST(TestWafIntegration, UpdateEverything)
 
 TEST(TestWafIntegration, KnownAddressesDisabledRule)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -2374,7 +2397,8 @@ TEST(TestWafIntegration, KnownAddressesDisabledRule)
 
 TEST(TestWafIntegration, KnownActions)
 {
-    ddwaf_config config{{0, 0, 0}, {nullptr, nullptr}, nullptr};
+    ddwaf_config config{{.max_container_size = 0, .max_container_depth = 0, .max_string_length = 0},
+        {.key_regex = nullptr, .value_regex = nullptr}, nullptr};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {

--- a/tests/integration/matchers/equals/test.cpp
+++ b/tests/integration/matchers/equals/test.cpp
@@ -27,9 +27,10 @@ TEST(TestEqualsMatcherIntegration, StringEquals)
     ddwaf_object_string(&value, "arachni");
     ddwaf_object_map_add(&map, "input", &value);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1-string-equals",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -40,7 +41,7 @@ TEST(TestEqualsMatcherIntegration, StringEquals)
                                    .address = "input",
                                }}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -61,9 +62,10 @@ TEST(TestEqualsMatcherIntegration, BoolEquals)
     ddwaf_object_bool(&value, false);
     ddwaf_object_map_add(&map, "input", &value);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2-bool-equals",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -76,7 +78,7 @@ TEST(TestEqualsMatcherIntegration, BoolEquals)
                                }},
                            }}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -97,9 +99,10 @@ TEST(TestEqualsMatcherIntegration, SignedEquals)
     ddwaf_object_signed(&value, -42);
     ddwaf_object_map_add(&map, "input", &value);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
                            .name = "rule3-signed-equals",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -110,7 +113,7 @@ TEST(TestEqualsMatcherIntegration, SignedEquals)
                                    .address = "input",
                                }}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -131,9 +134,10 @@ TEST(TestEqualsMatcherIntegration, UnsignedEquals)
     ddwaf_object_unsigned(&value, 42);
     ddwaf_object_map_add(&map, "input", &value);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "4",
                            .name = "rule4-unsigned-equals",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -146,7 +150,7 @@ TEST(TestEqualsMatcherIntegration, UnsignedEquals)
                                }},
                            }}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -167,9 +171,10 @@ TEST(TestEqualsMatcherIntegration, FloatEquals)
     ddwaf_object_float(&value, 42.01);
     ddwaf_object_map_add(&map, "input", &value);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "5",
                            .name = "rule5-float-equals",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -182,7 +187,7 @@ TEST(TestEqualsMatcherIntegration, FloatEquals)
                                }},
                            }}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }

--- a/tests/integration/matchers/is_sqli/test.cpp
+++ b/tests/integration/matchers/is_sqli/test.cpp
@@ -29,11 +29,12 @@ TEST(TestIsSQLiIntegration, Match)
     ddwaf_object_map(&param);
     ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "'OR 1=1/*"));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
 
     auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
-    EXPECT_FALSE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -43,7 +44,7 @@ TEST(TestIsSQLiIntegration, Match)
                                    .value = "'OR 1=1/*",
                                    .address = "arg1",
                                }}}}});
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);

--- a/tests/integration/matchers/is_xss/test.cpp
+++ b/tests/integration/matchers/is_xss/test.cpp
@@ -29,11 +29,12 @@ TEST(TestIsXSSIntegration, Match)
     ddwaf_object_map(&param);
     ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "<script>alert(1);</script>"));
 
-    ddwaf_result ret;
+    ddwaf_object ret;
 
     auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
-    EXPECT_FALSE(ret.timeout);
+    const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -42,7 +43,7 @@ TEST(TestIsXSSIntegration, Match)
                                    .value = "<script>alert(1);</script>",
                                    .address = "arg1",
                                }}}}});
-    ddwaf_result_free(&ret);
+    ddwaf_object_free(&ret);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);

--- a/tests/integration/matchers/phrase_match/test.cpp
+++ b/tests/integration/matchers/phrase_match/test.cpp
@@ -27,9 +27,10 @@ TEST(TestPhraseMatchMatcherIntegration, Match)
     ddwaf_object_string(&value, "string00");
     ddwaf_object_map_add(&map, "input1", &value);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1-phrase-match",
                            .tags = {{"type", "flow"}, {"category", "category"}},
@@ -40,7 +41,7 @@ TEST(TestPhraseMatchMatcherIntegration, Match)
                                    .address = "input1",
                                }}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -62,9 +63,10 @@ TEST(TestPhraseMatchMatcherIntegration, MatchWordBound)
         ddwaf_object_string(&value, "string01;");
         ddwaf_object_map_add(&map, "input2", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2-phrase-match-word-bound",
                                .tags = {{"type", "flow"}, {"category", "category"}},
@@ -75,7 +77,7 @@ TEST(TestPhraseMatchMatcherIntegration, MatchWordBound)
                                        .address = "input2",
                                    }}}}});
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -88,11 +90,12 @@ TEST(TestPhraseMatchMatcherIntegration, MatchWordBound)
         ddwaf_object_string(&value, "string010");
         ddwaf_object_map_add(&map, "input2", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 

--- a/tests/integration/matchers/regex_match/test.cpp
+++ b/tests/integration/matchers/regex_match/test.cpp
@@ -31,11 +31,12 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
         ddwaf_object_map_add(
             &param, "arg1", ddwaf_object_string(&tmp, "<script>alert(1);</script>"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
 
         auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
-        EXPECT_FALSE(ret.timeout);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -46,7 +47,7 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
                                        .value = "<script>alert(1);</script>",
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
 
         ddwaf_context_destroy(context);
     }
@@ -61,12 +62,13 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
         ddwaf_object_map_add(
             &param, "arg1", ddwaf_object_string(&tmp, "<script>AlErT(1);</script>"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
 
         auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
-        EXPECT_FALSE(ret.timeout);
-        ddwaf_result_free(&ret);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+        ddwaf_object_free(&ret);
 
         ddwaf_context_destroy(context);
     }
@@ -94,11 +96,12 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
         ddwaf_object_map_add(
             &param, "arg1", ddwaf_object_string(&tmp, "<script>alert(1);</script>"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
 
         auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
-        EXPECT_FALSE(ret.timeout);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -109,7 +112,7 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
                                        .value = "<script>alert(1);</script>",
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
 
         ddwaf_context_destroy(context);
     }
@@ -124,7 +127,7 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
         ddwaf_object_map_add(
             &param, "arg1", ddwaf_object_string(&tmp, "<script>AlErT(1);</script>"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
 
         auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
@@ -139,8 +142,9 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
                                        .address = "arg1",
                                    }}}}});
 
-        EXPECT_FALSE(ret.timeout);
-        ddwaf_result_free(&ret);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+        ddwaf_object_free(&ret);
 
         ddwaf_context_destroy(context);
     }
@@ -167,11 +171,11 @@ TEST(TestRegexMatchIntegration, MinLength)
         ddwaf_object_map(&param);
         ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "alert("));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
 
         auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
-        ddwaf_result_free(&ret);
+        ddwaf_object_free(&ret);
 
         ddwaf_context_destroy(context);
     }
@@ -186,7 +190,7 @@ TEST(TestRegexMatchIntegration, MinLength)
         ddwaf_object_map_add(
             &param, "arg1", ddwaf_object_string(&tmp, "<script>AlErT(1);</script>"));
 
-        ddwaf_result ret;
+        ddwaf_object ret;
 
         auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
@@ -201,8 +205,9 @@ TEST(TestRegexMatchIntegration, MinLength)
                                        .address = "arg1",
                                    }}}}});
 
-        EXPECT_FALSE(ret.timeout);
-        ddwaf_result_free(&ret);
+        const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+        ddwaf_object_free(&ret);
 
         ddwaf_context_destroy(context);
     }

--- a/tests/integration/processors/fingerprint/test.cpp
+++ b/tests/integration/processors/fingerprint/test.cpp
@@ -96,19 +96,21 @@ TEST(TestFingerprintIntegration, Postprocessor)
     ddwaf_object_map_add(&settings, "fingerprint", ddwaf_object_bool(&tmp, true));
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-    EXPECT_EQ(ddwaf_object_size(&out.derivatives), 4);
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 4);
 
-    auto derivatives = test::object_to_map(out.derivatives);
+    auto derivatives = test::object_to_map(*attributes);
     EXPECT_STRV(derivatives["_dd.appsec.fp.http.endpoint"], "http-put-729d56c3-2c70e12b-2c70e12b");
     EXPECT_STRV(derivatives["_dd.appsec.fp.http.header"], "hdr-1111111111-a441b15f-0-");
     EXPECT_STRV(derivatives["_dd.appsec.fp.http.network"], "net-1-1111111111");
     EXPECT_STRV(derivatives["_dd.appsec.fp.session"], "ssn-8c6976e5-df6143bc-60ba1602-269500d3");
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -177,18 +179,20 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&settings, "fingerprint", ddwaf_object_bool(&tmp, true));
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 3);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 3);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(derivatives["_dd.appsec.fp.http.endpoint"], "http-put-729d56c3--");
         EXPECT_STRV(derivatives["_dd.appsec.fp.http.header"], "hdr-1111111111-a441b15f-0-");
         EXPECT_STRV(derivatives["_dd.appsec.fp.http.network"], "net-1-1111111111");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -200,16 +204,18 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&body, "key", ddwaf_object_invalid(&tmp));
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(derivatives["_dd.appsec.fp.http.endpoint"], "http-put-729d56c3--2c70e12b");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -221,17 +227,19 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&query, "key", ddwaf_object_invalid(&tmp));
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(
             derivatives["_dd.appsec.fp.http.endpoint"], "http-put-729d56c3-2c70e12b-2c70e12b");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -251,16 +259,18 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
             &cookies, "last_visit", ddwaf_object_string(&tmp, "2024-07-16T12:00:00Z"));
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(derivatives["_dd.appsec.fp.session"], "ssn--df6143bc-60ba1602-");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -270,16 +280,18 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
 
         ddwaf_object_map_add(&map, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(derivatives["_dd.appsec.fp.session"], "ssn-8c6976e5-df6143bc-60ba1602-");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -288,17 +300,19 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object map = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(
             derivatives["_dd.appsec.fp.session"], "ssn-8c6976e5-df6143bc-60ba1602-269500d3");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     ddwaf_context_destroy(context);
@@ -394,9 +408,10 @@ TEST(TestFingerprintIntegration, Preprocessor)
     ddwaf_object_map_add(&settings, "fingerprint", ddwaf_object_bool(&tmp, true));
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
     EXPECT_EVENTS(out,
         {.id = "rule1",
@@ -444,9 +459,10 @@ TEST(TestFingerprintIntegration, Preprocessor)
                     .path = {},
                 }}}}}, );
 
-    EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 0);
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -519,9 +535,10 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&settings, "fingerprint", ddwaf_object_bool(&tmp, true));
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
         EXPECT_EVENTS(out,
             {.id = "rule2",
@@ -547,8 +564,9 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
                         .path = {},
                     }}}}}, );
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
-        ddwaf_result_free(&out);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 0);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -560,13 +578,15 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&query, "key", ddwaf_object_invalid(&tmp));
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 0);
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -578,9 +598,10 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&body, "key", ddwaf_object_invalid(&tmp));
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
         EXPECT_EVENTS(out,
             {.id = "rule1",
@@ -595,8 +616,9 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
                         .path = {},
                     }}}}}, );
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
-        ddwaf_result_free(&out);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 0);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -617,12 +639,17 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
 
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
-        EXPECT_EQ(ddwaf_object_size(&out.events), 0);
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
-        ddwaf_result_free(&out);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        const auto *events = ddwaf_object_find(&out, STRL("events"));
+        EXPECT_EQ(ddwaf_object_size(events), 0);
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 0);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -633,9 +660,10 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "usr.id", ddwaf_object_string(&tmp, "admin"));
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
         EXPECT_EVENTS(out,
             {.id = "rule4",
@@ -650,8 +678,9 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
                         .path = {},
                     }}}}}, );
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 0);
-        ddwaf_result_free(&out);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 0);
+        ddwaf_object_free(&out);
     }
 
     ddwaf_context_destroy(context);
@@ -748,9 +777,10 @@ TEST(TestFingerprintIntegration, Processor)
     ddwaf_object_map_add(&settings, "fingerprint", ddwaf_object_bool(&tmp, true));
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
     EXPECT_EVENTS(out,
         {.id = "rule1",
@@ -798,15 +828,16 @@ TEST(TestFingerprintIntegration, Processor)
                     .path = {},
                 }}}}}, );
 
-    EXPECT_EQ(ddwaf_object_size(&out.derivatives), 4);
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 4);
 
-    auto derivatives = test::object_to_map(out.derivatives);
+    auto derivatives = test::object_to_map(*attributes);
     EXPECT_STRV(derivatives["_dd.appsec.fp.http.endpoint"], "http-put-729d56c3-2c70e12b-2c70e12b");
     EXPECT_STRV(derivatives["_dd.appsec.fp.http.header"], "hdr-1111111111-a441b15f-0-");
     EXPECT_STRV(derivatives["_dd.appsec.fp.http.network"], "net-1-1111111111");
     EXPECT_STRV(derivatives["_dd.appsec.fp.session"], "ssn-8c6976e5-df6143bc-60ba1602-269500d3");
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -880,9 +911,10 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&settings, "fingerprint", ddwaf_object_bool(&tmp, true));
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
         EXPECT_EVENTS(out,
             {.id = "rule2",
@@ -908,14 +940,15 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
                         .path = {},
                     }}}}}, );
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 3);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 3);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(derivatives["_dd.appsec.fp.http.endpoint"], "http-put-729d56c3--");
         EXPECT_STRV(derivatives["_dd.appsec.fp.http.header"], "hdr-1111111111-a441b15f-0-");
         EXPECT_STRV(derivatives["_dd.appsec.fp.http.network"], "net-1-1111111111");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -927,16 +960,18 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&query, "key", ddwaf_object_invalid(&tmp));
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(derivatives["_dd.appsec.fp.http.endpoint"], "http-put-729d56c3-2c70e12b-");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -948,9 +983,10 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&body, "key", ddwaf_object_invalid(&tmp));
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
         EXPECT_EVENTS(out,
             {.id = "rule1",
@@ -965,13 +1001,14 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
                         .path = {},
                     }}}}}, );
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(
             derivatives["_dd.appsec.fp.http.endpoint"], "http-put-729d56c3-2c70e12b-2c70e12b");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -992,16 +1029,21 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
 
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
-        EXPECT_EQ(ddwaf_object_size(&out.events), 0);
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        const auto *events = ddwaf_object_find(&out, STRL("events"));
+        EXPECT_EQ(ddwaf_object_size(events), 0);
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(derivatives["_dd.appsec.fp.session"], "ssn--df6143bc-60ba1602-");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     {
@@ -1011,9 +1053,10 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "usr.id", ddwaf_object_string(&tmp, "admin"));
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
         EXPECT_EVENTS(out,
             {.id = "rule4",
@@ -1028,13 +1071,14 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
                         .path = {},
                     }}}}}, );
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto derivatives = test::object_to_map(out.derivatives);
+        auto derivatives = test::object_to_map(*attributes);
         EXPECT_STRV(
             derivatives["_dd.appsec.fp.session"], "ssn-8c6976e5-df6143bc-60ba1602-269500d3");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
     }
 
     ddwaf_context_destroy(context);

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -40,16 +40,18 @@ TEST(TestProcessorOverridesIntegration, AddScannersById)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -75,17 +77,19 @@ TEST(TestProcessorOverridesIntegration, AddScannersById)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema,
             R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -121,16 +125,18 @@ TEST(TestProcessorOverridesIntegration, AddScannersByTags)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -156,17 +162,19 @@ TEST(TestProcessorOverridesIntegration, AddScannersByTags)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema,
             R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -202,17 +210,19 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema,
             R"({"server.request.headers.schema":[{"email":[8,{"type":"token","category":"credential"}]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -238,17 +248,19 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema,
             R"({"server.request.headers.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -274,16 +286,18 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema, R"({"server.request.headers.schema":[{"email":[8]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -319,17 +333,19 @@ TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema,
             R"({"server.request.headers.schema":[{"email":[8,{"type":"token","category":"credential"}]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -355,16 +371,18 @@ TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema, R"({"server.request.headers.schema":[{"email":[8]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -400,16 +418,18 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -435,17 +455,19 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema,
             R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -467,16 +489,18 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -512,16 +536,18 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -547,17 +573,19 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema,
             R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -579,16 +607,18 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 1);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
 
-        auto schema = test::object_to_json(out.derivatives);
+        auto schema = test::object_to_json(*attributes);
         EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -628,12 +658,14 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 2);
-        ddwaf::raw_configuration derivatives_object(out.derivatives);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 2);
+        ddwaf::raw_configuration derivatives_object(*attributes);
         auto derivatives = static_cast<ddwaf::raw_configuration::map>(derivatives_object);
 
         auto headers_schema = test::object_to_json(derivatives["server.request.headers.schema"]);
@@ -642,7 +674,7 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
         auto body_schema = test::object_to_json(derivatives["server.request.body.schema"]);
         EXPECT_STR(body_schema, R"([{"email":[8]}])");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 
@@ -672,14 +704,16 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
         ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
-        ddwaf_result out;
+        ddwaf_object out;
         ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
-        EXPECT_FALSE(out.timeout);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 2);
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 2);
 
-        EXPECT_EQ(ddwaf_object_size(&out.derivatives), 2);
-        ddwaf::raw_configuration derivatives_object(out.derivatives);
+        EXPECT_EQ(ddwaf_object_size(attributes), 2);
+        ddwaf::raw_configuration derivatives_object(*attributes);
         auto derivatives = static_cast<ddwaf::raw_configuration::map>(derivatives_object);
 
         auto headers_schema = test::object_to_json(derivatives["server.request.headers.schema"]);
@@ -688,7 +722,7 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
         auto body_schema = test::object_to_json(derivatives["server.request.body.schema"]);
         EXPECT_STR(body_schema, R"([{"email":[8,{"type":"email","category":"pii"}]}])");
 
-        ddwaf_result_free(&out);
+        ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
     }
 

--- a/tests/integration/transformers/test.cpp
+++ b/tests/integration/transformers/test.cpp
@@ -27,9 +27,10 @@ TEST(TestTransformers, Base64Decode)
     ddwaf_object_string(&string, "J09SIDE9MS8q");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -37,7 +38,7 @@ TEST(TestTransformers, Base64Decode)
                                .highlight = "s&1c",
                                .args = {{.value = "'OR 1=1/*", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -58,9 +59,10 @@ TEST(TestTransformers, Base64DecodeAlias)
     ddwaf_object_string(&string, "J09SIDE9MS8q");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -68,7 +70,7 @@ TEST(TestTransformers, Base64DecodeAlias)
                                .highlight = "s&1c",
                                .args = {{.value = "'OR 1=1/*", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -89,9 +91,10 @@ TEST(TestTransformers, Base64UrlDecode)
     ddwaf_object_string(&string, "J09SIDE9MS8q");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -99,7 +102,7 @@ TEST(TestTransformers, Base64UrlDecode)
                                .highlight = "s&1c",
                                .args = {{.value = "'OR 1=1/*", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -120,9 +123,10 @@ TEST(TestTransformers, Base64Encode)
     ddwaf_object_string(&string, "'OR 1=1/*");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -131,7 +135,7 @@ TEST(TestTransformers, Base64Encode)
                                .highlight = "J09SIDE9MS8q",
                                .args = {{.value = "J09SIDE9MS8q", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -152,9 +156,10 @@ TEST(TestTransformers, Base64EncodeAlias)
     ddwaf_object_string(&string, "'OR 1=1/*");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -163,7 +168,7 @@ TEST(TestTransformers, Base64EncodeAlias)
                                .highlight = "J09SIDE9MS8q",
                                .args = {{.value = "J09SIDE9MS8q", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -184,9 +189,10 @@ TEST(TestTransformers, CompressWhitespace)
     ddwaf_object_string(&string, "attack      value");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -195,7 +201,7 @@ TEST(TestTransformers, CompressWhitespace)
                                .highlight = "attack value",
                                .args = {{.value = "attack value", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -216,9 +222,10 @@ TEST(TestTransformers, CompressWhitespaceAlias)
     ddwaf_object_string(&string, "attack      value");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -227,7 +234,7 @@ TEST(TestTransformers, CompressWhitespaceAlias)
                                .highlight = "attack value",
                                .args = {{.value = "attack value", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -248,9 +255,10 @@ TEST(TestTransformers, CssDecode)
     ddwaf_object_string(&string, "CSS\\\n tran\\sformations");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -259,7 +267,7 @@ TEST(TestTransformers, CssDecode)
                                .highlight = "CSS transformations",
                                .args = {{.value = "CSS transformations", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -280,9 +288,10 @@ TEST(TestTransformers, CssDecodeAlias)
     ddwaf_object_string(&string, "CSS\\\n tran\\sformations");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -291,7 +300,7 @@ TEST(TestTransformers, CssDecodeAlias)
                                .highlight = "CSS transformations",
                                .args = {{.value = "CSS transformations", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -312,9 +321,10 @@ TEST(TestTransformers, HtmlEntityDecode)
     ddwaf_object_string(&string, "HTML &#x0000000000000000000000000000041 &#x41; transformation");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
         out, {.id = "1",
                  .name = "rule1",
@@ -324,7 +334,7 @@ TEST(TestTransformers, HtmlEntityDecode)
                      .highlight = "HTML A A transformation",
                      .args = {{.value = "HTML A A transformation", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -345,9 +355,10 @@ TEST(TestTransformers, HtmlEntityDecodeAlias)
     ddwaf_object_string(&string, "HTML &#x0000000000000000000000000000041 &#x41; transformation");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
         out, {.id = "2",
                  .name = "rule2",
@@ -357,7 +368,7 @@ TEST(TestTransformers, HtmlEntityDecodeAlias)
                      .highlight = "HTML A A transformation",
                      .args = {{.value = "HTML A A transformation", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -378,9 +389,10 @@ TEST(TestTransformers, JsDecode)
     ddwaf_object_string(&string, R"(\x41\x20\x4aS\x20transf\x6Frmation)");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -389,7 +401,7 @@ TEST(TestTransformers, JsDecode)
                                .highlight = "A JS transformation",
                                .args = {{.value = "A JS transformation", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -410,9 +422,10 @@ TEST(TestTransformers, JsDecodeAlias)
     ddwaf_object_string(&string, R"(\x41\x20\x4aS\x20transf\x6Frmation)");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -421,7 +434,7 @@ TEST(TestTransformers, JsDecodeAlias)
                                .highlight = "A JS transformation",
                                .args = {{.value = "A JS transformation", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -442,9 +455,10 @@ TEST(TestTransformers, Lowercase)
     ddwaf_object_string(&string, "ArAcHnI");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -453,7 +467,7 @@ TEST(TestTransformers, Lowercase)
                                .highlight = "arachni",
                                .args = {{.value = "arachni", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -474,9 +488,10 @@ TEST(TestTransformers, NormalizePath)
     ddwaf_object_string(&string, "/etc/dir1/dir2/../../passwd");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -485,7 +500,7 @@ TEST(TestTransformers, NormalizePath)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -506,9 +521,10 @@ TEST(TestTransformers, NormalizePathAlias)
     ddwaf_object_string(&string, "/etc/dir1/dir2/../../passwd");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -517,7 +533,7 @@ TEST(TestTransformers, NormalizePathAlias)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -538,9 +554,10 @@ TEST(TestTransformers, NormalizePathWin)
     ddwaf_object_string(&string, R"(\etc\dir1\dir2\..\..\passwd)");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -549,7 +566,7 @@ TEST(TestTransformers, NormalizePathWin)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -570,9 +587,10 @@ TEST(TestTransformers, NormalizePathAliasWin)
     ddwaf_object_string(&string, R"(\etc\dir1\dir2\..\..\passwd)");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -581,7 +599,7 @@ TEST(TestTransformers, NormalizePathAliasWin)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -602,9 +620,10 @@ TEST(TestTransformers, RemoveComments)
     ddwaf_object_string(&string, "passwd#asdsd");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -613,7 +632,7 @@ TEST(TestTransformers, RemoveComments)
                                .highlight = "passwd",
                                .args = {{.value = "passwd", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -634,9 +653,10 @@ TEST(TestTransformers, RemoveCommentsAlias)
     ddwaf_object_string(&string, "passwd#asdsd");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -645,7 +665,7 @@ TEST(TestTransformers, RemoveCommentsAlias)
                                .highlight = "passwd",
                                .args = {{.value = "passwd", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -666,9 +686,10 @@ TEST(TestTransformers, RemoveNulls)
     ddwaf_object_stringl(&string, "/etc/\0passwd", sizeof("/etc/\0passwd") - 1);
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -677,7 +698,7 @@ TEST(TestTransformers, RemoveNulls)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -698,9 +719,10 @@ TEST(TestTransformers, RemoveNullsAlias)
     ddwaf_object_stringl(&string, "/etc/\0passwd", sizeof("/etc/\0passwd") - 1);
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -709,7 +731,7 @@ TEST(TestTransformers, RemoveNullsAlias)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -730,9 +752,10 @@ TEST(TestTransformers, ShellUnescape)
     ddwaf_object_string(&string, "/\\etc/\"pass^wd");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -741,7 +764,7 @@ TEST(TestTransformers, ShellUnescape)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -762,9 +785,10 @@ TEST(TestTransformers, ShellUnescapeAlias)
     ddwaf_object_string(&string, "/\\etc/\"pass^wd");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -773,7 +797,7 @@ TEST(TestTransformers, ShellUnescapeAlias)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -794,9 +818,10 @@ TEST(TestTransformers, UnicodeNormalize)
     ddwaf_object_string(&string, "/étc/p𝑎ßwd");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -805,7 +830,7 @@ TEST(TestTransformers, UnicodeNormalize)
                                .highlight = "/etc/passwd",
                                .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -826,9 +851,10 @@ TEST(TestTransformers, UrlBasename)
     ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -837,7 +863,7 @@ TEST(TestTransformers, UrlBasename)
                                .highlight = "index.php",
                                .args = {{.value = "index.php", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -858,9 +884,10 @@ TEST(TestTransformers, UrlBasenameAlias)
     ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -869,7 +896,7 @@ TEST(TestTransformers, UrlBasenameAlias)
                                .highlight = "index.php",
                                .args = {{.value = "index.php", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -890,9 +917,10 @@ TEST(TestTransformers, UrlDecode)
     ddwaf_object_string(&string, "%61n+%61ttack%20valu%65");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -901,7 +929,7 @@ TEST(TestTransformers, UrlDecode)
                                .highlight = "an attack value",
                                .args = {{.value = "an attack value", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -922,9 +950,10 @@ TEST(TestTransformers, UrlDecodeAlias)
     ddwaf_object_string(&string, "%61n+%61ttack%20valu%65");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -933,7 +962,7 @@ TEST(TestTransformers, UrlDecodeAlias)
                                .highlight = "an attack value",
                                .args = {{.value = "an attack value", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -954,9 +983,10 @@ TEST(TestTransformers, UrlDecodeIis)
     ddwaf_object_string(&string, "%61n+%61ttack%20valu%65");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -965,7 +995,7 @@ TEST(TestTransformers, UrlDecodeIis)
                                .highlight = "an attack value",
                                .args = {{.value = "an attack value", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -986,9 +1016,10 @@ TEST(TestTransformers, UrlDecodeIisAlias)
     ddwaf_object_string(&string, "%61n+%61ttack%20valu%65");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -997,7 +1028,7 @@ TEST(TestTransformers, UrlDecodeIisAlias)
                                .highlight = "an attack value",
                                .args = {{.value = "an attack value", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -1018,9 +1049,10 @@ TEST(TestTransformers, UrlPath)
     ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -1029,7 +1061,7 @@ TEST(TestTransformers, UrlPath)
                                .highlight = "/path/to/index.php",
                                .args = {{.value = "/path/to/index.php", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -1050,9 +1082,10 @@ TEST(TestTransformers, UrlPathAlias)
     ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -1061,7 +1094,7 @@ TEST(TestTransformers, UrlPathAlias)
                                .highlight = "/path/to/index.php",
                                .args = {{.value = "/path/to/index.php", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -1082,9 +1115,10 @@ TEST(TestTransformers, UrlQuerystring)
     ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -1093,7 +1127,7 @@ TEST(TestTransformers, UrlQuerystring)
                                .highlight = "a=b",
                                .args = {{.value = "a=b", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -1114,9 +1148,10 @@ TEST(TestTransformers, UrlQuerystringAlias)
     ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
     ddwaf_object_map_add(&map, "value2", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -1125,7 +1160,7 @@ TEST(TestTransformers, UrlQuerystringAlias)
                                .highlight = "a=b",
                                .args = {{.value = "a=b", .address = "value2"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -1146,9 +1181,10 @@ TEST(TestTransformers, Mixed)
     ddwaf_object_string(&string, "L3AgIGEgIHRIL3QgIE8vRmlsRS5QSFA/YT1iI2ZyYWc=");
     ddwaf_object_map_add(&map, "value1", &string);
 
-    ddwaf_result out;
+    ddwaf_object out;
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
-    EXPECT_FALSE(out.timeout);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
         out, {.id = "1",
                  .name = "rule1",
@@ -1158,7 +1194,7 @@ TEST(TestTransformers, Mixed)
                      .highlight = "L3AgYSB0aC90IG8vZmlsZS5waHA=",
                      .args = {{.value = "L3AgYSB0aC90IG8vZmlsZS5waHA=", .address = "value1"}}}}});
 
-    ddwaf_result_free(&out);
+    ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }

--- a/tests/unit/context_test.cpp
+++ b/tests/unit/context_test.cpp
@@ -63,7 +63,8 @@ TEST(TestContext, MatchTimeout)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
     ctx.insert(root);
 
-    EXPECT_THROW(ctx.eval_rules({}, deadline), ddwaf::timeout_exception);
+    std::vector<ddwaf::event> events;
+    EXPECT_THROW(ctx.eval_rules({}, events, deadline), ddwaf::timeout_exception);
 }
 
 TEST(TestContext, NoMatch)
@@ -88,7 +89,8 @@ TEST(TestContext, NoMatch)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.2"));
     ctx.insert(root);
 
-    auto events = ctx.eval_rules({}, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules({}, events, deadline);
     EXPECT_EQ(events.size(), 0);
 }
 
@@ -114,7 +116,8 @@ TEST(TestContext, Match)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
     ctx.insert(root);
 
-    auto events = ctx.eval_rules({}, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules({}, events, deadline);
     EXPECT_EQ(events.size(), 1);
 }
 
@@ -157,7 +160,8 @@ TEST(TestContext, MatchMultipleRulesInCollectionSingleRun)
     ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
     ctx.insert(root);
 
-    auto events = ctx.eval_rules({}, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules({}, events, deadline);
     EXPECT_EQ(events.size(), 1);
 
     auto &event = events[0];
@@ -222,7 +226,8 @@ TEST(TestContext, MatchMultipleRulesWithPrioritySingleRun)
         ctx.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
 
         auto event = events[0];
@@ -242,7 +247,8 @@ TEST(TestContext, MatchMultipleRulesWithPrioritySingleRun)
         ctx.insert(root);
 
         ddwaf::timer deadline{2s};
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
 
         auto event = events[0];
@@ -292,7 +298,8 @@ TEST(TestContext, MatchMultipleRulesInCollectionDoubleRun)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
 
         auto &event = events[0];
@@ -320,7 +327,8 @@ TEST(TestContext, MatchMultipleRulesInCollectionDoubleRun)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 }
@@ -366,7 +374,8 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
 
         auto &event = events[0];
@@ -396,7 +405,8 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
 
         auto &event = events[0];
@@ -461,7 +471,8 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
 
         auto &event = events[0];
@@ -491,7 +502,8 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 }
@@ -536,7 +548,8 @@ TEST(TestContext, MatchMultipleCollectionsSingleRun)
     ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
     ctx.insert(root);
 
-    auto events = ctx.eval_rules({}, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules({}, events, deadline);
     EXPECT_EQ(events.size(), 2);
 }
 
@@ -583,7 +596,8 @@ TEST(TestContext, MatchPriorityCollectionsSingleRun)
     ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
     ctx.insert(root);
 
-    auto events = ctx.eval_rules({}, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules({}, events, deadline);
     EXPECT_EQ(events.size(), 1);
 }
 
@@ -627,7 +641,8 @@ TEST(TestContext, MatchMultipleCollectionsDoubleRun)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
     }
 
@@ -638,7 +653,8 @@ TEST(TestContext, MatchMultipleCollectionsDoubleRun)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
     }
 }
@@ -686,7 +702,8 @@ TEST(TestContext, MatchMultiplePriorityCollectionsDoubleRun)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
     }
 
@@ -697,7 +714,8 @@ TEST(TestContext, MatchMultiplePriorityCollectionsDoubleRun)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
         ctx.insert(root);
 
-        auto events = ctx.eval_rules({}, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules({}, events, deadline);
         EXPECT_EQ(events.size(), 1);
     }
 }
@@ -747,7 +765,8 @@ TEST(TestContext, RuleFilterWithCondition)
     EXPECT_EQ(rules_to_exclude.size(), 1);
     EXPECT_TRUE(rules_to_exclude.contains(rule));
 
-    auto events = ctx.eval_rules(rules_to_exclude, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules(rules_to_exclude, events, deadline);
     EXPECT_EQ(events.size(), 0);
 }
 
@@ -1057,7 +1076,8 @@ TEST(TestContext, NoRuleFilterWithCondition)
     auto rules_to_exclude = ctx.eval_filters(deadline);
     EXPECT_TRUE(rules_to_exclude.empty());
 
-    auto events = ctx.eval_rules(rules_to_exclude, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules(rules_to_exclude, events, deadline);
     EXPECT_EQ(events.size(), 1);
 }
 
@@ -1436,7 +1456,8 @@ TEST(TestContext, InputFilterExclude)
     auto objects_to_exclude = ctx.eval_filters(deadline);
     EXPECT_EQ(objects_to_exclude.size(), 1);
 
-    auto events = ctx.eval_rules(objects_to_exclude, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules(objects_to_exclude, events, deadline);
     EXPECT_EQ(events.size(), 0);
 }
 
@@ -1581,7 +1602,8 @@ TEST(TestContext, InputFilterExcludeRule)
     it->second.mode = filter_mode::none;
     EXPECT_TRUE(it->second.objects.empty());
 
-    auto events = ctx.eval_rules(objects_to_exclude, deadline);
+    std::vector<ddwaf::event> events;
+    ctx.eval_rules(objects_to_exclude, events, deadline);
     EXPECT_EQ(events.size(), 1);
 }
 
@@ -1819,7 +1841,8 @@ TEST(TestContext, InputFilterWithCondition)
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(objects_to_exclude.size(), 0);
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 1);
     }
 
@@ -1837,7 +1860,8 @@ TEST(TestContext, InputFilterWithCondition)
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(objects_to_exclude.size(), 0);
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 1);
     }
 
@@ -1855,7 +1879,8 @@ TEST(TestContext, InputFilterWithCondition)
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(objects_to_exclude.size(), 1);
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 }
@@ -1980,7 +2005,8 @@ TEST(TestContext, InputFilterMultipleRules)
             EXPECT_EQ(policy.objects.size(), 1);
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2002,7 +2028,8 @@ TEST(TestContext, InputFilterMultipleRules)
             EXPECT_EQ(policy.objects.size(), 2);
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2024,7 +2051,8 @@ TEST(TestContext, InputFilterMultipleRules)
             EXPECT_EQ(policy.objects.size(), 2);
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 }
@@ -2095,7 +2123,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
             EXPECT_EQ(objects.size(), 1);
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2118,7 +2147,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
             EXPECT_EQ(objects.size(), 1);
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2141,7 +2171,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
             EXPECT_EQ(objects.size(), 1);
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 }
@@ -2241,7 +2272,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
             EXPECT_TRUE(objects.contains(&root.array[0]));
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2263,7 +2295,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
             EXPECT_TRUE(objects.contains(&root.array[0]));
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2290,7 +2323,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
             EXPECT_TRUE(objects.contains(&root.array[0]));
         }
 
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2313,7 +2347,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
             EXPECT_TRUE(objects.contains(&root.array[0]));
             EXPECT_TRUE(objects.contains(&root.array[1]));
         }
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2341,7 +2376,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
             EXPECT_TRUE(objects.contains(&root.array[0]));
             EXPECT_TRUE(objects.contains(&root.array[1]));
         }
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 
@@ -2371,7 +2407,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
             EXPECT_TRUE(objects.contains(&root.array[1]));
             EXPECT_TRUE(objects.contains(&root.array[2]));
         }
-        auto events = ctx.eval_rules(objects_to_exclude, deadline);
+        std::vector<ddwaf::event> events;
+        ctx.eval_rules(objects_to_exclude, events, deadline);
         EXPECT_EQ(events.size(), 0);
     }
 }

--- a/tests/unit/event_serializer_test.cpp
+++ b/tests/unit/event_serializer_test.cpp
@@ -24,11 +24,18 @@ TEST(TestEventSerializer, SerializeNothing)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({}, output);
 
-    const auto *events = ddwaf_object_find(&output, STRL("events"));
-    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(events), 0);
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({}, events_object, actions_object);
+
+    EXPECT_EVENTS(output, ); // This means no events
+    EXPECT_ACTIONS(output, {});
 
     ddwaf_object_free(&output);
 }
@@ -40,8 +47,18 @@ TEST(TestEventSerializer, SerializeEmptyEvent)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({ddwaf::event{}}, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({ddwaf::event{}}, events_object, actions_object);
+
     EXPECT_EVENTS(output, {});
+    EXPECT_ACTIONS(output, {});
 
     ddwaf_object_free(&output);
 }
@@ -70,7 +87,15 @@ TEST(TestEventSerializer, SerializeSingleEventSingleMatch)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({event}, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({event}, events_object, actions_object);
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
                               .tags = {{"type", "test"}, {"category", "none"}},
@@ -129,7 +154,15 @@ TEST(TestEventSerializer, SerializeSingleEventMultipleMatches)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({event}, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({event}, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -231,7 +264,15 @@ TEST(TestEventSerializer, SerializeMultipleEvents)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize(events, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize(events, events_object, actions_object);
     EXPECT_EVENTS(output,
         {.id = "xasd1022",
             .name = "random rule",
@@ -300,7 +341,15 @@ TEST(TestEventSerializer, SerializeEventNoActions)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({event}, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({event}, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -347,7 +396,15 @@ TEST(TestEventSerializer, SerializeAllTags)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({event}, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({event}, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -393,7 +450,15 @@ TEST(TestEventSerializer, NoMonitorActions)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({event}, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({event}, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -440,7 +505,15 @@ TEST(TestEventSerializer, UndefinedActions)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({event}, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({event}, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -487,7 +560,15 @@ TEST(TestEventSerializer, StackTraceAction)
 
     ddwaf_object output;
     ddwaf_object_map(&output);
-    serializer.serialize({event}, output);
+
+    ddwaf_object tmp;
+    ddwaf_object_map_addl(&output, STRL("events"), ddwaf_object_array(&tmp));
+    ddwaf_object_map_addl(&output, STRL("actions"), ddwaf_object_map(&tmp));
+
+    ddwaf_object &events_object = output.array[0];
+    ddwaf_object &actions_object = output.array[1];
+
+    serializer.serialize({event}, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -507,9 +588,7 @@ TEST(TestEventSerializer, StackTraceAction)
     std::string stack_id;
 
     {
-        const auto *object = ddwaf_object_find(&output, STRL("events"));
-        EXPECT_NE(object, nullptr);
-        auto data = ddwaf::test::object_to_json(*object);
+        auto data = ddwaf::test::object_to_json(events_object);
         YAML::Node doc = YAML::Load(data.c_str());
         auto events = doc.as<std::list<ddwaf::test::event>>();
         ASSERT_EQ(events.size(), 1);
@@ -517,9 +596,7 @@ TEST(TestEventSerializer, StackTraceAction)
     }
 
     {
-        const auto *object = ddwaf_object_find(&output, STRL("actions"));
-        EXPECT_NE(object, nullptr);
-        auto data = ddwaf::test::object_to_json(*object);
+        auto data = ddwaf::test::object_to_json(actions_object);
         YAML::Node doc = YAML::Load(data.c_str());
         auto obtained = doc.as<ddwaf::test::action_map>();
         EXPECT_TRUE(obtained.contains("generate_stack"));

--- a/tests/unit/waf_test.cpp
+++ b/tests/unit/waf_test.cpp
@@ -54,7 +54,9 @@ TEST(TestWaf, BasicContextRun)
     ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
 
     auto *ctx = instance.create_context();
-    EXPECT_EQ(ctx->run(root, std::nullopt, std::nullopt, LONG_TIME), DDWAF_MATCH);
+    auto [code, res] = ctx->run(root, std::nullopt, LONG_TIME);
+    EXPECT_EQ(code, DDWAF_MATCH);
+    ddwaf_object_free(&res);
     delete ctx;
 }
 

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -126,44 +126,49 @@ int main(int argc, char *argv[])
             }
         }
 
-        ddwaf_result ret;
+        ddwaf_object ret;
         auto code =
             ddwaf_run(context, &persistent, &ephemeral, &ret, std::numeric_limits<uint64_t>::max());
-        if (code == DDWAF_MATCH && ddwaf_object_size(&ret.events) > 0) {
+
+        const auto *events = ddwaf_object_find(&ret, "events", sizeof("events") - 1);
+        if (code == DDWAF_MATCH && ddwaf_object_size(events) > 0) {
             std::stringstream ss;
             YAML::Emitter out(ss);
             out.SetIndent(2);
             out.SetMapFormat(YAML::Block);
             out.SetSeqFormat(YAML::Block);
-            out << object_to_yaml(ret.events);
+            out << object_to_yaml(*events);
 
             std::cout << "Events:\n" << ss.str() << "\n\n";
         }
 
-        if (code == DDWAF_MATCH && ddwaf_object_size(&ret.actions) > 0) {
+        const auto *actions = ddwaf_object_find(&ret, "actions", sizeof("actions") - 1);
+        if (code == DDWAF_MATCH && ddwaf_object_size(actions) > 0) {
             std::stringstream ss;
             YAML::Emitter out(ss);
             out.SetIndent(2);
             out.SetMapFormat(YAML::Block);
             out.SetSeqFormat(YAML::Block);
-            out << object_to_yaml(ret.actions);
+            out << object_to_yaml(*actions);
 
             std::cout << "Actions:\n" << ss.str() << "\n\n";
         }
 
-        if (ddwaf_object_size(&ret.derivatives) > 0) {
+        const auto *attributes = ddwaf_object_find(&ret, "attributes", sizeof("attributes") - 1);
+        if (ddwaf_object_size(attributes) > 0) {
             std::stringstream ss;
             YAML::Emitter out(ss);
             out.SetIndent(2);
             out.SetMapFormat(YAML::Block);
             out.SetSeqFormat(YAML::Block);
-            out << object_to_yaml(ret.derivatives);
+            out << object_to_yaml(*attributes);
 
-            std::cout << "Derivatives:\n" << ss.str() << "\n\n";
+            std::cout << "Attributes:\n" << ss.str() << "\n\n";
         }
 
-        std::cout << "Total time: " << ret.total_runtime << '\n';
-        ddwaf_result_free(&ret);
+        const auto *duration = ddwaf_object_find(&ret, "duration", sizeof("duration") - 1);
+        std::cout << "Total time: " << ddwaf_object_get_unsigned(duration) << '\n';
+        ddwaf_object_free(&ret);
     }
 
     ddwaf_context_destroy(context);


### PR DESCRIPTION
This PR replaces `ddwaf_result`  with a `ddwaf_object` in the `ddwaf_run` call. This result object is only filled when the result is a non-error one and it contains a map with the following contents:

```
{
  "events": [ ... ],
  "actions": { ... },
  "timeout": (true | false),
  "duration": integer,
  "attributes": { ... },
  "keep": (true | false)
}
```

Note that `derivatives` have been replaced with `attributes` and `keep` is provided but not yet supported internally.

Related Jiras: [APPSEC-57573]


[APPSEC-57573]: https://datadoghq.atlassian.net/browse/APPSEC-57573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ