### PR TITLE
Support for partial event obfuscation

### DIFF
--- a/src/condition/base.hpp
+++ b/src/condition/base.hpp
@@ -12,6 +12,7 @@
 
 #include "clock.hpp"
 #include "context_allocator.hpp"
+#include "dynamic_string.hpp"
 #include "exclusion/common.hpp"
 #include "matcher/base.hpp"
 #include "object_store.hpp"
@@ -25,13 +26,13 @@ enum class data_source : uint8_t { values, keys, object };
 struct condition_match {
     struct argument {
         std::string_view name;
-        std::string resolved;
+        dynamic_string resolved;
         std::string_view address{};
         std::vector<std::string> key_path{};
     };
 
     std::vector<argument> args;
-    std::vector<std::string> highlights;
+    std::vector<dynamic_string> highlights;
     std::string_view operator_name;
     std::string_view operator_value;
     bool ephemeral{false};

--- a/src/condition/lfi_detector.cpp
+++ b/src/condition/lfi_detector.cpp
@@ -139,14 +139,14 @@ eval_result lfi_detector::eval_impl(const unary_argument<std::string_view> &path
             DDWAF_TRACE("Target {} matched parameter value {}", param.address, highlight);
 
             cache.match = condition_match{.args = {{.name = "resource"sv,
-                                                       .resolved = std::string{path.value},
+                                                       .resolved = path.value,
                                                        .address = path.address,
                                                        .key_path = path_kp},
                                               {.name = "params"sv,
                                                   .resolved = highlight,
                                                   .address = param.address,
                                                   .key_path = param_kp}},
-                .highlights = {std::move(highlight)},
+                .highlights = {highlight},
                 .operator_name = "lfi_detector",
                 .operator_value = {},
                 .ephemeral = ephemeral};

--- a/src/condition/scalar_condition.cpp
+++ b/src/condition/scalar_condition.cpp
@@ -65,7 +65,7 @@ ResultType eval_object(Iterator &it, std::string_view address, bool ephemeral,
                     return true;
                 } else {
                     return {{{{"input"sv, object_to_string(dst), address, it.get_current_path()}},
-                        {std::move(highlight)}, matcher.name(), matcher.to_string(), ephemeral}};
+                        {highlight}, matcher.name(), matcher.to_string(), ephemeral}};
                 }
             }
         }
@@ -81,8 +81,8 @@ ResultType eval_object(Iterator &it, std::string_view address, bool ephemeral,
     if constexpr (std::is_same_v<ResultType, bool>) {
         return true;
     } else {
-        return {{{{"input"sv, object_to_string(src), address, it.get_current_path()}},
-            {std::move(highlight)}, matcher.name(), matcher.to_string(), ephemeral}};
+        return {{{{"input"sv, object_to_string(src), address, it.get_current_path()}}, {highlight},
+            matcher.name(), matcher.to_string(), ephemeral}};
     }
 }
 

--- a/src/condition/scalar_condition.cpp
+++ b/src/condition/scalar_condition.cpp
@@ -230,6 +230,6 @@ eval_result scalar_negated_condition::eval(condition_cache &cache, const object_
     }
 
     return {.outcome = false, .ephemeral = false};
-} // NOLINT(clang-analyzer-unix.Malloc)
+}
 
 } // namespace ddwaf

--- a/src/condition/scalar_condition.cpp
+++ b/src/condition/scalar_condition.cpp
@@ -230,6 +230,6 @@ eval_result scalar_negated_condition::eval(condition_cache &cache, const object_
     }
 
     return {.outcome = false, .ephemeral = false};
-}
+} // NOLINT(clang-analyzer-unix.Malloc)
 
 } // namespace ddwaf

--- a/src/configuration/configuration_manager.hpp
+++ b/src/configuration/configuration_manager.hpp
@@ -14,6 +14,8 @@
 #include "configuration/common/raw_configuration.hpp"
 #include "ruleset_info.hpp"
 
+#include "re2.h"
+
 namespace ddwaf {
 
 class configuration_manager {

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <string>
 #include <string_view>
 
 namespace ddwaf {

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -1,0 +1,118 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+
+#include "ddwaf.h"
+
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string_view>
+
+class dynamic_string {
+public:
+    explicit dynamic_string(std::size_t capacity)
+        // NOLINTNEXTLINE(hicpp-no-malloc)
+        : buffer(static_cast<char *>(malloc(capacity)), free), capacity_(capacity)
+    {
+        if (buffer == nullptr) {
+            throw std::bad_alloc{};
+        }
+    }
+
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    dynamic_string(std::string_view str)
+    // NOLINTNEXTLINE(hicpp-no-malloc)
+        : buffer(static_cast<char *>(malloc(str.size())), free), size_(str.size()),
+          capacity_(str.size())
+    {
+        if (buffer == nullptr) {
+            throw std::bad_alloc{};
+        }
+
+        memcpy(buffer.get(), str.data(), str.size());
+    }
+
+    ~dynamic_string() = default;
+
+    dynamic_string(const dynamic_string &) = delete;
+    dynamic_string &operator=(const dynamic_string &) = delete;
+
+    dynamic_string(dynamic_string &&other) noexcept
+        : buffer(std::move(other.buffer)), size_(other.size_), capacity_(other.capacity_)
+    {
+        other.size_ = other.capacity_ = 0;
+    }
+
+    dynamic_string &operator=(dynamic_string &&other) noexcept
+    {
+        buffer = std::move(other.buffer);
+        size_ = other.size_;
+        capacity_ = other.capacity_;
+
+        other.size_ = other.capacity_ = 0;
+
+        return *this;
+    }
+
+    [[nodiscard]] std::size_t size() const noexcept { return size_; }
+    [[nodiscard]] bool empty() const noexcept { return size_ == 0; }
+    [[nodiscard]] std::size_t capacity() const noexcept { return capacity_; }
+
+    void append(std::string_view str)
+    {
+        realloc_if_needed(str.size());
+        if (!str.empty() && (size_ + str.size()) <= capacity_) [[likely]] {
+            memcpy(&buffer.get()[size_], str.data(), str.size());
+            size_ += str.size();
+        }
+    }
+
+    void append(char c)
+    {
+        realloc_if_needed(1);
+        buffer.get()[size_++] = c;
+    }
+
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    operator std::string_view() const { return {buffer.get(), size_}; }
+
+    ddwaf_object move()
+    {
+        ddwaf_object object;
+        ddwaf_object_stringl_nc(&object, buffer.release(), size_);
+        size_ = capacity_ = 0;
+        return object; // NOLINT(clang-analyzer-unix.Malloc)
+    }
+
+    void clear()
+    {
+        buffer.reset(nullptr);
+        size_ = capacity_ = 0;
+    }
+
+protected:
+    void realloc_if_needed(std::size_t at_least)
+    {
+        if ((size_ + at_least) >= capacity_) {
+            auto new_capacity_ = capacity_ + std::max(capacity_, at_least);
+            // NOLINTNEXTLINE(hicpp-no-malloc)
+            char *new_buffer = static_cast<char *>(malloc(new_capacity_));
+            if (new_buffer == nullptr) {
+                throw std::bad_alloc{};
+            }
+
+            memcpy(new_buffer, buffer.get(), size_);
+
+            buffer.reset(new_buffer);
+            capacity_ = new_capacity_;
+        }
+    }
+
+    std::unique_ptr<char, decltype(&free)> buffer{nullptr, free};
+    std::size_t size_{0};
+    std::size_t capacity_{};
+};

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -28,10 +28,11 @@ public:
         }
     }
 
-    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     template <typename T>
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     dynamic_string(T str)
-        requires std::is_same_v<std::string_view, T> || std::is_same_v<std::string, T>
+        requires std::is_same_v<std::string_view, std::decay_t<T>> ||
+                     std::is_same_v<std::string, std::decay_t<T>>
         // NOLINTNEXTLINE(hicpp-no-malloc)
         : buffer(static_cast<char *>(malloc(str.size())), free), size_(str.size()),
           capacity_(str.size())

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -19,7 +19,7 @@ namespace ddwaf {
 
 class dynamic_string {
 public:
-    dynamic_string() : dynamic_string(0UL){};
+    dynamic_string() : dynamic_string(static_cast<std::size_t>(0)){};
 
     explicit dynamic_string(std::size_t capacity)
     {

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -128,7 +128,7 @@ public:
 protected:
     void ensure_spare_capacity(std::size_t at_least)
     {
-        // We need to be able to allocate at_least + 1 to include the nul-character
+        // We need to be able to allocate at_least + 1 to include the null character
         if (at_least >= (std::numeric_limits<std::size_t>::max() - capacity_)) {
             throw std::bad_alloc{};
         }
@@ -151,8 +151,8 @@ protected:
     }
 
     std::unique_ptr<char, decltype(&free)> buffer_{nullptr, free};
-    // Size explicitly excludes the nul-character, while capacity includes it as
-    // if refers to the total memory allocated.
+    // Size explicitly excludes the null character, while capacity includes it
+    // as if refers to the total memory allocated.
     std::size_t size_{0};
     std::size_t capacity_{0};
 };

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -40,7 +40,7 @@ void serialize_match(condition_match &match, ddwaf_object &match_map, auto &obfu
     ddwaf_object highlight_arr;
     ddwaf_object_array(&highlight_arr);
     for (auto &highlight : match.highlights) {
-        auto value = highlight.move();
+        auto value = highlight.to_object();
         ddwaf_object_array_add(&highlight_arr, &value);
     }
 
@@ -56,7 +56,7 @@ void serialize_match(condition_match &match, ddwaf_object &match_map, auto &obfu
 
         ddwaf_object_map_add(&param, "address", to_object(tmp, arg.address));
         ddwaf_object_map_add(&param, "key_path", &key_path);
-        auto resolved = arg.resolved.move();
+        auto resolved = arg.resolved.to_object();
         ddwaf_object_map_add(&param, "value", &resolved);
     } else {
         for (auto &arg : match.args) {
@@ -72,7 +72,7 @@ void serialize_match(condition_match &match, ddwaf_object &match_map, auto &obfu
             ddwaf_object_map_add(&argument, "address", to_object(tmp, arg.address));
             ddwaf_object_map_add(&argument, "key_path", &key_path);
 
-            auto resolved = arg.resolved.move();
+            auto resolved = arg.resolved.to_object();
             ddwaf_object_map_add(&argument, "value", &resolved);
 
             ddwaf_object_map_addl(&param, arg.name.data(), arg.name.size(), &argument);

--- a/src/event.hpp
+++ b/src/event.hpp
@@ -33,7 +33,7 @@ public:
         : obfuscator_(event_obfuscator), actions_(actions)
     {}
 
-    void serialize(const std::vector<event> &events, ddwaf_object &output_events,
+    void serialize(std::vector<event> &events, ddwaf_object &output_events,
         ddwaf_object &output_actions) const;
 
 protected:

--- a/src/obfuscator.cpp
+++ b/src/obfuscator.cpp
@@ -147,12 +147,13 @@ bool obfuscator::obfuscate_value(dynamic_string &value) const
         if (find_and_consume(&input, *value_regex_, matches)) {
             for (auto &match : matches) {
                 if (!match.empty()) {
-                    output.append({prev.data(), match.data() - prev.data()});
+                    output.append(
+                        {prev.data(), static_cast<std::size_t>(match.data() - prev.data())});
                     output.append(redaction_msg);
 
                     const auto *next = match.data() + match.size();
                     if (next != input.data()) {
-                        output.append({next, input.data() - next});
+                        output.append({next, static_cast<std::size_t>(input.data() - next)});
                     }
                     break;
                 }

--- a/src/obfuscator.cpp
+++ b/src/obfuscator.cpp
@@ -161,7 +161,7 @@ bool obfuscator::obfuscate_value(dynamic_string &value) const
     }
 
     if (!output.empty()) {
-        output.append({read, value.data() + value.size() - read});
+        output.append({read, static_cast<std::size_t>(value.data() + value.size() - read)});
         value = output;
     }
 

--- a/src/obfuscator.cpp
+++ b/src/obfuscator.cpp
@@ -144,22 +144,23 @@ bool obfuscator::obfuscate_value(dynamic_string &value) const
     auto prev = input;
     while (!input.empty()) {
         std::array<re2::StringPiece, 8> matches;
-        if (find_and_consume(&input, *value_regex_, matches)) {
-            for (auto &match : matches) {
-                if (!match.empty()) {
-                    output.append(
-                        {prev.data(), static_cast<std::size_t>(match.data() - prev.data())});
-                    output.append(redaction_msg);
-
-                    const auto *next = match.data() + match.size();
-                    if (next != input.data()) {
-                        output.append({next, static_cast<std::size_t>(input.data() - next)});
-                    }
-                    break;
-                }
-            }
-            prev = input;
+        if (!find_and_consume(&input, *value_regex_, matches)) {
+            break;
         }
+
+        for (auto &match : matches) {
+            if (!match.empty()) {
+                output.append({prev.data(), static_cast<std::size_t>(match.data() - prev.data())});
+                output.append(redaction_msg);
+
+                const auto *next = match.data() + match.size();
+                if (next != input.data()) {
+                    output.append({next, static_cast<std::size_t>(input.data() - next)});
+                }
+                break;
+            }
+        }
+        prev = input;
     }
 
     if (!output.empty()) {

--- a/src/obfuscator.cpp
+++ b/src/obfuscator.cpp
@@ -3,11 +3,15 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <stdexcept>
 #include <string_view>
+#include <utility>
 
+#include "condition/base.hpp"
+#include "dynamic_string.hpp"
 #include "log.hpp"
 #include "obfuscator.hpp"
 #include "re2.h"
@@ -23,51 +27,146 @@ bool match(re2::RE2 &regex, std::string_view value)
     return regex.Match(key_ref, 0, value.size(), re2::RE2::UNANCHORED, nullptr, 0);
 }
 
-} // namespace
-
-obfuscator::obfuscator(std::string_view key_regex_str, std::string_view value_regex_str)
+bool load_regex(std::string_view regex_str, std::unique_ptr<re2::RE2> &regex)
 {
+    if (regex_str.empty()) {
+        return true;
+    }
+
     re2::RE2::Options options;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
     options.set_max_mem(static_cast<int64_t>(512 * 1024));
     options.set_log_errors(false);
     options.set_case_sensitive(false);
 
-    if (!key_regex_str.empty()) {
-        re2::StringPiece sp(key_regex_str.data(), key_regex_str.size());
-        key_regex = std::make_unique<re2::RE2>(sp, options);
+    const re2::StringPiece sp(regex_str.data(), regex_str.size());
+    regex = std::make_unique<re2::RE2>(sp, options);
 
-        if (!key_regex->ok()) {
-            DDWAF_ERROR("invalid obfuscator key regex: {} - using default", key_regex->error_arg());
+    return regex->ok();
+}
 
-            sp = re2::StringPiece(default_key_regex_str.data(), default_key_regex_str.size());
-            key_regex = std::make_unique<re2::RE2>(sp, options);
+template <std::size_t N, std::size_t... I>
+bool find_and_consume_sequence(re2::StringPiece *input, re2::RE2 &regex,
+    std::array<re2::StringPiece, N> &array, std::index_sequence<I...> /*unused*/)
+{
+    return re2::RE2::FindAndConsume(input, regex, &array[I]...);
+}
 
-            if (!key_regex->ok()) {
-                throw std::runtime_error(
-                    "invalid default obfuscator key regex: " + key_regex->error_arg());
+template <std::size_t N>
+bool find_and_consume(
+    re2::StringPiece *input, re2::RE2 &regex, std::array<re2::StringPiece, N> &array)
+{
+    return find_and_consume_sequence(input, regex, array, std::make_index_sequence<N>{});
+}
+
+} // namespace
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+obfuscator::obfuscator(std::string_view key_regex_str, std::string_view value_regex_str)
+{
+    if (!load_regex(key_regex_str, key_regex_)) {
+        DDWAF_ERROR("invalid obfuscator key regex: {} - using default", key_regex_->error_arg());
+
+        // Assume the default regex won't fail, this will be validated during testing
+        load_regex(default_key_regex_str, key_regex_);
+    }
+
+    bool value_regex_is_default = (value_regex_str == default_value_regex_str);
+    if (!load_regex(value_regex_str, value_regex_)) {
+        DDWAF_ERROR(
+            "invalid obfuscator value regex: {} - using default", value_regex_->error_arg());
+
+        // Assume the default regex won't fail, this will be validated during testing
+        load_regex(default_value_regex_str, value_regex_);
+        value_regex_is_default = true;
+    }
+
+    if (value_regex_ && value_regex_->ok()) {
+        partial_value_obfuscation_ = value_regex_is_default;
+    }
+}
+
+void obfuscator::obfuscate_match(condition_match &match) const
+{
+    bool redact_highlight = false;
+    for (auto &arg : match.args) {
+        bool sensitive_key = false;
+        for (const auto &key : arg.key_path) {
+            if (is_sensitive_key(key)) {
+                sensitive_key = true;
+                break;
+            }
+        }
+
+        if (sensitive_key) {
+            // The key is sensitive, we must replace the resolved value and highlight
+            redact_highlight = (arg.name == "params" || arg.name == "input");
+
+            arg.resolved = redaction_msg;
+        } else {
+            if (obfuscate_value(arg.resolved)) {
+                redact_highlight = (arg.name == "params" || arg.name == "input");
             }
         }
     }
 
-    if (!value_regex_str.empty()) {
-        const re2::StringPiece sp(value_regex_str.data(), value_regex_str.size());
-        value_regex = std::make_unique<re2::RE2>(sp, options);
-
-        if (!value_regex->ok()) {
-            DDWAF_ERROR("invalid obfuscator value regex: {}", value_regex->error_arg());
-        }
+    // Since the highlight may be partial, there's no guarantee that the
+    // regular expressions will correctly match, therefore we fully redact
+    // them
+    if (redact_highlight) {
+        for (auto &highlight : match.highlights) { highlight = redaction_msg; }
     }
 }
 
 bool obfuscator::is_sensitive_key(std::string_view key) const
 {
-    return key_regex ? match(*key_regex, key) : false;
+    return (key_regex_ && key_regex_->ok()) ? match(*key_regex_, key) : false;
 }
 
 bool obfuscator::is_sensitive_value(std::string_view value) const
 {
-    return value_regex ? match(*value_regex, value) : false;
+    return (value_regex_ && value_regex_->ok()) ? match(*value_regex_, value) : false;
+}
+
+bool obfuscator::obfuscate_value(dynamic_string &value) const
+{
+    if (!partial_value_obfuscation_) {
+        if (is_sensitive_value(value)) {
+            value = redaction_msg;
+            return true;
+        }
+        return false;
+    }
+
+    dynamic_string output{value.size()};
+    re2::StringPiece input{value.data(), value.size()};
+
+    auto prev = input;
+    while (!input.empty()) {
+        std::array<re2::StringPiece, 8> matches;
+        if (find_and_consume(&input, *value_regex_, matches)) {
+            for (auto &match : matches) {
+                if (!match.empty()) {
+                    output.append({prev.data(), match.data() - prev.data()});
+                    output.append(redaction_msg);
+
+                    const auto *next = match.data() + match.size();
+                    if (next != input.data()) {
+                        output.append({next, input.data() - next});
+                    }
+                    break;
+                }
+            }
+            prev = input;
+        }
+    }
+
+    if (!output.empty()) {
+        output.append({prev.data(), prev.size()});
+        value = output;
+    }
+
+    return !output.empty();
 }
 
 } // namespace ddwaf

--- a/src/obfuscator.hpp
+++ b/src/obfuscator.hpp
@@ -10,7 +10,7 @@
 #include <re2/re2.h>
 #include <string_view>
 
-#include "ddwaf.h"
+#include "condition/base.hpp"
 
 namespace ddwaf {
 
@@ -23,6 +23,9 @@ class obfuscator {
 public:
     explicit obfuscator(std::string_view key_regex_str = std::string_view(),
         std::string_view value_regex_str = std::string_view());
+
+    void obfuscate_match(condition_match &match) const;
+
     [[nodiscard]] bool is_sensitive_key(std::string_view key) const;
     [[nodiscard]] bool is_sensitive_value(std::string_view value) const;
 
@@ -31,9 +34,15 @@ public:
     static constexpr std::string_view default_key_regex_str{
         R"((?i)pass|pw(?:or)?d|secret|(?:api|private|public|access)[_-]?key|token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\.net[_-]sessionid|sid|jwt)"};
 
+    static constexpr std::string_view default_value_regex_str{
+        R"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key(?:[_-]?id)?|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?|jsessionid|phpsessid|asp\.net(?:[_-]|-)sessionid|sid|jwt)(?:\s*=([^;&]+)|"\s*:\s*("[^"]+"|\d+))|bearer\s+([a-z0-9\._\-]+)|token\s*:\s*([a-z0-9]{13})|gh[opsu]_([0-9a-zA-Z]{36})|ey[I-L][\w=-]+\.(ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?)|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}([^\-]+)[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*([a-z0-9\/\.+]{100,}))"};
+
 protected:
-    std::unique_ptr<re2::RE2> key_regex{nullptr};
-    std::unique_ptr<re2::RE2> value_regex{nullptr};
+    [[nodiscard]] bool obfuscate_value(dynamic_string &value) const;
+
+    bool partial_value_obfuscation_{false};
+    std::unique_ptr<re2::RE2> key_regex_{nullptr};
+    std::unique_ptr<re2::RE2> value_regex_{nullptr};
 };
 
 } // namespace ddwaf

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "ddwaf.h"
-#include "dynamic_string.hpp"
 
 // Convert numbers to strings
 #define STR_HELPER(x) #x
@@ -123,11 +122,11 @@ inline bool isspace(char c)
 {
     return c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v';
 }
-inline bool isupper(char c) { return static_cast<unsigned>(c) - 'A' < 26; }
+inline constexpr bool isupper(char c) { return static_cast<unsigned>(c) - 'A' < 26; }
 inline bool islower(char c) { return static_cast<unsigned>(c) - 'a' < 26; }
 inline bool isalnum(char c) { return isalpha(c) || isdigit(c); }
 inline bool isboundary(char c) { return !isalnum(c) && c != '_'; }
-inline char tolower(char c) { return isupper(c) ? static_cast<char>(c | 32) : c; }
+inline constexpr char tolower(char c) { return isupper(c) ? static_cast<char>(c | 32) : c; }
 inline uint8_t from_hex(char c)
 {
     auto uc = static_cast<uint8_t>(c);
@@ -158,7 +157,8 @@ concept has_from_chars = requires(T v) { std::from_chars(nullptr, nullptr, std::
 template <typename StringType, typename T>
 StringType to_string(T value)
     requires std::is_integral_v<T> && (!std::is_same_v<T, bool>) &&
-             (std::is_same_v<StringType, std::string> || std::is_same_v<StringType, dynamic_string>)
+             std::is_same_v<StringType, std::basic_string<char, typename StringType::traits_type,
+                                            typename StringType::allocator_type>>
 {
     // Maximum number of characters required to represent a 64 bit integer as a string
     // 20 bytes for UINT64_MAX or INT64_MIN
@@ -169,7 +169,7 @@ StringType to_string(T value)
     [[unlikely]] if (ec != std::errc()) {
         return {};
     }
-    return {str.data(), static_cast<std::size_t>(ptr - str.data())};
+    return {str.data(), ptr};
 }
 
 template <typename T>
@@ -181,7 +181,8 @@ inline constexpr std::size_t max_exp_digits = sizeof(T) == 4 ? 2 : 4;
 template <typename StringType, typename T>
 StringType to_string(T value)
     requires(std::is_same_v<T, float> || std::is_same_v<T, double>) &&
-            (std::is_same_v<StringType, std::string> || std::is_same_v<StringType, dynamic_string>)
+            std::is_same_v<StringType, std::basic_string<char, typename StringType::traits_type,
+                                           typename StringType::allocator_type>>
 {
     if constexpr (has_to_chars<T>) {
         static constexpr std::size_t max_chars = std::numeric_limits<T>::digits10 + 1 +
@@ -195,25 +196,24 @@ StringType to_string(T value)
             // This is likely unreachable if the max_chars calculation is accurate
             return {};
         }
-        return {str.data(), static_cast<std::size_t>(ptr - str.data())};
+        return {str.data(), ptr};
     } else {
         using char_type = typename StringType::value_type;
         using traits_type = typename StringType::traits_type;
         using allocator_type = typename StringType::allocator_type;
         std::basic_ostringstream<char_type, traits_type, allocator_type> ss;
         ss << std::setprecision(std::numeric_limits<T>::digits10) << value;
-        auto str = ss.str();
-        return {str.data(), str.size()};
+        return std::move(ss).str();
     }
 }
 
 template <typename StringType, typename T>
 StringType to_string(T value)
     requires std::is_same_v<T, bool> &&
-             (std::is_same_v<StringType, std::string> || std::is_same_v<StringType, dynamic_string>)
+             std::is_same_v<StringType, std::basic_string<char, typename StringType::traits_type,
+                                            typename StringType::allocator_type>>
 {
-    using namespace std::literals;
-    return StringType{value ? "true"sv : "false"sv};
+    return value ? "true" : "false";
 }
 
 template <typename T> std::pair<bool, T> from_string(std::string_view str)
@@ -236,26 +236,26 @@ template <typename T> std::pair<bool, T> from_string(std::string_view str)
     return {false, {}};
 }
 
-inline dynamic_string object_to_string(const ddwaf_object &object)
+inline std::string object_to_string(const ddwaf_object &object)
 {
     if (object.type == DDWAF_OBJ_STRING) {
-        return dynamic_string{object.stringValue, static_cast<std::size_t>(object.nbEntries)};
+        return std::string{object.stringValue, static_cast<std::size_t>(object.nbEntries)};
     }
 
     if (object.type == DDWAF_OBJ_BOOL) {
-        return to_string<dynamic_string>(object.boolean);
+        return to_string<std::string>(object.boolean);
     }
 
     if (object.type == DDWAF_OBJ_SIGNED) {
-        return to_string<dynamic_string>(object.intValue);
+        return to_string<std::string>(object.intValue);
     }
 
     if (object.type == DDWAF_OBJ_UNSIGNED) {
-        return to_string<dynamic_string>(object.uintValue);
+        return to_string<std::string>(object.uintValue);
     }
 
     if (object.type == DDWAF_OBJ_FLOAT) {
-        return to_string<dynamic_string>(object.f64);
+        return to_string<std::string>(object.f64);
     }
 
     return {};

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -203,7 +203,7 @@ StringType to_string(T value)
         std::basic_ostringstream<char_type, traits_type, allocator_type> ss;
         ss << std::setprecision(std::numeric_limits<T>::digits10) << value;
         auto str = ss.str();
-        return {str.data, str.size()};
+        return {str.data(), str.size()};
     }
 }
 

--- a/tests/common/gtest_utils.cpp
+++ b/tests/common/gtest_utils.cpp
@@ -37,6 +37,11 @@ struct indent {
     unsigned size_;
 };
 
+std::ostream &operator<<(std::ostream &os, const ddwaf::dynamic_string &str)
+{
+    return os << std::string_view{str};
+}
+
 std::ostream &operator<<(std::ostream &os, const indent &offset)
 {
     for (unsigned i = 0; i < offset.size_; i++) { os << ' '; }

--- a/tests/common/gtest_utils.hpp
+++ b/tests/common/gtest_utils.hpp
@@ -12,6 +12,7 @@
 #include <rapidjson/document.h>
 #include <yaml-cpp/yaml.h>
 
+#include "condition/base.hpp"
 #include "condition/scalar_condition.hpp"
 #include "ddwaf.h"
 
@@ -19,8 +20,10 @@
 #include "common/json_utils.hpp"
 #include "common/yaml_utils.hpp"
 
-#define EXPECT_STR(a, b) EXPECT_STREQ(a.c_str(), b)
-#define EXPECT_STRV(a, b) EXPECT_STR(std::string{a}, b)
+#include "dynamic_string.hpp"
+
+#define EXPECT_STR(a, b) EXPECT_EQ(std::string_view{a}, std::string_view{b})
+#define EXPECT_STRV(a, b) EXPECT_STR(a, b)
 
 namespace ddwaf::test {
 
@@ -28,13 +31,13 @@ struct event {
     struct match {
         struct argument {
             std::string name{"input"};
-            std::string value{};
+            dynamic_string value{};
             std::string address{};
             std::vector<std::string> path{};
         };
         std::string op{};
         std::string op_value{};
-        std::string highlight{};
+        dynamic_string highlight{};
         std::vector<argument> args;
     };
 

--- a/tests/integration/actions/test.cpp
+++ b/tests/integration/actions/test.cpp
@@ -8,6 +8,7 @@
 #include "ddwaf.h"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/actions/";
@@ -38,9 +39,9 @@ TEST(TestActionsIntegration, DefaultActions)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "^block",
-                                   .highlight = "block",
+                                   .highlight = "block"sv,
                                    .args = {{
-                                       .value = "block",
+                                       .value = "block"sv,
                                        .address = "value",
                                    }}}}});
 
@@ -63,9 +64,9 @@ TEST(TestActionsIntegration, DefaultActions)
                                .actions = {"stack_trace"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "stack_trace",
-                                   .highlight = "stack_trace",
+                                   .highlight = "stack_trace"sv,
                                    .args = {{
-                                       .value = "stack_trace",
+                                       .value = "stack_trace"sv,
                                        .address = "value",
                                    }}}}});
 
@@ -111,9 +112,9 @@ TEST(TestActionsIntegration, DefaultActions)
                                .actions = {"extract_schema"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "extract_schema",
-                                   .highlight = "extract_schema",
+                                   .highlight = "extract_schema"sv,
                                    .args = {{
-                                       .value = "extract_schema",
+                                       .value = "extract_schema"sv,
                                        .address = "value",
                                    }}}}});
 
@@ -135,9 +136,9 @@ TEST(TestActionsIntegration, DefaultActions)
                                .actions = {"unblock"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "unblock",
-                                   .highlight = "unblock",
+                                   .highlight = "unblock"sv,
                                    .args = {{
-                                       .value = "unblock",
+                                       .value = "unblock"sv,
                                        .address = "value",
                                    }}}}});
 
@@ -181,9 +182,9 @@ TEST(TestActionsIntegration, OverrideDefaultAction)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "^block",
-                                   .highlight = "block",
+                                   .highlight = "block"sv,
                                    .args = {{
-                                       .value = "block",
+                                       .value = "block"sv,
                                        .address = "value",
                                    }}}}});
 
