### PR TITLE
Add support for backwards-incompatible rules through the rules_compat key

### DIFF
--- a/schema/diagnostics.json
+++ b/schema/diagnostics.json
@@ -19,6 +19,9 @@
     "rules": {
       "$ref": "#/definitions/feature"
     },
+    "rules_compat": {
+      "$ref": "#/definitions/feature"
+    },
     "custom_rules": {
       "$ref": "#/definitions/feature"
     },

--- a/src/configuration/configuration_manager.cpp
+++ b/src/configuration/configuration_manager.cpp
@@ -97,6 +97,21 @@ void configuration_manager::load(
         }
     }
 
+    it = root.find("rules_compat");
+    if (it != root.end()) {
+        DDWAF_DEBUG("Parsing base backwards-incompatible rules");
+        auto &section = info.add_section("rules_compat");
+        try {
+            auto rules = static_cast<raw_configuration::vector>(it->second);
+            if (!rules.empty()) {
+                parse_base_rules(rules, collector, section);
+            }
+        } catch (const std::exception &e) {
+            DDWAF_WARN("Failed to parse backwards-incompatible rules: {}", e.what());
+            section.set_error(e.what());
+        }
+    }
+
     it = root.find("custom_rules");
     if (it != root.end()) {
         DDWAF_DEBUG("Parsing custom rules");

--- a/tests/integration/rules/rules_compat/test.cpp
+++ b/tests/integration/rules/rules_compat/test.cpp
@@ -1,0 +1,179 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "common/gtest_utils.hpp"
+#include "configuration/common/common.hpp"
+#include "configuration/common/raw_configuration.hpp"
+#include "ddwaf.h"
+
+using namespace ddwaf;
+using namespace std::literals;
+
+namespace {
+constexpr std::string_view base_dir = "integration/rules/rules_compat";
+
+TEST(TestRuleCompatIntegration, VerifyBothBaseAndCompat)
+{
+    auto rule = read_file("rules.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object tmp;
+
+    {
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+        ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
+
+        ddwaf_object result;
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
+
+        EXPECT_EVENTS(result,
+            {.id = "rule1",
+                .name = "rule1",
+                .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"}},
+                .matches = {{.op = "match_regex",
+                    .op_value = "^rule1",
+                    .highlight = "rule1"sv,
+                    .args = {{.value = "rule1"sv, .address = "value1"}}}}},
+            {.id = "rule2",
+                .name = "rule2",
+                .tags = {{"type", "flow2"}, {"category", "category2"}},
+                .matches = {{.op = "match_regex",
+                    .op_value = "^rule2",
+                    .highlight = "rule2"sv,
+                    .args = {{.value = "rule2"sv, .address = "value2"}}}}});
+
+        const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
+        EXPECT_NE(attributes, nullptr);
+        EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        const auto *tag = ddwaf_object_find(attributes, STRL("result.rule2"));
+        EXPECT_NE(tag, nullptr);
+        EXPECT_EQ(ddwaf_object_type(tag), DDWAF_OBJ_STRING);
+
+        std::size_t length;
+        const auto *str = ddwaf_object_get_string(tag, &length);
+
+        std::string_view value{str, length};
+        EXPECT_EQ(value, "something"sv);
+
+        const auto *keep = ddwaf_object_find(&result, STRL("keep"));
+        EXPECT_NE(keep, nullptr);
+        EXPECT_TRUE(ddwaf_object_get_bool(keep));
+
+        ddwaf_object_free(&result);
+    }
+    ddwaf_context_destroy(context);
+}
+
+TEST(TestRuleCompatIntegration, DuplicateRules)
+{
+    auto rule = read_file("duplicate_rules.yaml", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+
+    ddwaf_object diagnostics;
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, &diagnostics);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    EXPECT_TRUE(ValidateDiagnosticsSchema(diagnostics));
+
+    ddwaf::raw_configuration root(diagnostics);
+    auto root_map = static_cast<ddwaf::raw_configuration::map>(root);
+
+    {
+        auto rules = ddwaf::at<raw_configuration::map>(root_map, "rules_compat");
+
+        auto loaded = ddwaf::at<raw_configuration::string_set>(rules, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = ddwaf::at<raw_configuration::string_set>(rules, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("rule1"), failed.end());
+
+        auto errors = ddwaf::at<raw_configuration::map>(rules, "errors");
+        EXPECT_EQ(errors.size(), 1);
+
+        auto it = errors.find("duplicate rule");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<ddwaf::raw_configuration::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("rule1"), error_rules.end());
+    }
+
+    {
+        auto rules = ddwaf::at<raw_configuration::map>(root_map, "rules");
+
+        auto loaded = ddwaf::at<raw_configuration::string_set>(rules, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("rule1"), loaded.end());
+
+        auto failed = ddwaf::at<raw_configuration::string_set>(rules, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = ddwaf::at<raw_configuration::map>(rules, "errors");
+        EXPECT_EQ(errors.size(), 0);
+    }
+
+    ddwaf_object_free(&diagnostics);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    // Destroying the handle should not invalidate it
+    ddwaf_destroy(handle);
+
+    ddwaf_object tmp;
+
+    {
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+        ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
+
+        ddwaf_object result;
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
+
+        EXPECT_EVENTS(
+            result, {.id = "rule1",
+                        .name = "rule1",
+                        .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"}},
+                        .matches = {{.op = "match_regex",
+                            .op_value = "^rule1",
+                            .highlight = "rule1"sv,
+                            .args = {{.value = "rule1"sv, .address = "value1"}}}}});
+
+        const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
+        EXPECT_NE(attributes, nullptr);
+        EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
+        EXPECT_EQ(ddwaf_object_size(attributes), 0);
+
+        const auto *keep = ddwaf_object_find(&result, STRL("keep"));
+        EXPECT_NE(keep, nullptr);
+        EXPECT_TRUE(ddwaf_object_get_bool(keep));
+
+        ddwaf_object_free(&result);
+    }
+    ddwaf_context_destroy(context);
+}
+
+} // namespace

--- a/tests/integration/rules/rules_compat/yaml/duplicate_rules.yaml
+++ b/tests/integration/rules/rules_compat/yaml/duplicate_rules.yaml
@@ -1,0 +1,27 @@
+version: '2.1'
+rules:
+  - id: rule1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+      confidence: 1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: ^rule1
+rules_compat:
+  - id: rule1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+      confidence: 1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: ^rule1

--- a/tests/integration/rules/rules_compat/yaml/rules.yaml
+++ b/tests/integration/rules/rules_compat/yaml/rules.yaml
@@ -1,0 +1,32 @@
+version: '2.1'
+rules:
+  - id: rule1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+      confidence: 1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: ^rule1
+rules_compat:
+  - id: rule2
+    name: rule2
+    tags:
+      type: flow2
+      category: category2
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value2
+          regex: ^rule2
+    output:
+      event: true
+      keep: false
+      attributes:
+        result.rule2: 
+          value: something


### PR DESCRIPTION
This PR adds support for `rules_compat` as another source of base rules. These rules are merged with standard rules as this key is meant as a _temporary_ measure for backwards-incompatible rules, until a suitable mechanism exists to provide them separately based on capabilities.