### PR TITLE
[v2] Reenable attribute collector unit test

### DIFF
--- a/tests/unit/attribute_collector_test.cpp
+++ b/tests/unit/attribute_collector_test.cpp
@@ -12,714 +12,520 @@ using namespace ddwaf;
 
 namespace {
 
-/*TEST(TestAttributeCollector, InsertNoCopy)*/
-/*{*/
-/*ddwaf_object expected;*/
-/*ddwaf_object_string(&expected, "value");*/
+TEST(TestAttributeCollector, InsertNoCopy)
+{
+    std::string_view expected = "value";
+    owned_object input{expected};
 
-/*attribute_collector collector;*/
-/*EXPECT_TRUE(collector.insert("address", expected, false));*/
+    attribute_collector collector;
+    EXPECT_TRUE(collector.insert("address", std::move(input)));
 
-/*object_store store;*/
-/*collector.collect_pending(store);*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
+    object_store store;
+    collector.collect_pending(store);
+    auto attributes = collector.get_available_attributes_and_reset();
 
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
+    EXPECT_FALSE(collector.has_pending_attributes());
 
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
+    EXPECT_EQ(attributes.size(), 1);
 
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_EQ(obtained->stringValue, expected.stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected.stringValue);*/
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
 
-/*ddwaf_object_free(&attributes);*/
-/*}*/
+TEST(TestAttributeCollector, InsertDuplicate)
+{
+    std::string_view expected = "value";
+    owned_object input{expected};
 
-/*TEST(TestAttributeCollector, InsertCopy)*/
-/*{*/
-/*ddwaf_object expected;*/
-/*ddwaf_object_string(&expected, "value");*/
+    attribute_collector collector;
+    EXPECT_TRUE(collector.insert("address", input.clone()));
+    EXPECT_FALSE(collector.insert("address", std::move(input)));
+
+    object_store store;
+    collector.collect_pending(store);
+    auto attributes = collector.get_available_attributes_and_reset();
 
-/*attribute_collector collector;*/
-/*EXPECT_TRUE(collector.insert("address", expected, true));*/
+    EXPECT_FALSE(collector.has_pending_attributes());
 
-/*object_store store;*/
-/*collector.collect_pending(store);*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
+    EXPECT_EQ(attributes.size(), 1);
 
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
 
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
+TEST(TestAttributeCollector, CollectAvailableScalar)
+{
+    std::string_view expected = "value";
+    auto input = owned_object::make_map({{"input_address", expected}});
 
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected.stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected.stringValue);*/
+    object_store store;
+    store.insert(std::move(input));
 
-/*ddwaf_object_free(&expected);*/
-/*ddwaf_object_free(&attributes);*/
-/*}*/
+    attribute_collector collector;
+    EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
 
-/*TEST(TestAttributeCollector, InsertDuplicate)*/
-/*{*/
-/*ddwaf_object expected;*/
-/*ddwaf_object_string(&expected, "value");*/
+    EXPECT_FALSE(collector.has_pending_attributes());
 
-/*attribute_collector collector;*/
-/*EXPECT_TRUE(collector.insert("address", expected, true));*/
-/*EXPECT_FALSE(collector.insert("address", expected, true));*/
+    EXPECT_EQ(attributes.size(), 1);
 
-/*object_store store;*/
-/*collector.collect_pending(store);*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
 
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
+TEST(TestAttributeCollector, CollectAvailableKeyPathScalar)
+{
+    std::string_view expected = "value";
+    auto input = owned_object::make_map({{"input_address",
+        owned_object::make_map({{"first", owned_object::make_map({{"second", expected}})}})}});
+
+    object_store store;
+    store.insert(std::move(input));
+
+    attribute_collector collector;
+    std::vector<std::string> key_path{"first", "second"};
+    EXPECT_TRUE(
+        collector.collect(store, get_target_index("input_address"), key_path, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectAvailableKeyPathSingleValueArray)
+{
+    std::string_view expected = "value";
+    auto input = owned_object::make_map({{"input_address",
+        owned_object::make_map({{"first",
+            owned_object::make_map({{"second", owned_object::make_array({expected})}})}})}});
+
+    object_store store;
+    store.insert(std::move(input));
+
+    attribute_collector collector;
+    std::vector<std::string> key_path{"first", "second"};
+    EXPECT_TRUE(
+        collector.collect(store, get_target_index("input_address"), key_path, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectAvailableKeyPathMultiValueArray)
+{
+    std::string_view expected = "value0";
+    auto input = owned_object::make_map({{"input_address",
+        owned_object::make_map(
+            {{"first", owned_object::make_map({{"second",
+                           owned_object::make_array({expected, "value1", "value2"})}})}})}});
+
+    object_store store;
+    store.insert(std::move(input));
+
+    attribute_collector collector;
+    std::vector<std::string> key_path{"first", "second"};
+    EXPECT_TRUE(
+        collector.collect(store, get_target_index("input_address"), key_path, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectUnavailableKeyPath)
+{
+    auto input = owned_object::make_map({{"input_address",
+        owned_object::make_map({{"first", owned_object::make_map({{"second",
+                                              owned_object::make_map({{"third", "value"}})}})}})}});
 
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
+    object_store store;
+    store.insert(std::move(input));
+
+    attribute_collector collector;
+    std::vector<std::string> key_path{"first", "second"};
+    EXPECT_FALSE(
+        collector.collect(store, get_target_index("input_address"), key_path, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 0);
+}
+
+TEST(TestAttributeCollector, CollectPendingKeyPathScalar)
+{
+    std::string_view expected = "value";
+    auto input = owned_object::make_map({{"input_address",
+        owned_object::make_map({{"first", owned_object::make_map({{"second", expected}})}})}});
+    object_store store;
+
+    attribute_collector collector;
+    std::vector<std::string> key_path{"first", "second"};
+    EXPECT_TRUE(
+        collector.collect(store, get_target_index("input_address"), key_path, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+    EXPECT_EQ(attributes.size(), 0);
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    store.insert(std::move(input));
+    collector.collect_pending(store);
+    attributes = collector.get_available_attributes_and_reset();
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
 
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected.stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected.stringValue);*/
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
 
-/*ddwaf_object_free(&expected);*/
-/*ddwaf_object_free(&attributes);*/
-/*}*/
+TEST(TestAttributeCollector, CollectAvailableKeyPathInvalidValue)
+{
+    auto input = owned_object::make_map(
+        {{"input_address", owned_object::make_map({{"first",
+                               owned_object::make_map({{"second", owned_object::make_map()}})}})}});
 
-/*TEST(TestAttributeCollector, CollectAvailableScalar)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", ddwaf_object_string(&tmp, "value"));*/
+    object_store store;
+    store.insert(std::move(input));
 
-/*object_store store;*/
-/*store.insert(input_map);*/
+    attribute_collector collector;
+    std::vector<std::string> key_path{"first", "second"};
+    EXPECT_FALSE(
+        collector.collect(store, get_target_index("input_address"), key_path, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
 
-/*attribute_collector collector;*/
-/*EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
+    EXPECT_FALSE(collector.has_pending_attributes());
 
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
+    EXPECT_EQ(attributes.size(), 0);
+}
 
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
+TEST(TestAttributeCollector, CollectDuplicateScalar)
+{
+    std::string_view expected = "value";
+    auto input = owned_object::make_map({{"input_address", expected}});
 
-/*const auto *expected = ddwaf_object_at_value(&input_map, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
+    object_store store;
+    store.insert(std::move(input));
 
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectAvailableKeyPathScalar)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object second_map;*/
-/*ddwaf_object_map(&second_map);*/
-/*ddwaf_object_map_add(&second_map, "second", ddwaf_object_string(&tmp, "value"));*/
-
-/*ddwaf_object first_map;*/
-/*ddwaf_object_map(&first_map);*/
-/*ddwaf_object_map_add(&first_map, "first", &second_map);*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &first_map);*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*std::vector<std::string> key_path{"first", "second"};*/
-/*EXPECT_TRUE(*/
-/*collector.collect(store, get_target_index("input_address"), key_path, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(&second_map, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectAvailableKeyPathSingleValueArray)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object third_array;*/
-/*ddwaf_object_array(&third_array);*/
-/*ddwaf_object_array_add(&third_array, ddwaf_object_string(&tmp, "value"));*/
-
-/*ddwaf_object second_map;*/
-/*ddwaf_object_map(&second_map);*/
-/*ddwaf_object_map_add(&second_map, "second", &third_array);*/
-
-/*ddwaf_object first_map;*/
-/*ddwaf_object_map(&first_map);*/
-/*ddwaf_object_map_add(&first_map, "first", &second_map);*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &first_map);*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*std::vector<std::string> key_path{"first", "second"};*/
-/*EXPECT_TRUE(*/
-/*collector.collect(store, get_target_index("input_address"), key_path, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(&third_array, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectAvailableKeyPathMultiValueArray)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object third_array;*/
-/*ddwaf_object_array(&third_array);*/
-/*ddwaf_object_array_add(&third_array, ddwaf_object_string(&tmp, "value0"));*/
-/*ddwaf_object_array_add(&third_array, ddwaf_object_string(&tmp, "value1"));*/
-/*ddwaf_object_array_add(&third_array, ddwaf_object_string(&tmp, "value2"));*/
-
-/*ddwaf_object second_map;*/
-/*ddwaf_object_map(&second_map);*/
-/*ddwaf_object_map_add(&second_map, "second", &third_array);*/
-
-/*ddwaf_object first_map;*/
-/*ddwaf_object_map(&first_map);*/
-/*ddwaf_object_map_add(&first_map, "first", &second_map);*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &first_map);*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*std::vector<std::string> key_path{"first", "second"};*/
-/*EXPECT_TRUE(*/
-/*collector.collect(store, get_target_index("input_address"), key_path, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(&third_array, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectUnavailableKeyPath)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object second_map;*/
-/*ddwaf_object_map(&second_map);*/
-/*ddwaf_object_map_add(&second_map, "third", ddwaf_object_string(&tmp, "value"));*/
-
-/*ddwaf_object first_map;*/
-/*ddwaf_object_map(&first_map);*/
-/*ddwaf_object_map_add(&first_map, "first", &second_map);*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &first_map);*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*std::vector<std::string> key_path{"first", "second"};*/
-/*EXPECT_FALSE(*/
-/*collector.collect(store, get_target_index("input_address"), key_path, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectPendingKeyPathScalar)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object second_map;*/
-/*ddwaf_object_map(&second_map);*/
-/*ddwaf_object_map_add(&second_map, "second", ddwaf_object_string(&tmp, "value"));*/
-
-/*ddwaf_object first_map;*/
-/*ddwaf_object_map(&first_map);*/
-/*ddwaf_object_map_add(&first_map, "first", &second_map);*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &first_map);*/
-
-/*object_store store;*/
-
-/*attribute_collector collector;*/
-/*std::vector<std::string> key_path{"first", "second"};*/
-/*EXPECT_TRUE(*/
-/*collector.collect(store, get_target_index("input_address"), key_path, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*store.insert(input_map);*/
-/*collector.collect_pending(store);*/
-/*attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*const auto *expected = ddwaf_object_at_value(&second_map, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectAvailableKeyPathInvalidValue)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object second_map;*/
-/*ddwaf_object_map(&second_map);*/
-/*ddwaf_object_map_add(&second_map, "second", ddwaf_object_map(&tmp));*/
-
-/*ddwaf_object first_map;*/
-/*ddwaf_object_map(&first_map);*/
-/*ddwaf_object_map_add(&first_map, "first", &second_map);*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &first_map);*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*std::vector<std::string> key_path{"first", "second"};*/
-/*EXPECT_FALSE(*/
-/*collector.collect(store, get_target_index("input_address"), key_path, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectDuplicateScalar)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", ddwaf_object_string(&tmp, "value"));*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*EXPECT_FALSE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(&input_map, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectAvailableScalarFromSingleValueArray)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object intermediate_array;*/
-/*ddwaf_object_array(&intermediate_array);*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_string(&tmp, "value"));*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &intermediate_array);*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(ddwaf_object_at_value(&input_map, 0), 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectAvailableScalarFromMultiValueArray)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object intermediate_array;*/
-/*ddwaf_object_array(&intermediate_array);*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_string(&tmp, "value0"));*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_string(&tmp, "value1"));*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_string(&tmp, "value2"));*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &intermediate_array);*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(ddwaf_object_at_value(&input_map, 0), 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectInvalidObjectFromArray)*/
-/*{*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object intermediate_array;*/
-/*ddwaf_object_array(&intermediate_array);*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_map(&tmp));*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &intermediate_array);*/
-
-/*object_store store;*/
-/*store.insert(input_map);*/
-
-/*attribute_collector collector;*/
-/*EXPECT_FALSE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectUnavailableScalar)*/
-/*{*/
-/*object_store store;*/
-/*attribute_collector collector;*/
-
-/*// The attribute should be in the pending queue*/
-/*EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*collector.collect_pending(store);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-
-/*// After adding the attribute, collect_pending should extract, copy and return*/
-/*// the expected attribute*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", ddwaf_object_string(&tmp, "value"));*/
-
-/*store.insert(input_map);*/
-/*collector.collect_pending(store);*/
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(&input_map, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectUnavailableScalarFromSingleValueArray)*/
-/*{*/
-/*object_store store;*/
-/*attribute_collector collector;*/
-
-/*// The attribute should be in the pending queue*/
-/*EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*collector.collect_pending(store);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-
-/*// After adding the attribute, collect_pending should extract, copy and return*/
-/*// the expected attribute*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object intermediate_array;*/
-/*ddwaf_object_array(&intermediate_array);*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_string(&tmp, "value"));*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &intermediate_array);*/
-
-/*store.insert(input_map);*/
-/*collector.collect_pending(store);*/
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(ddwaf_object_at_value(&input_map, 0), 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectUnavailableScalarFromMultiValueArray)*/
-/*{*/
-/*object_store store;*/
-/*attribute_collector collector;*/
-
-/*// The attribute should be in the pending queue*/
-/*EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*collector.collect_pending(store);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-
-/*// After adding the attribute, collect_pending should extract, copy and return*/
-/*// the expected attribute*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object intermediate_array;*/
-/*ddwaf_object_array(&intermediate_array);*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_string(&tmp, "value0"));*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_string(&tmp, "value1"));*/
-/*ddwaf_object_array_add(&intermediate_array, ddwaf_object_string(&tmp, "value2"));*/
-
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", &intermediate_array);*/
-
-/*store.insert(input_map);*/
-/*collector.collect_pending(store);*/
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(ddwaf_object_at_value(&input_map, 0), 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectUnavailableInvalidObject)*/
-/*{*/
-/*object_store store;*/
-/*attribute_collector collector;*/
-
-/*// The attribute should be in the pending queue*/
-/*EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*collector.collect_pending(store);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-
-/*// After adding the attribute, collect_pending should extract, copy and return*/
-/*// the expected attribute*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address", ddwaf_object_array(&tmp));*/
-
-/*store.insert(input_map);*/
-/*collector.collect_pending(store);*/
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*TEST(TestAttributeCollector, CollectMultipleUnavailableScalars)*/
-/*{*/
-/*object_store store;*/
-/*attribute_collector collector;*/
-
-/*{*/
-/*// The attribute should be in the pending queue*/
-/*EXPECT_TRUE(*/
-/*collector.collect(store, get_target_index("input_address_0"), {}, "output_address_0"));*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*// Nothing to be collected*/
-/*collector.collect_pending(store);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-/*}*/
-
-/*{*/
-/*// The attribute should be in the pending queue*/
-/*EXPECT_TRUE(*/
-/*collector.collect(store, get_target_index("input_address_1"), {}, "output_address_1"));*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*// Nothing to be collected*/
-/*collector.collect_pending(store);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 0);*/
-/*}*/
-
-/*{*/
-/*// After adding the attribute, collect_pending should extract, copy and return*/
-/*// the expected attribute*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address_0", ddwaf_object_string(&tmp, "value"));*/
-
-/*store.insert(input_map);*/
-
-/*EXPECT_TRUE(*/
-/*collector.collect(store, get_target_index("input_address_2"), {}, "output_address_2"));*/
-
-/*collector.collect_pending(store);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(&input_map, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*{*/
-/*// After adding the attribute, collect_pending should extract, copy and return*/
-/*// the expected attribute*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address_2", ddwaf_object_string(&tmp, "value"));*/
-
-/*store.insert(input_map);*/
-
-/*collector.collect_pending(store);*/
-/*EXPECT_TRUE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(&input_map, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-
-/*{*/
-/*// After adding the attribute, collect_pending should extract, copy and return*/
-/*// the expected attribute*/
-/*ddwaf_object tmp;*/
-/*ddwaf_object input_map;*/
-/*ddwaf_object_map(&input_map);*/
-/*ddwaf_object_map_add(&input_map, "input_address_1", ddwaf_object_string(&tmp, "value"));*/
-
-/*store.insert(input_map);*/
-
-/*collector.collect_pending(store);*/
-/*EXPECT_FALSE(collector.has_pending_attributes());*/
-
-/*auto attributes = collector.get_available_attributes_and_reset();*/
-/*EXPECT_EQ(ddwaf_object_size(&attributes), 1);*/
-
-/*const auto *expected = ddwaf_object_at_value(&input_map, 0);*/
-/*const auto *obtained = ddwaf_object_at_value(&attributes, 0);*/
-/*EXPECT_EQ(ddwaf_object_type(obtained), DDWAF_OBJ_STRING);*/
-/*EXPECT_NE(obtained->stringValue, expected->stringValue);*/
-/*EXPECT_STREQ(obtained->stringValue, expected->stringValue);*/
-
-/*ddwaf_object_free(&attributes);*/
-/*}*/
-/*}*/
+    attribute_collector collector;
+    EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    EXPECT_FALSE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectAvailableScalarFromSingleValueArray)
+{
+    std::string_view expected = "value";
+    auto input = owned_object::make_map({{"input_address", owned_object::make_array({expected})}});
+
+    object_store store;
+    store.insert(std::move(input));
+
+    attribute_collector collector;
+    EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectAvailableScalarFromMultiValueArray)
+{
+    std::string_view expected = "value0";
+    auto input = owned_object::make_map(
+        {{"input_address", owned_object::make_array({expected, "value1", "value2"})}});
+
+    object_store store;
+    store.insert(std::move(input));
+
+    attribute_collector collector;
+    EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectInvalidObjectFromArray)
+{
+    auto input = owned_object::make_map(
+        {{"input_address", owned_object::make_array({owned_object::make_map()})}});
+
+    object_store store;
+    store.insert(std::move(input));
+
+    attribute_collector collector;
+    EXPECT_FALSE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    auto attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 0);
+}
+
+TEST(TestAttributeCollector, CollectUnavailableScalar)
+{
+    object_store store;
+    attribute_collector collector;
+
+    // The attribute should be in the pending queue
+    EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    collector.collect_pending(store);
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    auto attributes = collector.get_available_attributes_and_reset();
+    EXPECT_EQ(attributes.size(), 0);
+
+    // After adding the attribute, collect_pending should extract, copy and return
+    // the expected attribute
+    std::string_view expected = "value";
+    auto input = owned_object::make_map({{"input_address", expected}});
+
+    store.insert(std::move(input));
+    collector.collect_pending(store);
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectUnavailableScalarFromSingleValueArray)
+{
+    object_store store;
+    attribute_collector collector;
+
+    // The attribute should be in the pending queue
+    EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    collector.collect_pending(store);
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    auto attributes = collector.get_available_attributes_and_reset();
+    EXPECT_EQ(attributes.size(), 0);
+
+    // After adding the attribute, collect_pending should extract, copy and return
+    // the expected attribute
+    std::string_view expected = "value";
+    auto input = owned_object::make_map({{"input_address", owned_object::make_array({expected})}});
+
+    store.insert(std::move(input));
+    collector.collect_pending(store);
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectUnavailableScalarFromMultiValueArray)
+{
+    object_store store;
+    attribute_collector collector;
+
+    // The attribute should be in the pending queue
+    EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    collector.collect_pending(store);
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    auto attributes = collector.get_available_attributes_and_reset();
+    EXPECT_EQ(attributes.size(), 0);
+
+    // After adding the attribute, collect_pending should extract, copy and return
+    // the expected attribute
+    std::string_view expected = "value0";
+    auto input = owned_object::make_map(
+        {{"input_address", owned_object::make_array({expected, "value1", "value2"})}});
+
+    store.insert(std::move(input));
+    collector.collect_pending(store);
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    attributes = collector.get_available_attributes_and_reset();
+
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    EXPECT_EQ(attributes.size(), 1);
+
+    const auto obtained = attributes.at(0);
+    EXPECT_TRUE(obtained.is_string());
+    EXPECT_STRV(obtained.as<std::string_view>(), expected);
+}
+
+TEST(TestAttributeCollector, CollectUnavailableInvalidObject)
+{
+    object_store store;
+    attribute_collector collector;
+
+    // The attribute should be in the pending queue
+    EXPECT_TRUE(collector.collect(store, get_target_index("input_address"), {}, "output_address"));
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    collector.collect_pending(store);
+    EXPECT_TRUE(collector.has_pending_attributes());
+
+    auto attributes = collector.get_available_attributes_and_reset();
+    EXPECT_EQ(attributes.size(), 0);
+
+    // After adding the attribute, collect_pending should extract, copy and return
+    // the expected attribute
+    auto input = owned_object::make_map({{"input_address", owned_object::make_array()}});
+
+    store.insert(std::move(input));
+    collector.collect_pending(store);
+    EXPECT_FALSE(collector.has_pending_attributes());
+
+    attributes = collector.get_available_attributes_and_reset();
+    EXPECT_EQ(attributes.size(), 0);
+}
+
+TEST(TestAttributeCollector, CollectMultipleUnavailableScalars)
+{
+    object_store store;
+    attribute_collector collector;
+
+    {
+        // The attribute should be in the pending queue
+        EXPECT_TRUE(
+            collector.collect(store, get_target_index("input_address_0"), {}, "output_address_0"));
+        EXPECT_TRUE(collector.has_pending_attributes());
+
+        // Nothing to be collected
+        collector.collect_pending(store);
+        EXPECT_TRUE(collector.has_pending_attributes());
+
+        auto attributes = collector.get_available_attributes_and_reset();
+        EXPECT_EQ(attributes.size(), 0);
+    }
+
+    {
+        // The attribute should be in the pending queue
+        EXPECT_TRUE(
+            collector.collect(store, get_target_index("input_address_1"), {}, "output_address_1"));
+        EXPECT_TRUE(collector.has_pending_attributes());
+
+        // Nothing to be collected
+        collector.collect_pending(store);
+        EXPECT_TRUE(collector.has_pending_attributes());
+
+        auto attributes = collector.get_available_attributes_and_reset();
+        EXPECT_EQ(attributes.size(), 0);
+    }
+
+    {
+        // After adding the attribute, collect_pending should extract, copy and return
+        // the expected attribute
+        std::string_view expected = "value";
+        auto input = owned_object::make_map({{"input_address_0", expected}});
+
+        store.insert(std::move(input));
+
+        EXPECT_TRUE(
+            collector.collect(store, get_target_index("input_address_2"), {}, "output_address_2"));
+
+        collector.collect_pending(store);
+        EXPECT_TRUE(collector.has_pending_attributes());
+
+        auto attributes = collector.get_available_attributes_and_reset();
+        EXPECT_EQ(attributes.size(), 1);
+
+        const auto obtained = attributes.at(0);
+        EXPECT_TRUE(obtained.is_string());
+        EXPECT_STRV(obtained.as<std::string_view>(), expected);
+    }
+
+    {
+        // After adding the attribute, collect_pending should extract, copy and return
+        // the expected attribute
+
+        std::string_view expected = "value";
+        auto input = owned_object::make_map({{"input_address_2", expected}});
+        store.insert(std::move(input));
+
+        collector.collect_pending(store);
+        EXPECT_TRUE(collector.has_pending_attributes());
+
+        auto attributes = collector.get_available_attributes_and_reset();
+        EXPECT_EQ(attributes.size(), 1);
+
+        const auto obtained = attributes.at(0);
+        EXPECT_TRUE(obtained.is_string());
+        EXPECT_STRV(obtained.as<std::string_view>(), expected);
+    }
+
+    {
+        // After adding the attribute, collect_pending should extract, copy and return
+        // the expected attribute
+
+        std::string_view expected = "value";
+        auto input = owned_object::make_map({{"input_address_1", expected}});
+
+        store.insert(std::move(input));
+
+        collector.collect_pending(store);
+        EXPECT_FALSE(collector.has_pending_attributes());
+
+        auto attributes = collector.get_available_attributes_and_reset();
+        EXPECT_EQ(attributes.size(), 1);
+
+        const auto obtained = attributes.at(0);
+        EXPECT_TRUE(obtained.is_string());
+        EXPECT_STRV(obtained.as<std::string_view>(), expected);
+    }
+}
 
 } // namespace


### PR DESCRIPTION
This PR just updates the attribute collector test which was missing from a previous merge.