@@ -222,9 +223,9 @@ TEST(TestActionsIntegration, OverrideDefaultAction)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "^block",
-                                   .highlight = "block",
+                                   .highlight = "block"sv,
                                    .args = {{
-                                       .value = "block",
+                                       .value = "block"sv,
                                        .address = "value",
                                    }}}}});
 
@@ -269,9 +270,9 @@ TEST(TestActionsIntegration, AddNewAction)
                                .actions = {"unblock"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "unblock",
-                                   .highlight = "unblock",
+                                   .highlight = "unblock"sv,
                                    .args = {{
-                                       .value = "unblock",
+                                       .value = "unblock"sv,
                                        .address = "value",
                                    }}}}});
 
@@ -309,9 +310,9 @@ TEST(TestActionsIntegration, AddNewAction)
                                .actions = {"unblock"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "unblock",
-                                   .highlight = "unblock",
+                                   .highlight = "unblock"sv,
                                    .args = {{
-                                       .value = "unblock",
+                                       .value = "unblock"sv,
                                        .address = "value",
                                    }}}}});
 
@@ -351,9 +352,9 @@ TEST(TestActionsIntegration, EmptyOrInvalidActions)
                            .actions = {"block"},
                            .matches = {{.op = "match_regex",
                                .op_value = "^block",
-                               .highlight = "block",
+                               .highlight = "block"sv,
                                .args = {{
-                                   .value = "block",
+                                   .value = "block"sv,
                                    .address = "value",
                                }}}}});
 

--- a/tests/integration/conditions/exists/test.cpp
+++ b/tests/integration/conditions/exists/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/conditions/exists";
@@ -35,7 +36,7 @@ TEST(TestConditionExistsIntegration, AddressAvailable)
                            .name = "rule1-exists",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "exists",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
                                    .address = "input-1",
                                }}}}});
@@ -92,7 +93,7 @@ TEST(TestConditionExistsIntegration, KeyPathAvailable)
                            .name = "rule2-exists-kp",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "exists",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{.address = "input-2", .path = {"path"}}}}}});
 
     ddwaf_object_free(&out);
@@ -148,7 +149,7 @@ TEST(TestConditionExistsIntegration, AddressAvailableVariadicRule)
                            .name = "rule3-exists-multi",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "exists",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
                                    .address = "input-3-1",
                                }}}}});
@@ -183,7 +184,7 @@ TEST(TestConditionExistsIntegration, KeyPathAvailableVariadicRule)
                            .name = "rule3-exists-multi",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "exists",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{.address = "input-3-2", .path = {"path"}}}}}});
 
     ddwaf_object_free(&out);
@@ -217,7 +218,7 @@ TEST(TestConditionExistsIntegration, AddressAvailableKeyPathNotAvailableVariadic
                            .name = "rule3-exists-multi",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "exists",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
                                    .address = "input-3-1",
                                }}}}});
@@ -301,7 +302,7 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathNotAvailable)
                            .name = "rule2-not-exists-kp",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "!exists",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{.address = "input-2", .path = {"path"}}}}}});
 
     ddwaf_object_free(&out);

--- a/tests/integration/context/test.cpp
+++ b/tests/integration/context/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/context/";
@@ -42,16 +43,16 @@ TEST(TestContextIntegration, Basic)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                            .op_value = "rule2",
-                                           .highlight = "rule2",
+                                           .highlight = "rule2"sv,
                                            .args = {{
-                                               .value = "rule2",
+                                               .value = "rule2"sv,
                                                .address = "value",
                                            }}},
                                {.op = "match_regex",
                                    .op_value = "rule3",
-                                   .highlight = "rule3",
+                                   .highlight = "rule3"sv,
                                    .args = {{
-                                       .value = "rule3",
+                                       .value = "rule3"sv,
                                        .address = "value2",
                                        .path = {"key"},
                                    }}}}});
@@ -90,9 +91,9 @@ TEST(TestContextIntegration, KeyPaths)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "Sqreen",
-                               .highlight = "Sqreen",
+                               .highlight = "Sqreen"sv,
                                .args = {{
-                                   .value = "Sqreen",
+                                   .value = "Sqreen"sv,
                                    .address = "param",
                                    .path = {"x"},
                                }}}}});
@@ -113,9 +114,9 @@ TEST(TestContextIntegration, KeyPaths)
                            .tags = {{"type", "flow2"}, {"category", "category2"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "Sqreen",
-                               .highlight = "Sqreen",
+                               .highlight = "Sqreen"sv,
                                .args = {{
-                                   .value = "Sqreen",
+                                   .value = "Sqreen"sv,
                                    .address = "param",
                                    .path = {"z"},
                                }}}}});
@@ -140,9 +141,9 @@ TEST(TestContextIntegration, KeyPaths)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "Sqreen",
-                               .highlight = "Sqreen",
+                               .highlight = "Sqreen"sv,
                                .args = {{
-                                   .value = "Sqreen",
+                                   .value = "Sqreen"sv,
                                    .address = "param",
                                    .path = {"y"},
                                }}}}});
@@ -257,9 +258,9 @@ TEST(TestContextIntegration, SingleCollectionMatch)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "Sqreen",
-                                   .highlight = "Sqreen",
+                                   .highlight = "Sqreen"sv,
                                    .args = {{
-                                       .value = "Sqreen",
+                                       .value = "Sqreen"sv,
                                        .address = "param1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -312,9 +313,9 @@ TEST(TestContextIntegration, MultiCollectionMatches)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "Sqreen",
-                                   .highlight = "Sqreen",
+                                   .highlight = "Sqreen"sv,
                                    .args = {{
-                                       .value = "Sqreen",
+                                       .value = "Sqreen"sv,
                                        .address = "param1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -348,9 +349,9 @@ TEST(TestContextIntegration, MultiCollectionMatches)
                                .tags = {{"type", "flow2"}, {"category", "category2"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "Sqreen",
-                                   .highlight = "Sqreen",
+                                   .highlight = "Sqreen"sv,
                                    .args = {{
-                                       .value = "Sqreen",
+                                       .value = "Sqreen"sv,
                                        .address = "param2",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -423,16 +424,16 @@ TEST(TestContextIntegration, ParameterOverride)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                            .op_value = "^string.*",
-                                           .highlight = "string 1",
+                                           .highlight = "string 1"sv,
                                            .args = {{
-                                               .value = "string 1",
+                                               .value = "string 1"sv,
                                                .address = "arg1",
                                            }}},
                                {.op = "match_regex",
                                    .op_value = ".*",
-                                   .highlight = "string 2",
+                                   .highlight = "string 2"sv,
                                    .args = {{
-                                       .value = "string 2",
+                                       .value = "string 2"sv,
                                        .address = "arg2",
                                    }}}}});
 
@@ -475,9 +476,9 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "Sqreen",
-                                   .highlight = "Sqreen",
+                                   .highlight = "Sqreen"sv,
                                    .args = {{
-                                       .value = "Sqreen",
+                                       .value = "Sqreen"sv,
                                        .address = "param1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -495,9 +496,9 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "Sqreen",
-                                   .highlight = "Sqreen",
+                                   .highlight = "Sqreen"sv,
                                    .args = {{
-                                       .value = "Sqreen",
+                                       .value = "Sqreen"sv,
                                        .address = "param1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -533,16 +534,16 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                                .op_value = "^string.*",
-                                               .highlight = "string 1",
+                                               .highlight = "string 1"sv,
                                                .args = {{
-                                                   .value = "string 1",
+                                                   .value = "string 1"sv,
                                                    .address = "arg1",
                                                }}},
                                    {.op = "match_regex",
                                        .op_value = ".*",
-                                       .highlight = "string 2",
+                                       .highlight = "string 2"sv,
                                        .args = {{
-                                           .value = "string 2",
+                                           .value = "string 2"sv,
                                            .address = "arg2",
                                        }}}}});
         ddwaf_object_free(&ret);
@@ -560,16 +561,16 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                                .op_value = "^string.*",
-                                               .highlight = "string 1",
+                                               .highlight = "string 1"sv,
                                                .args = {{
-                                                   .value = "string 1",
+                                                   .value = "string 1"sv,
                                                    .address = "arg1",
                                                }}},
                                    {.op = "match_regex",
                                        .op_value = ".*",
-                                       .highlight = "string 8",
+                                       .highlight = "string 8"sv,
                                        .args = {{
-                                           .value = "string 8",
+                                           .value = "string 8"sv,
                                            .address = "arg2",
                                        }}}}});
         ddwaf_object_free(&ret);
@@ -587,16 +588,16 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                                .op_value = "^string.*",
-                                               .highlight = "string 1",
+                                               .highlight = "string 1"sv,
                                                .args = {{
-                                                   .value = "string 1",
+                                                   .value = "string 1"sv,
                                                    .address = "arg1",
                                                }}},
                                    {.op = "match_regex",
                                        .op_value = ".*",
-                                       .highlight = "string 3",
+                                       .highlight = "string 3"sv,
                                        .args = {{
-                                           .value = "string 3",
+                                           .value = "string 3"sv,
                                            .address = "arg2",
                                        }}}}});
         ddwaf_object_free(&ret);
@@ -630,9 +631,9 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "^string.*",
-                                   .highlight = "string 1",
+                                   .highlight = "string 1"sv,
                                    .args = {{
-                                       .value = "string 1",
+                                       .value = "string 1"sv,
                                        .address = "arg1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -652,9 +653,9 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = ".*",
-                                   .highlight = "string 8",
+                                   .highlight = "string 8"sv,
                                    .args = {{
-                                       .value = "string 8",
+                                       .value = "string 8"sv,
                                        .address = "arg2",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -690,9 +691,9 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = ".*",
-                                   .highlight = "string 8",
+                                   .highlight = "string 8"sv,
                                    .args = {{
-                                       .value = "string 8",
+                                       .value = "string 8"sv,
                                        .address = "arg2",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -710,9 +711,9 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "^string.*",
-                                   .highlight = "string 1",
+                                   .highlight = "string 1"sv,
                                    .args = {{
-                                       .value = "string 1",
+                                       .value = "string 1"sv,
                                        .address = "arg1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -746,9 +747,9 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "^string.*",
-                                   .highlight = "string 1",
+                                   .highlight = "string 1"sv,
                                    .args = {{
-                                       .value = "string 1",
+                                       .value = "string 1"sv,
                                        .address = "arg1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -767,9 +768,9 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = ".*",
-                                   .highlight = "string 8",
+                                   .highlight = "string 8"sv,
                                    .args = {{
-                                       .value = "string 8",
+                                       .value = "string 8"sv,
                                        .address = "arg2",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -804,9 +805,9 @@ TEST(TestContextIntegration, ReplaceEphemeral)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "^string.*",
-                                   .highlight = "string 1",
+                                   .highlight = "string 1"sv,
                                    .args = {{
-                                       .value = "string 1",
+                                       .value = "string 1"sv,
                                        .address = "arg1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -841,9 +842,9 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = ".*",
-                                   .highlight = "string 8",
+                                   .highlight = "string 8"sv,
                                    .args = {{
-                                       .value = "string 8",
+                                       .value = "string 8"sv,
                                        .address = "arg2",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -861,9 +862,9 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "^string.*",
-                                   .highlight = "string 1",
+                                   .highlight = "string 1"sv,
                                    .args = {{
-                                       .value = "string 1",
+                                       .value = "string 1"sv,
                                        .address = "arg1",
                                    }}}}});
 
@@ -899,9 +900,9 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = ".*",
-                                   .highlight = "string 8",
+                                   .highlight = "string 8"sv,
                                    .args = {{
-                                       .value = "string 8",
+                                       .value = "string 8"sv,
                                        .address = "arg2",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -1030,9 +1031,9 @@ TEST(TestContextIntegration, MultipleModuleSingleCollectionMatch)
             .tags = {{"type", "flow1"}, {"category", "category1"}, {"module", "rasp"}},
             .matches = {{.op = "match_regex",
                 .op_value = "Sqreen",
-                .highlight = "Sqreen",
+                .highlight = "Sqreen"sv,
                 .args = {{
-                    .value = "Sqreen",
+                    .value = "Sqreen"sv,
                     .address = "param1",
                 }}}}},
         {.id = "2",
@@ -1040,9 +1041,9 @@ TEST(TestContextIntegration, MultipleModuleSingleCollectionMatch)
             .tags = {{"type", "flow1"}, {"category", "category1"}},
             .matches = {{.op = "match_regex",
                 .op_value = "Sqreen",
-                .highlight = "Sqreen",
+                .highlight = "Sqreen"sv,
                 .args = {{
-                    .value = "Sqreen",
+                    .value = "Sqreen"sv,
                     .address = "param1",
                 }}}}});
     ddwaf_object_free(&ret);
@@ -1083,16 +1084,16 @@ TEST(TestContextIntegration, TimeoutBeyondLimit)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                            .op_value = "rule2",
-                                           .highlight = "rule2",
+                                           .highlight = "rule2"sv,
                                            .args = {{
-                                               .value = "rule2",
+                                               .value = "rule2"sv,
                                                .address = "value",
                                            }}},
                                {.op = "match_regex",
                                    .op_value = "rule3",
-                                   .highlight = "rule3",
+                                   .highlight = "rule3"sv,
                                    .args = {{
-                                       .value = "rule3",
+                                       .value = "rule3"sv,
                                        .address = "value2",
                                        .path = {"key"},
                                    }}}}});

--- a/tests/integration/custom_rules/test.cpp
+++ b/tests/integration/custom_rules/test.cpp
@@ -8,6 +8,7 @@
 #include "ddwaf.h"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/custom_rules/";
@@ -123,8 +124,8 @@ TEST(TestCustomRulesIntegration, RegularCustomRulesPrecedence)
                                .tags = {{"type", "flow34"}, {"category", "category3"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value3"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value3"}}}}});
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
     }
@@ -164,8 +165,8 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value4"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
 
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
@@ -209,8 +210,8 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -271,8 +272,8 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule",
-                                   .highlight = "rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -293,8 +294,8 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -359,8 +360,8 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -380,8 +381,8 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
                                .tags = {{"type", "flow5"}, {"category", "category5"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -467,8 +468,8 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -489,8 +490,8 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule",
-                                   .highlight = "rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -555,8 +556,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -577,8 +578,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -657,8 +658,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule",
-                                   .highlight = "rule",
-                                   .args = {{.value = "custom_rule", .address = "value4"}}}}});
+                                   .highlight = "rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -688,8 +689,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value4"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -755,8 +756,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "custom_rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -777,8 +778,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule",
-                                   .highlight = "rule",
-                                   .args = {{.value = "custom_rule", .address = "value34"}}}}});
+                                   .highlight = "rule"sv,
+                                   .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}});
 
@@ -857,9 +858,9 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule",
-                                   .highlight = "rule",
+                                   .highlight = "rule"sv,
                                    .args = {{
-                                       .value = "custom_rule",
+                                       .value = "custom_rule"sv,
                                        .address = "value34",
                                    }}}}});
         EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
@@ -881,9 +882,9 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                .tags = {{"type", "flow34"}, {"category", "category3"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule",
-                                   .highlight = "rule",
+                                   .highlight = "rule"sv,
                                    .args = {{
-                                       .value = "custom_rule",
+                                       .value = "custom_rule"sv,
                                        .address = "value34",
                                    }}}}});
 
@@ -903,9 +904,9 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                .tags = {{"type", "flow34"}, {"category", "category3"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "custom_rule",
-                                   .highlight = "custom_rule",
+                                   .highlight = "custom_rule"sv,
                                    .args = {{
-                                       .value = "custom_rule",
+                                       .value = "custom_rule"sv,
                                        .address = "value34",
                                    }}}}});
 

--- a/tests/integration/diagnostics/v1/test.cpp
+++ b/tests/integration/diagnostics/v1/test.cpp
@@ -8,6 +8,7 @@
 #include "configuration/common/common.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 
@@ -39,25 +40,25 @@ void run_test(ddwaf_handle handle)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                            .op_value = ".*",
-                                           .highlight = "string 1",
+                                           .highlight = "string 1"sv,
                                            .args = {{
-                                               .value = "string 1",
+                                               .value = "string 1"sv,
                                                .address = "arg1",
                                                .path = {},
                                            }}},
                                {.op = "match_regex",
                                    .op_value = ".*",
-                                   .highlight = "string 2",
+                                   .highlight = "string 2"sv,
                                    .args = {{
-                                       .value = "string 2",
+                                       .value = "string 2"sv,
                                        .address = "arg2",
                                        .path = {"x"},
                                    }}},
                                {.op = "match_regex",
                                    .op_value = ".*",
-                                   .highlight = "string 3",
+                                   .highlight = "string 3"sv,
                                    .args = {{
-                                       .value = "string 3",
+                                       .value = "string 3"sv,
                                        .address = "arg2",
                                        .path = {"y"},
                                    }}}}});

--- a/tests/integration/events/obfuscator/test.cpp
+++ b/tests/integration/events/obfuscator/test.cpp
@@ -299,7 +299,7 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
     auto rule = read_file("obfuscator.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{0, 0, 0}, {nullptr, "^badvalue$"}, ddwaf_object_free};
+    ddwaf_config config{{0, 0, 0}, {nullptr, "^badvalue"}, ddwaf_object_free};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ddwaf_object_free(&rule);

--- a/tests/integration/events/obfuscator/test.cpp
+++ b/tests/integration/events/obfuscator/test.cpp
@@ -39,9 +39,9 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -63,9 +63,9 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "<Redacted>",
+                                   .highlight = "<Redacted>"sv,
                                    .args = {{
-                                       .value = "<Redacted>",
+                                       .value = "<Redacted>"sv,
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
@@ -87,9 +87,9 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "<Redacted>",
+                                   .highlight = "<Redacted>"sv,
                                    .args = {{
-                                       .value = "<Redacted>",
+                                       .value = "<Redacted>"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -111,9 +111,9 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "<Redacted>",
+                                   .highlight = "<Redacted>"sv,
                                    .args = {{
-                                       .value = "<Redacted>",
+                                       .value = "<Redacted>"sv,
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
@@ -149,9 +149,9 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -173,9 +173,9 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "<Redacted>",
+                                   .highlight = "<Redacted>"sv,
                                    .args = {{
-                                       .value = "<Redacted>",
+                                       .value = "<Redacted>"sv,
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
@@ -197,9 +197,9 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1_obf",
+                                       .value = "rule1_obf"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -234,9 +234,9 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -258,9 +258,9 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
@@ -282,9 +282,9 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "<Redacted>",
+                                   .highlight = "<Redacted>"sv,
                                    .args = {{
-                                       .value = "<Redacted>",
+                                       .value = "<Redacted>"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -318,9 +318,9 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
                                .name = "rule2",
                                .tags = {{"type", "security_scanner"}, {"category", "category2"}},
                                .matches = {{.op = "phrase_match",
-                                   .highlight = "<Redacted>",
+                                   .highlight = "<Redacted>"sv,
                                    .args = {{
-                                       .value = "<Redacted>",
+                                       .value = "<Redacted>"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -340,9 +340,9 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
                                .name = "rule2",
                                .tags = {{"type", "security_scanner"}, {"category", "category2"}},
                                .matches = {{.op = "phrase_match",
-                                   .highlight = "othervalue",
+                                   .highlight = "othervalue"sv,
                                    .args = {{
-                                       .value = "othervalue_badvalue",
+                                       .value = "othervalue_badvalue"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -377,9 +377,9 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -401,9 +401,9 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
@@ -425,9 +425,9 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1_obf",
+                                       .value = "rule1_obf"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -462,9 +462,9 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -486,9 +486,9 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "<Redacted>",
+                                   .highlight = "<Redacted>"sv,
                                    .args = {{
-                                       .value = "<Redacted>",
+                                       .value = "<Redacted>"sv,
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
@@ -510,9 +510,9 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1_obf",
+                                       .value = "rule1_obf"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -547,9 +547,9 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);
@@ -571,9 +571,9 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1",
+                                       .value = "rule1"sv,
                                        .address = "value",
                                        .path = {"passwordle"},
                                    }}}}});
@@ -595,9 +595,9 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "rule1",
-                                   .highlight = "rule1",
+                                   .highlight = "rule1"sv,
                                    .args = {{
-                                       .value = "rule1_obf",
+                                       .value = "rule1_obf"sv,
                                        .address = "value",
                                    }}}}});
         ddwaf_object_free(&out);

--- a/tests/integration/exclusion/rule_filter/test.cpp
+++ b/tests/integration/exclusion/rule_filter/test.cpp
@@ -36,9 +36,9 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRule)
                            .name = "rule2",
                            .tags = {{"type", "type2"}, {"category", "category"}},
                            .matches = {{.op = "ip_match",
-                               .highlight = "192.168.0.1",
+                               .highlight = "192.168.0.1"sv,
                                .args = {{
-                                   .value = "192.168.0.1",
+                                   .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
     ddwaf_object_free(&out);
@@ -69,9 +69,9 @@ TEST(TestRuleFilterIntegration, ExcludeByType)
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
                            .matches = {{.op = "ip_match",
-                               .highlight = "192.168.0.1",
+                               .highlight = "192.168.0.1"sv,
                                .args = {{
-                                   .value = "192.168.0.1",
+                                   .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
     ddwaf_object_free(&out);
@@ -127,9 +127,9 @@ TEST(TestRuleFilterIntegration, ExcludeByTags)
                            .name = "rule2",
                            .tags = {{"type", "type2"}, {"category", "category"}},
                            .matches = {{.op = "ip_match",
-                               .highlight = "192.168.0.1",
+                               .highlight = "192.168.0.1"sv,
                                .args = {{
-                                   .value = "192.168.0.1",
+                                   .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
     ddwaf_object_free(&out);
@@ -179,18 +179,18 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
         ddwaf_object_free(&out);
@@ -224,9 +224,9 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.1",
+                                   .highlight = "192.168.0.1"sv,
                                    .args = {{
-                                       .value = "192.168.0.1",
+                                       .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
 
@@ -250,18 +250,18 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
         ddwaf_object_free(&out);
@@ -295,9 +295,9 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.1",
+                                   .highlight = "192.168.0.1"sv,
                                    .args = {{
-                                       .value = "192.168.0.1",
+                                       .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
 
@@ -321,18 +321,18 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
         ddwaf_object_free(&out);
@@ -365,9 +365,9 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.1",
+                                   .highlight = "192.168.0.1"sv,
                                    .args = {{
-                                       .value = "192.168.0.1",
+                                       .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
 
@@ -391,18 +391,18 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
         ddwaf_object_free(&out);
@@ -453,18 +453,18 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
         ddwaf_object_free(&out);
@@ -498,9 +498,9 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.1",
+                                   .highlight = "192.168.0.1"sv,
                                    .args = {{
-                                       .value = "192.168.0.1",
+                                       .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
 
@@ -524,18 +524,18 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
         ddwaf_object_free(&out);
@@ -568,9 +568,9 @@ TEST(TestRuleFilterIntegration, MonitorSingleRule)
                            .tags = {{"type", "type1"}, {"category", "category"}},
                            .actions = {"monitor"},
                            .matches = {{.op = "ip_match",
-                               .highlight = "192.168.0.1",
+                               .highlight = "192.168.0.1"sv,
                                .args = {{
-                                   .value = "192.168.0.1",
+                                   .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
     EXPECT_ACTIONS(out, {});
@@ -604,9 +604,9 @@ TEST(TestRuleFilterIntegration, AvoidHavingTwoMonitorOnActions)
                            .tags = {{"type", "type1"}, {"category", "category"}},
                            .actions = {"monitor"},
                            .matches = {{.op = "ip_match",
-                               .highlight = "192.168.0.1",
+                               .highlight = "192.168.0.1"sv,
                                .args = {{
-                                   .value = "192.168.0.1",
+                                   .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
     EXPECT_ACTIONS(out, {});
@@ -662,9 +662,9 @@ TEST(TestRuleFilterIntegration, MonitorCustomFilterModePrecedence)
                            .tags = {{"type", "type1"}, {"category", "category"}},
                            .actions = {"monitor"},
                            .matches = {{.op = "ip_match",
-                               .highlight = "192.168.0.1",
+                               .highlight = "192.168.0.1"sv,
                                .args = {{
-                                   .value = "192.168.0.1",
+                                   .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
     EXPECT_ACTIONS(out, {});
@@ -721,9 +721,9 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
                            .tags = {{"type", "type1"}, {"category", "category"}},
                            .actions = {"block"},
                            .matches = {{.op = "ip_match",
-                               .highlight = "192.168.0.1",
+                               .highlight = "192.168.0.1"sv,
                                .args = {{
-                                   .value = "192.168.0.1",
+                                   .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
     EXPECT_ACTIONS(out,
@@ -759,9 +759,9 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
                                .tags = {{"type", "type1"}, {"category", "category"}},
                                .actions = {"block"},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.1",
+                                   .highlight = "192.168.0.1"sv,
                                    .args = {{
-                                       .value = "192.168.0.1",
+                                       .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
         EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
@@ -786,9 +786,9 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.2",
+                                   .highlight = "192.168.0.2"sv,
                                    .args = {{
-                                       .value = "192.168.0.2",
+                                       .value = "192.168.0.2"sv,
                                        .address = "http.client_ip",
                                    }}}}});
         EXPECT_ACTIONS(out, {})
@@ -828,9 +828,9 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.1",
+                                   .highlight = "192.168.0.1"sv,
                                    .args = {{
-                                       .value = "192.168.0.1",
+                                       .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
         EXPECT_ACTIONS(out, {});
@@ -865,9 +865,9 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
                                .tags = {{"type", "type1"}, {"category", "category"}},
                                .actions = {"block2"},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.1",
+                                   .highlight = "192.168.0.1"sv,
                                    .args = {{
-                                       .value = "192.168.0.1",
+                                       .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
         EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
@@ -909,9 +909,9 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
                            .tags = {{"type", "type1"}, {"category", "category"}},
                            .actions = {"block"},
                            .matches = {{.op = "ip_match",
-                               .highlight = "192.168.0.1",
+                               .highlight = "192.168.0.1"sv,
                                .args = {{
-                                   .value = "192.168.0.1",
+                                   .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
     EXPECT_ACTIONS(out,

--- a/tests/integration/exclusion_data/test.cpp
+++ b/tests/integration/exclusion_data/test.cpp
@@ -8,6 +8,7 @@
 #include "ddwaf.h"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/exclusion_data/";
@@ -43,18 +44,18 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
 
@@ -88,9 +89,9 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
                                .matches = {{.op = "ip_match",
-                                   .highlight = "192.168.0.1",
+                                   .highlight = "192.168.0.1"sv,
                                    .args = {{
-                                       .value = "192.168.0.1",
+                                       .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
 
@@ -119,18 +120,18 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "ip_match",
-                    .highlight = "192.168.0.1",
+                    .highlight = "192.168.0.1"sv,
                     .args = {{
-                        .value = "192.168.0.1",
+                        .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
 
@@ -176,18 +177,18 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}});
 
@@ -221,9 +222,9 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
                                .matches = {{.op = "exact_match",
-                                   .highlight = "admin",
+                                   .highlight = "admin"sv,
                                    .args = {{
-                                       .value = "admin",
+                                       .value = "admin"sv,
                                        .address = "usr.id",
                                    }}}}});
 
@@ -252,18 +253,18 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}});
         ddwaf_object_free(&out);
@@ -308,18 +309,18 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}});
 
@@ -353,9 +354,9 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
                                .matches = {{.op = "exact_match",
-                                   .highlight = "admin",
+                                   .highlight = "admin"sv,
                                    .args = {{
-                                       .value = "admin",
+                                       .value = "admin"sv,
                                        .address = "usr.id",
                                    }}}}});
 
@@ -390,18 +391,18 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}});
         ddwaf_object_free(&out);
@@ -446,18 +447,18 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}});
 
@@ -491,9 +492,9 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
                                .matches = {{.op = "exact_match",
-                                   .highlight = "admin",
+                                   .highlight = "admin"sv,
                                    .args = {{
-                                       .value = "admin",
+                                       .value = "admin"sv,
                                        .address = "usr.id",
                                    }}}}});
 
@@ -522,18 +523,18 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
                 .name = "rule1",
                 .tags = {{"type", "type1"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}},
             {.id = "2",
                 .name = "rule2",
                 .tags = {{"type", "type2"}, {"category", "category"}},
                 .matches = {{.op = "exact_match",
-                    .highlight = "admin",
+                    .highlight = "admin"sv,
                     .args = {{
-                        .value = "admin",
+                        .value = "admin"sv,
                         .address = "usr.id",
                     }}}}});
         ddwaf_object_free(&out);

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -9,6 +9,7 @@
 #include "version.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 
@@ -828,9 +829,9 @@ TEST(TestWafIntegration, UpdateTagsByID)
                 .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_EVENTS(result2,
             {.id = "1",
@@ -839,9 +840,9 @@ TEST(TestWafIntegration, UpdateTagsByID)
                     {"new_tag", "value"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         ddwaf_object_free(&parameter);
 
@@ -878,9 +879,9 @@ TEST(TestWafIntegration, UpdateTagsByID)
                 .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_EVENTS(result2,
             {.id = "1",
@@ -889,9 +890,9 @@ TEST(TestWafIntegration, UpdateTagsByID)
                     {"new_tag", "value"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         ddwaf_object_free(&parameter);
 
@@ -961,9 +962,9 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                 .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_EVENTS(result2,
             {.id = "1",
@@ -972,9 +973,9 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                     {"new_tag", "value"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -1008,9 +1009,9 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                 .tags = {{"type", "flow2"}, {"category", "category2"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule2",
-                    .highlight = "rule2",
+                    .highlight = "rule2"sv,
                     .args = {
-                        {.name = "input", .value = "rule2", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule2"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_EVENTS(result2,
             {.id = "2",
@@ -1018,9 +1019,9 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                 .tags = {{"type", "flow2"}, {"category", "category2"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule2",
-                    .highlight = "rule2",
+                    .highlight = "rule2"sv,
                     .args = {
-                        {.name = "input", .value = "rule2", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule2"sv, .address = "value1", .path = {}}}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -1054,9 +1055,9 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                 .tags = {{"type", "flow2"}, {"category", "category3"}, {"confidence", "1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule3",
-                    .highlight = "rule3",
+                    .highlight = "rule3"sv,
                     .args = {
-                        {.name = "input", .value = "rule3", .address = "value2", .path = {}}}}}});
+                        {.name = "input", .value = "rule3"sv, .address = "value2", .path = {}}}}}});
 
         EXPECT_EVENTS(result2,
             {.id = "3",
@@ -1065,9 +1066,9 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                     {"new_tag", "value"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule3",
-                    .highlight = "rule3",
+                    .highlight = "rule3"sv,
                     .args = {
-                        {.name = "input", .value = "rule3", .address = "value2", .path = {}}}}}});
+                        {.name = "input", .value = "rule3"sv, .address = "value2", .path = {}}}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -1104,9 +1105,9 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                 .tags = {{"type", "flow2"}, {"category", "category3"}, {"confidence", "1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule3",
-                    .highlight = "rule3",
+                    .highlight = "rule3"sv,
                     .args = {
-                        {.name = "input", .value = "rule3", .address = "value2", .path = {}}}}}});
+                        {.name = "input", .value = "rule3"sv, .address = "value2", .path = {}}}}}});
 
         EXPECT_EVENTS(result2,
             {.id = "3",
@@ -1115,9 +1116,9 @@ TEST(TestWafIntegration, UpdateTagsByTags)
                     {"new_tag", "value"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule3",
-                    .highlight = "rule3",
+                    .highlight = "rule3"sv,
                     .args = {
-                        {.name = "input", .value = "rule3", .address = "value2", .path = {}}}}}});
+                        {.name = "input", .value = "rule3"sv, .address = "value2", .path = {}}}}}});
         ddwaf_object_free(&result3);
         ddwaf_object_free(&result2);
 
@@ -1182,9 +1183,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                 .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_EVENTS(result2,
             {.id = "1",
@@ -1194,9 +1195,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                 .actions = {"block"},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(
@@ -1248,9 +1249,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                 .actions = {"block"},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_EVENTS(result3,
             {.id = "1",
@@ -1258,9 +1259,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                 .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "rule1",
-                    .highlight = "rule1",
+                    .highlight = "rule1"sv,
                     .args = {
-                        {.name = "input", .value = "rule1", .address = "value1", .path = {}}}}}});
+                        {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_ACTIONS(
             result2, {{"block_request",

--- a/tests/integration/matchers/equals/test.cpp
+++ b/tests/integration/matchers/equals/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/matchers/equals/";
@@ -35,9 +36,9 @@ TEST(TestEqualsMatcherIntegration, StringEquals)
                            .name = "rule1-string-equals",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "equals",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
-                                   .value = "arachni",
+                                   .value = "arachni"sv,
                                    .address = "input",
                                }}}}});
 
@@ -71,9 +72,9 @@ TEST(TestEqualsMatcherIntegration, BoolEquals)
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{
                                .op = "equals",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
-                                   .value = "false",
+                                   .value = "false"sv,
                                    .address = "input",
                                }},
                            }}});
@@ -107,9 +108,9 @@ TEST(TestEqualsMatcherIntegration, SignedEquals)
                            .name = "rule3-signed-equals",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "equals",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
-                                   .value = "-42",
+                                   .value = "-42"sv,
                                    .address = "input",
                                }}}}});
 
@@ -143,9 +144,9 @@ TEST(TestEqualsMatcherIntegration, UnsignedEquals)
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{
                                .op = "equals",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
-                                   .value = "42",
+                                   .value = "42"sv,
                                    .address = "input",
                                }},
                            }}});
@@ -180,9 +181,9 @@ TEST(TestEqualsMatcherIntegration, FloatEquals)
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{
                                .op = "equals",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
-                                   .value = "42.01",
+                                   .value = "42.01"sv,
                                    .address = "input",
                                }},
                            }}});

--- a/tests/integration/matchers/is_sqli/test.cpp
+++ b/tests/integration/matchers/is_sqli/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf::matcher;
+using namespace std::literals;
 
 namespace {
 
@@ -39,9 +40,9 @@ TEST(TestIsSQLiIntegration, Match)
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "is_sqli",
-                               .highlight = "s&1c",
+                               .highlight = "s&1c"sv,
                                .args = {{
-                                   .value = "'OR 1=1/*",
+                                   .value = "'OR 1=1/*"sv,
                                    .address = "arg1",
                                }}}}});
     ddwaf_object_free(&ret);

--- a/tests/integration/matchers/is_xss/test.cpp
+++ b/tests/integration/matchers/is_xss/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf::matcher;
+using namespace std::literals;
 
 namespace {
 
@@ -40,7 +41,7 @@ TEST(TestIsXSSIntegration, Match)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "is_xss",
                                .args = {{
-                                   .value = "<script>alert(1);</script>",
+                                   .value = "<script>alert(1);</script>"sv,
                                    .address = "arg1",
                                }}}}});
     ddwaf_object_free(&ret);

--- a/tests/integration/matchers/phrase_match/test.cpp
+++ b/tests/integration/matchers/phrase_match/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/matchers/phrase_match/";
@@ -35,9 +36,9 @@ TEST(TestPhraseMatchMatcherIntegration, Match)
                            .name = "rule1-phrase-match",
                            .tags = {{"type", "flow"}, {"category", "category"}},
                            .matches = {{.op = "phrase_match",
-                               .highlight = "string00",
+                               .highlight = "string00"sv,
                                .args = {{
-                                   .value = "string00",
+                                   .value = "string00"sv,
                                    .address = "input1",
                                }}}}});
 
@@ -71,9 +72,9 @@ TEST(TestPhraseMatchMatcherIntegration, MatchWordBound)
                                .name = "rule2-phrase-match-word-bound",
                                .tags = {{"type", "flow"}, {"category", "category"}},
                                .matches = {{.op = "phrase_match",
-                                   .highlight = "string01",
+                                   .highlight = "string01"sv,
                                    .args = {{
-                                       .value = "string01;",
+                                       .value = "string01;"sv,
                                        .address = "input2",
                                    }}}}});
 

--- a/tests/integration/matchers/regex_match/test.cpp
+++ b/tests/integration/matchers/regex_match/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf::matcher;
+using namespace std::literals;
 
 namespace {
 
@@ -42,9 +43,9 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "alert",
-                                   .highlight = "alert",
+                                   .highlight = "alert"sv,
                                    .args = {{
-                                       .value = "<script>alert(1);</script>",
+                                       .value = "<script>alert(1);</script>"sv,
                                        .address = "arg1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -107,9 +108,9 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "alert",
-                                   .highlight = "alert",
+                                   .highlight = "alert"sv,
                                    .args = {{
-                                       .value = "<script>alert(1);</script>",
+                                       .value = "<script>alert(1);</script>"sv,
                                        .address = "arg1",
                                    }}}}});
         ddwaf_object_free(&ret);
@@ -136,9 +137,9 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "alert",
-                                   .highlight = "AlErT",
+                                   .highlight = "AlErT"sv,
                                    .args = {{
-                                       .value = "<script>AlErT(1);</script>",
+                                       .value = "<script>AlErT(1);</script>"sv,
                                        .address = "arg1",
                                    }}}}});
 
@@ -199,9 +200,9 @@ TEST(TestRegexMatchIntegration, MinLength)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "match_regex",
                                    .op_value = "alert",
-                                   .highlight = "AlErT",
+                                   .highlight = "AlErT"sv,
                                    .args = {{
-                                       .value = "<script>AlErT(1);</script>",
+                                       .value = "<script>AlErT(1);</script>"sv,
                                        .address = "arg1",
                                    }}}}});
 

--- a/tests/integration/processors/extract_schema/test.cpp
+++ b/tests/integration/processors/extract_schema/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/processors/extract_schema";
@@ -97,9 +98,9 @@ TEST(TestExtractSchemaIntegration, Preprocessor)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "equals",
                                .op_value = "",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
-                                   .value = "8",
+                                   .value = "8"sv,
                                    .address = "server.request.body.schema",
                                    .path = {"0"},
                                }}}}});
@@ -154,9 +155,9 @@ TEST(TestExtractSchemaIntegration, Processor)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "equals",
                                .op_value = "",
-                               .highlight = "",
+                               .highlight = ""sv,
                                .args = {{
-                                   .value = "8",
+                                   .value = "8"sv,
                                    .address = "server.request.body.schema",
                                    .path = {"0"},
                                }}}}});
@@ -871,9 +872,9 @@ TEST(TestExtractSchemaIntegration, PreprocessorWithEphemeralMapping)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "equals",
                                    .op_value = "",
-                                   .highlight = "",
+                                   .highlight = ""sv,
                                    .args = {{
-                                       .value = "8",
+                                       .value = "8"sv,
                                        .address = "server.request.body.schema",
                                        .path = {"0"},
                                    }}}}});
@@ -899,9 +900,9 @@ TEST(TestExtractSchemaIntegration, PreprocessorWithEphemeralMapping)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "equals",
                                    .op_value = "",
-                                   .highlight = "",
+                                   .highlight = ""sv,
                                    .args = {{
-                                       .value = "8",
+                                       .value = "8"sv,
                                        .address = "server.request.body.schema",
                                        .path = {"0"},
                                    }}}}});
@@ -996,9 +997,9 @@ TEST(TestExtractSchemaIntegration, ProcessorEphemeralExpression)
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .matches = {{.op = "equals",
                                    .op_value = "",
-                                   .highlight = "",
+                                   .highlight = ""sv,
                                    .args = {{
-                                       .value = "8",
+                                       .value = "8"sv,
                                        .address = "server.request.body.schema",
                                        .path = {"0"},
                                    }}}}});

--- a/tests/integration/processors/fingerprint/test.cpp
+++ b/tests/integration/processors/fingerprint/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/processors/fingerprint";
@@ -419,9 +420,9 @@ TEST(TestFingerprintIntegration, Preprocessor)
             .tags = {{"type", "flow1"}, {"category", "category1"}},
             .matches = {{.op = "match_regex",
                 .op_value = "http-put-729d56c3-2c70e12b-2c70e12b",
-                .highlight = "http-put-729d56c3-2c70e12b-2c70e12b",
+                .highlight = "http-put-729d56c3-2c70e12b-2c70e12b"sv,
                 .args = {{
-                    .value = "http-put-729d56c3-2c70e12b-2c70e12b",
+                    .value = "http-put-729d56c3-2c70e12b-2c70e12b"sv,
                     .address = "_dd.appsec.fp.http.endpoint",
                     .path = {},
                 }}}}},
@@ -430,9 +431,9 @@ TEST(TestFingerprintIntegration, Preprocessor)
             .tags = {{"type", "flow2"}, {"category", "category2"}},
             .matches = {{.op = "match_regex",
                 .op_value = "hdr-1111111111-a441b15f-0-",
-                .highlight = "hdr-1111111111-a441b15f-0-",
+                .highlight = "hdr-1111111111-a441b15f-0-"sv,
                 .args = {{
-                    .value = "hdr-1111111111-a441b15f-0-",
+                    .value = "hdr-1111111111-a441b15f-0-"sv,
                     .address = "_dd.appsec.fp.http.header",
                     .path = {},
                 }}}}},
@@ -441,9 +442,9 @@ TEST(TestFingerprintIntegration, Preprocessor)
             .tags = {{"type", "flow3"}, {"category", "category3"}},
             .matches = {{.op = "match_regex",
                 .op_value = "net-1-1111111111",
-                .highlight = "net-1-1111111111",
+                .highlight = "net-1-1111111111"sv,
                 .args = {{
-                    .value = "net-1-1111111111",
+                    .value = "net-1-1111111111"sv,
                     .address = "_dd.appsec.fp.http.network",
                     .path = {},
                 }}}}},
@@ -452,9 +453,9 @@ TEST(TestFingerprintIntegration, Preprocessor)
             .tags = {{"type", "flow4"}, {"category", "category4"}},
             .matches = {{.op = "match_regex",
                 .op_value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
-                .highlight = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
+                .highlight = "ssn-8c6976e5-df6143bc-60ba1602-269500d3"sv,
                 .args = {{
-                    .value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
+                    .value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3"sv,
                     .address = "_dd.appsec.fp.session",
                     .path = {},
                 }}}}}, );
@@ -546,9 +547,9 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
                 .tags = {{"type", "flow2"}, {"category", "category2"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "hdr-1111111111-a441b15f-0-",
-                    .highlight = "hdr-1111111111-a441b15f-0-",
+                    .highlight = "hdr-1111111111-a441b15f-0-"sv,
                     .args = {{
-                        .value = "hdr-1111111111-a441b15f-0-",
+                        .value = "hdr-1111111111-a441b15f-0-"sv,
                         .address = "_dd.appsec.fp.http.header",
                         .path = {},
                     }}}}},
@@ -557,9 +558,9 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
                 .tags = {{"type", "flow3"}, {"category", "category3"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "net-1-1111111111",
-                    .highlight = "net-1-1111111111",
+                    .highlight = "net-1-1111111111"sv,
                     .args = {{
-                        .value = "net-1-1111111111",
+                        .value = "net-1-1111111111"sv,
                         .address = "_dd.appsec.fp.http.network",
                         .path = {},
                     }}}}}, );
@@ -609,9 +610,9 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
                 .tags = {{"type", "flow1"}, {"category", "category1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "http-put-729d56c3-2c70e12b-2c70e12b",
-                    .highlight = "http-put-729d56c3-2c70e12b-2c70e12b",
+                    .highlight = "http-put-729d56c3-2c70e12b-2c70e12b"sv,
                     .args = {{
-                        .value = "http-put-729d56c3-2c70e12b-2c70e12b",
+                        .value = "http-put-729d56c3-2c70e12b-2c70e12b"sv,
                         .address = "_dd.appsec.fp.http.endpoint",
                         .path = {},
                     }}}}}, );
@@ -671,9 +672,9 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
                 .tags = {{"type", "flow4"}, {"category", "category4"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
-                    .highlight = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
+                    .highlight = "ssn-8c6976e5-df6143bc-60ba1602-269500d3"sv,
                     .args = {{
-                        .value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
+                        .value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3"sv,
                         .address = "_dd.appsec.fp.session",
                         .path = {},
                     }}}}}, );
@@ -788,9 +789,9 @@ TEST(TestFingerprintIntegration, Processor)
             .tags = {{"type", "flow1"}, {"category", "category1"}},
             .matches = {{.op = "match_regex",
                 .op_value = "http-put-729d56c3-2c70e12b-2c70e12b",
-                .highlight = "http-put-729d56c3-2c70e12b-2c70e12b",
+                .highlight = "http-put-729d56c3-2c70e12b-2c70e12b"sv,
                 .args = {{
-                    .value = "http-put-729d56c3-2c70e12b-2c70e12b",
+                    .value = "http-put-729d56c3-2c70e12b-2c70e12b"sv,
                     .address = "_dd.appsec.fp.http.endpoint",
                     .path = {},
                 }}}}},
@@ -799,9 +800,9 @@ TEST(TestFingerprintIntegration, Processor)
             .tags = {{"type", "flow2"}, {"category", "category2"}},
             .matches = {{.op = "match_regex",
                 .op_value = "hdr-1111111111-a441b15f-0-",
-                .highlight = "hdr-1111111111-a441b15f-0-",
+                .highlight = "hdr-1111111111-a441b15f-0-"sv,
                 .args = {{
-                    .value = "hdr-1111111111-a441b15f-0-",
+                    .value = "hdr-1111111111-a441b15f-0-"sv,
                     .address = "_dd.appsec.fp.http.header",
                     .path = {},
                 }}}}},
@@ -810,9 +811,9 @@ TEST(TestFingerprintIntegration, Processor)
             .tags = {{"type", "flow3"}, {"category", "category3"}},
             .matches = {{.op = "match_regex",
                 .op_value = "net-1-1111111111",
-                .highlight = "net-1-1111111111",
+                .highlight = "net-1-1111111111"sv,
                 .args = {{
-                    .value = "net-1-1111111111",
+                    .value = "net-1-1111111111"sv,
                     .address = "_dd.appsec.fp.http.network",
                     .path = {},
                 }}}}},
@@ -821,9 +822,9 @@ TEST(TestFingerprintIntegration, Processor)
             .tags = {{"type", "flow4"}, {"category", "category4"}},
             .matches = {{.op = "match_regex",
                 .op_value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
-                .highlight = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
+                .highlight = "ssn-8c6976e5-df6143bc-60ba1602-269500d3"sv,
                 .args = {{
-                    .value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
+                    .value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3"sv,
                     .address = "_dd.appsec.fp.session",
                     .path = {},
                 }}}}}, );
@@ -922,9 +923,9 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
                 .tags = {{"type", "flow2"}, {"category", "category2"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "hdr-1111111111-a441b15f-0-",
-                    .highlight = "hdr-1111111111-a441b15f-0-",
+                    .highlight = "hdr-1111111111-a441b15f-0-"sv,
                     .args = {{
-                        .value = "hdr-1111111111-a441b15f-0-",
+                        .value = "hdr-1111111111-a441b15f-0-"sv,
                         .address = "_dd.appsec.fp.http.header",
                         .path = {},
                     }}}}},
@@ -933,9 +934,9 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
                 .tags = {{"type", "flow3"}, {"category", "category3"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "net-1-1111111111",
-                    .highlight = "net-1-1111111111",
+                    .highlight = "net-1-1111111111"sv,
                     .args = {{
-                        .value = "net-1-1111111111",
+                        .value = "net-1-1111111111"sv,
                         .address = "_dd.appsec.fp.http.network",
                         .path = {},
                     }}}}}, );
@@ -994,9 +995,9 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
                 .tags = {{"type", "flow1"}, {"category", "category1"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "http-put-729d56c3-2c70e12b-2c70e12b",
-                    .highlight = "http-put-729d56c3-2c70e12b-2c70e12b",
+                    .highlight = "http-put-729d56c3-2c70e12b-2c70e12b"sv,
                     .args = {{
-                        .value = "http-put-729d56c3-2c70e12b-2c70e12b",
+                        .value = "http-put-729d56c3-2c70e12b-2c70e12b"sv,
                         .address = "_dd.appsec.fp.http.endpoint",
                         .path = {},
                     }}}}}, );
@@ -1064,9 +1065,9 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
                 .tags = {{"type", "flow4"}, {"category", "category4"}},
                 .matches = {{.op = "match_regex",
                     .op_value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
-                    .highlight = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
+                    .highlight = "ssn-8c6976e5-df6143bc-60ba1602-269500d3"sv,
                     .args = {{
-                        .value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3",
+                        .value = "ssn-8c6976e5-df6143bc-60ba1602-269500d3"sv,
                         .address = "_dd.appsec.fp.session",
                         .path = {},
                     }}}}}, );

--- a/tests/integration/processors/jwt_decode/test.cpp
+++ b/tests/integration/processors/jwt_decode/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/processors/jwt_decode";
@@ -59,7 +60,7 @@ TEST(TestJwtDecoderIntegration, Preprocessor)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "equals",
                                .args = {{
-                                   .value = "RS384",
+                                   .value = "RS384"sv,
                                    .address = "server.request.jwt",
                                    .path = {"header", "alg"},
                                }}}}});
@@ -173,7 +174,7 @@ TEST(TestJwtDecoderIntegration, Processor)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "equals",
                                .args = {{
-                                   .value = "RS384",
+                                   .value = "RS384"sv,
                                    .address = "server.request.jwt",
                                    .path = {"header", "alg"},
                                }}}}});

--- a/tests/integration/regressions/test.cpp
+++ b/tests/integration/regressions/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/regressions/";
@@ -74,16 +75,16 @@ TEST(TestRegressionsIntegration, DuplicateFlowMatches)
                            .tags = {{"type", "flow1"}, {"category", "category2"}},
                            .matches = {{.op = "match_regex",
                                            .op_value = "Sqreen",
-                                           .highlight = "Sqreen",
+                                           .highlight = "Sqreen"sv,
                                            .args = {{
-                                               .value = "Sqreen",
+                                               .value = "Sqreen"sv,
                                                .address = "param1",
                                            }}},
                                {.op = "match_regex",
                                    .op_value = "Duplicate",
-                                   .highlight = "Duplicate",
+                                   .highlight = "Duplicate"sv,
                                    .args = {{
-                                       .value = "Duplicate",
+                                       .value = "Duplicate"sv,
                                        .address = "param2",
                                    }}}}});
 

--- a/tests/integration/transformers/test.cpp
+++ b/tests/integration/transformers/test.cpp
@@ -7,6 +7,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace std::literals;
 
 namespace {
 constexpr std::string_view base_dir = "integration/transformers/";
@@ -35,8 +36,8 @@ TEST(TestTransformers, Base64Decode)
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "is_sqli",
-                               .highlight = "s&1c",
-                               .args = {{.value = "'OR 1=1/*", .address = "value1"}}}}});
+                               .highlight = "s&1c"sv,
+                               .args = {{.value = "'OR 1=1/*"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -67,8 +68,8 @@ TEST(TestTransformers, Base64DecodeAlias)
                            .name = "rule2",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "is_sqli",
-                               .highlight = "s&1c",
-                               .args = {{.value = "'OR 1=1/*", .address = "value2"}}}}});
+                               .highlight = "s&1c"sv,
+                               .args = {{.value = "'OR 1=1/*"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -99,8 +100,8 @@ TEST(TestTransformers, Base64UrlDecode)
                            .name = "rule1",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "is_sqli",
-                               .highlight = "s&1c",
-                               .args = {{.value = "'OR 1=1/*", .address = "value1"}}}}});
+                               .highlight = "s&1c"sv,
+                               .args = {{.value = "'OR 1=1/*"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -132,8 +133,8 @@ TEST(TestTransformers, Base64Encode)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "J09SIDE9MS8q",
-                               .highlight = "J09SIDE9MS8q",
-                               .args = {{.value = "J09SIDE9MS8q", .address = "value1"}}}}});
+                               .highlight = "J09SIDE9MS8q"sv,
+                               .args = {{.value = "J09SIDE9MS8q"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -165,8 +166,8 @@ TEST(TestTransformers, Base64EncodeAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "J09SIDE9MS8q",
-                               .highlight = "J09SIDE9MS8q",
-                               .args = {{.value = "J09SIDE9MS8q", .address = "value2"}}}}});
+                               .highlight = "J09SIDE9MS8q"sv,
+                               .args = {{.value = "J09SIDE9MS8q"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -198,8 +199,8 @@ TEST(TestTransformers, CompressWhitespace)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "attack value",
-                               .highlight = "attack value",
-                               .args = {{.value = "attack value", .address = "value1"}}}}});
+                               .highlight = "attack value"sv,
+                               .args = {{.value = "attack value"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -231,8 +232,8 @@ TEST(TestTransformers, CompressWhitespaceAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "attack value",
-                               .highlight = "attack value",
-                               .args = {{.value = "attack value", .address = "value2"}}}}});
+                               .highlight = "attack value"sv,
+                               .args = {{.value = "attack value"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -259,13 +260,14 @@ TEST(TestTransformers, CssDecode)
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
-    EXPECT_EVENTS(out, {.id = "1",
-                           .name = "rule1",
-                           .tags = {{"type", "flow1"}, {"category", "category1"}},
-                           .matches = {{.op = "match_regex",
-                               .op_value = "CSS transformations",
-                               .highlight = "CSS transformations",
-                               .args = {{.value = "CSS transformations", .address = "value1"}}}}});
+    EXPECT_EVENTS(
+        out, {.id = "1",
+                 .name = "rule1",
+                 .tags = {{"type", "flow1"}, {"category", "category1"}},
+                 .matches = {{.op = "match_regex",
+                     .op_value = "CSS transformations",
+                     .highlight = "CSS transformations"sv,
+                     .args = {{.value = "CSS transformations"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -292,13 +294,14 @@ TEST(TestTransformers, CssDecodeAlias)
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
-    EXPECT_EVENTS(out, {.id = "2",
-                           .name = "rule2",
-                           .tags = {{"type", "flow1"}, {"category", "category1"}},
-                           .matches = {{.op = "match_regex",
-                               .op_value = "CSS transformations",
-                               .highlight = "CSS transformations",
-                               .args = {{.value = "CSS transformations", .address = "value2"}}}}});
+    EXPECT_EVENTS(
+        out, {.id = "2",
+                 .name = "rule2",
+                 .tags = {{"type", "flow1"}, {"category", "category1"}},
+                 .matches = {{.op = "match_regex",
+                     .op_value = "CSS transformations",
+                     .highlight = "CSS transformations"sv,
+                     .args = {{.value = "CSS transformations"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -331,8 +334,8 @@ TEST(TestTransformers, HtmlEntityDecode)
                  .tags = {{"type", "flow1"}, {"category", "category1"}},
                  .matches = {{.op = "match_regex",
                      .op_value = "HTML A A transformation",
-                     .highlight = "HTML A A transformation",
-                     .args = {{.value = "HTML A A transformation", .address = "value1"}}}}});
+                     .highlight = "HTML A A transformation"sv,
+                     .args = {{.value = "HTML A A transformation"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -365,8 +368,8 @@ TEST(TestTransformers, HtmlEntityDecodeAlias)
                  .tags = {{"type", "flow1"}, {"category", "category1"}},
                  .matches = {{.op = "match_regex",
                      .op_value = "HTML A A transformation",
-                     .highlight = "HTML A A transformation",
-                     .args = {{.value = "HTML A A transformation", .address = "value2"}}}}});
+                     .highlight = "HTML A A transformation"sv,
+                     .args = {{.value = "HTML A A transformation"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -393,13 +396,14 @@ TEST(TestTransformers, JsDecode)
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
-    EXPECT_EVENTS(out, {.id = "1",
-                           .name = "rule1",
-                           .tags = {{"type", "flow1"}, {"category", "category1"}},
-                           .matches = {{.op = "match_regex",
-                               .op_value = "A JS transformation",
-                               .highlight = "A JS transformation",
-                               .args = {{.value = "A JS transformation", .address = "value1"}}}}});
+    EXPECT_EVENTS(
+        out, {.id = "1",
+                 .name = "rule1",
+                 .tags = {{"type", "flow1"}, {"category", "category1"}},
+                 .matches = {{.op = "match_regex",
+                     .op_value = "A JS transformation",
+                     .highlight = "A JS transformation"sv,
+                     .args = {{.value = "A JS transformation"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -426,13 +430,14 @@ TEST(TestTransformers, JsDecodeAlias)
     ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
-    EXPECT_EVENTS(out, {.id = "2",
-                           .name = "rule2",
-                           .tags = {{"type", "flow1"}, {"category", "category1"}},
-                           .matches = {{.op = "match_regex",
-                               .op_value = "A JS transformation",
-                               .highlight = "A JS transformation",
-                               .args = {{.value = "A JS transformation", .address = "value2"}}}}});
+    EXPECT_EVENTS(
+        out, {.id = "2",
+                 .name = "rule2",
+                 .tags = {{"type", "flow1"}, {"category", "category1"}},
+                 .matches = {{.op = "match_regex",
+                     .op_value = "A JS transformation",
+                     .highlight = "A JS transformation"sv,
+                     .args = {{.value = "A JS transformation"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -464,8 +469,8 @@ TEST(TestTransformers, Lowercase)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "arachni",
-                               .highlight = "arachni",
-                               .args = {{.value = "arachni", .address = "value1"}}}}});
+                               .highlight = "arachni"sv,
+                               .args = {{.value = "arachni"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -497,8 +502,8 @@ TEST(TestTransformers, NormalizePath)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -530,8 +535,8 @@ TEST(TestTransformers, NormalizePathAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value2"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -563,8 +568,8 @@ TEST(TestTransformers, NormalizePathWin)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -596,8 +601,8 @@ TEST(TestTransformers, NormalizePathAliasWin)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value2"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -629,8 +634,8 @@ TEST(TestTransformers, RemoveComments)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "passwd",
-                               .highlight = "passwd",
-                               .args = {{.value = "passwd", .address = "value1"}}}}});
+                               .highlight = "passwd"sv,
+                               .args = {{.value = "passwd"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -662,8 +667,8 @@ TEST(TestTransformers, RemoveCommentsAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "passwd",
-                               .highlight = "passwd",
-                               .args = {{.value = "passwd", .address = "value2"}}}}});
+                               .highlight = "passwd"sv,
+                               .args = {{.value = "passwd"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -695,8 +700,8 @@ TEST(TestTransformers, RemoveNulls)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -728,8 +733,8 @@ TEST(TestTransformers, RemoveNullsAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value2"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -761,8 +766,8 @@ TEST(TestTransformers, ShellUnescape)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -794,8 +799,8 @@ TEST(TestTransformers, ShellUnescapeAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value2"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -827,8 +832,8 @@ TEST(TestTransformers, UnicodeNormalize)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/etc/passwd",
-                               .highlight = "/etc/passwd",
-                               .args = {{.value = "/etc/passwd", .address = "value1"}}}}});
+                               .highlight = "/etc/passwd"sv,
+                               .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -860,8 +865,8 @@ TEST(TestTransformers, UrlBasename)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "index.php",
-                               .highlight = "index.php",
-                               .args = {{.value = "index.php", .address = "value1"}}}}});
+                               .highlight = "index.php"sv,
+                               .args = {{.value = "index.php"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -893,8 +898,8 @@ TEST(TestTransformers, UrlBasenameAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "index.php",
-                               .highlight = "index.php",
-                               .args = {{.value = "index.php", .address = "value2"}}}}});
+                               .highlight = "index.php"sv,
+                               .args = {{.value = "index.php"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -926,8 +931,8 @@ TEST(TestTransformers, UrlDecode)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "an attack value",
-                               .highlight = "an attack value",
-                               .args = {{.value = "an attack value", .address = "value1"}}}}});
+                               .highlight = "an attack value"sv,
+                               .args = {{.value = "an attack value"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -959,8 +964,8 @@ TEST(TestTransformers, UrlDecodeAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "an attack value",
-                               .highlight = "an attack value",
-                               .args = {{.value = "an attack value", .address = "value2"}}}}});
+                               .highlight = "an attack value"sv,
+                               .args = {{.value = "an attack value"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -992,8 +997,8 @@ TEST(TestTransformers, UrlDecodeIis)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "an attack value",
-                               .highlight = "an attack value",
-                               .args = {{.value = "an attack value", .address = "value1"}}}}});
+                               .highlight = "an attack value"sv,
+                               .args = {{.value = "an attack value"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -1025,8 +1030,8 @@ TEST(TestTransformers, UrlDecodeIisAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "an attack value",
-                               .highlight = "an attack value",
-                               .args = {{.value = "an attack value", .address = "value2"}}}}});
+                               .highlight = "an attack value"sv,
+                               .args = {{.value = "an attack value"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -1058,8 +1063,8 @@ TEST(TestTransformers, UrlPath)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/path/to/index.php",
-                               .highlight = "/path/to/index.php",
-                               .args = {{.value = "/path/to/index.php", .address = "value1"}}}}});
+                               .highlight = "/path/to/index.php"sv,
+                               .args = {{.value = "/path/to/index.php"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -1091,8 +1096,8 @@ TEST(TestTransformers, UrlPathAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "/path/to/index.php",
-                               .highlight = "/path/to/index.php",
-                               .args = {{.value = "/path/to/index.php", .address = "value2"}}}}});
+                               .highlight = "/path/to/index.php"sv,
+                               .args = {{.value = "/path/to/index.php"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -1124,8 +1129,8 @@ TEST(TestTransformers, UrlQuerystring)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "a=b",
-                               .highlight = "a=b",
-                               .args = {{.value = "a=b", .address = "value1"}}}}});
+                               .highlight = "a=b"sv,
+                               .args = {{.value = "a=b"sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -1157,8 +1162,8 @@ TEST(TestTransformers, UrlQuerystringAlias)
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .matches = {{.op = "match_regex",
                                .op_value = "a=b",
-                               .highlight = "a=b",
-                               .args = {{.value = "a=b", .address = "value2"}}}}});
+                               .highlight = "a=b"sv,
+                               .args = {{.value = "a=b"sv, .address = "value2"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -1191,8 +1196,8 @@ TEST(TestTransformers, Mixed)
                  .tags = {{"type", "flow1"}, {"category", "category1"}},
                  .matches = {{.op = "match_regex",
                      .op_value = "L3AgYSB0aC90IG8vZmlsZS5waHA=",
-                     .highlight = "L3AgYSB0aC90IG8vZmlsZS5waHA=",
-                     .args = {{.value = "L3AgYSB0aC90IG8vZmlsZS5waHA=", .address = "value1"}}}}});
+                     .highlight = "L3AgYSB0aC90IG8vZmlsZS5waHA="sv,
+                     .args = {{.value = "L3AgYSB0aC90IG8vZmlsZS5waHA="sv, .address = "value1"}}}}});
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);

--- a/tests/unit/condition/cmdi_detector_test.cpp
+++ b/tests/unit/condition/cmdi_detector_test.cpp
@@ -289,7 +289,7 @@ TEST(TestCmdiDetector, ExecutableInjectionLinux)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STRV(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");

--- a/tests/unit/condition/ssrf_detector_test.cpp
+++ b/tests/unit/condition/ssrf_detector_test.cpp
@@ -51,16 +51,16 @@ void match_path_and_input(
             EXPECT_TRUE(cache.match);
             if (cache.match) { // Silence linter
                 EXPECT_STRV(cache.match->args[0].address, "server.io.net.url");
-                EXPECT_STR(cache.match->args[0].resolved, path.c_str());
+                EXPECT_STR(cache.match->args[0].resolved, path);
                 EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
                 EXPECT_STRV(cache.match->args[1].address, "server.request.query");
                 if (sample.resolved.empty()) {
-                    EXPECT_STR(cache.match->args[1].resolved, sample.yaml.c_str());
-                    EXPECT_STR(cache.match->highlights[0], sample.yaml.c_str());
+                    EXPECT_STR(cache.match->args[1].resolved, sample.yaml);
+                    EXPECT_STR(cache.match->highlights[0], sample.yaml);
                 } else {
-                    EXPECT_STR(cache.match->args[1].resolved, sample.resolved.c_str());
-                    EXPECT_STR(cache.match->highlights[0], sample.resolved.c_str());
+                    EXPECT_STR(cache.match->args[1].resolved, sample.resolved);
+                    EXPECT_STR(cache.match->highlights[0], sample.resolved);
                 }
                 EXPECT_TRUE(cache.match->args[1].key_path == sample.key_path) << path;
             }

--- a/tests/unit/context_test.cpp
+++ b/tests/unit/context_test.cpp
@@ -174,8 +174,8 @@ TEST(TestContext, MatchMultipleRulesInCollectionSingleRun)
     EXPECT_EQ(event.matches.size(), 1);
 
     auto &match = event.matches[0];
-    EXPECT_STREQ(match.args[0].resolved.c_str(), "192.168.0.1");
-    EXPECT_STREQ(match.highlights[0].c_str(), "192.168.0.1");
+    EXPECT_STR(match.args[0].resolved, "192.168.0.1");
+    EXPECT_STR(match.highlights[0], "192.168.0.1");
     EXPECT_STRV(match.operator_name, "ip_match");
     EXPECT_STRV(match.operator_value, "");
     EXPECT_STRV(match.args[0].address, "http.client_ip");
@@ -312,8 +312,8 @@ TEST(TestContext, MatchMultipleRulesInCollectionDoubleRun)
         EXPECT_EQ(event.matches.size(), 1);
 
         auto &match = event.matches[0];
-        EXPECT_STREQ(match.args[0].resolved.c_str(), "192.168.0.1");
-        EXPECT_STREQ(match.highlights[0].c_str(), "192.168.0.1");
+        EXPECT_STR(match.args[0].resolved, "192.168.0.1");
+        EXPECT_STR(match.highlights[0], "192.168.0.1");
         EXPECT_STRV(match.operator_name, "ip_match");
         EXPECT_STRV(match.operator_value, "");
         EXPECT_STRV(match.args[0].address, "http.client_ip");
@@ -388,8 +388,8 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
         EXPECT_EQ(event.matches.size(), 1);
 
         auto &match = event.matches[0];
-        EXPECT_STREQ(match.args[0].resolved.c_str(), "192.168.0.1");
-        EXPECT_STREQ(match.highlights[0].c_str(), "192.168.0.1");
+        EXPECT_STR(match.args[0].resolved, "192.168.0.1");
+        EXPECT_STR(match.highlights[0], "192.168.0.1");
         EXPECT_STRV(match.operator_name, "ip_match");
         EXPECT_STRV(match.operator_value, "");
         EXPECT_STRV(match.args[0].address, "http.client_ip");
@@ -420,8 +420,8 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
         EXPECT_EQ(event.matches.size(), 1);
 
         auto &match = event.matches[0];
-        EXPECT_STREQ(match.args[0].resolved.c_str(), "admin");
-        EXPECT_STREQ(match.highlights[0].c_str(), "admin");
+        EXPECT_STR(match.args[0].resolved, "admin");
+        EXPECT_STR(match.highlights[0], "admin");
         EXPECT_STRV(match.operator_name, "exact_match");
         EXPECT_STRV(match.operator_value, "");
         EXPECT_STRV(match.args[0].address, "usr.id");
@@ -485,8 +485,8 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
         EXPECT_EQ(event.matches.size(), 1);
 
         auto &match = event.matches[0];
-        EXPECT_STREQ(match.args[0].resolved.c_str(), "192.168.0.1");
-        EXPECT_STREQ(match.highlights[0].c_str(), "192.168.0.1");
+        EXPECT_STR(match.args[0].resolved, "192.168.0.1");
+        EXPECT_STR(match.highlights[0], "192.168.0.1");
         EXPECT_STRV(match.operator_name, "ip_match");
         EXPECT_STRV(match.operator_value, "");
         EXPECT_STRV(match.args[0].address, "http.client_ip");

--- a/tests/unit/dynamic_string_test.cpp
+++ b/tests/unit/dynamic_string_test.cpp
@@ -79,22 +79,6 @@ TEST(TestDynamicString, StringConstructor)
     EXPECT_EQ(str, str);
 }
 
-TEST(TestDynamicString, CstringConstructor)
-{
-    dynamic_string str{"thisisastring"};
-
-    // +1 for nul-character
-    EXPECT_EQ(str.capacity(), 14);
-
-    EXPECT_EQ(str.size(), 13);
-    EXPECT_FALSE(str.empty());
-    EXPECT_NE(str.data(), nullptr);
-    EXPECT_STREQ(str.data(), "thisisastring");
-    EXPECT_STR(static_cast<std::string_view>(str), "thisisastring");
-    EXPECT_STR(static_cast<std::string>(str), "thisisastring");
-    EXPECT_EQ(str, str);
-}
-
 TEST(TestDynamicString, CopyConstructor)
 {
     dynamic_string str{"thisisastring"sv};
@@ -168,7 +152,7 @@ TEST(TestDynamicString, MoveToObject)
     dynamic_string str{"thisisastring"sv};
     EXPECT_NE(str.data(), nullptr);
 
-    auto object = str.move();
+    auto object = str.to_object();
 
     std::size_t length;
     const char *cstr = ddwaf_object_get_string(&object, &length);
@@ -254,19 +238,19 @@ TEST(TestDynamicString, AppendCharsAndStrings)
 
 TEST(TestDynamicString, Equality)
 {
-    dynamic_string hello{"hello"};
-    dynamic_string bye{"bye"};
+    dynamic_string hello{"hello"sv};
+    dynamic_string bye{"bye"sv};
 
     EXPECT_NE(hello, bye);
     EXPECT_EQ(hello, hello);
     EXPECT_EQ(bye, bye);
 
-    dynamic_string hello2{"hello"};
+    dynamic_string hello2{"hello"sv};
     EXPECT_NE(hello.data(), hello2.data());
     EXPECT_EQ(hello, hello2);
     EXPECT_EQ(hello2, hello);
 
-    dynamic_string hello_plus{"hello is just a substring"};
+    dynamic_string hello_plus{"hello is just a substring"sv};
     EXPECT_NE(hello, hello_plus);
     EXPECT_NE(hello_plus, hello);
 }

--- a/tests/unit/dynamic_string_test.cpp
+++ b/tests/unit/dynamic_string_test.cpp
@@ -1,0 +1,274 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+#include <stdexcept>
+
+#include <dynamic_string.hpp>
+
+#include "common/gtest_utils.hpp"
+
+using namespace ddwaf;
+using namespace std::literals;
+
+namespace {
+
+TEST(TestDynamicString, DefaultConstructor)
+{
+    dynamic_string str;
+
+    // +1 for nul-character
+    EXPECT_EQ(str.capacity(), 1);
+
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_TRUE(str.empty());
+    EXPECT_NE(str.data(), nullptr);
+    EXPECT_STREQ(str.data(), "");
+    EXPECT_STR(static_cast<std::string_view>(str), "");
+    EXPECT_STR(static_cast<std::string>(str), "");
+    EXPECT_EQ(str, str);
+}
+
+TEST(TestDynamicString, PreallocatedConstructor)
+{
+    dynamic_string str{20};
+
+    // +1 for nul-character
+    EXPECT_EQ(str.capacity(), 21);
+
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_TRUE(str.empty());
+    EXPECT_NE(str.data(), nullptr);
+    EXPECT_STREQ(str.data(), "");
+    EXPECT_STR(static_cast<std::string_view>(str), "");
+    EXPECT_STR(static_cast<std::string>(str), "");
+    EXPECT_EQ(str, str);
+}
+
+TEST(TestDynamicString, StringViewConstructor)
+{
+    dynamic_string str{"thisisastring"sv};
+
+    // +1 for nul-character
+    EXPECT_EQ(str.capacity(), 14);
+
+    EXPECT_EQ(str.size(), 13);
+    EXPECT_FALSE(str.empty());
+    EXPECT_NE(str.data(), nullptr);
+    EXPECT_STREQ(str.data(), "thisisastring");
+    EXPECT_STR(static_cast<std::string_view>(str), "thisisastring");
+    EXPECT_STR(static_cast<std::string>(str), "thisisastring");
+    EXPECT_EQ(str, str);
+}
+
+TEST(TestDynamicString, StringConstructor)
+{
+    dynamic_string str{"thisisastring"s};
+
+    // +1 for nul-character
+    EXPECT_EQ(str.capacity(), 14);
+
+    EXPECT_EQ(str.size(), 13);
+    EXPECT_FALSE(str.empty());
+    EXPECT_NE(str.data(), nullptr);
+    EXPECT_STREQ(str.data(), "thisisastring");
+    EXPECT_STR(static_cast<std::string_view>(str), "thisisastring");
+    EXPECT_STR(static_cast<std::string>(str), "thisisastring");
+    EXPECT_EQ(str, str);
+}
+
+TEST(TestDynamicString, CstringConstructor)
+{
+    dynamic_string str{"thisisastring"};
+
+    // +1 for nul-character
+    EXPECT_EQ(str.capacity(), 14);
+
+    EXPECT_EQ(str.size(), 13);
+    EXPECT_FALSE(str.empty());
+    EXPECT_NE(str.data(), nullptr);
+    EXPECT_STREQ(str.data(), "thisisastring");
+    EXPECT_STR(static_cast<std::string_view>(str), "thisisastring");
+    EXPECT_STR(static_cast<std::string>(str), "thisisastring");
+    EXPECT_EQ(str, str);
+}
+
+TEST(TestDynamicString, CopyConstructor)
+{
+    dynamic_string str{"thisisastring"sv};
+    EXPECT_NE(str.data(), nullptr);
+
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    dynamic_string copy{str};
+    EXPECT_NE(copy.data(), nullptr);
+    EXPECT_NE(str.data(), copy.data());
+    EXPECT_STREQ(str.data(), "thisisastring");
+    EXPECT_STREQ(copy.data(), "thisisastring");
+    EXPECT_EQ(str, copy);
+}
+
+TEST(TestDynamicString, CopyAssignment)
+{
+    dynamic_string str{"thisisastring"sv};
+    EXPECT_NE(str.data(), nullptr);
+
+    dynamic_string copy;
+    EXPECT_NE(copy.data(), nullptr);
+
+    copy = str;
+    EXPECT_NE(str.data(), copy.data());
+    EXPECT_STREQ(str.data(), "thisisastring");
+    EXPECT_STREQ(copy.data(), "thisisastring");
+    EXPECT_EQ(str, copy);
+}
+
+TEST(TestDynamicString, MoveConstructor)
+{
+    dynamic_string str{"thisisastring"sv};
+    EXPECT_NE(str.data(), nullptr);
+
+    // A move completely invalidates the original string
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    dynamic_string copy{std::move(str)};
+    EXPECT_EQ(str.capacity(), 0);
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_TRUE(str.empty());
+    EXPECT_EQ(str.data(), nullptr);
+
+    EXPECT_NE(copy.data(), nullptr);
+    EXPECT_NE(str.data(), copy.data());
+    EXPECT_STREQ(copy.data(), "thisisastring");
+    EXPECT_EQ(copy, copy);
+}
+
+TEST(TestDynamicString, MoveAssignment)
+{
+    dynamic_string str{"thisisastring"sv};
+    EXPECT_NE(str.data(), nullptr);
+
+    dynamic_string copy;
+    EXPECT_NE(copy.data(), nullptr);
+
+    copy = std::move(str);
+    EXPECT_EQ(str.capacity(), 0);
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_TRUE(str.empty());
+    EXPECT_EQ(str.data(), nullptr);
+
+    EXPECT_NE(copy.data(), nullptr);
+    EXPECT_NE(str.data(), copy.data());
+    EXPECT_STREQ(copy.data(), "thisisastring");
+    EXPECT_EQ(copy, copy);
+}
+
+TEST(TestDynamicString, MoveToObject)
+{
+    dynamic_string str{"thisisastring"sv};
+    EXPECT_NE(str.data(), nullptr);
+
+    auto object = str.move();
+
+    std::size_t length;
+    const char *cstr = ddwaf_object_get_string(&object, &length);
+
+    EXPECT_EQ(str.capacity(), 0);
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_TRUE(str.empty());
+    EXPECT_EQ(str.data(), nullptr);
+
+    EXPECT_NE(cstr, nullptr);
+    EXPECT_STREQ(cstr, "thisisastring");
+    EXPECT_EQ(length, 13);
+
+    ddwaf_object_free(&object);
+}
+
+TEST(TestDynamicString, AppendDefaultString)
+{
+    dynamic_string str;
+
+    // +1 for nul-character
+    EXPECT_EQ(str.capacity(), 1);
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_STREQ(str.data(), "");
+
+    str.append('c');
+    EXPECT_GT(str.capacity(), 2);
+    EXPECT_EQ(str.size(), 1);
+    EXPECT_STREQ(str.data(), "c");
+
+    str.append("string");
+    EXPECT_GT(str.capacity(), 8);
+    EXPECT_EQ(str.size(), 7);
+    EXPECT_STREQ(str.data(), "cstring");
+}
+
+TEST(TestDynamicString, AppendPreallocatedString)
+{
+    dynamic_string str{20};
+
+    // +1 for nul-character
+    EXPECT_EQ(str.capacity(), 21);
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_STREQ(str.data(), "");
+
+    str.append('c');
+    EXPECT_EQ(str.capacity(), 21);
+    EXPECT_EQ(str.size(), 1);
+    EXPECT_STREQ(str.data(), "c");
+
+    str.append("string");
+    EXPECT_EQ(str.capacity(), 21);
+    EXPECT_EQ(str.size(), 7);
+    EXPECT_STREQ(str.data(), "cstring");
+}
+
+TEST(TestDynamicString, AppendCharsAndStrings)
+{
+    dynamic_string str;
+
+    // +1 for nul-character
+    EXPECT_EQ(str.capacity(), 1);
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_STREQ(str.data(), "");
+
+    str.append("this");
+    str.append(' ');
+    str.append('i');
+    str.append('s');
+    str.append(" a string");
+    str.append(' ');
+    str.append("that");
+    str.append(" has");
+    str.append(' ');
+    str.append("been appended");
+    str.append(' ');
+    str.append('h');
+    str.append("ere");
+
+    EXPECT_EQ(str.size(), 44);
+    EXPECT_STREQ(str.data(), "this is a string that has been appended here");
+}
+
+TEST(TestDynamicString, Equality)
+{
+    dynamic_string hello{"hello"};
+    dynamic_string bye{"bye"};
+
+    EXPECT_NE(hello, bye);
+    EXPECT_EQ(hello, hello);
+    EXPECT_EQ(bye, bye);
+
+    dynamic_string hello2{"hello"};
+    EXPECT_NE(hello.data(), hello2.data());
+    EXPECT_EQ(hello, hello2);
+    EXPECT_EQ(hello2, hello);
+
+    dynamic_string hello_plus{"hello is just a substring"};
+    EXPECT_NE(hello, hello_plus);
+    EXPECT_NE(hello_plus, hello);
+}
+
+} // namespace

--- a/tests/unit/event_serializer_test.cpp
+++ b/tests/unit/event_serializer_test.cpp
@@ -32,7 +32,8 @@ TEST(TestEventSerializer, SerializeNothing)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({}, events_object, actions_object);
+    std::vector<ddwaf::event> events;
+    serializer.serialize(events, events_object, actions_object);
 
     EXPECT_EVENTS(output, ); // This means no events
     EXPECT_ACTIONS(output, {});
@@ -55,7 +56,8 @@ TEST(TestEventSerializer, SerializeEmptyEvent)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({ddwaf::event{}}, events_object, actions_object);
+    std::vector<ddwaf::event> events{ddwaf::event{}};
+    serializer.serialize(events, events_object, actions_object);
 
     EXPECT_EVENTS(output, {});
     EXPECT_ACTIONS(output, {});
@@ -95,7 +97,8 @@ TEST(TestEventSerializer, SerializeSingleEventSingleMatch)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({event}, events_object, actions_object);
+    std::vector<ddwaf::event> events{event};
+    serializer.serialize(events, events_object, actions_object);
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
                               .tags = {{"type", "test"}, {"category", "none"}},
@@ -162,7 +165,8 @@ TEST(TestEventSerializer, SerializeSingleEventMultipleMatches)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({event}, events_object, actions_object);
+    std::vector<ddwaf::event> events{event};
+    serializer.serialize(events, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -349,7 +353,8 @@ TEST(TestEventSerializer, SerializeEventNoActions)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({event}, events_object, actions_object);
+    std::vector<ddwaf::event> events{event};
+    serializer.serialize(events, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -404,7 +409,8 @@ TEST(TestEventSerializer, SerializeAllTags)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({event}, events_object, actions_object);
+    std::vector<ddwaf::event> events{event};
+    serializer.serialize(events, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -458,7 +464,8 @@ TEST(TestEventSerializer, NoMonitorActions)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({event}, events_object, actions_object);
+    std::vector<ddwaf::event> events{event};
+    serializer.serialize(events, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -513,7 +520,8 @@ TEST(TestEventSerializer, UndefinedActions)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({event}, events_object, actions_object);
+    std::vector<ddwaf::event> events{event};
+    serializer.serialize(events, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",
@@ -568,7 +576,8 @@ TEST(TestEventSerializer, StackTraceAction)
     ddwaf_object &events_object = output.array[0];
     ddwaf_object &actions_object = output.array[1];
 
-    serializer.serialize({event}, events_object, actions_object);
+    std::vector<ddwaf::event> events{event};
+    serializer.serialize(events, events_object, actions_object);
 
     EXPECT_EVENTS(output, {.id = "xasd1022",
                               .name = "random rule",

--- a/tests/unit/event_serializer_test.cpp
+++ b/tests/unit/event_serializer_test.cpp
@@ -73,10 +73,10 @@ TEST(TestEventSerializer, SerializeSingleEventSingleMatch)
     ddwaf::event event;
     event.rule = &rule;
     event.matches = {{.args = {{.name = "input",
-                          .resolved = "value",
+                          .resolved = "value"sv,
                           .address = "query",
                           .key_path = {"root", "key"}}},
-        .highlights = {"val"},
+        .highlights = {"val"sv},
         .operator_name = "random",
         .operator_value = "val"}};
 
@@ -105,9 +105,9 @@ TEST(TestEventSerializer, SerializeSingleEventSingleMatch)
                               .actions = {"block", "monitor_request"},
                               .matches = {{.op = "random",
                                   .op_value = "val",
-                                  .highlight = "val",
+                                  .highlight = "val"sv,
                                   .args = {{.name = "input",
-                                      .value = "value",
+                                      .value = "value"sv,
                                       .address = "query",
                                       .path = {"root", "key"}}}}}});
 
@@ -126,22 +126,22 @@ TEST(TestEventSerializer, SerializeSingleEventMultipleMatches)
     ddwaf::event event;
     event.rule = &rule;
     event.matches = {{.args = {{.name = "input",
-                          .resolved = "value",
+                          .resolved = "value"sv,
                           .address = "query",
                           .key_path = {"root", "key"}}},
-                         .highlights = {"val"},
+                         .highlights = {"val"sv},
                          .operator_name = "random",
                          .operator_value = "val"},
-        {.args = {{.name = "input", .resolved = "string", .address = "response.body"}},
-            .highlights = {"string"},
+        {.args = {{.name = "input", .resolved = "string"sv, .address = "response.body"}},
+            .highlights = {"string"sv},
             .operator_name = "match_regex",
             .operator_value = ".*"},
-        {.args = {{.name = "input", .resolved = "192.168.0.1", .address = "client.ip"}},
-            .highlights = {"192.168.0.1"},
+        {.args = {{.name = "input", .resolved = "192.168.0.1"sv, .address = "client.ip"}},
+            .highlights = {"192.168.0.1"sv},
             .operator_name = "ip_match",
             .operator_value = ""},
         {.args = {{.name = "input",
-             .resolved = "<script>",
+             .resolved = "<script>"sv,
              .address = "path_params",
              .key_path = {"key"}}},
             .highlights = {},
@@ -174,34 +174,34 @@ TEST(TestEventSerializer, SerializeSingleEventMultipleMatches)
                               .actions = {"block", "monitor_request"},
                               .matches = {{.op = "random",
                                               .op_value = "val",
-                                              .highlight = "val",
+                                              .highlight = "val"sv,
                                               .args = {{
                                                   .name = "input",
-                                                  .value = "value",
+                                                  .value = "value"sv,
                                                   .address = "query",
                                                   .path = {"root", "key"},
                                               }}},
                                   {
                                       .op = "match_regex",
                                       .op_value = ".*",
-                                      .highlight = "string",
+                                      .highlight = "string"sv,
                                       .args = {{
                                           .name = "input",
-                                          .value = "string",
+                                          .value = "string"sv,
                                           .address = "response.body",
                                       }},
                                   },
                                   {.op = "ip_match",
-                                      .highlight = "192.168.0.1",
+                                      .highlight = "192.168.0.1"sv,
                                       .args = {{
                                           .name = "input",
-                                          .value = "192.168.0.1",
+                                          .value = "192.168.0.1"sv,
                                           .address = "client.ip",
                                       }}},
                                   {.op = "is_xss",
                                       .args = {{
                                           .name = "input",
-                                          .value = "<script>",
+                                          .value = "<script>"sv,
                                           .address = "path_params",
                                           .path = {"key"},
                                       }}}}});
@@ -232,18 +232,18 @@ TEST(TestEventSerializer, SerializeMultipleEvents)
         ddwaf::event event;
         event.rule = &rule1;
         event.matches = {{.args = {{.name = "input",
-                              .resolved = "value",
+                              .resolved = "value"sv,
                               .address = "query",
                               .key_path = {"root", "key"}}},
-                             .highlights = {"val"},
+                             .highlights = {"val"sv},
                              .operator_name = "random",
                              .operator_value = "val"},
-            {.args = {{.name = "input", .resolved = "string", .address = "response.body"}},
-                .highlights = {"string"},
+            {.args = {{.name = "input", .resolved = "string"sv, .address = "response.body"}},
+                .highlights = {"string"sv},
                 .operator_name = "match_regex",
                 .operator_value = ".*"},
             {.args = {{.name = "input",
-                 .resolved = "<script>",
+                 .resolved = "<script>"sv,
                  .address = "path_params",
                  .key_path = {"key"}}},
                 .highlights = {},
@@ -256,8 +256,8 @@ TEST(TestEventSerializer, SerializeMultipleEvents)
         ddwaf::event event;
         event.rule = &rule2;
         event.matches = {
-            {.args = {{.name = "input", .resolved = "192.168.0.1", .address = "client.ip"}},
-                .highlights = {"192.168.0.1"},
+            {.args = {{.name = "input", .resolved = "192.168.0.1"sv, .address = "client.ip"}},
+                .highlights = {"192.168.0.1"sv},
                 .operator_name = "ip_match",
                 .operator_value = ""},
         };
@@ -284,22 +284,22 @@ TEST(TestEventSerializer, SerializeMultipleEvents)
             .actions = {"block", "monitor_request"},
             .matches = {{.op = "random",
                             .op_value = "val",
-                            .highlight = "val",
+                            .highlight = "val"sv,
                             .args = {{
-                                .value = "value",
+                                .value = "value"sv,
                                 .address = "query",
                                 .path = {"root", "key"},
                             }}},
                 {.op = "match_regex",
                     .op_value = ".*",
-                    .highlight = "string",
+                    .highlight = "string"sv,
                     .args = {{
-                        .value = "string",
+                        .value = "string"sv,
                         .address = "response.body",
                     }}},
                 {.op = "is_xss",
                     .args = {{
-                        .value = "<script>",
+                        .value = "<script>"sv,
                         .address = "path_params",
                         .path = {"key"},
                     }}}}},
@@ -308,9 +308,9 @@ TEST(TestEventSerializer, SerializeMultipleEvents)
             .tags = {{"type", "test"}, {"category", "none"}},
             .actions = {"unblock"},
             .matches = {{.op = "ip_match",
-                .highlight = "192.168.0.1",
+                .highlight = "192.168.0.1"sv,
                 .args = {{
-                    .value = "192.168.0.1",
+                    .value = "192.168.0.1"sv,
                     .address = "client.ip",
                 }}}}},
         {});
@@ -331,10 +331,10 @@ TEST(TestEventSerializer, SerializeEventNoActions)
     event.rule = &rule;
     event.matches = {
         {.args = {{.name = "input",
-             .resolved = "value",
+             .resolved = "value"sv,
              .address = "query",
              .key_path = {"root", "key"}}},
-            .highlights = {"val"},
+            .highlights = {"val"sv},
             .operator_name = "random",
             .operator_value = "val"},
     };
@@ -361,9 +361,9 @@ TEST(TestEventSerializer, SerializeEventNoActions)
                               .tags = {{"type", "test"}, {"category", "none"}},
                               .matches = {{.op = "random",
                                   .op_value = "val",
-                                  .highlight = "val",
+                                  .highlight = "val"sv,
                                   .args = {{
-                                      .value = "value",
+                                      .value = "value"sv,
                                       .address = "query",
                                       .path = {"root", "key"},
                                   }}}}});
@@ -384,10 +384,10 @@ TEST(TestEventSerializer, SerializeAllTags)
     event.rule = &rule;
     event.matches = {
         {.args = {{.name = "input",
-             .resolved = "value",
+             .resolved = "value"sv,
              .address = "query",
              .key_path = {"root", "key"}}},
-            .highlights = {"val"},
+            .highlights = {"val"sv},
             .operator_name = "random",
             .operator_value = "val"},
     };
@@ -419,9 +419,9 @@ TEST(TestEventSerializer, SerializeAllTags)
                               .actions = {"unblock"},
                               .matches = {{.op = "random",
                                   .op_value = "val",
-                                  .highlight = "val",
+                                  .highlight = "val"sv,
                                   .args = {{
-                                      .value = "value",
+                                      .value = "value"sv,
                                       .address = "query",
                                       .path = {"root", "key"},
                                   }}}}});
@@ -442,10 +442,10 @@ TEST(TestEventSerializer, NoMonitorActions)
     event.rule = &rule;
     event.matches = {
         {.args = {{.name = "input",
-             .resolved = "value",
+             .resolved = "value"sv,
              .address = "query",
              .key_path = {"root", "key"}}},
-            .highlights = {"val"},
+            .highlights = {"val"sv},
             .operator_name = "random",
             .operator_value = "val"},
     };
@@ -474,9 +474,9 @@ TEST(TestEventSerializer, NoMonitorActions)
                               .actions = {"monitor"},
                               .matches = {{.op = "random",
                                   .op_value = "val",
-                                  .highlight = "val",
+                                  .highlight = "val"sv,
                                   .args = {{
-                                      .value = "value",
+                                      .value = "value"sv,
                                       .address = "query",
                                       .path = {"root", "key"},
                                   }}}}});
@@ -498,10 +498,10 @@ TEST(TestEventSerializer, UndefinedActions)
     event.rule = &rule;
     event.matches = {
         {.args = {{.name = "input",
-             .resolved = "value",
+             .resolved = "value"sv,
              .address = "query",
              .key_path = {"root", "key"}}},
-            .highlights = {"val"},
+            .highlights = {"val"sv},
             .operator_name = "random",
             .operator_value = "val"},
     };
@@ -530,9 +530,9 @@ TEST(TestEventSerializer, UndefinedActions)
                               .actions = {"unblock_request"},
                               .matches = {{.op = "random",
                                   .op_value = "val",
-                                  .highlight = "val",
+                                  .highlight = "val"sv,
                                   .args = {{
-                                      .value = "value",
+                                      .value = "value"sv,
                                       .address = "query",
                                       .path = {"root", "key"},
                                   }}}}});
@@ -554,10 +554,10 @@ TEST(TestEventSerializer, StackTraceAction)
     event.rule = &rule;
     event.matches = {
         {.args = {{.name = "input",
-             .resolved = "value",
+             .resolved = "value"sv,
              .address = "query",
              .key_path = {"root", "key"}}},
-            .highlights = {"val"},
+            .highlights = {"val"sv},
             .operator_name = "random",
             .operator_value = "val"},
     };
@@ -587,9 +587,9 @@ TEST(TestEventSerializer, StackTraceAction)
                               .actions = {"stack_trace"},
                               .matches = {{.op = "random",
                                   .op_value = "val",
-                                  .highlight = "val",
+                                  .highlight = "val"sv,
                                   .args = {{
-                                      .value = "value",
+                                      .value = "value"sv,
                                       .address = "query",
                                       .path = {"root", "key"},
                                   }}}}});

--- a/tests/unit/expression_test.cpp
+++ b/tests/unit/expression_test.cpp
@@ -42,9 +42,9 @@ TEST(TestExpression, SimpleMatch)
     EXPECT_FALSE(matches[0].ephemeral);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = ".*",
-                                .highlight = "value",
+                                .highlight = "value"sv,
                                 .args = {{
-                                    .value = "value",
+                                    .value = "value"sv,
                                     .address = "server.request.query",
                                 }}});
 }
@@ -79,9 +79,9 @@ TEST(TestExpression, SimpleNegatedMatch)
     EXPECT_FALSE(matches[0].ephemeral);
     EXPECT_MATCHES(matches, {.op = "!match_regex",
                                 .op_value = ".*",
-                                .highlight = "",
+                                .highlight = ""sv,
                                 .args = {{
-                                    .value = "val",
+                                    .value = "val"sv,
                                     .address = "server.request.query",
                                 }}});
 }
@@ -116,9 +116,9 @@ TEST(TestExpression, EphemeralMatch)
     EXPECT_TRUE(matches[0].ephemeral);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = ".*",
-                                .highlight = "value",
+                                .highlight = "value"sv,
                                 .args = {{
-                                    .value = "value",
+                                    .value = "value"sv,
                                     .address = "server.request.query",
                                 }}});
 }
@@ -173,9 +173,9 @@ TEST(TestExpression, MultiInputMatchOnSecondEval)
         auto matches = expr->get_matches(cache);
         EXPECT_MATCHES(matches, {.op = "match_regex",
                                     .op_value = "^value$",
-                                    .highlight = "value",
+                                    .highlight = "value"sv,
                                     .args = {{
-                                        .value = "value",
+                                        .value = "value"sv,
                                         .address = "server.request.body",
                                     }}});
     }
@@ -230,9 +230,9 @@ TEST(TestExpression, EphemeralMatchOnSecondEval)
         auto matches = expr->get_matches(cache);
         EXPECT_MATCHES(matches, {.op = "match_regex",
                                     .op_value = "^value$",
-                                    .highlight = "value",
+                                    .highlight = "value"sv,
                                     .args = {{
-                                        .value = "value",
+                                        .value = "value"sv,
                                         .address = "server.request.body",
                                     }}});
     }
@@ -282,16 +282,16 @@ TEST(TestExpression, EphemeralMatchTwoConditions)
     EXPECT_MATCHES(matches,
         {.op = "match_regex",
             .op_value = "^value$",
-            .highlight = "value",
+            .highlight = "value"sv,
             .args = {{
-                .value = "value",
+                .value = "value"sv,
                 .address = "server.request.query",
             }}},
         {.op = "match_regex",
             .op_value = "^value$",
-            .highlight = "value",
+            .highlight = "value"sv,
             .args = {{
-                .value = "value",
+                .value = "value"sv,
                 .address = "server.request.body",
             }}});
 }
@@ -545,9 +545,9 @@ TEST(TestExpression, MatchDuplicateInputNoCache)
         EXPECT_FALSE(matches[0].ephemeral);
         EXPECT_MATCHES(matches, {.op = "match_regex",
                                     .op_value = "^value$",
-                                    .highlight = "value",
+                                    .highlight = "value"sv,
                                     .args = {{
-                                        .value = "value",
+                                        .value = "value"sv,
                                         .address = "server.request.query",
                                     }}});
     }
@@ -740,9 +740,9 @@ TEST(TestExpression, MatchWithKeyPath)
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = ".*",
-                                .highlight = "value",
+                                .highlight = "value"sv,
                                 .args = {{
-                                    .value = "value",
+                                    .value = "value"sv,
                                     .address = "server.request.query",
                                     .path = {"key"},
                                 }}});
@@ -772,9 +772,9 @@ TEST(TestExpression, MatchWithTransformer)
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = "value",
-                                .highlight = "value",
+                                .highlight = "value"sv,
                                 .args = {{
-                                    .value = "value",
+                                    .value = "value"sv,
                                     .address = "server.request.query",
                                 }}});
 }
@@ -804,9 +804,9 @@ TEST(TestExpression, MatchWithMultipleTransformers)
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = "^ value $",
-                                .highlight = " value ",
+                                .highlight = " value "sv,
                                 .args = {{
-                                    .value = " value ",
+                                    .value = " value "sv,
                                     .address = "server.request.query",
                                 }}});
 }
@@ -838,9 +838,9 @@ TEST(TestExpression, MatchOnKeys)
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = "value",
-                                .highlight = "value",
+                                .highlight = "value"sv,
                                 .args = {{
-                                    .value = "value",
+                                    .value = "value"sv,
                                     .address = "server.request.query",
                                     .path = {"value"},
                                 }}});
@@ -873,9 +873,9 @@ TEST(TestExpression, MatchOnKeysWithTransformer)
     auto matches = expr->get_matches(cache);
     EXPECT_MATCHES(matches, {.op = "match_regex",
                                 .op_value = "value",
-                                .highlight = "value",
+                                .highlight = "value"sv,
                                 .args = {{
-                                    .value = "value",
+                                    .value = "value"sv,
                                     .address = "server.request.query",
                                     .path = {"VALUE"},
                                 }}});

--- a/tests/unit/obfuscator_test.cpp
+++ b/tests/unit/obfuscator_test.cpp
@@ -12,7 +12,7 @@ using namespace std::literals;
 
 namespace {
 
-TEST(TestObfuscator, TestKeyValueObfuscator)
+TEST(TestObfuscator, IsSensitiveKeyValue)
 {
     ddwaf::obfuscator event_obfuscator("^password$"sv, "value"sv);
 
@@ -25,7 +25,7 @@ TEST(TestObfuscator, TestKeyValueObfuscator)
     EXPECT_FALSE(event_obfuscator.is_sensitive_value("random"sv));
 }
 
-TEST(TestObfuscator, TestKeyObfuscator)
+TEST(TestObfuscator, IsSensitiveKey)
 {
     ddwaf::obfuscator event_obfuscator("^password$"sv);
 
@@ -36,7 +36,7 @@ TEST(TestObfuscator, TestKeyObfuscator)
     EXPECT_FALSE(event_obfuscator.is_sensitive_value("random value"sv));
 }
 
-TEST(TestObfuscator, TestValueObfuscator)
+TEST(TestObfuscator, IsSensitiveValue)
 {
     ddwaf::obfuscator event_obfuscator({}, "value"sv);
 
@@ -47,7 +47,7 @@ TEST(TestObfuscator, TestValueObfuscator)
     EXPECT_FALSE(event_obfuscator.is_sensitive_value("random"sv));
 }
 
-TEST(TestObfuscator, TestEmptyObfuscator)
+TEST(TestObfuscator, IsSensitiveKeyValueNoRegexes)
 {
     ddwaf::obfuscator event_obfuscator;
 
@@ -55,7 +55,7 @@ TEST(TestObfuscator, TestEmptyObfuscator)
     EXPECT_FALSE(event_obfuscator.is_sensitive_value("value"sv));
 }
 
-TEST(TestObfuscator, TestDefaultObfuscator)
+TEST(TestObfuscator, IsSensitiveKeyDefaultRegex)
 {
     std::vector<std::string> samples{"password", "pwd", "pword", "passwd", "pass", "passphrase",
         "pass-phrase", "passphrase", "secret", "api_key", "api-key", "apikey", "private_key",
@@ -78,6 +78,232 @@ TEST(TestObfuscator, TestDefaultObfuscator)
 
     ddwaf::obfuscator event_obfuscator{ddwaf::obfuscator::default_key_regex_str, {}};
     for (auto &sample : samples) { EXPECT_TRUE(event_obfuscator.is_sensitive_key(sample)); }
+}
+
+TEST(TestObfuscator, MatchObfuscationCustomRegexes)
+{
+    ddwaf::obfuscator event_obfuscator("^password$"sv, "value"sv);
+    {
+        // Verify that when the key matches, both value and highlight are redacted
+        condition_match match{
+            .args = {{.name = "input", .resolved = "random", .key_path = {"password"}}},
+            .highlights = {"random"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], obfuscator::redaction_msg);
+        EXPECT_STR(match.args[0].resolved, obfuscator::redaction_msg);
+    }
+
+    {
+        // Verify that the value is redacted when it matches the regex and that
+        // the highlight is redacted due to the condition argument being input
+        condition_match match{
+            .args = {{.name = "input", .resolved = "value", .key_path = {"unrelated"}}},
+            .highlights = {"not sensitive"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], obfuscator::redaction_msg);
+        EXPECT_STR(match.args[0].resolved, obfuscator::redaction_msg);
+    }
+
+    {
+        // Verify that the value is redacted when it matches the regex and that
+        // the highlight is redacted due to the condition argument being param
+        condition_match match{
+            .args = {{.name = "params", .resolved = "value", .key_path = {"unrelated"}}},
+            .highlights = {"not sensitive"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], obfuscator::redaction_msg);
+        EXPECT_STR(match.args[0].resolved, obfuscator::redaction_msg);
+    }
+
+    {
+        // Verify that the value is redacted when it matches the regex and that
+        // the highlight isn't because it isn't related to the value
+        condition_match match{.args = {{.name = "unrelated to highlight",
+                                  .resolved = "value",
+                                  .key_path = {"unrelated"}}},
+            .highlights = {"not sensitive"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], "not sensitive");
+        EXPECT_STR(match.args[0].resolved, obfuscator::redaction_msg);
+    }
+
+    {
+        // Verify that the highlight is only redacted when the value is
+        condition_match match{
+            .args = {{.name = "params", .resolved = "not sensitive", .key_path = {"unrelated"}}},
+            .highlights = {"value"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], "value");
+        EXPECT_STR(match.args[0].resolved, "not sensitive");
+    }
+
+    {
+        // Verify that when neither the key nor the value match, no redaction is
+        // performed
+        condition_match match{
+            .args = {{.name = "input", .resolved = "random", .key_path = {"unredacted"}}},
+            .highlights = {"random"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], "random");
+        EXPECT_STR(match.args[0].resolved, "random");
+    }
+}
+
+TEST(TestObfuscator, MatchObfuscationDefaultRegexes)
+{
+    ddwaf::obfuscator event_obfuscator{
+        obfuscator::default_key_regex_str, obfuscator::default_value_regex_str};
+
+    {
+        // Verify that when the key matches, both value and highlight are redacted
+        condition_match match{
+            .args = {{.name = "input", .resolved = "random", .key_path = {"password"}}},
+            .highlights = {"random"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], obfuscator::redaction_msg);
+        EXPECT_STR(match.args[0].resolved, obfuscator::redaction_msg);
+    }
+
+    {
+        // Verify that the value is redacted when it matches the regex and that
+        // the highlight is redacted due to the condition argument being input
+        condition_match match{.args = {{.name = "input", .resolved = "password=something"}},
+            .highlights = {"not sensitive"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], obfuscator::redaction_msg);
+        EXPECT_STR(match.args[0].resolved, "password=<Redacted>");
+    }
+
+    {
+        // Verify that the value is redacted when it matches the regex and that
+        // the highlight is redacted due to the condition argument being param
+        condition_match match{.args = {{.name = "params",
+                                  .resolved = "token:qweqweqweqweq",
+                                  .key_path = {"unrelated"}}},
+            .highlights = {"not sensitive"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], obfuscator::redaction_msg);
+        EXPECT_STR(match.args[0].resolved, "token:<Redacted>");
+    }
+
+    {
+        // Verify that the value is redacted when it matches the regex and that
+        // the highlight isn't because the it isn't related to the value
+        condition_match match{.args = {{.name = "unrelated to highlight",
+                                  .resolved = "ssh-rsa "
+                                              "1234567890123456789012345678901234567890123456789012"
+                                              "345678901234567890123456789012345678901234567890",
+                                  .key_path = {"unrelated"}}},
+            .highlights = {"not sensitive"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], "not sensitive");
+        EXPECT_STR(match.args[0].resolved, "ssh-rsa <Redacted>");
+    }
+
+    {
+        // Verify that the highlight is only redacted when the value is
+        condition_match match{
+            .args = {{.name = "params", .resolved = "not sensitive", .key_path = {"unrelated"}}},
+            .highlights = {"password=2020"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], "password=2020");
+        EXPECT_STR(match.args[0].resolved, "not sensitive");
+    }
+
+    {
+        // Verify that when neither the key nor the value match, no redaction is
+        // performed
+        condition_match match{
+            .args = {{.name = "input", .resolved = "random", .key_path = {"unredacted"}}},
+            .highlights = {"random"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.highlights[0], "random");
+        EXPECT_STR(match.args[0].resolved, "random");
+    }
+}
+
+TEST(TestObfuscator, ValueObfuscationDefaultRegexes)
+{
+    std::vector<std::pair<std::string_view, std::string_view>> test_cases{
+        {R"(blapassword=123456&)", R"(blapassword=<Redacted>&)"},
+        {R"(password=SuperSecret123)", R"(password=<Redacted>)"},
+        {R"(asp.net-sessionid=qwertyuiop1234567890)", R"(asp.net-sessionid=<Redacted>)"},
+        {R"(api_key="12345-abcde-67890-fghij")", R"(api_key=<Redacted>)"},
+        {R"(refresh_token=xyz098zyx7654321)", R"(refresh_token=<Redacted>)"},
+        {R"("password":123)", R"("password":<Redacted>)"},
+        {R"("password":"123",)", R"("password":<Redacted>,)"},
+        {R"("token":"abc123def456ghi789")", R"("token":<Redacted>)"},
+        {R"(bla.com/?password=123&v=x)", R"(bla.com/?password=<Redacted>&v=x)"},
+        {R"(bla.com/?v=x&password=123&v=x)", R"(bla.com/?v=x&password=<Redacted>&v=x)"},
+        {R"(bearer qweqweqweqewqew)", R"(bearer <Redacted>)"},
+        {R"(Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9)", R"(Bearer <Redacted>)"},
+        {R"(token:qweqweqweqweq)", R"(token:<Redacted>)"},
+        {R"(gho_123456789012345678901234567890123456)", R"(gho_<Redacted>)"},
+        {R"(ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcd)", R"(ghp_<Redacted>abcd)"},
+        {R"(eyIqwe.eyIqwe.eyqweqwe)", R"(eyIqwe.<Redacted>)"},
+        {R"(eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoidXNlcklkIn0.KvBcTejQwR6j1z2y3x4v)",
+            R"(eyJhbGciOiJIUzI1NiJ9.<Redacted>)"},
+        {R"(-----BEGIN PRIVATE KEY-----qwe-----END PRIVATE KEY)",
+            R"(-----BEGIN PRIVATE KEY-----<Redacted>-----END PRIVATE KEY)"},
+        {R"(-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAwKFIxQKIn8FJyX1TqV2QIDAQABAoIBAQC/UYHm6+NHmY6U
+-----END RSA PRIVATE KEY-----)",
+            R"(-----BEGIN RSA PRIVATE KEY-----<Redacted>-----END RSA PRIVATE KEY-----)"},
+
+        {R"(ssh-rsa 1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890)",
+            R"(ssh-rsa <Redacted>)"},
+        {R"(ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1xjOvnPJuorR8lHymz4uoypHy1h7uMKw29lJr3p6eJ6OxNc1Rkqv8hDxnN9nJSxIOLRG2fDu1K5XmRe+Jp0iYzPcwupTV6Mg93clo0BhE0mzwIoxFDq2w==)",
+            R"(ssh-rsa <Redacted>==)"},
+    };
+
+    ddwaf::obfuscator event_obfuscator{
+        obfuscator::default_key_regex_str, obfuscator::default_value_regex_str};
+
+    for (const auto &[original, expected] : test_cases) {
+        condition_match match{.args = {{.name = "input", .resolved = original}},
+            .highlights = {"random"},
+            .operator_name = {},
+            .operator_value = {}};
+
+        event_obfuscator.obfuscate_match(match);
+        EXPECT_STR(match.args[0].resolved, expected);
+    }
 }
 
 } // namespace

--- a/tests/unit/obfuscator_test.cpp
+++ b/tests/unit/obfuscator_test.cpp
@@ -101,8 +101,8 @@ TEST(TestObfuscator, MatchObfuscationCustomRegexes)
     {
         // Verify that when the key matches, both value and highlight are redacted
         condition_match match{
-            .args = {{.name = "input", .resolved = "random", .key_path = {"password"}}},
-            .highlights = {"random"},
+            .args = {{.name = "input", .resolved = "random"sv, .key_path = {"password"}}},
+            .highlights = {"random"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -115,8 +115,8 @@ TEST(TestObfuscator, MatchObfuscationCustomRegexes)
         // Verify that the value is redacted when it matches the regex and that
         // the highlight is redacted due to the condition argument being input
         condition_match match{
-            .args = {{.name = "input", .resolved = "value", .key_path = {"unrelated"}}},
-            .highlights = {"not sensitive"},
+            .args = {{.name = "input", .resolved = "value"sv, .key_path = {"unrelated"}}},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -129,8 +129,8 @@ TEST(TestObfuscator, MatchObfuscationCustomRegexes)
         // Verify that the value is redacted when it matches the regex and that
         // the highlight is redacted due to the condition argument being param
         condition_match match{
-            .args = {{.name = "params", .resolved = "value", .key_path = {"unrelated"}}},
-            .highlights = {"not sensitive"},
+            .args = {{.name = "params", .resolved = "value"sv, .key_path = {"unrelated"}}},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -143,9 +143,9 @@ TEST(TestObfuscator, MatchObfuscationCustomRegexes)
         // Verify that the value is redacted when it matches the regex and that
         // the highlight isn't because it isn't related to the value
         condition_match match{.args = {{.name = "unrelated to highlight",
-                                  .resolved = "value",
+                                  .resolved = "value"sv,
                                   .key_path = {"unrelated"}}},
-            .highlights = {"not sensitive"},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -157,8 +157,8 @@ TEST(TestObfuscator, MatchObfuscationCustomRegexes)
     {
         // Verify that the highlight is only redacted when the value is
         condition_match match{
-            .args = {{.name = "params", .resolved = "not sensitive", .key_path = {"unrelated"}}},
-            .highlights = {"value"},
+            .args = {{.name = "params", .resolved = "not sensitive"sv, .key_path = {"unrelated"}}},
+            .highlights = {"value"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -171,8 +171,8 @@ TEST(TestObfuscator, MatchObfuscationCustomRegexes)
         // Verify that when neither the key nor the value match, no redaction is
         // performed
         condition_match match{
-            .args = {{.name = "input", .resolved = "random", .key_path = {"unredacted"}}},
-            .highlights = {"random"},
+            .args = {{.name = "input", .resolved = "random"sv, .key_path = {"unredacted"}}},
+            .highlights = {"random"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -190,8 +190,8 @@ TEST(TestObfuscator, MatchObfuscationDefaultRegexes)
     {
         // Verify that when the key matches, both value and highlight are redacted
         condition_match match{
-            .args = {{.name = "input", .resolved = "random", .key_path = {"password"}}},
-            .highlights = {"random"},
+            .args = {{.name = "input", .resolved = "random"sv, .key_path = {"password"}}},
+            .highlights = {"random"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -203,8 +203,8 @@ TEST(TestObfuscator, MatchObfuscationDefaultRegexes)
     {
         // Verify that the value is redacted when it matches the regex and that
         // the highlight is redacted due to the condition argument being input
-        condition_match match{.args = {{.name = "input", .resolved = "password=something"}},
-            .highlights = {"not sensitive"},
+        condition_match match{.args = {{.name = "input", .resolved = "password=something"sv}},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -217,9 +217,9 @@ TEST(TestObfuscator, MatchObfuscationDefaultRegexes)
         // Verify that the value is redacted when it matches the regex and that
         // the highlight is redacted due to the condition argument being param
         condition_match match{.args = {{.name = "params",
-                                  .resolved = "token:qweqweqweqweq",
+                                  .resolved = "token:qweqweqweqweq"sv,
                                   .key_path = {"unrelated"}}},
-            .highlights = {"not sensitive"},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -232,11 +232,11 @@ TEST(TestObfuscator, MatchObfuscationDefaultRegexes)
         // Verify that the value is redacted when it matches the regex and that
         // the highlight isn't because the it isn't related to the value
         condition_match match{.args = {{.name = "unrelated to highlight",
-                                  .resolved = "ssh-rsa "
+                                  .resolved = "ssh-rsa "sv
                                               "1234567890123456789012345678901234567890123456789012"
                                               "345678901234567890123456789012345678901234567890",
                                   .key_path = {"unrelated"}}},
-            .highlights = {"not sensitive"},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -248,9 +248,9 @@ TEST(TestObfuscator, MatchObfuscationDefaultRegexes)
     {
         // Verify that the highlight is only redacted when the value is
         condition_match match{
-            .args = {{.name = "params", .resolved = "not sensitive", .key_path = {"unrelated"}},
-                {.name = "not_params", .resolved = "password=paco"}},
-            .highlights = {"password=2020"},
+            .args = {{.name = "params", .resolved = "not sensitive"sv, .key_path = {"unrelated"}},
+                {.name = "not_params", .resolved = "password=paco"sv}},
+            .highlights = {"password=2020"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -264,8 +264,8 @@ TEST(TestObfuscator, MatchObfuscationDefaultRegexes)
         // Verify that when neither the key nor the value match, no redaction is
         // performed
         condition_match match{
-            .args = {{.name = "input", .resolved = "random", .key_path = {"unredacted"}}},
-            .highlights = {"random"},
+            .args = {{.name = "input", .resolved = "random"sv, .key_path = {"unredacted"}}},
+            .highlights = {"random"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -309,6 +309,10 @@ MIIEpAIBAAKCAQEAwKFIxQKIn8FJyX1TqV2QIDAQABAoIBAQC/UYHm6+NHmY6U
             R"(ssh-rsa <Redacted>==)"},
         {R"(site.com/?api_token=sensitive&value=something&PHPSESSID=something&json={"token":"value","somethingelse":"ghp_000000000000000000000000000000000000"})",
             R"(site.com/?api_token=<Redacted>&value=something&PHPSESSID=<Redacted>&json={"token":<Redacted>,"somethingelse":"ghp_<Redacted>"})"},
+        {R"(-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAwKFIxQKIn8FJyX1TqV2QIDAQABAoIBAQC/UYHm6+NHmY6U
+-----END RSA PRIVATE KEY-----,ghp_000000000000000000000000000000000000)",
+            R"(-----BEGIN RSA PRIVATE KEY-----<Redacted>-----END RSA PRIVATE KEY-----,ghp_<Redacted>)"},
     };
 
     ddwaf::obfuscator event_obfuscator{
@@ -316,7 +320,7 @@ MIIEpAIBAAKCAQEAwKFIxQKIn8FJyX1TqV2QIDAQABAoIBAQC/UYHm6+NHmY6U
 
     for (const auto &[original, expected] : test_cases) {
         condition_match match{.args = {{.name = "input", .resolved = original}},
-            .highlights = {"random"},
+            .highlights = {"random"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -334,8 +338,8 @@ TEST(TestObfuscator, FallbackToDefaultRegexes)
     {
         // Verify that when the key matches, both value and highlight are redacted
         condition_match match{
-            .args = {{.name = "input", .resolved = "random", .key_path = {"password"}}},
-            .highlights = {"random"},
+            .args = {{.name = "input", .resolved = "random"sv, .key_path = {"password"}}},
+            .highlights = {"random"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -347,8 +351,8 @@ TEST(TestObfuscator, FallbackToDefaultRegexes)
     {
         // Verify that the value is redacted when it matches the regex and that
         // the highlight is redacted due to the condition argument being input
-        condition_match match{.args = {{.name = "input", .resolved = "password=something"}},
-            .highlights = {"not sensitive"},
+        condition_match match{.args = {{.name = "input", .resolved = "password=something"sv}},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -361,9 +365,9 @@ TEST(TestObfuscator, FallbackToDefaultRegexes)
         // Verify that the value is redacted when it matches the regex and that
         // the highlight is redacted due to the condition argument being param
         condition_match match{.args = {{.name = "params",
-                                  .resolved = "token:qweqweqweqweq",
+                                  .resolved = "token:qweqweqweqweq"sv,
                                   .key_path = {"unrelated"}}},
-            .highlights = {"not sensitive"},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -376,11 +380,11 @@ TEST(TestObfuscator, FallbackToDefaultRegexes)
         // Verify that the value is redacted when it matches the regex and that
         // the highlight isn't because the it isn't related to the value
         condition_match match{.args = {{.name = "unrelated to highlight",
-                                  .resolved = "ssh-rsa "
+                                  .resolved = "ssh-rsa "sv
                                               "1234567890123456789012345678901234567890123456789012"
                                               "345678901234567890123456789012345678901234567890",
                                   .key_path = {"unrelated"}}},
-            .highlights = {"not sensitive"},
+            .highlights = {"not sensitive"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -392,8 +396,8 @@ TEST(TestObfuscator, FallbackToDefaultRegexes)
     {
         // Verify that the highlight is only redacted when the value is
         condition_match match{
-            .args = {{.name = "params", .resolved = "not sensitive", .key_path = {"unrelated"}}},
-            .highlights = {"password=2020"},
+            .args = {{.name = "params", .resolved = "not sensitive"sv, .key_path = {"unrelated"}}},
+            .highlights = {"password=2020"sv},
             .operator_name = {},
             .operator_value = {}};
 
@@ -406,8 +410,8 @@ TEST(TestObfuscator, FallbackToDefaultRegexes)
         // Verify that when neither the key nor the value match, no redaction is
         // performed
         condition_match match{
-            .args = {{.name = "input", .resolved = "random", .key_path = {"unredacted"}}},
-            .highlights = {"random"},
+            .args = {{.name = "input", .resolved = "random"sv, .key_path = {"unredacted"}}},
+            .highlights = {"random"sv},
             .operator_name = {},
             .operator_value = {}};
 

--- a/tests/unit/obfuscator_test.cpp
+++ b/tests/unit/obfuscator_test.cpp
@@ -290,6 +290,8 @@ MIIEpAIBAAKCAQEAwKFIxQKIn8FJyX1TqV2QIDAQABAoIBAQC/UYHm6+NHmY6U
             R"(ssh-rsa <Redacted>)"},
         {R"(ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC1xjOvnPJuorR8lHymz4uoypHy1h7uMKw29lJr3p6eJ6OxNc1Rkqv8hDxnN9nJSxIOLRG2fDu1K5XmRe+Jp0iYzPcwupTV6Mg93clo0BhE0mzwIoxFDq2w==)",
             R"(ssh-rsa <Redacted>==)"},
+        {R"(site.com/?api_token=sensitive&value=something&PHPSESSID=something&json={"token":"value","somethingelse":"ghp_000000000000000000000000000000000000"})",
+            R"(site.com/?api_token=<Redacted>&value=something&PHPSESSID=<Redacted>&json={"token":<Redacted>,"somethingelse":"ghp_<Redacted>"})"},
     };
 
     ddwaf::obfuscator event_obfuscator{

--- a/tests/unit/rule_test.cpp
+++ b/tests/unit/rule_test.cpp
@@ -54,8 +54,8 @@ TEST(TestRule, Match)
         EXPECT_FALSE(event->ephemeral);
 
         auto &match = event->matches[0];
-        EXPECT_STREQ(match.args[0].resolved.c_str(), "192.168.0.1");
-        EXPECT_STREQ(match.highlights[0].c_str(), "192.168.0.1");
+        EXPECT_STR(match.args[0].resolved, "192.168.0.1");
+        EXPECT_STR(match.highlights[0], "192.168.0.1");
         EXPECT_STREQ(match.operator_name.data(), "ip_match");
         EXPECT_STREQ(match.operator_value.data(), "");
         EXPECT_STREQ(match.args[0].address.data(), "http.client_ip");
@@ -202,8 +202,8 @@ TEST(TestRule, ValidateCachedMatch)
 
         {
             auto &match = event->matches[0];
-            EXPECT_STREQ(match.args[0].resolved.c_str(), "192.168.0.1");
-            EXPECT_STREQ(match.highlights[0].c_str(), "192.168.0.1");
+            EXPECT_STR(match.args[0].resolved, "192.168.0.1");
+            EXPECT_STR(match.highlights[0], "192.168.0.1");
             EXPECT_STREQ(match.operator_name.data(), "ip_match");
             EXPECT_STREQ(match.operator_value.data(), "");
             EXPECT_STREQ(match.args[0].address.data(), "http.client_ip");
@@ -211,8 +211,8 @@ TEST(TestRule, ValidateCachedMatch)
         }
         {
             auto &match = event->matches[1];
-            EXPECT_STREQ(match.args[0].resolved.c_str(), "admin");
-            EXPECT_STREQ(match.highlights[0].c_str(), "admin");
+            EXPECT_STR(match.args[0].resolved, "admin");
+            EXPECT_STR(match.highlights[0], "admin");
             EXPECT_STREQ(match.operator_name.data(), "exact_match");
             EXPECT_STREQ(match.operator_value.data(), "");
             EXPECT_STREQ(match.args[0].address.data(), "usr.id");
@@ -269,8 +269,8 @@ TEST(TestRule, MatchWithoutCache)
 
         {
             auto &match = event->matches[0];
-            EXPECT_STREQ(match.args[0].resolved.c_str(), "192.168.0.1");
-            EXPECT_STREQ(match.highlights[0].c_str(), "192.168.0.1");
+            EXPECT_STR(match.args[0].resolved, "192.168.0.1");
+            EXPECT_STR(match.highlights[0], "192.168.0.1");
             EXPECT_STREQ(match.operator_name.data(), "ip_match");
             EXPECT_STREQ(match.operator_value.data(), "");
             EXPECT_STREQ(match.args[0].address.data(), "http.client_ip");
@@ -278,8 +278,8 @@ TEST(TestRule, MatchWithoutCache)
         }
         {
             auto &match = event->matches[1];
-            EXPECT_STREQ(match.args[0].resolved.c_str(), "admin");
-            EXPECT_STREQ(match.highlights[0].c_str(), "admin");
+            EXPECT_STR(match.args[0].resolved, "admin");
+            EXPECT_STR(match.highlights[0], "admin");
             EXPECT_STREQ(match.operator_name.data(), "exact_match");
             EXPECT_STREQ(match.operator_value.data(), "");
             EXPECT_STREQ(match.args[0].address.data(), "usr.id");

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -48,9 +48,11 @@ auto parse_args(int argc, char *argv[])
     }
     return args;
 }
-const char *key_regex = R"((?i)pass|pw(?:or)?d|secret|(?:api|private|public|access)[_-]?key|token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\.net[_-]sessionid|sid|jwt)";
 
-const char *value_regex = R"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key(?:[_-]?id)?|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?|jsessionid|phpsessid|asp\.net(?:[_-]|-)sessionid|sid|jwt)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,})";
+const char *key_regex {
+        R"((?i)pass|pw(?:or)?d|secret|(?:api|private|public|access)[_-]?key|token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\.net[_-]sessionid|sid|jwt)"};
+
+const char *value_regex{R"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key(?:[_-]?id)?|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?|jsessionid|phpsessid|asp\.net(?:[_-]|-)sessionid|sid|jwt)(?:\s*=([^;&]+)|"\s*:\s*("[^"]+"|\d+))|bearer\s+([a-z0-9\._\-]+)|token\s*:\s*([a-z0-9]{13})|gh[opsu]_([0-9a-zA-Z]{36})|ey[I-L][\w=-]+\.(ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?)|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}([^\-]+)[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*([a-z0-9\/\.+]{100,}))"};
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
The goal of this PR is to change how the event obfuscation process works:
- First it introduces a new value regular expression which contains a number of capture groups aimed at identifying the parts of the value which should be obfuscated.
- Second it changes the obfuscation process, when the value regex is the default one, only the matched capture groups are redacted rather than the whole value.
- Third it changes how the highlight is obfuscated, ensuring that it's only obfuscated when the relevant value is as well rather than relying on the regular expression, which may not work on a substring of the original value.

Finally, this PR also introduces a new type called `dynamic_string` which allows making changes to a string buffer which can then be directly moved into a `ddwaf_object`, preventing the need for extra copies.

Related Jiras: [APPSEC-57575]

[APPSEC-57575]: https://datadoghq.atlassian.net/browse/APPSEC-57575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