### PR TITLE
[v2] Use allocators internally instead of malloc/free and stop generating zero-terminated strings

### DIFF
--- a/BINDING_IMPL_NOTES.md
+++ b/BINDING_IMPL_NOTES.md
@@ -127,11 +127,11 @@ ddwaf_context create_context() {
 On the other hand, `ddwaf_context` is not thread-safe. If a `ddwaf_context` is
 used by multiple threads (in web servers where the processing of the request
 can move between several threads, or happen in several threads simultaneously),
-you need to use locks so that calls to `ddwaf_run/destroy` are not run
+you need to use locks so that calls to `ddwaf_context_eval/destroy` are not run
 concurrently, and that changes made to the `ddwaf_context` in one thread through
-`ddwaf_run/destroy` are visible to the other threads subsequently run
-`ddwaf_run/destroy` on the same context. You also need to ensure that no calls
-to `ddwaf_run/destroy` happen after `ddwaf_destroy` is called.
+`ddwaf_context_eval/destroy` are visible to the other threads subsequently run
+`ddwaf_context_eval/destroy` on the same context. You also need to ensure that no calls
+to `ddwaf_context_eval/destroy` happen after `ddwaf_destroy` is called.
 
 ```c++
 // each request will have one of these associated with it
@@ -145,7 +145,7 @@ DDWAF_RET_CODE run_waf(
 {
     std::lock_guard<std::mutex> lock{wrapper.mutex}; // acquire exclusive lock
     if (wrapper.ctx == nullptr) { /* context already destroyed */ }
-    return ddwaf_run(wrapper.ctx, data, result, timeout);
+    return ddwaf_context_eval(wrapper.ctx, data, result, timeout);
     // lock is released on return
 }
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ int main()
     ddwaf_object_map_add(&root, "arg2", ddwaf_object_string(&tmp, "string 2"));
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &root, nullptr, &ret, 1000000 /* microseconds */);
+    auto code = ddwaf_context_eval(context, &root, nullptr, &ret, 1000000 /* microseconds */);
     std::cout << "Output second run: " << code << '\n';
     if (code == DDWAF_MATCH) {
         YAML::Emitter out(std::cout);

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
             auto name = spec["scenario"].as<std::string>();
             auto ruleset = spec["ruleset"].as<ddwaf_object>();
 
-            ddwaf_config config{{}, nullptr};
+            ddwaf_config config{{}};
             ddwaf_handle handle = ddwaf_init(&ruleset, &config, nullptr);
             ddwaf_object_free(&ruleset);
             if (handle == nullptr) {

--- a/benchmark/run_fixture.cpp
+++ b/benchmark/run_fixture.cpp
@@ -54,7 +54,7 @@ uint64_t run_fixture::test_main()
 
     for (auto &object : objects_) {
         ddwaf_object res{};
-        auto code = ddwaf_run(ctx_, nullptr, &object, &res, std::numeric_limits<uint32_t>::max());
+        auto code = ddwaf_run(ctx_, nullptr, &object, false, &res, std::numeric_limits<uint32_t>::max());
         if (code < 0) {
             throw std::runtime_error("WAF returned " + std::to_string(code));
         }

--- a/benchmark/run_fixture.cpp
+++ b/benchmark/run_fixture.cpp
@@ -54,7 +54,8 @@ uint64_t run_fixture::test_main()
 
     for (auto &object : objects_) {
         ddwaf_object res{};
-        auto code = ddwaf_run(ctx_, nullptr, &object, false, &res, std::numeric_limits<uint32_t>::max());
+        auto code =
+            ddwaf_run(ctx_, nullptr, &object, false, &res, std::numeric_limits<uint32_t>::max());
         if (code < 0) {
             throw std::runtime_error("WAF returned " + std::to_string(code));
         }

--- a/benchmark/run_fixture.cpp
+++ b/benchmark/run_fixture.cpp
@@ -54,8 +54,8 @@ uint64_t run_fixture::test_main()
 
     for (auto &object : objects_) {
         ddwaf_object res{};
-        auto code =
-            ddwaf_run(ctx_, nullptr, &object, false, &res, std::numeric_limits<uint32_t>::max());
+        auto code = ddwaf_context_eval(
+            ctx_, nullptr, &object, false, &res, std::numeric_limits<uint32_t>::max());
         if (code < 0) {
             throw std::runtime_error("WAF returned " + std::to_string(code));
         }

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -197,7 +197,7 @@ int main()
     ddwaf_object_map_add(&root, "arg2", ddwaf_object_string(&tmp, "string 2"));
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &root, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &root, nullptr, &ret, LONG_TIME);
     std::cout << "Output second run: " << code << '\n';
     if (code == DDWAF_MATCH) {
         YAML::Emitter out(std::cout);

--- a/fuzzer/global/src/interface.cpp
+++ b/fuzzer/global/src/interface.cpp
@@ -92,8 +92,7 @@ ddwaf_handle init_waf()
     ddwaf_config config{
         {.key_regex =
                 R"((p(ass)?w(or)?d|pass(_?phrase)?|secret|(api_?|private_?|public_?)key)|token|consumer_?(id|key|secret)|sign(ed|ature)|bearer|authorization)",
-            .value_regex = R"(^(?:\d[ -]*?){13,16}$)"},
-        ddwaf_object_free};
+            .value_regex = R"(^(?:\d[ -]*?){13,16}$)"}};
     ddwaf_object rule = file_to_object("sample_rules.yml");
     ddwaf_object ruleset_info;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &ruleset_info);

--- a/fuzzer/global/src/interface.cpp
+++ b/fuzzer/global/src/interface.cpp
@@ -111,12 +111,12 @@ void run_waf(ddwaf_handle handle, ddwaf_object args, bool ephemeral, size_t time
 
     ddwaf_object res;
     if (ephemeral) {
-        ddwaf_run(context, nullptr, &args, true, &res, timeLeftInUs);
+        ddwaf_context_eval(context, nullptr, &args, true, &res, timeLeftInUs);
     } else {
-        ddwaf_run(context, &args, nullptr, true, &res, timeLeftInUs);
+        ddwaf_context_eval(context, &args, nullptr, true, &res, timeLeftInUs);
     }
 
-    // TODO split input in several ddwaf_object, and call ddwaf_run on the same context
+    // TODO split input in several ddwaf_object, and call ddwaf_context_eval on the same context
 
     ddwaf_object_free(&res);
     ddwaf_context_destroy(context);

--- a/fuzzer/global/src/interface.cpp
+++ b/fuzzer/global/src/interface.cpp
@@ -111,9 +111,9 @@ void run_waf(ddwaf_handle handle, ddwaf_object args, bool ephemeral, size_t time
 
     ddwaf_object res;
     if (ephemeral) {
-        ddwaf_run(context, nullptr, &args, &res, timeLeftInUs);
+        ddwaf_run(context, nullptr, &args, true, &res, timeLeftInUs);
     } else {
-        ddwaf_run(context, &args, nullptr, &res, timeLeftInUs);
+        ddwaf_run(context, &args, nullptr, true, &res, timeLeftInUs);
     }
 
     // TODO split input in several ddwaf_object, and call ddwaf_run on the same context

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -833,6 +833,11 @@ const ddwaf_object* ddwaf_object_at_value(const ddwaf_object *object, size_t ind
 const ddwaf_object* ddwaf_object_find(const ddwaf_object *object, const char *key, size_t length);
 
 /**
+ * ddwaf_object_clone
+ **/
+ddwaf_object* ddwaf_object_clone(const ddwaf_object *source, ddwaf_object *destination);
+
+/**
  * ddwaf_object_free
  *
  * @param object Object to free. (nonnull)

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -180,13 +180,6 @@ static_assert(sizeof(struct _ddwaf_object_kv) == 32);
 #endif
 
 /**
- * @typedef ddwaf_object_free_fn
- *
- * Type of the function to free ddwaf::objects.
- **/
-typedef void (*ddwaf_object_free_fn)(ddwaf_object *object);
-
-/**
  * @struct ddwaf_config
  *
  * Configuration to be provided to the WAF
@@ -200,11 +193,6 @@ struct _ddwaf_config
         /** Regular expression for value-based obfuscation */
         const char *value_regex;
     } obfuscator;
-
-    /** Function to free the ddwaf::object provided to the context during calls
-     *  to ddwaf_run. If the value of this function is NULL, the objects will
-     *  not be freed. The default value should be ddwaf_object_free. */
-    ddwaf_object_free_fn free_fn;
 };
 
 /**
@@ -396,8 +384,7 @@ void ddwaf_context_destroy(ddwaf_context context);
  *
  * @return Handle to the builer instance or NULL on error.
  *
- * @note If config is NULL, default values will be used, including the default
- *       free function (ddwaf_object_free).
+ * @note If config is NULL, default values will be used
  **/
 ddwaf_builder ddwaf_builder_init(const ddwaf_config *config);
 

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -58,7 +58,7 @@ typedef enum
 /**
  * @enum DDWAF_RET_CODE
  *
- * Codes returned by ddwaf_run.
+ * Codes returned by ddwaf_context_eval.
  **/
 typedef enum
 {
@@ -291,7 +291,7 @@ const char *const *ddwaf_known_actions(const ddwaf_handle handle, uint32_t *size
 ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
 
 /**
- * ddwaf_run
+ * ddwaf_context_eval
  *
  * Perform a matching operation on the provided data
  *
@@ -311,7 +311,7 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
  * @param ephemeral_data Data on which to perform the pattern matching. This
  *    data will not be cached by the WAF. Matches arising from this data will
  *    also not be cached at any level. The data will be freed at the end of the
- *    call to ddwaf_run. The object must be a map of {string, <value>} in which
+ *    call to ddwaf_context_eval. The object must be a map of {string, <value>} in which
  *    each key represents the relevant address associated to the value, which
  *    can be of an arbitrary type. This parameter can be null if persistent data
  *    is provided.
@@ -328,7 +328,7 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
  *               - keep: whether the data contained herein must override any
  *                       transport sampling through the relevant mechanism.
  *               This structure must be freed by the caller and will contain all
- *               specified keys when the value returned by ddwaf_run is either
+ *               specified keys when the value returned by ddwaf_context_eval is either
  *               DDWAF_OK or DDWAF_MATCH and will be empty otherwise.
  * @param timeout Maximum time budget in microseconds.
  *
@@ -362,14 +362,14 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
  *  batch by a persistent address, however taking advantage of this is not
  *  recommended and might be explicitly rejected in the future.
  **/
-DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
+DDWAF_RET_CODE ddwaf_context_eval(ddwaf_context context, ddwaf_object *persistent_data,
     ddwaf_object *ephemeral_data, bool free_objects, ddwaf_object *result,  uint64_t timeout);
 
 /**
  * ddwaf_context_destroy
  *
  * Performs the destruction of the context, freeing the data passed to it through
- * ddwaf_run using the used-defined free function.
+ * ddwaf_context_eval using the used-defined free function.
  *
  * @param context Context to destroy. (nonnull)
  **/

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -363,7 +363,7 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
  *  recommended and might be explicitly rejected in the future.
  **/
 DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
-    ddwaf_object *ephemeral_data, ddwaf_object *result,  uint64_t timeout);
+    ddwaf_object *ephemeral_data, bool free_objects, ddwaf_object *result,  uint64_t timeout);
 
 /**
  * ddwaf_context_destroy

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -9,7 +9,7 @@ EXPORTS
   ddwaf_builder_destroy
   ddwaf_known_addresses
   ddwaf_context_init
-  ddwaf_run
+  ddwaf_context_eval
   ddwaf_context_destroy
   ddwaf_object_invalid
   ddwaf_object_null

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -43,3 +43,4 @@ EXPORTS
   ddwaf_set_log_cb
   ddwaf_known_actions
   ddwaf_object_find
+  ddwaf_object_clone

--- a/smoketest/smoke.c
+++ b/smoketest/smoke.c
@@ -256,7 +256,7 @@ int main() {
     ddwaf_object_map_add(&data, "key", DDSTR("Arachni"));
 
     ddwaf_object result = {0};
-    ddwaf_run(ctx, &data, NULL, &result, (uint32_t)-1);
+    ddwaf_run(ctx, &data, NULL, true, &result, (uint32_t)-1);
     
 
     const ddwaf_object *events = ddwaf_object_find(&result, "events", sizeof("events") - 1);

--- a/smoketest/smoke.c
+++ b/smoketest/smoke.c
@@ -256,7 +256,7 @@ int main() {
     ddwaf_object_map_add(&data, "key", DDSTR("Arachni"));
 
     ddwaf_object result = {0};
-    ddwaf_run(ctx, &data, NULL, true, &result, (uint32_t)-1);
+    ddwaf_context_eval(ctx, &data, NULL, true, &result, (uint32_t)-1);
     
 
     const ddwaf_object *events = ddwaf_object_find(&result, "events", sizeof("events") - 1);

--- a/src/builder/ruleset_builder.cpp
+++ b/src/builder/ruleset_builder.cpp
@@ -256,7 +256,6 @@ std::shared_ptr<ruleset> ruleset_builder::build(
     rs->exclusion_matchers = exclusion_matchers_;
     rs->scanners = scanners_;
     rs->actions = actions_;
-    rs->free_fn = free_fn_;
     rs->obfuscator = obfuscator_;
 
     // An instance is valid if it contains primitives with side-effects, such as

--- a/src/builder/ruleset_builder.hpp
+++ b/src/builder/ruleset_builder.hpp
@@ -18,9 +18,9 @@ namespace ddwaf {
 
 class ruleset_builder {
 public:
-    explicit ruleset_builder(ddwaf_object_free_fn free_fn = ddwaf_object_free,
+    explicit ruleset_builder(
         std::shared_ptr<match_obfuscator> obfuscator = std::make_shared<match_obfuscator>())
-        : free_fn_(free_fn), obfuscator_(std::move(obfuscator))
+        : obfuscator_(std::move(obfuscator))
     {}
 
     ~ruleset_builder() = default;
@@ -35,7 +35,6 @@ public:
 protected:
     // These members are obtained through ddwaf_config and are persistent across
     // all updates.
-    ddwaf_object_free_fn free_fn_;
     std::shared_ptr<match_obfuscator> obfuscator_;
 
     // These contain the specification of each main component obtained directly

--- a/src/builder/waf_builder.hpp
+++ b/src/builder/waf_builder.hpp
@@ -17,9 +17,7 @@ namespace ddwaf {
 
 class waf_builder {
 public:
-    waf_builder(ddwaf_object_free_fn free_fn, std::shared_ptr<match_obfuscator> obfuscator)
-        : rbuilder_(free_fn, std::move(obfuscator))
-    {}
+    waf_builder(std::shared_ptr<match_obfuscator> obfuscator) : rbuilder_(std::move(obfuscator)) {}
 
     ~waf_builder() = default;
     waf_builder(waf_builder &&) = delete;

--- a/src/condition/scalar_condition.cpp
+++ b/src/condition/scalar_condition.cpp
@@ -41,12 +41,10 @@ ResultType eval_object(Iterator &it, std::string_view address, bool ephemeral,
     const object_view src = *it;
     if (src.is_string()) {
         if (!transformers.empty()) {
-            owned_object dst{};
-
             auto transformed = transformer::manager::transform(src, transformers);
             if (transformed) {
-                auto [res, highlight] =
-                    matcher.match(static_cast<std::string_view>(transformed.value()));
+                auto transformed_sv = static_cast<std::string_view>(transformed.value());
+                auto [res, highlight] = matcher.match(transformed_sv);
                 if (!res) {
                     return {};
                 }
@@ -56,10 +54,8 @@ ResultType eval_object(Iterator &it, std::string_view address, bool ephemeral,
                 if constexpr (std::is_same_v<ResultType, bool>) {
                     return true;
                 } else {
-                    return {
-                        {{{"input"sv, dst.convert<std::string>(), address, it.get_current_path()}},
-                            {std::move(highlight)}, matcher.name(), matcher.to_string(),
-                            ephemeral}};
+                    return {{{{"input"sv, transformed_sv, address, it.get_current_path()}},
+                        {std::move(highlight)}, matcher.name(), matcher.to_string(), ephemeral}};
                 }
             }
         }

--- a/src/condition/scalar_condition.cpp
+++ b/src/condition/scalar_condition.cpp
@@ -43,9 +43,10 @@ ResultType eval_object(Iterator &it, std::string_view address, bool ephemeral,
         if (!transformers.empty()) {
             owned_object dst{};
 
-            auto transformed = transformer::manager::transform(src, dst, transformers);
+            auto transformed = transformer::manager::transform(src, transformers);
             if (transformed) {
-                auto [res, highlight] = matcher.match(dst);
+                auto [res, highlight] =
+                    matcher.match(static_cast<std::string_view>(transformed.value()));
                 if (!res) {
                     return {};
                 }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -50,8 +50,7 @@ void set_context_event_address(object_store &store)
 
 } // namespace
 
-// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-std::pair<bool, owned_object> context::run(uint64_t timeout)
+std::pair<bool, owned_object> context::eval(uint64_t timeout)
 {
     // This scope ensures that all ephemeral and cached objects are removed
     // from the store at the end of the evaluation

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -58,6 +58,15 @@ public:
         return true;
     }
 
+    bool insert(map_view data, attribute attr = attribute::none) noexcept
+    {
+        if (!store_.insert(data, attr)) {
+            DDWAF_WARN("Illegal WAF call: parameter structure invalid!");
+            return false;
+        }
+        return true;
+    }
+
     std::pair<bool, owned_object> run(uint64_t);
 
     void eval_preprocessors(ddwaf::timer &deadline);
@@ -151,6 +160,12 @@ public:
     {
         memory::memory_resource_guard guard(&mr_);
         return ctx_->insert(std::forward<owned_object>(data), attr);
+    }
+
+    bool insert(map_view data, context::attribute attr = context::attribute::none) noexcept
+    {
+        memory::memory_resource_guard guard(&mr_);
+        return ctx_->insert(data, attr);
     }
 
     std::pair<bool, owned_object> run(uint64_t timeout)

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -15,6 +15,7 @@
 #include "exclusion/common.hpp"
 #include "exclusion/input_filter.hpp"
 #include "exclusion/rule_filter.hpp"
+#include "memory_resource.hpp"
 #include "obfuscator.hpp"
 #include "ruleset.hpp"
 
@@ -60,8 +61,6 @@ public:
 
     std::pair<bool, owned_object> run(uint64_t);
 
-    [[nodiscard]] ddwaf_object_free_fn get_free_fn() const noexcept { return ruleset_->free_fn; }
-
     void eval_preprocessors(ddwaf::timer &deadline);
     void eval_postprocessors(ddwaf::timer &deadline);
     // This function below returns a reference to an internal object,
@@ -92,6 +91,8 @@ protected:
         }
         return false;
     }
+
+    memory::memory_resource *alloc{memory::get_default_resource()};
 
     std::shared_ptr<ruleset> ruleset_;
     ddwaf::object_store store_;
@@ -159,11 +160,9 @@ public:
         return ctx_->run(timeout);
     }
 
-    [[nodiscard]] ddwaf_object_free_fn get_free_fn() const noexcept { return ctx_->get_free_fn(); }
-
 protected:
     context *ctx_;
-    std::pmr::monotonic_buffer_resource mr_;
+    memory::monotonic_buffer_resource mr_;
 };
 
 } // namespace ddwaf

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -11,7 +11,6 @@
 
 #include "attribute_collector.hpp"
 #include "context_allocator.hpp"
-#include "ddwaf.h"
 #include "exclusion/common.hpp"
 #include "exclusion/input_filter.hpp"
 #include "exclusion/rule_filter.hpp"

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -67,7 +67,7 @@ public:
         return true;
     }
 
-    std::pair<bool, owned_object> run(uint64_t);
+    std::pair<bool, owned_object> eval(uint64_t);
 
     void eval_preprocessors(ddwaf::timer &deadline);
     void eval_postprocessors(ddwaf::timer &deadline);
@@ -168,10 +168,10 @@ public:
         return ctx_->insert(data, attr);
     }
 
-    std::pair<bool, owned_object> run(uint64_t timeout)
+    std::pair<bool, owned_object> eval(uint64_t timeout)
     {
         memory::memory_resource_guard guard(&mr_);
-        return ctx_->run(timeout);
+        return ctx_->eval(timeout);
     }
 
 protected:

--- a/src/context_allocator.hpp
+++ b/src/context_allocator.hpp
@@ -15,15 +15,15 @@
 #include "memory_resource.hpp"
 
 namespace ddwaf::memory {
-extern thread_local std::pmr::memory_resource *local_memory_resource;
+extern thread_local memory_resource *local_memory_resource;
 
-inline std::pmr::memory_resource *get_local_memory_resource() { return local_memory_resource; }
+inline memory_resource *get_local_memory_resource() { return local_memory_resource; }
 
-inline void set_local_memory_resource(std::pmr::memory_resource *mr) { local_memory_resource = mr; }
+inline void set_local_memory_resource(memory_resource *mr) { local_memory_resource = mr; }
 
 // The null memory resource is used as the default onef or the static thread
 // local memory resource. Only exposed for testing purposes.
-class null_memory_resource final : public std::pmr::memory_resource {
+class null_memory_resource final : public memory_resource {
     void *do_allocate(size_t /*bytes*/, size_t /*alignment*/) override { throw std::bad_alloc(); }
     void do_deallocate(void * /*p*/, size_t /*bytes*/, size_t /*alignment*/) noexcept override {}
     [[nodiscard]] bool do_is_equal(const memory_resource &other) const noexcept override
@@ -37,7 +37,7 @@ class null_memory_resource final : public std::pmr::memory_resource {
 // destruction.
 class memory_resource_guard {
 public:
-    explicit memory_resource_guard(std::pmr::memory_resource *mr) noexcept
+    explicit memory_resource_guard(memory_resource *mr) noexcept
         : old_mr_(get_local_memory_resource())
     {
         if (mr != nullptr) {
@@ -53,7 +53,7 @@ public:
     memory_resource_guard &operator=(memory_resource_guard &&) = delete;
 
 protected:
-    std::pmr::memory_resource *old_mr_;
+    memory_resource *old_mr_;
 };
 
 // The context allocator uses the static thread local memory resource to

--- a/src/cow_string.hpp
+++ b/src/cow_string.hpp
@@ -8,7 +8,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <ddwaf.h>
 #include <stdexcept>
 #include <string_view>
 

--- a/src/cow_string.hpp
+++ b/src/cow_string.hpp
@@ -12,7 +12,7 @@
 #include <stdexcept>
 #include <string_view>
 
-#include "memory_resource"
+#include "memory_resource.hpp"
 
 namespace ddwaf {
 

--- a/src/cow_string.hpp
+++ b/src/cow_string.hpp
@@ -73,6 +73,7 @@ public:
 
     constexpr explicit operator std::string_view() { return {buffer_, length_}; }
 
+    [[nodiscard]] std::pmr::memory_resource *alloc() { return alloc_; }
     [[nodiscard]] constexpr std::size_t length() const { return length_; }
     [[nodiscard]] constexpr const char *data() const { return buffer_; }
     [[nodiscard]] char *modifiable_data()
@@ -119,6 +120,7 @@ public:
         modified_ = false;
         buffer_ = nullptr;
         length_ = 0;
+        capacity_ = 0;
         return res;
     }
 

--- a/src/cow_string.hpp
+++ b/src/cow_string.hpp
@@ -72,7 +72,7 @@ public:
 
     constexpr explicit operator std::string_view() { return {buffer_, length_}; }
 
-    [[nodiscard]] std::pmr::memory_resource *alloc() { return alloc_; }
+    [[nodiscard]] memory::memory_resource *alloc() { return alloc_; }
     [[nodiscard]] constexpr std::size_t length() const { return length_; }
     [[nodiscard]] constexpr const char *data() const { return buffer_; }
     [[nodiscard]] char *modifiable_data()
@@ -156,7 +156,7 @@ protected:
         }
     }
 
-    std::pmr::memory_resource *alloc_{std::pmr::get_default_resource()};
+    memory::memory_resource *alloc_{memory::get_default_resource()};
 
     // TODO Use capacity to determine if the string has been modified
     bool modified_{false};

--- a/src/dynamic_string.cpp
+++ b/src/dynamic_string.cpp
@@ -11,9 +11,16 @@ namespace ddwaf {
 
 owned_object dynamic_string::to_object()
 {
-    auto final_size = size_;
+    owned_object object;
+    if (size_ != capacity_) {
+        object = owned_object::make_string_nocopy(buffer_, size_);
+    } else {
+        object = owned_object::make_string(buffer_, size_);
+        alloc_->deallocate(buffer_, capacity_, alignof(char));
+    }
+    buffer_ = nullptr;
     size_ = capacity_ = 0;
-    return owned_object::make_string_nocopy(buffer_.release(), final_size);
+    return object;
 }
 
 } // namespace ddwaf

--- a/src/dynamic_string.cpp
+++ b/src/dynamic_string.cpp
@@ -12,7 +12,7 @@ namespace ddwaf {
 owned_object dynamic_string::to_object()
 {
     owned_object object;
-    if (size_ != capacity_) {
+    if (size_ == capacity_) {
         object = owned_object::make_string_nocopy(buffer_, size_);
     } else {
         object = owned_object::make_string(buffer_, size_);

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <string_view>
 
-#include "memory_resource"
+#include "memory_resource.hpp"
 
 namespace ddwaf {
 

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -55,7 +55,7 @@ public:
     ~dynamic_string()
     {
         if (buffer_ != nullptr) {
-            std::pmr::memory_resource *alloc{std::pmr::get_default_resource()};
+            memory::memory_resource *alloc{memory::get_default_resource()};
             alloc->deallocate(buffer_, capacity_, alignof(char));
             buffer_ = nullptr;
             size_ = capacity_ = 0;
@@ -164,7 +164,7 @@ protected:
         }
     }
 
-    std::pmr::memory_resource *alloc_{std::pmr::get_default_resource()};
+    memory::memory_resource *alloc_{memory::get_default_resource()};
 
     char *buffer_{nullptr};
     // Size explicitly excludes the null character, while capacity includes it

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -12,7 +12,7 @@
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <limits>
-#include <memory>
+#include <memory_resource>
 #include <string>
 #include <string_view>
 
@@ -25,21 +25,18 @@ class owned_object;
 // result in an output object, as it prevents copying unnecessary strings.
 class dynamic_string {
 public:
-    dynamic_string() : dynamic_string(static_cast<std::size_t>(0)){};
+    using size_type = uint32_t;
 
-    explicit dynamic_string(std::size_t capacity)
-    {
-        ensure_spare_capacity(capacity);
-        buffer_.get()[0] = '\0';
-    }
+    dynamic_string() : dynamic_string(static_cast<size_type>(0)){};
 
-    dynamic_string(const char *str, std::size_t size) : size_(size)
+    explicit dynamic_string(size_type capacity) { ensure_spare_capacity(capacity); }
+
+    dynamic_string(const char *str, size_type size) : size_(size)
     {
         ensure_spare_capacity(size_);
         if (size_ != 0) {
-            memcpy(buffer_.get(), str, size_);
+            memcpy(buffer_, str, size_);
         }
-        buffer_.get()[size_] = '\0';
     }
 
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
@@ -54,7 +51,15 @@ public:
         : dynamic_string(std::string_view{str})
     {}
 
-    ~dynamic_string() = default;
+    ~dynamic_string()
+    {
+        if (buffer_ != nullptr) {
+            std::pmr::memory_resource *alloc{std::pmr::get_default_resource()};
+            alloc->deallocate(buffer_, capacity_, alignof(char));
+            buffer_ = nullptr;
+            size_ = capacity_ = 0;
+        }
+    }
 
     dynamic_string(const dynamic_string &str) : dynamic_string(str.data(), str.size()) {}
 
@@ -71,17 +76,20 @@ public:
     // object leaves the original string in an unusable state and must be
     // reinitialised if reuse is required.
     dynamic_string(dynamic_string &&other) noexcept
-        : buffer_(std::move(other.buffer_)), size_(other.size_), capacity_(other.capacity_)
+        : buffer_(other.buffer_), size_(other.size_), capacity_(other.capacity_)
     {
+        other.buffer_ = nullptr;
         other.size_ = other.capacity_ = 0;
     }
 
     dynamic_string &operator=(dynamic_string &&other) noexcept
     {
-        buffer_ = std::move(other.buffer_);
+        alloc_->deallocate(buffer_, capacity_, alignof(char));
+        buffer_ = other.buffer_;
         size_ = other.size_;
         capacity_ = other.capacity_;
 
+        other.buffer_ = nullptr;
         other.size_ = other.capacity_ = 0;
 
         return *this;
@@ -90,76 +98,73 @@ public:
     // This method moves the contents of the string into the resulting object
     owned_object to_object();
 
-    [[nodiscard]] std::size_t size() const noexcept { return size_; }
+    [[nodiscard]] size_type size() const noexcept { return size_; }
     [[nodiscard]] bool empty() const noexcept { return size_ == 0; }
-    [[nodiscard]] std::size_t capacity() const noexcept { return capacity_; }
-    [[nodiscard]] const char *data() const noexcept { return buffer_.get(); }
+    [[nodiscard]] size_type capacity() const noexcept { return capacity_; }
+    [[nodiscard]] const char *data() const noexcept { return buffer_; }
 
     void append(std::string_view str)
     {
         ensure_spare_capacity(str.size());
         if (!str.empty()) [[likely]] {
-            memcpy(&buffer_.get()[size_], str.data(), str.size());
+            memcpy(&buffer_[size_], str.data(), str.size());
             size_ += str.size();
         }
-        buffer_.get()[size_] = '\0';
     }
 
     void append(char c)
     {
         ensure_spare_capacity(1);
-        buffer_.get()[size_++] = c;
-        buffer_.get()[size_] = '\0';
+        buffer_[size_++] = c;
     }
 
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
-    operator std::string_view() const noexcept { return {buffer_.get(), size_}; }
-    explicit operator std::string() const { return {buffer_.get(), size_}; }
+    operator std::string_view() const noexcept { return {buffer_, size_}; }
+    explicit operator std::string() const { return {buffer_, size_}; }
 
     bool operator==(const dynamic_string &other) const noexcept
     {
-        return size_ == other.size_ && (memcmp(buffer_.get(), other.buffer_.get(), size_) == 0);
+        return size_ == other.size_ && (memcmp(buffer_, other.buffer_, size_) == 0);
     }
 
     template <typename T> static dynamic_string from_movable_string(T &str)
     {
         dynamic_string dynstr;
         auto [ptr, size] = str.move();
-        dynstr.buffer_.reset(ptr);
+        dynstr.buffer_ = ptr;
         dynstr.size_ = size;
         return dynstr;
     }
 
 protected:
-    void ensure_spare_capacity(std::size_t at_least)
+    void ensure_spare_capacity(size_type at_least)
     {
         // We need to be able to allocate at_least + 1 to include the null character
-        if (at_least >= (std::numeric_limits<std::size_t>::max() - capacity_)) {
+        if (at_least > (std::numeric_limits<size_type>::max() - capacity_)) {
             throw std::bad_alloc{};
         }
 
-        if ((size_ + at_least + 1) >= capacity_) {
-            auto new_capacity_ = capacity_ + std::max(capacity_, at_least + 1);
+        if ((size_ + at_least) >= capacity_) {
+            auto new_capacity = capacity_ + std::max(capacity_, at_least);
             // NOLINTNEXTLINE(hicpp-no-malloc)
-            char *new_buffer = static_cast<char *>(malloc(new_capacity_));
-            if (new_buffer == nullptr) {
-                throw std::bad_alloc{};
+            char *new_buffer = static_cast<char *>(alloc_->allocate(new_capacity, alignof(char)));
+            if (buffer_ != nullptr) {
+                memcpy(new_buffer, buffer_, size_);
+                alloc_->deallocate(buffer_, capacity_, alignof(char));
             }
 
-            if (buffer_) {
-                memcpy(new_buffer, buffer_.get(), size_);
-            }
-
-            buffer_.reset(new_buffer);
-            capacity_ = new_capacity_;
+            buffer_ = new_buffer;
+            capacity_ = new_capacity;
         }
     }
 
-    std::unique_ptr<char, decltype(&free)> buffer_{nullptr, free};
+    std::pmr::memory_resource *alloc_{std::pmr::get_default_resource()};
+
+    char *buffer_{nullptr};
     // Size explicitly excludes the null character, while capacity includes it
     // as if refers to the total memory allocated.
-    std::size_t size_{0};
-    std::size_t capacity_{0};
+    size_type size_{0};
+    size_type capacity_{0};
 };
 
 template <> struct fmt::formatter<dynamic_string> : fmt::formatter<std::string_view> {

--- a/src/exclusion/common.hpp
+++ b/src/exclusion/common.hpp
@@ -9,7 +9,6 @@
 #include <unordered_set>
 
 #include "context_allocator.hpp"
-#include "ddwaf.h"
 #include "log.hpp"
 #include "object.hpp"
 #include "utils.hpp"

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -283,7 +283,7 @@ DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
                     return DDWAF_ERR_INVALID_OBJECT;
                 }
             } else {
-                object_view input{to_ref(persistent_data)};
+                const object_view input{to_ref(persistent_data)};
                 if (!input.is_map() || !context->insert(input.as<map_view>())) {
                     return DDWAF_ERR_INVALID_OBJECT;
                 }
@@ -297,7 +297,7 @@ DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
                     return DDWAF_ERR_INVALID_OBJECT;
                 }
             } else {
-                object_view input{to_ref(ephemeral_data)};
+                const object_view input{to_ref(ephemeral_data)};
                 if (!input.is_map() || !context->insert(input.as<map_view>(), attr)) {
                     return DDWAF_ERR_INVALID_OBJECT;
                 }

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -309,7 +309,7 @@ DDWAF_RET_CODE ddwaf_context_eval(ddwaf_context context, ddwaf_object *persisten
         constexpr uint64_t max_timeout_ms = std::chrono::nanoseconds::max().count() / 1000;
         timeout = std::min(timeout, max_timeout_ms);
 
-        auto [code, res] = context->run(timeout);
+        auto [code, res] = context->eval(timeout);
         if (result != nullptr) {
             to_ref(result) = res.move();
         }
@@ -445,7 +445,6 @@ uint32_t ddwaf_builder_get_config_paths(
 
         if (paths != nullptr) {
             ddwaf_object_array(paths);
-            // NOLINTNEXTLINE(clang-analyzer-unix.Malloc)
             for (const auto &value : config_paths) {
                 ddwaf_object tmp{};
                 ddwaf_object_array_add(

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -267,7 +267,7 @@ ddwaf_context ddwaf_context_init(ddwaf::waf *handle)
     return nullptr;
 }
 
-DDWAF_RET_CODE ddwaf_run(ddwaf_context context, ddwaf_object *persistent_data,
+DDWAF_RET_CODE ddwaf_context_eval(ddwaf_context context, ddwaf_object *persistent_data,
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     ddwaf_object *ephemeral_data, bool free_objects, ddwaf_object *result, uint64_t timeout)
 {

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -150,7 +150,6 @@ public:
 
         assert(key_.is_invalid());
 
-        // NOLINTNEXTLINE(hicpp-no-malloc)
         key_ = owned_object::make_string(str, length);
 
         return true;

--- a/src/matcher/lower_than.hpp
+++ b/src/matcher/lower_than.hpp
@@ -10,7 +10,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "ddwaf.h"
 #include "matcher/base.hpp"
 
 namespace ddwaf::matcher {

--- a/src/matcher/regex_match.cpp
+++ b/src/matcher/regex_match.cpp
@@ -49,7 +49,7 @@ std::pair<bool, dynamic_string> regex_match::match_impl(std::string_view pattern
         return {false, {}};
     }
 
-    return {true, {match[0].data(), match[0].size()}};
+    return {true, {match[0].data(), static_cast<dynamic_string::size_type>(match[0].size())}};
 }
 
 } // namespace ddwaf::matcher

--- a/src/memory_resource.hpp
+++ b/src/memory_resource.hpp
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <version>
 #include <stdexcept>
+#include <version>
 
 #if defined(__cpp_lib_memory_resource)
 #  include <memory_resource>

--- a/src/memory_resource.hpp
+++ b/src/memory_resource.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <version>
+#include <stdexcept>
 
 #if defined(__cpp_lib_memory_resource)
 #  include <memory_resource>

--- a/src/memory_resource.hpp
+++ b/src/memory_resource.hpp
@@ -22,3 +22,12 @@
 #  endif
 
 #endif
+
+namespace ddwaf::memory {
+
+using memory_resource = std::pmr::memory_resource;
+using monotonic_buffer_resource = std::pmr::monotonic_buffer_resource;
+
+const auto get_default_resource = std::pmr::get_default_resource;
+
+} // namespace ddwaf::memory

--- a/src/memory_resource.hpp
+++ b/src/memory_resource.hpp
@@ -30,4 +30,45 @@ using monotonic_buffer_resource = std::pmr::monotonic_buffer_resource;
 
 const auto get_default_resource = std::pmr::get_default_resource;
 
+class user_resource : public memory_resource {
+public:
+    using alloc_fn_type = void *(*)(void *, size_t size, size_t alignment);
+    using free_fn_type = void (*)(void *, void *, size_t size, size_t alignment);
+
+    user_resource(void *data, alloc_fn_type alloc_fn, free_fn_type free_fn)
+        : data_(data), alloc_fn_(alloc_fn), free_fn_(free_fn)
+    {
+        if (alloc_fn_ == nullptr || free_fn_ == nullptr) {
+            throw std::invalid_argument("undefined user alloc/free function");
+        }
+    }
+
+private:
+    void *do_allocate(std::size_t bytes, std::size_t alignment) override
+    {
+        return alloc_fn_(data_, bytes, alignment);
+    }
+
+    void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override
+    {
+        free_fn_(data_, p, bytes, alignment);
+    }
+
+    [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override
+    {
+        // Two memory_resources compare equal if and only if memory allocated from one
+        //  memory_resource can be deallocated from the other and vice versa.
+        try {
+            const auto &user_mr = dynamic_cast<const user_resource &>(other);
+            return free_fn_ == user_mr.free_fn_;
+        } catch (const std::bad_cast &) {
+            return false;
+        }
+    }
+
+    void *data_;
+    alloc_fn_type alloc_fn_;
+    free_fn_type free_fn_;
+};
+
 } // namespace ddwaf::memory

--- a/src/memory_resource.hpp
+++ b/src/memory_resource.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <stdexcept>
 #include <version>
 
 #if defined(__cpp_lib_memory_resource)
@@ -30,46 +29,5 @@ using memory_resource = std::pmr::memory_resource;
 using monotonic_buffer_resource = std::pmr::monotonic_buffer_resource;
 
 const auto get_default_resource = std::pmr::get_default_resource;
-
-class user_resource : public memory_resource {
-public:
-    using alloc_fn_type = void *(*)(void *, size_t size, size_t alignment);
-    using free_fn_type = void (*)(void *, void *, size_t size, size_t alignment);
-
-    user_resource(void *data, alloc_fn_type alloc_fn, free_fn_type free_fn)
-        : data_(data), alloc_fn_(alloc_fn), free_fn_(free_fn)
-    {
-        if (alloc_fn_ == nullptr || free_fn_ == nullptr) {
-            throw std::invalid_argument("undefined user alloc/free function");
-        }
-    }
-
-private:
-    void *do_allocate(std::size_t bytes, std::size_t alignment) override
-    {
-        return alloc_fn_(data_, bytes, alignment);
-    }
-
-    void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override
-    {
-        free_fn_(data_, p, bytes, alignment);
-    }
-
-    [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override
-    {
-        // Two memory_resources compare equal if and only if memory allocated from one
-        //  memory_resource can be deallocated from the other and vice versa.
-        try {
-            const auto &user_mr = dynamic_cast<const user_resource &>(other);
-            return free_fn_ == user_mr.free_fn_;
-        } catch (const std::bad_cast &) {
-            return false;
-        }
-    }
-
-    void *data_;
-    alloc_fn_type alloc_fn_;
-    free_fn_type free_fn_;
-};
 
 } // namespace ddwaf::memory

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "dynamic_string.hpp"
-#include "memory_resource"
+#include "memory_resource.hpp"
 #include "object_type.hpp"
 #include "traits.hpp"
 #include "utils.hpp"

--- a/src/processor/fingerprint.cpp
+++ b/src/processor/fingerprint.cpp
@@ -169,7 +169,7 @@ struct string_field : field_generator<string_field> {
         auto str_lc = cow_string::from_mutable_buffer(buffer.data(), buffer.size());
         transformer::lowercase::transform(str_lc);
 
-        return buffer; // NOLINT(clang-analyzer-unix.Malloc)
+        return buffer;
     }
 
     std::string_view value;
@@ -404,7 +404,6 @@ owned_object generate_fragment(std::string_view header, Generators... generators
         buffer.append(field);
     }
 
-    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc)
     return buffer.to_object();
 }
 
@@ -465,7 +464,6 @@ owned_object generate_fragment_cached(std::string_view header,
         }
     }
 
-    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc)
     return buffer.to_object();
 }
 

--- a/src/processor/fingerprint.cpp
+++ b/src/processor/fingerprint.cpp
@@ -394,9 +394,10 @@ owned_object generate_fragment(std::string_view header, Generators... generators
     std::array<std::string, num_fields> fields;
 
     auto length =
+        header.size() + num_fields +
         generate_fragment_field(std::span<std::string, num_fields>{fields}, generators...);
 
-    dynamic_string buffer{length + header.size() + num_fields};
+    dynamic_string buffer{static_cast<dynamic_string::size_type>(length)};
     buffer.append(header);
     for (const auto &field : fields) {
         buffer.append('-');
@@ -453,9 +454,9 @@ owned_object generate_fragment_cached(std::string_view header,
         cache.resize(num_fields);
     }
 
-    auto length = generate_fragment_field_cached(cache, generators...);
+    auto length = header.size() + num_fields + generate_fragment_field_cached(cache, generators...);
 
-    dynamic_string buffer{length + header.size() + num_fields};
+    dynamic_string buffer{static_cast<dynamic_string::size_type>(length)};
     buffer.append(header);
     for (const auto &field : cache) {
         buffer.append('-');

--- a/src/processor/fingerprint.cpp
+++ b/src/processor/fingerprint.cpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <new>
 #include <optional>
 #include <span>
 #include <stdexcept>
@@ -22,6 +21,7 @@
 #include "argument_retriever.hpp"
 #include "clock.hpp"
 #include "cow_string.hpp"
+#include "dynamic_string.hpp"
 #include "exception.hpp"
 #include "log.hpp"
 #include "object.hpp"

--- a/src/processor/jwt_decode.cpp
+++ b/src/processor/jwt_decode.cpp
@@ -124,7 +124,7 @@ std::pair<owned_object, object_store::attribute> jwt_decode::eval_impl(
     token.remove_prefix(prefix.size());
 
     std::size_t spaces = 0;
-    while (!token.empty() && ddwaf::isspace(token[spaces])) { ++spaces; }
+    while (spaces < token.size() && ddwaf::isspace(token[spaces])) { ++spaces; }
 
     token.remove_prefix(spaces);
 

--- a/src/ruleset.hpp
+++ b/src/ruleset.hpp
@@ -127,7 +127,6 @@ struct ruleset {
         return available_action_types;
     }
 
-    ddwaf_object_free_fn free_fn{ddwaf_object_free};
     std::shared_ptr<const match_obfuscator> obfuscator;
 
     std::shared_ptr<const std::vector<std::unique_ptr<base_processor>>> preprocessors;

--- a/src/transformer/base64_encode.cpp
+++ b/src/transformer/base64_encode.cpp
@@ -11,7 +11,7 @@
 #include <limits>
 
 #include "cow_string.hpp"
-#include "memory_resource"
+#include "memory_resource.hpp"
 #include "transformer/base64_encode.hpp"
 
 namespace ddwaf::transformer {

--- a/src/transformer/base64_encode.cpp
+++ b/src/transformer/base64_encode.cpp
@@ -11,6 +11,7 @@
 #include <limits>
 
 #include "cow_string.hpp"
+#include "memory_resource"
 #include "transformer/base64_encode.hpp"
 
 namespace ddwaf::transformer {
@@ -23,8 +24,9 @@ bool base64_encode::transform_impl(cow_string &str)
 
     // We need to allocate a buffer to contain the base64 encoded string
     const size_t encoded_length = (str.length() + 2) / 3 * 4;
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,hicpp-no-malloc)
-    auto *new_string = static_cast<char *>(malloc(encoded_length + 1));
+
+    auto *alloc = std::pmr::get_default_resource();
+    auto *new_string = static_cast<char *>(alloc->allocate(encoded_length, alignof(char)));
 
     // We don't have a good way to make this test fail in the CI, thus crapping on the coverage
     if (new_string == nullptr) {
@@ -79,9 +81,7 @@ bool base64_encode::transform_impl(cow_string &str)
         new_string[write++] = '=';
     }
 
-    new_string[write] = 0;
-
-    str.replace_buffer(new_string, write);
+    str.replace_buffer(new_string, write, encoded_length);
 
     return true;
 }

--- a/src/transformer/base64_encode.cpp
+++ b/src/transformer/base64_encode.cpp
@@ -26,7 +26,7 @@ bool base64_encode::transform_impl(cow_string &str)
     const size_t encoded_length = (str.length() + 2) / 3 * 4;
 
     // NOLINTNEXTLINE(misc-include-cleaner)
-    auto *alloc = std::pmr::get_default_resource();
+    auto *alloc = memory::get_default_resource();
     auto *new_string = static_cast<char *>(alloc->allocate(encoded_length, alignof(char)));
 
     // We don't have a good way to make this test fail in the CI, thus crapping on the coverage

--- a/src/transformer/base64_encode.cpp
+++ b/src/transformer/base64_encode.cpp
@@ -11,7 +11,7 @@
 #include <limits>
 
 #include "cow_string.hpp"
-#include "memory_resource.hpp"
+#include "memory_resource.hpp" // IWYU pragma: keep
 #include "transformer/base64_encode.hpp"
 
 namespace ddwaf::transformer {
@@ -25,6 +25,7 @@ bool base64_encode::transform_impl(cow_string &str)
     // We need to allocate a buffer to contain the base64 encoded string
     const size_t encoded_length = (str.length() + 2) / 3 * 4;
 
+    // NOLINTNEXTLINE(misc-include-cleaner)
     auto *alloc = std::pmr::get_default_resource();
     auto *new_string = static_cast<char *>(alloc->allocate(encoded_length, alignof(char)));
 
@@ -81,6 +82,7 @@ bool base64_encode::transform_impl(cow_string &str)
         new_string[write++] = '=';
     }
 
+    // NOLINTNEXTLINE(readability-suspicious-call-argument)
     str.replace_buffer(new_string, write, encoded_length);
 
     return true;

--- a/src/transformer/manager.cpp
+++ b/src/transformer/manager.cpp
@@ -3,8 +3,10 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
+#include <optional>
 #include <span>
 #include <string_view>
+#include <utility>
 
 #include "cow_string.hpp"
 #include "object.hpp"

--- a/src/transformer/manager.cpp
+++ b/src/transformer/manager.cpp
@@ -79,11 +79,11 @@ bool call_transformer(transformer_id id, cow_string &str)
 
 } // namespace
 
-bool manager::transform(object_view source, owned_object &destination,
-    const std::span<const transformer_id> &transformers)
+std::optional<cow_string> manager::transform(
+    object_view source, const std::span<const transformer_id> &transformers)
 {
     if (!source.is_string() || source.empty()) {
-        return false;
+        return std::nullopt;
     }
 
     bool transformed = false;
@@ -94,19 +94,10 @@ bool manager::transform(object_view source, owned_object &destination,
     }
 
     if (!transformed) {
-        return false;
+        return std::nullopt;
     }
 
-    // Note that this object might contain a string which is greater in
-    // capacity than the length specified
-    auto [buffer, length] = str.move();
-
-    // The memory returned by str.move() is now owned by destination, however
-    // clang-tidy believes it has been leaked as it can't track the fact that
-    // it has changed ownership.
-    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc)
-    destination = owned_object::make_string_nocopy(buffer, length);
-    return true;
+    return {std::move(str)};
 }
 
 } // namespace ddwaf::transformer

--- a/src/transformer/manager.hpp
+++ b/src/transformer/manager.hpp
@@ -18,8 +18,8 @@ namespace ddwaf::transformer {
 // this will also host the cache and will have to be shared by all conditions.
 class manager {
 public:
-    static bool transform(object_view source, owned_object &destination,
-        const std::span<const transformer_id> &transformers);
+    static std::optional<cow_string> transform(
+        object_view source, const std::span<const transformer_id> &transformers);
 };
 
 } // namespace ddwaf::transformer

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -15,7 +15,7 @@ extern "C" {
 }
 
 #include "cow_string.hpp"
-#include "memory_resource.hpp"
+#include "memory_resource.hpp" // IWYU pragma: keep
 #include "utf8.hpp"
 
 namespace ddwaf::utf8 {
@@ -211,12 +211,14 @@ struct ScratchpadChunk {
 
     explicit ScratchpadChunk(uint64_t chunkLength) : length(chunkLength)
     {
+        // NOLINTNEXTLINE(misc-include-cleaner)
         static auto *alloc = std::pmr::get_default_resource();
         scratchpad = static_cast<char *>(alloc->allocate(length, alignof(char)));
     }
 
     ~ScratchpadChunk()
     {
+        // NOLINTNEXTLINE(misc-include-cleaner)
         static auto *alloc = std::pmr::get_default_resource();
         alloc->deallocate(scratchpad, length, alignof(char));
     }
@@ -372,6 +374,7 @@ bool normalize_string(cow_string &str)
         // Compile the scratch pads into the final normalized string
         for (const ScratchpadChunk &chunk : scratchPad) { new_length += chunk.used; }
 
+        // NOLINTNEXTLINE(misc-include-cleaner)
         static auto *alloc = std::pmr::get_default_resource();
         new_buffer = static_cast<char *>(alloc->allocate(new_length, alignof(char)));
 

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -379,7 +379,7 @@ bool normalize_string(cow_string &str)
             for (const ScratchpadChunk &chunk : scratchPad) { new_length += chunk.used; }
 
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-no-malloc,hicpp-no-malloc)
-            new_buffer = reinterpret_cast<char *>(malloc(new_length + 1));
+            new_buffer = reinterpret_cast<char *>(malloc(new_length));
             if (new_buffer == nullptr) {
                 return false;
             }
@@ -391,8 +391,7 @@ bool normalize_string(cow_string &str)
             }
         }
 
-        new_buffer[new_length] = '\0';
-        str.replace_buffer(new_buffer, new_length);
+        str.replace_buffer(new_buffer, new_length, new_length);
 
         return true;
     } catch (const std::bad_alloc & /*unused*/) {} // NOLINT(bugprone-empty-catch)

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -212,14 +212,14 @@ struct ScratchpadChunk {
     explicit ScratchpadChunk(uint64_t chunkLength) : length(chunkLength)
     {
         // NOLINTNEXTLINE(misc-include-cleaner)
-        static auto *alloc = std::pmr::get_default_resource();
+        static auto *alloc = memory::get_default_resource();
         scratchpad = static_cast<char *>(alloc->allocate(length, alignof(char)));
     }
 
     ~ScratchpadChunk()
     {
         // NOLINTNEXTLINE(misc-include-cleaner)
-        static auto *alloc = std::pmr::get_default_resource();
+        static auto *alloc = memory::get_default_resource();
         alloc->deallocate(scratchpad, length, alignof(char));
     }
 
@@ -375,7 +375,7 @@ bool normalize_string(cow_string &str)
         for (const ScratchpadChunk &chunk : scratchPad) { new_length += chunk.used; }
 
         // NOLINTNEXTLINE(misc-include-cleaner)
-        static auto *alloc = std::pmr::get_default_resource();
+        static auto *alloc = memory::get_default_resource();
         new_buffer = static_cast<char *>(alloc->allocate(new_length, alignof(char)));
 
         uint64_t writeIndex = 0;

--- a/src/utf8.cpp
+++ b/src/utf8.cpp
@@ -15,7 +15,7 @@ extern "C" {
 }
 
 #include "cow_string.hpp"
-#include "memory_resource"
+#include "memory_resource.hpp"
 #include "utf8.hpp"
 
 namespace ddwaf::utf8 {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -24,8 +24,6 @@
 #include <utility>
 #include <vector>
 
-#include "ddwaf.h"
-
 // Convert numbers to strings
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
@@ -33,13 +31,6 @@
 #define STRL(value) value, sizeof(value) - 1
 
 template <typename T> using optional_ref = std::optional<std::reference_wrapper<T>>;
-
-// Internals
-// clang-format off
-#define PWI_DATA_TYPES (DDWAF_OBJ_SIGNED | DDWAF_OBJ_UNSIGNED | DDWAF_OBJ_STRING | DDWAF_OBJ_BOOL | DDWAF_OBJ_FLOAT)
-#define PWI_CONTAINER_TYPES (DDWAF_OBJ_ARRAY | DDWAF_OBJ_MAP)
-#define DDWAF_RESULT_INITIALISER {false, {{.str = nullptr}, DDWAF_OBJ_ARRAY, 0, 0}, {{.str = nullptr}, DDWAF_OBJ_MAP, 0, 0}, {{.str = nullptr}, DDWAF_OBJ_MAP, 0, 0}, 0}
-// clang-format on
 
 namespace ddwaf {
 

--- a/src/waf.hpp
+++ b/src/waf.hpp
@@ -9,7 +9,6 @@
 
 #include "configuration/common/raw_configuration.hpp"
 #include "context.hpp"
-#include "ddwaf.h"
 #include "ruleset.hpp"
 #include "ruleset_info.hpp"
 #include "utils.hpp"

--- a/tests/common/base_utils.hpp
+++ b/tests/common/base_utils.hpp
@@ -100,9 +100,8 @@ protected:
 
 // Convenience structure to build rulesets
 struct ruleset_builder {
-    explicit ruleset_builder(ddwaf_object_free_fn free_fn = ddwaf_object_free)
-        : free_fn(free_fn),
-          preprocessors(std::make_shared<typename decltype(preprocessors)::element_type>()),
+    ruleset_builder()
+        : preprocessors(std::make_shared<typename decltype(preprocessors)::element_type>()),
           postprocessors(std::make_shared<typename decltype(postprocessors)::element_type>()),
           rule_filters(std::make_shared<typename decltype(rule_filters)::element_type>()),
           input_filters(std::make_shared<typename decltype(input_filters)::element_type>()),
@@ -154,7 +153,6 @@ struct ruleset_builder {
         auto ruleset = std::make_shared<ddwaf::ruleset>();
         ruleset->obfuscator = std::make_shared<ddwaf::match_obfuscator>();
 
-        ruleset->free_fn = free_fn;
         ruleset->insert_preprocessors(preprocessors);
         ruleset->insert_rules(base_rules, user_rules);
         ruleset->insert_filters(rule_filters);
@@ -169,7 +167,6 @@ struct ruleset_builder {
         return ruleset;
     }
 
-    ddwaf_object_free_fn free_fn;
     std::shared_ptr<std::vector<std::unique_ptr<base_processor>>> preprocessors;
     std::shared_ptr<std::vector<std::unique_ptr<base_processor>>> postprocessors;
 

--- a/tests/integration/actions/test.cpp
+++ b/tests/integration/actions/test.cpp
@@ -31,7 +31,8 @@ TEST(TestActionsIntegration, DefaultActions)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "block"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "block-rule",
                                .name = "block-rule",
@@ -55,7 +56,8 @@ TEST(TestActionsIntegration, DefaultActions)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "stack_trace"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "stack-trace-rule",
                                .name = "stack-trace-rule",
@@ -104,7 +106,8 @@ TEST(TestActionsIntegration, DefaultActions)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "extract_schema"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "extract-schema-rule",
                                .name = "extract-schema-rule",
@@ -128,7 +131,8 @@ TEST(TestActionsIntegration, DefaultActions)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "unblock"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "unblock-rule",
                                .name = "unblock-rule",
@@ -174,7 +178,8 @@ TEST(TestActionsIntegration, OverrideDefaultAction)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "block-rule",
                                .name = "block-rule",
@@ -215,7 +220,8 @@ TEST(TestActionsIntegration, OverrideDefaultAction)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "block-rule",
                                .name = "block-rule",
@@ -262,7 +268,8 @@ TEST(TestActionsIntegration, AddNewAction)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "unblock-rule",
                                .name = "unblock-rule",
@@ -302,7 +309,8 @@ TEST(TestActionsIntegration, AddNewAction)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "unblock-rule",
                                .name = "unblock-rule",
@@ -344,7 +352,7 @@ TEST(TestActionsIntegration, EmptyOrInvalidActions)
     ASSERT_NE(context, nullptr);
 
     ddwaf_object res;
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
     EXPECT_EVENTS(res, {.id = "block-rule",
                            .name = "block-rule",

--- a/tests/integration/actions/test.cpp
+++ b/tests/integration/actions/test.cpp
@@ -31,7 +31,7 @@ TEST(TestActionsIntegration, DefaultActions)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "block"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "block-rule",
                                .name = "block-rule",
@@ -55,7 +55,7 @@ TEST(TestActionsIntegration, DefaultActions)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "stack_trace"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "stack-trace-rule",
                                .name = "stack-trace-rule",
@@ -104,7 +104,7 @@ TEST(TestActionsIntegration, DefaultActions)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "extract_schema"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "extract-schema-rule",
                                .name = "extract-schema-rule",
@@ -128,7 +128,7 @@ TEST(TestActionsIntegration, DefaultActions)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "unblock"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "unblock-rule",
                                .name = "unblock-rule",
@@ -174,7 +174,7 @@ TEST(TestActionsIntegration, OverrideDefaultAction)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "block-rule",
                                .name = "block-rule",
@@ -215,7 +215,7 @@ TEST(TestActionsIntegration, OverrideDefaultAction)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "block-rule",
                                .name = "block-rule",
@@ -262,7 +262,7 @@ TEST(TestActionsIntegration, AddNewAction)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "unblock-rule",
                                .name = "unblock-rule",
@@ -302,7 +302,7 @@ TEST(TestActionsIntegration, AddNewAction)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "unblock-rule",
                                .name = "unblock-rule",
@@ -344,7 +344,7 @@ TEST(TestActionsIntegration, EmptyOrInvalidActions)
     ASSERT_NE(context, nullptr);
 
     ddwaf_object res;
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
     EXPECT_EVENTS(res, {.id = "block-rule",
                            .name = "block-rule",

--- a/tests/integration/conditions/exists/test.cpp
+++ b/tests/integration/conditions/exists/test.cpp
@@ -28,7 +28,7 @@ TEST(TestConditionExistsIntegration, AddressAvailable)
     ddwaf_object_map_add(&map, "input-1", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -62,7 +62,7 @@ TEST(TestConditionExistsIntegration, AddressNotAvailable)
     ddwaf_object_map_add(&map, "input", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
@@ -86,7 +86,7 @@ TEST(TestConditionExistsIntegration, KeyPathAvailable)
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -119,7 +119,7 @@ TEST(TestConditionExistsIntegration, KeyPathNotAvailable)
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -142,7 +142,7 @@ TEST(TestConditionExistsIntegration, AddressAvailableVariadicRule)
     ddwaf_object_map_add(&map, "input-3-1", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
@@ -177,7 +177,7 @@ TEST(TestConditionExistsIntegration, KeyPathAvailableVariadicRule)
     ddwaf_object_map_add(&map, "input-3-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
@@ -211,7 +211,7 @@ TEST(TestConditionExistsIntegration, AddressAvailableKeyPathNotAvailableVariadic
     ddwaf_object_map_add(&map, "input-3-1", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
@@ -244,7 +244,7 @@ TEST(TestConditionExistsNegatedIntegration, AddressAvailable)
     ddwaf_object_map_add(&map, "input-1", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -270,7 +270,7 @@ TEST(TestConditionExistsNegatedIntegration, AddressNotAvailable)
     // as the !exists operator only supports address + key path, since we can't
     // assert the absence of an address given that these are provided in stages
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -295,7 +295,7 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathNotAvailable)
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -328,7 +328,7 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathAvailable)
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);

--- a/tests/integration/conditions/exists/test.cpp
+++ b/tests/integration/conditions/exists/test.cpp
@@ -28,7 +28,7 @@ TEST(TestConditionExistsIntegration, AddressAvailable)
     ddwaf_object_map_add(&map, "input-1", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -62,7 +62,7 @@ TEST(TestConditionExistsIntegration, AddressNotAvailable)
     ddwaf_object_map_add(&map, "input", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
@@ -86,7 +86,7 @@ TEST(TestConditionExistsIntegration, KeyPathAvailable)
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -119,7 +119,7 @@ TEST(TestConditionExistsIntegration, KeyPathNotAvailable)
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -142,7 +142,7 @@ TEST(TestConditionExistsIntegration, AddressAvailableVariadicRule)
     ddwaf_object_map_add(&map, "input-3-1", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
@@ -177,7 +177,7 @@ TEST(TestConditionExistsIntegration, KeyPathAvailableVariadicRule)
     ddwaf_object_map_add(&map, "input-3-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
@@ -211,7 +211,7 @@ TEST(TestConditionExistsIntegration, AddressAvailableKeyPathNotAvailableVariadic
     ddwaf_object_map_add(&map, "input-3-1", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
@@ -244,7 +244,7 @@ TEST(TestConditionExistsNegatedIntegration, AddressAvailable)
     ddwaf_object_map_add(&map, "input-1", ddwaf_object_invalid(&value));
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -270,7 +270,7 @@ TEST(TestConditionExistsNegatedIntegration, AddressNotAvailable)
     // as the !exists operator only supports address + key path, since we can't
     // assert the absence of an address given that these are provided in stages
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -295,7 +295,7 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathNotAvailable)
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -328,7 +328,7 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathAvailable)
     ddwaf_object_map_add(&map, "input-2", &intermediate);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);

--- a/tests/integration/conditions/transformers/test.cpp
+++ b/tests/integration/conditions/transformers/test.cpp
@@ -17,7 +17,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
     auto rule = read_file<ddwaf_object>("global_transformer.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -80,7 +80,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
     auto rule = read_file<ddwaf_object>("global_transformer.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -151,7 +151,7 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
     auto rule = read_file<ddwaf_object>("input_transformer.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -214,7 +214,7 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
     auto rule = read_file<ddwaf_object>("input_transformer.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -285,7 +285,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
     auto rule = read_file<ddwaf_object>("overlapping_transformers.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -384,7 +384,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
     auto rule = read_file<ddwaf_object>("overlapping_transformers.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);

--- a/tests/integration/conditions/transformers/test.cpp
+++ b/tests/integration/conditions/transformers/test.cpp
@@ -31,7 +31,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "RULE1"));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -43,7 +43,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, "RULE1"));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -55,7 +55,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_0", ddwaf_object_string(&tmp, "  RULE2    "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -67,7 +67,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_1", ddwaf_object_string(&tmp, "      RULE2   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -96,7 +96,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
         ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
         ddwaf_object_map_add(&parameter, "value3_0", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -110,7 +110,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
         ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
         ddwaf_object_map_add(&parameter, "value3_0", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -124,7 +124,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
         ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
         ddwaf_object_map_add(&parameter, "value3_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -138,7 +138,7 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
         ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
         ddwaf_object_map_add(&parameter, "value3_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -165,7 +165,7 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "RULE1"));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -177,7 +177,7 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, "RULE1"));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -189,7 +189,7 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_0", ddwaf_object_string(&tmp, "  RULE2    "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -201,7 +201,7 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_1", ddwaf_object_string(&tmp, "      RULE2   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -230,7 +230,7 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
         ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
         ddwaf_object_map_add(&parameter, "value3_0", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -244,7 +244,7 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
         ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
         ddwaf_object_map_add(&parameter, "value3_0", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -258,7 +258,7 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
         ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
         ddwaf_object_map_add(&parameter, "value3_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -272,7 +272,7 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
         ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
         ddwaf_object_map_add(&parameter, "value3_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -299,7 +299,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, " RULE1 "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -311,7 +311,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "    rule1 "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -323,7 +323,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, " rule1 "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -335,7 +335,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, " RULE1 "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -347,7 +347,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_2", ddwaf_object_string(&tmp, "   rule1   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -359,7 +359,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_2", ddwaf_object_string(&tmp, "  RULE1   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -371,7 +371,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_3", ddwaf_object_string(&tmp, "    RULE1   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -400,7 +400,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
     /*ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));*/
     /*ddwaf_object_map_add(&parameter, "value2_0", &map);*/
 
-    /*EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);*/
+    /*EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);*/
 
     /*ddwaf_context_destroy(context);*/
     /*}*/
@@ -414,7 +414,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
         ddwaf_object_map_add(&parameter, "value2_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -428,7 +428,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "rule2"));
         ddwaf_object_map_add(&parameter, "value2_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -442,7 +442,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
         ddwaf_object_map_add(&parameter, "value2_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -456,7 +456,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
         ddwaf_object_map_add(&parameter, "value2_2", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -470,7 +470,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
         ddwaf_object_map_add(&parameter, "value2_2", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -484,7 +484,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
         ddwaf_object_map_add(&parameter, "value2_3", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -498,7 +498,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "rule2"));
         ddwaf_object_map_add(&parameter, "value2_3", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -512,7 +512,7 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
         ddwaf_object_map_add(&parameter, "value2_3", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }

--- a/tests/integration/conditions/transformers/test.cpp
+++ b/tests/integration/conditions/transformers/test.cpp
@@ -31,7 +31,8 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "RULE1"));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -43,7 +44,8 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, "RULE1"));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -55,7 +57,8 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_0", ddwaf_object_string(&tmp, "  RULE2    "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -67,7 +70,8 @@ TEST(TestConditionTransformersIntegration, GlobalTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_1", ddwaf_object_string(&tmp, "      RULE2   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -96,7 +100,8 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
         ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
         ddwaf_object_map_add(&parameter, "value3_0", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -110,7 +115,8 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
         ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
         ddwaf_object_map_add(&parameter, "value3_0", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -124,7 +130,8 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
         ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
         ddwaf_object_map_add(&parameter, "value3_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -138,7 +145,8 @@ TEST(TestConditionTransformersIntegration, GlobalTransformerKeysOnly)
         ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
         ddwaf_object_map_add(&parameter, "value3_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -165,7 +173,8 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "RULE1"));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -177,7 +186,8 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, "RULE1"));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -189,7 +199,8 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_0", ddwaf_object_string(&tmp, "  RULE2    "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -201,7 +212,8 @@ TEST(TestConditionTransformersIntegration, InputTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2_1", ddwaf_object_string(&tmp, "      RULE2   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -230,7 +242,8 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
         ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
         ddwaf_object_map_add(&parameter, "value3_0", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -244,7 +257,8 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
         ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
         ddwaf_object_map_add(&parameter, "value3_0", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -258,7 +272,8 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
         ddwaf_object_map_add(&map, "key", ddwaf_object_string(&tmp, "RULE3"));
         ddwaf_object_map_add(&parameter, "value3_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -272,7 +287,8 @@ TEST(TestConditionTransformersIntegration, InputTransformerKeysOnly)
         ddwaf_object_map_add(&map, "RULE3", ddwaf_object_string(&tmp, "randomvalue"));
         ddwaf_object_map_add(&parameter, "value3_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -299,7 +315,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, " RULE1 "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -311,7 +328,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_0", ddwaf_object_string(&tmp, "    rule1 "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -323,7 +341,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, " rule1 "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -335,7 +354,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_1", ddwaf_object_string(&tmp, " RULE1 "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -347,7 +367,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_2", ddwaf_object_string(&tmp, "   rule1   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -359,7 +380,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_2", ddwaf_object_string(&tmp, "  RULE1   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -371,7 +393,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformer)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1_3", ddwaf_object_string(&tmp, "    RULE1   "));
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -400,7 +423,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
     /*ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));*/
     /*ddwaf_object_map_add(&parameter, "value2_0", &map);*/
 
-    /*EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);*/
+    /*EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+     * DDWAF_MATCH);*/
 
     /*ddwaf_context_destroy(context);*/
     /*}*/
@@ -414,7 +438,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
         ddwaf_object_map_add(&parameter, "value2_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -428,7 +453,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "rule2"));
         ddwaf_object_map_add(&parameter, "value2_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -442,7 +468,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
         ddwaf_object_map_add(&parameter, "value2_1", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -456,7 +483,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
         ddwaf_object_map_add(&parameter, "value2_2", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -470,7 +498,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
         ddwaf_object_map_add(&parameter, "value2_2", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -484,7 +513,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "rule2", ddwaf_object_string(&tmp, "value"));
         ddwaf_object_map_add(&parameter, "value2_3", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -498,7 +528,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "rule2"));
         ddwaf_object_map_add(&parameter, "value2_3", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -512,7 +543,8 @@ TEST(TestConditionTransformersIntegration, OverlappingTransformerKeysOnly)
         ddwaf_object_map_add(&map, "value", ddwaf_object_string(&tmp, "RULE2"));
         ddwaf_object_map_add(&parameter, "value2_3", &map);
 
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }

--- a/tests/integration/context/test.cpp
+++ b/tests/integration/context/test.cpp
@@ -34,7 +34,7 @@ TEST(TestContextIntegration, Basic)
     ddwaf_object_map_add(&parameter, "value2", &subMap); // ddwaf_object_string(&,"rule3"));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -83,7 +83,7 @@ TEST(TestContextIntegration, KeyPaths)
     ddwaf_object_map_add(&root, "param", &param);
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -106,7 +106,7 @@ TEST(TestContextIntegration, KeyPaths)
     ddwaf_object_map_add(&param, "z", ddwaf_object_string(&tmp, "Sqreen"));
     ddwaf_object_map_add(&root, "param", &param);
 
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -133,7 +133,7 @@ TEST(TestContextIntegration, KeyPaths)
     ddwaf_object_map_add(&param, "y", ddwaf_object_string(&tmp, "Sqreen"));
     ddwaf_object_map_add(&root, "param", &param);
 
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -175,7 +175,7 @@ TEST(TestContextIntegration, MissingParameter)
     ddwaf_object_map_add(&param, "param", ddwaf_object_signed(&tmp, 42));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -216,7 +216,7 @@ TEST(TestContextIntegration, InvalidUTF8Input)
     ddwaf_object_map_addl(&param, ba2.c_str(), ba2.length(), ddwaf_object_map(&tmp));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -254,7 +254,8 @@ TEST(TestContextIntegration, SingleCollectionMatch)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
-        EXPECT_EQ(ddwaf_run(context, &param1, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &param1, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "1",
@@ -275,7 +276,7 @@ TEST(TestContextIntegration, SingleCollectionMatch)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
-        EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -309,7 +310,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
-        EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "1",
@@ -330,7 +331,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param, "param", ddwaf_object_string(&tmp, "Pony"));
 
-        EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         const auto *events = ddwaf_object_find(&ret, STRL("events"));
@@ -345,7 +346,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
-        EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "2",
@@ -382,7 +383,7 @@ TEST(TestContextIntegration, Timeout)
     ddwaf_object tmp;
     ddwaf_object_map_add(&param, "pm_param", ddwaf_object_string(&tmp, "aaaabbbbbaaa"));
 
-    EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, SHORT_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_context_eval(context, &param, nullptr, true, &ret, SHORT_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_TRUE(ddwaf_object_get_bool(timeout));
 
@@ -414,14 +415,14 @@ TEST(TestContextIntegration, ParameterOverride)
     // Run with both arg1 and arg2, but arg1 is wrong
     //	// Run with just arg1
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param1, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param1, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     ddwaf_object_free(&ret);
 
     // Override `arg1`
-    code = ddwaf_run(context, &param2, nullptr, true, &ret, LONG_TIME);
+    code = ddwaf_context_eval(context, &param2, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
@@ -444,7 +445,7 @@ TEST(TestContextIntegration, ParameterOverride)
     ddwaf_object_free(&ret);
 
     // Run again without change
-    code = ddwaf_run(context, ddwaf_object_map(&tmp), nullptr, true, &ret, LONG_TIME);
+    code = ddwaf_context_eval(context, ddwaf_object_map(&tmp), nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_OK);
 
     timeout = ddwaf_object_find(&ret, STRL("timeout"));
@@ -474,7 +475,8 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &param1, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &param1, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -494,7 +496,8 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &param1, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &param1, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -532,7 +535,8 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 2"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, &persistent, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &persistent, &ephemeral, true, &ret, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -559,7 +563,8 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -586,7 +591,8 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 3"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -629,7 +635,8 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -650,7 +657,8 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -688,7 +696,8 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -709,7 +718,8 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -745,7 +755,8 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -765,7 +776,8 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
         ddwaf_object_map_add(&persistent, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -803,7 +815,8 @@ TEST(TestContextIntegration, ReplaceEphemeral)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -839,7 +852,8 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -860,7 +874,8 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
         ddwaf_object_map_add(&persistent, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -897,7 +912,8 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&persistent, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -918,7 +934,8 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_OK);
         ddwaf_object_free(&ret);
     }
 
@@ -957,7 +974,7 @@ TEST(TestContextIntegration, WafContextEventAddress)
         ddwaf_object_map_add(&map, "waf.trigger", ddwaf_object_string(&tmp, "irrelevant"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -989,7 +1006,7 @@ TEST(TestContextIntegration, WafContextEventAddress)
         ddwaf_object_map_add(&map, "waf.trigger", ddwaf_object_string(&tmp, "rule"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1026,7 +1043,7 @@ TEST(TestContextIntegration, MultipleModuleSingleCollectionMatch)
     ddwaf_object tmp;
     ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
-    EXPECT_EQ(ddwaf_run(context, &param1, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &param1, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret,
@@ -1078,8 +1095,8 @@ TEST(TestContextIntegration, TimeoutBeyondLimit)
     ddwaf_object_map_add(&parameter, "value2", &subMap); // ddwaf_object_string(&,"rule3"));
 
     ddwaf_object ret;
-    EXPECT_EQ(
-        ddwaf_run(context, &parameter, nullptr, true, &ret, std::numeric_limits<uint64_t>::max()),
+    EXPECT_EQ(ddwaf_context_eval(
+                  context, &parameter, nullptr, true, &ret, std::numeric_limits<uint64_t>::max()),
         DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));

--- a/tests/integration/context/test.cpp
+++ b/tests/integration/context/test.cpp
@@ -34,7 +34,7 @@ TEST(TestContextIntegration, Basic)
     ddwaf_object_map_add(&parameter, "value2", &subMap); // ddwaf_object_string(&,"rule3"));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -83,7 +83,7 @@ TEST(TestContextIntegration, KeyPaths)
     ddwaf_object_map_add(&root, "param", &param);
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -106,7 +106,7 @@ TEST(TestContextIntegration, KeyPaths)
     ddwaf_object_map_add(&param, "z", ddwaf_object_string(&tmp, "Sqreen"));
     ddwaf_object_map_add(&root, "param", &param);
 
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -133,7 +133,7 @@ TEST(TestContextIntegration, KeyPaths)
     ddwaf_object_map_add(&param, "y", ddwaf_object_string(&tmp, "Sqreen"));
     ddwaf_object_map_add(&root, "param", &param);
 
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -175,7 +175,7 @@ TEST(TestContextIntegration, MissingParameter)
     ddwaf_object_map_add(&param, "param", ddwaf_object_signed(&tmp, 42));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -216,7 +216,7 @@ TEST(TestContextIntegration, InvalidUTF8Input)
     ddwaf_object_map_addl(&param, ba2.c_str(), ba2.length(), ddwaf_object_map(&tmp));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -254,7 +254,7 @@ TEST(TestContextIntegration, SingleCollectionMatch)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
-        EXPECT_EQ(ddwaf_run(context, &param1, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &param1, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "1",
@@ -275,7 +275,7 @@ TEST(TestContextIntegration, SingleCollectionMatch)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
-        EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -309,7 +309,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
-        EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "1",
@@ -330,7 +330,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param, "param", ddwaf_object_string(&tmp, "Pony"));
 
-        EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         const auto *events = ddwaf_object_find(&ret, STRL("events"));
@@ -345,7 +345,7 @@ TEST(TestContextIntegration, MultiCollectionMatches)
         ddwaf_object tmp;
         ddwaf_object_map_add(&param, "param2", ddwaf_object_string(&tmp, "Sqreen"));
 
-        EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(ret, {.id = "2",
@@ -382,7 +382,7 @@ TEST(TestContextIntegration, Timeout)
     ddwaf_object tmp;
     ddwaf_object_map_add(&param, "pm_param", ddwaf_object_string(&tmp, "aaaabbbbbaaa"));
 
-    EXPECT_EQ(ddwaf_run(context, &param, nullptr, &ret, SHORT_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &param, nullptr, true, &ret, SHORT_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_TRUE(ddwaf_object_get_bool(timeout));
 
@@ -414,14 +414,14 @@ TEST(TestContextIntegration, ParameterOverride)
     // Run with both arg1 and arg2, but arg1 is wrong
     //	// Run with just arg1
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param1, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param1, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     ddwaf_object_free(&ret);
 
     // Override `arg1`
-    code = ddwaf_run(context, &param2, nullptr, &ret, LONG_TIME);
+    code = ddwaf_run(context, &param2, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     EXPECT_EVENTS(ret, {.id = "1",
                            .name = "rule1",
@@ -444,7 +444,7 @@ TEST(TestContextIntegration, ParameterOverride)
     ddwaf_object_free(&ret);
 
     // Run again without change
-    code = ddwaf_run(context, ddwaf_object_map(&tmp), nullptr, &ret, LONG_TIME);
+    code = ddwaf_run(context, ddwaf_object_map(&tmp), nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_OK);
 
     timeout = ddwaf_object_find(&ret, STRL("timeout"));
@@ -474,7 +474,7 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &param1, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &param1, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -494,7 +494,7 @@ TEST(TestContextIntegration, DuplicateEphemeralMatch)
         ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &param1, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &param1, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -532,7 +532,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 2"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, &persistent, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &persistent, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -559,7 +559,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -586,7 +586,7 @@ TEST(TestContextIntegration, EphemeralAndPersistentMatches)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 3"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -629,7 +629,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -650,7 +650,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -688,7 +688,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -709,7 +709,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -745,7 +745,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -765,7 +765,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
         ddwaf_object_map_add(&persistent, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -803,7 +803,7 @@ TEST(TestContextIntegration, ReplaceEphemeral)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -839,7 +839,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -860,7 +860,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
         ddwaf_object_map_add(&persistent, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -897,7 +897,7 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&persistent, "arg2", ddwaf_object_string(&tmp, "string 8"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
@@ -918,7 +918,7 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
         ddwaf_object_map_add(&ephemeral, "arg1", ddwaf_object_string(&tmp, "string 1"));
 
         ddwaf_object ret;
-        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &ret, LONG_TIME), DDWAF_OK);
         ddwaf_object_free(&ret);
     }
 
@@ -957,7 +957,7 @@ TEST(TestContextIntegration, WafContextEventAddress)
         ddwaf_object_map_add(&map, "waf.trigger", ddwaf_object_string(&tmp, "irrelevant"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -989,7 +989,7 @@ TEST(TestContextIntegration, WafContextEventAddress)
         ddwaf_object_map_add(&map, "waf.trigger", ddwaf_object_string(&tmp, "rule"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1026,7 +1026,7 @@ TEST(TestContextIntegration, MultipleModuleSingleCollectionMatch)
     ddwaf_object tmp;
     ddwaf_object_map_add(&param1, "param1", ddwaf_object_string(&tmp, "Sqreen"));
 
-    EXPECT_EQ(ddwaf_run(context, &param1, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &param1, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(ret,
@@ -1078,7 +1078,8 @@ TEST(TestContextIntegration, TimeoutBeyondLimit)
     ddwaf_object_map_add(&parameter, "value2", &subMap); // ddwaf_object_string(&,"rule3"));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &ret, std::numeric_limits<uint64_t>::max()),
+    EXPECT_EQ(
+        ddwaf_run(context, &parameter, nullptr, true, &ret, std::numeric_limits<uint64_t>::max()),
         DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));

--- a/tests/integration/diagnostics/v1/test.cpp
+++ b/tests/integration/diagnostics/v1/test.cpp
@@ -31,7 +31,7 @@ void run_test(ddwaf_handle handle)
     ddwaf_object ret;
 
     // Run with just arg1
-    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/diagnostics/v1/test.cpp
+++ b/tests/integration/diagnostics/v1/test.cpp
@@ -31,7 +31,7 @@ void run_test(ddwaf_handle handle)
     ddwaf_object ret;
 
     // Run with just arg1
-    auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/diagnostics/v2/test.cpp
+++ b/tests/integration/diagnostics/v2/test.cpp
@@ -499,7 +499,7 @@ TEST(TestDiagnosticsV2Integration, MultipleRules)
     auto rule = read_file<ddwaf_object>("rules.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
@@ -545,7 +545,7 @@ TEST(TestDiagnosticsV2Integration, RulesWithMinVersion)
     auto rule = read_file<ddwaf_object>("rules_min_version.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
@@ -589,7 +589,7 @@ TEST(TestDiagnosticsV2Integration, RulesWithMaxVersion)
     auto rule = read_file<ddwaf_object>("rules_max_version.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
@@ -633,7 +633,7 @@ TEST(TestDiagnosticsV2Integration, RulesWithMinMaxVersion)
     auto rule = read_file<ddwaf_object>("rules_min_max_version.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
@@ -678,7 +678,7 @@ TEST(TestDiagnosticsV2Integration, RulesWithErrors)
     auto rule = read_file<ddwaf_object>("rules_with_errors.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
@@ -763,7 +763,7 @@ TEST(TestDiagnosticsV2Integration, CustomRules)
     auto rule = read_file<ddwaf_object>("custom_rules.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
@@ -809,7 +809,7 @@ TEST(TestDiagnosticsV2Integration, InputFilter)
     auto rule = read_file<ddwaf_object>("input_filter.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
@@ -849,7 +849,7 @@ TEST(TestDiagnosticsV2Integration, RuleData)
     auto rule = read_file<ddwaf_object>("rule_data.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);
@@ -890,7 +890,7 @@ TEST(TestDiagnosticsV2Integration, Processor)
     auto rule = read_json_file("processor.json", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_object diagnostics;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &diagnostics);

--- a/tests/integration/events/obfuscator/test.cpp
+++ b/tests/integration/events/obfuscator/test.cpp
@@ -33,7 +33,8 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -57,7 +58,8 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -81,7 +83,8 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -105,7 +108,8 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -143,7 +147,8 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -167,7 +172,8 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -191,7 +197,8 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -228,7 +235,8 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -252,7 +260,8 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -276,7 +285,8 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -313,7 +323,8 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "badvalue_something"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "security_scanner"}, {"category", "category2"}},
@@ -335,7 +346,8 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "othervalue_badvalue"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "security_scanner"}, {"category", "category2"}},
@@ -371,7 +383,8 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -395,7 +408,8 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -419,7 +433,8 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -456,7 +471,8 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -480,7 +496,8 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -504,7 +521,8 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -541,7 +559,8 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -565,7 +584,8 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -589,7 +609,8 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},

--- a/tests/integration/events/obfuscator/test.cpp
+++ b/tests/integration/events/obfuscator/test.cpp
@@ -33,7 +33,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -57,7 +57,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -81,7 +81,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -105,7 +105,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -143,7 +143,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -167,7 +167,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -191,7 +191,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -228,7 +228,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -252,7 +252,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -276,7 +276,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -313,7 +313,7 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "badvalue_something"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "security_scanner"}, {"category", "category2"}},
@@ -335,7 +335,7 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "othervalue_badvalue"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "security_scanner"}, {"category", "category2"}},
@@ -371,7 +371,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -395,7 +395,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -419,7 +419,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -456,7 +456,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -480,7 +480,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -504,7 +504,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -541,7 +541,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -565,7 +565,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object_map_add(&parameter, "value", &inter);
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},
@@ -589,7 +589,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
         ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "rule1_obf"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "security_scanner"}, {"category", "category1"}},

--- a/tests/integration/events/obfuscator/test.cpp
+++ b/tests/integration/events/obfuscator/test.cpp
@@ -19,7 +19,7 @@ TEST(TestObfuscatorIntegration, TestConfigKeyValue)
     auto rule = read_file<ddwaf_object>("obfuscator.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{"password", "rule1_obf"}, ddwaf_object_free};
+    ddwaf_config config{{"password", "rule1_obf"}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ddwaf_object_free(&rule);
@@ -129,7 +129,7 @@ TEST(TestObfuscatorIntegration, TestConfigKey)
     auto rule = read_file<ddwaf_object>("obfuscator.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{"password", nullptr}, ddwaf_object_free};
+    ddwaf_config config{{"password", nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ddwaf_object_free(&rule);
@@ -214,7 +214,7 @@ TEST(TestObfuscatorIntegration, TestConfigValue)
     auto rule = read_file<ddwaf_object>("obfuscator.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, "rule1_obf"}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, "rule1_obf"}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ddwaf_object_free(&rule);
@@ -299,7 +299,7 @@ TEST(TestObfuscatorIntegration, TestConfigHighlight)
     auto rule = read_file<ddwaf_object>("obfuscator.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = "^badvalue"}, ddwaf_object_free};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = "^badvalue"}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ddwaf_object_free(&rule);
@@ -357,7 +357,7 @@ TEST(TestObfuscatorIntegration, TestConfigEmpty)
     auto rule = read_file<ddwaf_object>("obfuscator.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, ""}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, ""}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ddwaf_object_free(&rule);
@@ -442,7 +442,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigKey)
     auto rule = read_file<ddwaf_object>("obfuscator.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{"[", nullptr}, ddwaf_object_free};
+    ddwaf_config config{{"[", nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ddwaf_object_free(&rule);
@@ -527,7 +527,7 @@ TEST(TestObfuscatorIntegration, TestInvalidConfigValue)
     auto rule = read_file<ddwaf_object>("obfuscator.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, "]"}, ddwaf_object_free};
+    ddwaf_config config{{nullptr, "]"}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ddwaf_object_free(&rule);

--- a/tests/integration/events/schema/test.cpp
+++ b/tests/integration/events/schema/test.cpp
@@ -79,7 +79,7 @@ TEST_F(TestSchemaIntegration, SimpleResult)
     ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "rule1"));
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }
@@ -93,7 +93,7 @@ TEST_F(TestSchemaIntegration, SimpleResultWithKeyPath)
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }
@@ -110,7 +110,7 @@ TEST_F(TestSchemaIntegration, SimpleResultWithMultiKeyPath)
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }
@@ -127,7 +127,7 @@ TEST_F(TestSchemaIntegration, ResultWithMultiCondition)
     ddwaf_object_map_add(&param, "arg4", &arg4);
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }
@@ -152,7 +152,7 @@ TEST_F(TestSchemaIntegration, MultiResultWithMultiCondition)
     ddwaf_object_map_add(&param, "arg4", &arg4);
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }

--- a/tests/integration/events/schema/test.cpp
+++ b/tests/integration/events/schema/test.cpp
@@ -79,7 +79,7 @@ TEST_F(TestSchemaIntegration, SimpleResult)
     ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "rule1"));
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }
@@ -93,7 +93,7 @@ TEST_F(TestSchemaIntegration, SimpleResultWithKeyPath)
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }
@@ -110,7 +110,7 @@ TEST_F(TestSchemaIntegration, SimpleResultWithMultiKeyPath)
     ddwaf_object_map_add(&param, "arg2", &arg2);
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }
@@ -127,7 +127,7 @@ TEST_F(TestSchemaIntegration, ResultWithMultiCondition)
     ddwaf_object_map_add(&param, "arg4", &arg4);
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }
@@ -152,7 +152,7 @@ TEST_F(TestSchemaIntegration, MultiResultWithMultiCondition)
     ddwaf_object_map_add(&param, "arg4", &arg4);
 
     ddwaf_object ret;
-    auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
     Validate(ret, code);
     ddwaf_object_free(&ret);
 }

--- a/tests/integration/exclusion/rule_filter/test.cpp
+++ b/tests/integration/exclusion/rule_filter/test.cpp
@@ -31,7 +31,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRule)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "type2"}, {"category", "category"}},
@@ -64,7 +64,7 @@ TEST(TestRuleFilterIntegration, ExcludeByType)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -97,7 +97,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategory)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -122,7 +122,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTags)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "type2"}, {"category", "category"}},
@@ -157,7 +157,7 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
@@ -173,7 +173,7 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -219,7 +219,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -244,7 +244,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -291,7 +291,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "AD      MIN"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -316,7 +316,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -361,7 +361,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -386,7 +386,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -432,7 +432,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
@@ -448,7 +448,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -494,7 +494,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -519,7 +519,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -563,7 +563,7 @@ TEST(TestRuleFilterIntegration, MonitorSingleRule)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -599,7 +599,7 @@ TEST(TestRuleFilterIntegration, AvoidHavingTwoMonitorOnActions)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -634,7 +634,7 @@ TEST(TestRuleFilterIntegration, MonitorBypassFilterModePrecedence)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -657,7 +657,7 @@ TEST(TestRuleFilterIntegration, MonitorCustomFilterModePrecedence)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -692,7 +692,7 @@ TEST(TestRuleFilterIntegration, BypassCustomFilterModePrecedence)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
@@ -716,7 +716,7 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -754,7 +754,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -782,7 +782,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.2"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -824,7 +824,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -860,7 +860,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -904,7 +904,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},

--- a/tests/integration/exclusion/rule_filter/test.cpp
+++ b/tests/integration/exclusion/rule_filter/test.cpp
@@ -31,7 +31,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRule)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "type2"}, {"category", "category"}},
@@ -64,7 +64,7 @@ TEST(TestRuleFilterIntegration, ExcludeByType)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -97,7 +97,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategory)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -122,7 +122,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTags)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "2",
                            .name = "rule2",
                            .tags = {{"type", "type2"}, {"category", "category"}},
@@ -157,7 +157,7 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
@@ -173,7 +173,7 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -219,7 +219,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -244,7 +244,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -291,7 +291,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "AD      MIN"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -316,7 +316,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -361,7 +361,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -386,7 +386,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -432,7 +432,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
@@ -448,7 +448,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -494,7 +494,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -519,7 +519,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -563,7 +563,7 @@ TEST(TestRuleFilterIntegration, MonitorSingleRule)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -599,7 +599,7 @@ TEST(TestRuleFilterIntegration, AvoidHavingTwoMonitorOnActions)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -634,7 +634,7 @@ TEST(TestRuleFilterIntegration, MonitorBypassFilterModePrecedence)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
@@ -657,7 +657,7 @@ TEST(TestRuleFilterIntegration, MonitorCustomFilterModePrecedence)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -692,7 +692,7 @@ TEST(TestRuleFilterIntegration, BypassCustomFilterModePrecedence)
     ddwaf_object_map(&root);
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
@@ -716,7 +716,7 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},
@@ -754,7 +754,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -782,7 +782,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.2"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -824,7 +824,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -860,7 +860,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
                                .tags = {{"type", "type1"}, {"category", "category"}},
@@ -904,7 +904,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
     ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
 
     ddwaf_object out;
-    EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
                            .tags = {{"type", "type1"}, {"category", "category"}},

--- a/tests/integration/exclusion_data/test.cpp
+++ b/tests/integration/exclusion_data/test.cpp
@@ -38,7 +38,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -84,7 +84,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -114,7 +114,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -171,7 +171,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -217,7 +217,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -247,7 +247,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -303,7 +303,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -349,7 +349,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -385,7 +385,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -441,7 +441,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -487,7 +487,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -517,7 +517,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",

--- a/tests/integration/exclusion_data/test.cpp
+++ b/tests/integration/exclusion_data/test.cpp
@@ -38,7 +38,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -84,7 +84,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -114,7 +114,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByUserID)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -171,7 +171,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -217,7 +217,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -247,7 +247,7 @@ TEST(TestExclusionDataIntegration, ExcludeRuleByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -303,7 +303,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -349,7 +349,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -385,7 +385,7 @@ TEST(TestExclusionDataIntegration, UnknownDataTypeOnExclusionData)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -441,7 +441,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",
@@ -487,7 +487,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "2",
                                .name = "rule2",
                                .tags = {{"type", "type2"}, {"category", "category"}},
@@ -517,7 +517,7 @@ TEST(TestExclusionDataIntegration, ExcludeInputByClientIP)
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out,
             {.id = "1",
                 .name = "rule1",

--- a/tests/integration/interface/builder/test.cpp
+++ b/tests/integration/interface/builder/test.cpp
@@ -56,7 +56,7 @@ TEST(TestEngineBuilderFunctional, BaseRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -82,11 +82,11 @@ TEST(TestEngineBuilderFunctional, BaseRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value2", ddwaf_object_string(&tmp, "rule2"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -133,11 +133,11 @@ TEST(TestEngineBuilderFunctional, RemoveDuplicateBaseRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value2", ddwaf_object_string(&tmp, "rule2"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -157,11 +157,11 @@ TEST(TestEngineBuilderFunctional, RemoveDuplicateBaseRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value2", ddwaf_object_string(&tmp, "rule2"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -198,7 +198,7 @@ TEST(TestEngineBuilderFunctional, CustomRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -224,11 +224,11 @@ TEST(TestEngineBuilderFunctional, CustomRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value2", ddwaf_object_string(&tmp, "rule2"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }

--- a/tests/integration/interface/builder/test.cpp
+++ b/tests/integration/interface/builder/test.cpp
@@ -56,7 +56,8 @@ TEST(TestEngineBuilderFunctional, BaseRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -82,11 +83,12 @@ TEST(TestEngineBuilderFunctional, BaseRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value2", ddwaf_object_string(&tmp, "rule2"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -133,11 +135,13 @@ TEST(TestEngineBuilderFunctional, RemoveDuplicateBaseRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value2", ddwaf_object_string(&tmp, "rule2"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -157,11 +161,12 @@ TEST(TestEngineBuilderFunctional, RemoveDuplicateBaseRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value2", ddwaf_object_string(&tmp, "rule2"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -198,7 +203,8 @@ TEST(TestEngineBuilderFunctional, CustomRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -224,11 +230,12 @@ TEST(TestEngineBuilderFunctional, CustomRules)
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value1", ddwaf_object_string(&tmp, "rule1"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "value2", ddwaf_object_string(&tmp, "rule2"));
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }

--- a/tests/integration/interface/context/result/test.cpp
+++ b/tests/integration/interface/context/result/test.cpp
@@ -29,8 +29,8 @@ TEST(TestContextResultIntegration, ResultInvalidArgumentNullContext)
     ddwaf_object result;
     ddwaf_object_invalid(&result);
 
-    EXPECT_EQ(
-        ddwaf_run(nullptr, &persistent, nullptr, &result, LONG_TIME), DDWAF_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(ddwaf_run(nullptr, &persistent, nullptr, true, &result, LONG_TIME),
+        DDWAF_ERR_INVALID_ARGUMENT);
 
     // The result object must be unchanged
     EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
@@ -54,7 +54,8 @@ TEST(TestContextResultIntegration, ResultInvalidArgumentNoData)
     ddwaf_object result;
     ddwaf_object_invalid(&result);
 
-    EXPECT_EQ(ddwaf_run(context, nullptr, nullptr, &result, LONG_TIME), DDWAF_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(
+        ddwaf_run(context, nullptr, nullptr, true, &result, LONG_TIME), DDWAF_ERR_INVALID_ARGUMENT);
 
     // The result object must be unchanged
     EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
@@ -82,8 +83,8 @@ TEST(TestContextResultIntegration, ResultInvalidObjectInvalidPersistentDataSchem
     ddwaf_object result;
     ddwaf_object_invalid(&result);
 
-    EXPECT_EQ(
-        ddwaf_run(context, &persistent, nullptr, &result, LONG_TIME), DDWAF_ERR_INVALID_OBJECT);
+    EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, true, &result, LONG_TIME),
+        DDWAF_ERR_INVALID_OBJECT);
 
     // The result object must be unchanged
     EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
@@ -112,8 +113,8 @@ TEST(TestContextResultIntegration, ResultInvalidObjectInvalidEphemeralDataSchema
     ddwaf_object result;
     ddwaf_object_invalid(&result);
 
-    EXPECT_EQ(
-        ddwaf_run(context, nullptr, &ephemeral, &result, LONG_TIME), DDWAF_ERR_INVALID_OBJECT);
+    EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &result, LONG_TIME),
+        DDWAF_ERR_INVALID_OBJECT);
 
     // The result object must be unchanged
     EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
@@ -144,7 +145,7 @@ TEST(TestContextResultIntegration, ResultOk)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -206,7 +207,7 @@ TEST(TestContextResultIntegration, ResultOkWithAttributes)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -263,7 +264,7 @@ TEST(TestContextResultIntegration, ResultOkWithTimeout)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, 0), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, 0), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -320,7 +321,7 @@ TEST(TestContextResultIntegration, ResultMatch)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -377,7 +378,7 @@ TEST(TestContextResultIntegration, ResultMatchWithTimeout)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, 0), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, 0), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -440,7 +441,7 @@ TEST(TestContextResultIntegration, ResultMatchWithTimeoutOnPreprocessor)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, 0), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, 0), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);

--- a/tests/integration/interface/context/result/test.cpp
+++ b/tests/integration/interface/context/result/test.cpp
@@ -29,7 +29,7 @@ TEST(TestContextResultIntegration, ResultInvalidArgumentNullContext)
     ddwaf_object result;
     ddwaf_object_invalid(&result);
 
-    EXPECT_EQ(ddwaf_run(nullptr, &persistent, nullptr, true, &result, LONG_TIME),
+    EXPECT_EQ(ddwaf_context_eval(nullptr, &persistent, nullptr, true, &result, LONG_TIME),
         DDWAF_ERR_INVALID_ARGUMENT);
 
     // The result object must be unchanged
@@ -54,8 +54,8 @@ TEST(TestContextResultIntegration, ResultInvalidArgumentNoData)
     ddwaf_object result;
     ddwaf_object_invalid(&result);
 
-    EXPECT_EQ(
-        ddwaf_run(context, nullptr, nullptr, true, &result, LONG_TIME), DDWAF_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(ddwaf_context_eval(context, nullptr, nullptr, true, &result, LONG_TIME),
+        DDWAF_ERR_INVALID_ARGUMENT);
 
     // The result object must be unchanged
     EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
@@ -83,7 +83,7 @@ TEST(TestContextResultIntegration, ResultInvalidObjectInvalidPersistentDataSchem
     ddwaf_object result;
     ddwaf_object_invalid(&result);
 
-    EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, true, &result, LONG_TIME),
+    EXPECT_EQ(ddwaf_context_eval(context, &persistent, nullptr, true, &result, LONG_TIME),
         DDWAF_ERR_INVALID_OBJECT);
 
     // The result object must be unchanged
@@ -113,7 +113,7 @@ TEST(TestContextResultIntegration, ResultInvalidObjectInvalidEphemeralDataSchema
     ddwaf_object result;
     ddwaf_object_invalid(&result);
 
-    EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &result, LONG_TIME),
+    EXPECT_EQ(ddwaf_context_eval(context, nullptr, &ephemeral, true, &result, LONG_TIME),
         DDWAF_ERR_INVALID_OBJECT);
 
     // The result object must be unchanged
@@ -145,7 +145,7 @@ TEST(TestContextResultIntegration, ResultOk)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -207,7 +207,7 @@ TEST(TestContextResultIntegration, ResultOkWithAttributes)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -264,7 +264,7 @@ TEST(TestContextResultIntegration, ResultOkWithTimeout)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, 0), DDWAF_OK);
+    EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, 0), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -321,7 +321,8 @@ TEST(TestContextResultIntegration, ResultMatch)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(
+        ddwaf_context_eval(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -378,7 +379,7 @@ TEST(TestContextResultIntegration, ResultMatchWithTimeout)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, 0), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, 0), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
@@ -441,7 +442,7 @@ TEST(TestContextResultIntegration, ResultMatchWithTimeoutOnPreprocessor)
 
     ddwaf_object result;
     ddwaf_object_invalid(&result);
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, 0), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, 0), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);

--- a/tests/integration/interface/object/test.cpp
+++ b/tests/integration/interface/object/test.cpp
@@ -5,7 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 
 #include "ddwaf.h"
-#include "memory_resource"
+#include "memory_resource.hpp"
 #include "utils.hpp"
 
 #include "common/gtest_utils.hpp"

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -41,7 +41,7 @@ TEST(TestWafIntegration, HandleBad)
     EXPECT_NO_FATAL_FAILURE(ddwaf_destroy(nullptr));
 
     ddwaf_object_string(&object, "value");
-    EXPECT_EQ(ddwaf_run(nullptr, &object, nullptr, nullptr, 1), DDWAF_ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(ddwaf_run(nullptr, &object, nullptr, true, nullptr, 1), DDWAF_ERR_INVALID_ARGUMENT);
     ddwaf_object_free(&object);
 
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
@@ -55,15 +55,15 @@ TEST(TestWafIntegration, HandleBad)
     ASSERT_NE(context, nullptr);
 
     ddwaf_object_string(&object, "value");
-    EXPECT_EQ(ddwaf_run(context, &object, nullptr, nullptr, 1), DDWAF_ERR_INVALID_OBJECT);
+    EXPECT_EQ(ddwaf_run(context, &object, nullptr, true, nullptr, 1), DDWAF_ERR_INVALID_OBJECT);
 
     ddwaf_object_string(&object, "value");
-    EXPECT_EQ(ddwaf_run(context, nullptr, &object, nullptr, 1), DDWAF_ERR_INVALID_OBJECT);
+    EXPECT_EQ(ddwaf_run(context, nullptr, &object, true, nullptr, 1), DDWAF_ERR_INVALID_OBJECT);
 
     object = DDWAF_OBJECT_MAP;
     ddwaf_object_map_add(&object, "value1", ddwaf_object_string(&tmp, "value"));
     ddwaf_object res;
-    EXPECT_EQ(ddwaf_run(context, &object, nullptr, &res, 0), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context, &object, nullptr, true, &res, 0), DDWAF_OK);
 
     const auto *timeout = ddwaf_object_find(&res, STRL("timeout"));
     EXPECT_TRUE(ddwaf_object_get_bool(timeout));
@@ -127,7 +127,7 @@ TEST(TestWafIntegration, HandleLifetime)
     ddwaf_object_map_add(&parameter, "value1", &param_key);
     ddwaf_object_map_add(&parameter, "value2", &param_val);
 
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
     ddwaf_context_destroy(context);
 }
@@ -165,12 +165,10 @@ TEST(TestWafIntegration, HandleLifetimeMultipleContexts)
     ddwaf_object_map_add(&parameter, "value1", &param_key);
     ddwaf_object_map_add(&parameter, "value2", &param_val);
 
-    EXPECT_EQ(
-        ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-        DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
     ddwaf_context_destroy(context1);
 
-    EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
     ddwaf_context_destroy(context2);
 }
 
@@ -227,7 +225,7 @@ TEST(TestWafIntegration, PreloadRuleData)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -241,7 +239,7 @@ TEST(TestWafIntegration, PreloadRuleData)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "paco"));
 
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context);
     }
@@ -268,7 +266,7 @@ TEST(TestWafIntegration, PreloadRuleData)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -282,7 +280,7 @@ TEST(TestWafIntegration, PreloadRuleData)
         ddwaf_object_map(&root);
         ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "paco"));
 
-        EXPECT_EQ(ddwaf_run(context, &root, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context);
     }
@@ -331,15 +329,11 @@ TEST(TestWafIntegration, UpdateRules)
     ddwaf_object parameter2 = DDWAF_OBJECT_MAP;
     ddwaf_object_map_add(&parameter2, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-    EXPECT_EQ(
-        ddwaf_run(context1, ddwaf_object_clone(&parameter1, &tmp), nullptr, nullptr, LONG_TIME),
-        DDWAF_MATCH);
-    EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context1, &parameter1, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
-    EXPECT_EQ(
-        ddwaf_run(context1, ddwaf_object_clone(&parameter2, &tmp), nullptr, nullptr, LONG_TIME),
-        DDWAF_MATCH);
-    EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context1, &parameter2, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
     ddwaf_context_destroy(context2);
     ddwaf_context_destroy(context1);
@@ -386,15 +380,11 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByID)
     ddwaf_object parameter2 = DDWAF_OBJECT_MAP;
     ddwaf_object_map_add(&parameter2, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-    EXPECT_EQ(
-        ddwaf_run(context1, ddwaf_object_clone(&parameter1, &tmp), nullptr, nullptr, LONG_TIME),
-        DDWAF_MATCH);
-    EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+    EXPECT_EQ(ddwaf_run(context1, &parameter1, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
-    EXPECT_EQ(
-        ddwaf_run(context1, ddwaf_object_clone(&parameter2, &tmp), nullptr, nullptr, LONG_TIME),
-        DDWAF_MATCH);
-    EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context1, &parameter2, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
     ddwaf_context_destroy(context1);
     ddwaf_destroy(handle1);
@@ -410,10 +400,8 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByID)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
     }
 
     ddwaf_context_destroy(context2);
@@ -464,14 +452,12 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByTags)
         ddwaf_object_map_add(&parameter2, "value1", ddwaf_object_string(&tmp, "rule2"));
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter1, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter1, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter2, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+            ddwaf_run(context1, &parameter2, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
     }
 
     ddwaf_context_destroy(context1);
@@ -497,14 +483,11 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByTags)
         ddwaf_object_map_add(&parameter2, "value1", ddwaf_object_string(&tmp, "rule2"));
 
         EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter1, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context3, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context2, &parameter1, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter1, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
-        EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter2, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context3, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context3, &parameter2, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
     }
 
     ddwaf_context_destroy(context2);
@@ -569,9 +552,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(
@@ -600,9 +582,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(result2, {});
@@ -646,9 +627,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object result3;
 
         EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, &result2, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context2, &parameter, nullptr, false, &result2, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, &result3, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(
             result2, {{"block_request",
@@ -722,9 +702,8 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(
@@ -753,9 +732,8 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(result2, {});
@@ -813,9 +791,8 @@ TEST(TestWafIntegration, UpdateTagsByID)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result1,
             {.id = "1",
@@ -863,9 +840,8 @@ TEST(TestWafIntegration, UpdateTagsByID)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context3, ddwaf_object_clone(&parameter, &tmp), nullptr, &result3, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context3, &parameter, nullptr, false, &result3, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result3,
             {.id = "1",
@@ -943,9 +919,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result1,
             {.id = "1",
@@ -990,9 +965,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result1,
             {.id = "2",
@@ -1036,9 +1010,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result1,
             {.id = "3",
@@ -1086,9 +1059,8 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context3, ddwaf_object_clone(&parameter, &tmp), nullptr, &result3, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context3, &parameter, nullptr, false, &result3, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result3,
             {.id = "3",
@@ -1165,9 +1137,8 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object result2;
 
         EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context1, &parameter, nullptr, false, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result1,
             {.id = "1",
@@ -1229,9 +1200,8 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object result3;
 
         EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, &result2, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context2, &parameter, nullptr, false, &result2, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, &result3, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result2,
             {.id = "1",
@@ -1289,10 +1259,8 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context3, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context3);
         ddwaf_context_destroy(context4);
@@ -1382,26 +1350,18 @@ TEST(TestWafIntegration, UpdateRuleData)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
     }
 
     {
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "usr.id", ddwaf_object_string(&tmp, "paco"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
     }
 
     ddwaf_context_destroy(context1);
@@ -1452,10 +1412,8 @@ TEST(TestWafIntegration, UpdateAndRevertRuleData)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context1);
         ddwaf_context_destroy(context2);
@@ -1476,10 +1434,8 @@ TEST(TestWafIntegration, UpdateAndRevertRuleData)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
@@ -1529,10 +1485,8 @@ TEST(TestWafIntegration, UpdateRuleExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1549,10 +1503,8 @@ TEST(TestWafIntegration, UpdateRuleExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1574,10 +1526,8 @@ TEST(TestWafIntegration, UpdateRuleExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context3);
         ddwaf_context_destroy(context2);
@@ -1626,10 +1576,8 @@ TEST(TestWafIntegration, UpdateInputExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1646,10 +1594,8 @@ TEST(TestWafIntegration, UpdateInputExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1666,10 +1612,8 @@ TEST(TestWafIntegration, UpdateInputExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule3"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1691,10 +1635,8 @@ TEST(TestWafIntegration, UpdateInputExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context3);
         ddwaf_context_destroy(context2);
@@ -1746,10 +1688,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1767,10 +1707,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.params", ddwaf_object_string(&tmp, "rule4"));
 
-        EXPECT_EQ(
-            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1806,9 +1744,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result3;
 
         EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, &result2, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context2, &parameter, nullptr, false, &result2, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, &result3, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result2, {});
         EXPECT_ACTIONS(
@@ -1834,10 +1771,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        EXPECT_EQ(
-            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
@@ -1873,10 +1808,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result3;
         ddwaf_object result4;
 
-        EXPECT_EQ(
-            ddwaf_run(context3, ddwaf_object_clone(&parameter, &tmp), nullptr, &result3, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, &result4, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, false, &result3, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, true, &result4, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result3, {});
         EXPECT_ACTIONS(
@@ -1899,7 +1832,7 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context4);
     }
@@ -1935,9 +1868,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result5;
 
         EXPECT_EQ(
-            ddwaf_run(context4, ddwaf_object_clone(&parameter, &tmp), nullptr, &result4, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context4, &parameter, nullptr, false, &result4, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, true, &result5, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(
             result4, {{"block_request",
@@ -1964,10 +1896,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        EXPECT_EQ(
-            ddwaf_run(context4, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, false, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
 
         ddwaf_context_destroy(context4);
         ddwaf_context_destroy(context5);
@@ -1989,9 +1919,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result5;
 
         EXPECT_EQ(
-            ddwaf_run(context4, ddwaf_object_clone(&parameter, &tmp), nullptr, &result4, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_OK);
+            ddwaf_run(context4, &parameter, nullptr, false, &result4, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, true, &result5, LONG_TIME), DDWAF_OK);
 
         EXPECT_ACTIONS(
             result4, {{"block_request",
@@ -2035,10 +1964,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result5;
         ddwaf_object result6;
 
-        EXPECT_EQ(
-            ddwaf_run(context5, ddwaf_object_clone(&parameter, &tmp), nullptr, &result5, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, &result6, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, false, &result5, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, true, &result6, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result5, {});
         EXPECT_ACTIONS(
@@ -2068,9 +1995,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result6;
 
         EXPECT_EQ(
-            ddwaf_run(context5, ddwaf_object_clone(&parameter, &tmp), nullptr, &result5, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, &result6, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context5, &parameter, nullptr, false, &result5, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, true, &result6, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(
             result5, {{"block_request",
@@ -2095,7 +2021,7 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
         ddwaf_context_destroy(context6);
     }
@@ -2122,10 +2048,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result6;
         ddwaf_object result7;
 
-        EXPECT_EQ(
-            ddwaf_run(context6, ddwaf_object_clone(&parameter, &tmp), nullptr, &result6, LONG_TIME),
-            DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context7, &parameter, nullptr, &result7, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, false, &result6, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context7, &parameter, nullptr, true, &result7, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result6, {});
         EXPECT_ACTIONS(
@@ -2163,9 +2087,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result8;
 
         EXPECT_EQ(
-            ddwaf_run(context7, ddwaf_object_clone(&parameter, &tmp), nullptr, &result7, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context7, &parameter, nullptr, false, &result7, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, true, &result8, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(
             result7, {{"block_request",
@@ -2195,9 +2118,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result8;
 
         EXPECT_EQ(
-            ddwaf_run(context7, ddwaf_object_clone(&parameter, &tmp), nullptr, &result7, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context7, &parameter, nullptr, false, &result7, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, true, &result8, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(
             result7, {{"block_request",
@@ -2232,9 +2154,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result9;
 
         EXPECT_EQ(
-            ddwaf_run(context8, ddwaf_object_clone(&parameter, &tmp), nullptr, &result8, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context9, &parameter, nullptr, &result9, LONG_TIME), DDWAF_MATCH);
+            ddwaf_run(context8, &parameter, nullptr, false, &result8, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context9, &parameter, nullptr, true, &result9, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_ACTIONS(result8, {});
         EXPECT_ACTIONS(result9, {});
@@ -2262,9 +2183,8 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result9;
 
         EXPECT_EQ(
-            ddwaf_run(context8, ddwaf_object_clone(&parameter, &tmp), nullptr, &result8, LONG_TIME),
-            DDWAF_MATCH);
-        EXPECT_EQ(ddwaf_run(context9, &parameter, nullptr, &result9, LONG_TIME), DDWAF_OK);
+            ddwaf_run(context8, &parameter, nullptr, false, &result8, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context9, &parameter, nullptr, true, &result9, LONG_TIME), DDWAF_OK);
 
         EXPECT_ACTIONS(result9, {});
 

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -32,7 +32,7 @@ TEST(TestWafIntegration, GetWafVersion)
 
 TEST(TestWafIntegration, HandleBad)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, ddwaf_object_free};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
 
     ddwaf_object tmp;
     ddwaf_object object = DDWAF_OBJECT_INVALID;
@@ -79,7 +79,7 @@ TEST(TestWafIntegration, RootAddresses)
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -102,7 +102,7 @@ TEST(TestWafIntegration, HandleLifetime)
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -137,7 +137,7 @@ TEST(TestWafIntegration, HandleLifetimeMultipleContexts)
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -179,7 +179,7 @@ TEST(TestWafIntegration, InvalidVersion)
     auto rule = yaml_to_object<ddwaf_object>("{version: 3.0, rules: []}");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
 
     ddwaf_handle handle1 = ddwaf_init(&rule, &config, nullptr);
     ASSERT_EQ(handle1, nullptr);
@@ -191,7 +191,7 @@ TEST(TestWafIntegration, InvalidVersionNoRules)
     auto rule = yaml_to_object<ddwaf_object>("{version: 3.0}");
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
 
     ddwaf_handle handle1 = ddwaf_init(&rule, &config, nullptr);
     ASSERT_EQ(handle1, nullptr);
@@ -296,7 +296,7 @@ TEST(TestWafIntegration, UpdateRules)
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
 
     ddwaf_builder builder = ddwaf_builder_init(&config);
     ddwaf_builder_add_or_update_config(builder, "default", sizeof("default") - 1, &rule, nullptr);
@@ -349,7 +349,7 @@ TEST(TestWafIntegration, UpdateRules)
 
 TEST(TestWafIntegration, UpdateDisableEnableRuleByID)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
     ASSERT_NE(builder, nullptr);
 
@@ -426,7 +426,7 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByID)
 
 TEST(TestWafIntegration, UpdateDisableEnableRuleByTags)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -517,7 +517,7 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByTags)
 
 TEST(TestWafIntegration, UpdateActionsByID)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
     ASSERT_NE(builder, nullptr);
 
@@ -671,7 +671,7 @@ TEST(TestWafIntegration, UpdateActionsByID)
 
 TEST(TestWafIntegration, UpdateActionsByTags)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -775,7 +775,7 @@ TEST(TestWafIntegration, UpdateActionsByTags)
 
 TEST(TestWafIntegration, UpdateTagsByID)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -904,7 +904,7 @@ TEST(TestWafIntegration, UpdateTagsByID)
 
 TEST(TestWafIntegration, UpdateTagsByTags)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1126,7 +1126,7 @@ TEST(TestWafIntegration, UpdateTagsByTags)
 
 TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1308,7 +1308,7 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
 
 TEST(TestWafIntegration, UpdateInvalidOverrides)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
@@ -1334,7 +1334,7 @@ TEST(TestWafIntegration, UpdateInvalidOverrides)
 
 TEST(TestWafIntegration, UpdateRuleData)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1417,7 +1417,7 @@ TEST(TestWafIntegration, UpdateRuleData)
 
 TEST(TestWafIntegration, UpdateAndRevertRuleData)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1494,7 +1494,7 @@ TEST(TestWafIntegration, UpdateAndRevertRuleData)
 
 TEST(TestWafIntegration, UpdateRuleExclusions)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1591,7 +1591,7 @@ TEST(TestWafIntegration, UpdateRuleExclusions)
 
 TEST(TestWafIntegration, UpdateInputExclusions)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -1708,7 +1708,7 @@ TEST(TestWafIntegration, UpdateInputExclusions)
 
 TEST(TestWafIntegration, UpdateEverything)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -2316,7 +2316,7 @@ TEST(TestWafIntegration, UpdateEverything)
 
 TEST(TestWafIntegration, KnownAddressesDisabledRule)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -2383,7 +2383,7 @@ TEST(TestWafIntegration, KnownAddressesDisabledRule)
 
 TEST(TestWafIntegration, KnownActions)
 {
-    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}, nullptr};
+    ddwaf_config config{{.key_regex = nullptr, .value_regex = nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -114,8 +114,8 @@ TEST(TestWafIntegration, HandleLifetime)
     // Destroying the handle should not invalidate it
     ddwaf_destroy(handle);
 
-    ddwaf_object parameter = DDWAF_OBJECT_MAP;
     ddwaf_object tmp;
+    ddwaf_object parameter = DDWAF_OBJECT_MAP;
     ddwaf_object param_key = DDWAF_OBJECT_ARRAY;
     ddwaf_object param_val = DDWAF_OBJECT_ARRAY;
 
@@ -129,7 +129,6 @@ TEST(TestWafIntegration, HandleLifetime)
 
     EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
 
-    ddwaf_object_free(&parameter);
     ddwaf_context_destroy(context);
 }
 
@@ -153,8 +152,8 @@ TEST(TestWafIntegration, HandleLifetimeMultipleContexts)
     // Destroying the handle should not invalidate it
     ddwaf_destroy(handle);
 
-    ddwaf_object parameter = DDWAF_OBJECT_MAP;
     ddwaf_object tmp;
+    ddwaf_object parameter = DDWAF_OBJECT_MAP;
     ddwaf_object param_key = DDWAF_OBJECT_ARRAY;
     ddwaf_object param_val = DDWAF_OBJECT_ARRAY;
 
@@ -166,13 +165,13 @@ TEST(TestWafIntegration, HandleLifetimeMultipleContexts)
     ddwaf_object_map_add(&parameter, "value1", &param_key);
     ddwaf_object_map_add(&parameter, "value2", &param_val);
 
-    EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(
+        ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+        DDWAF_MATCH);
     ddwaf_context_destroy(context1);
 
     EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
     ddwaf_context_destroy(context2);
-
-    ddwaf_object_free(&parameter);
 }
 
 TEST(TestWafIntegration, InvalidVersion)
@@ -332,14 +331,15 @@ TEST(TestWafIntegration, UpdateRules)
     ddwaf_object parameter2 = DDWAF_OBJECT_MAP;
     ddwaf_object_map_add(&parameter2, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-    EXPECT_EQ(ddwaf_run(context1, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(
+        ddwaf_run(context1, ddwaf_object_clone(&parameter1, &tmp), nullptr, nullptr, LONG_TIME),
+        DDWAF_MATCH);
     EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
 
-    EXPECT_EQ(ddwaf_run(context1, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(
+        ddwaf_run(context1, ddwaf_object_clone(&parameter2, &tmp), nullptr, nullptr, LONG_TIME),
+        DDWAF_MATCH);
     EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-    ddwaf_object_free(&parameter1);
-    ddwaf_object_free(&parameter2);
 
     ddwaf_context_destroy(context2);
     ddwaf_context_destroy(context1);
@@ -386,14 +386,15 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByID)
     ddwaf_object parameter2 = DDWAF_OBJECT_MAP;
     ddwaf_object_map_add(&parameter2, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-    EXPECT_EQ(ddwaf_run(context1, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(
+        ddwaf_run(context1, ddwaf_object_clone(&parameter1, &tmp), nullptr, nullptr, LONG_TIME),
+        DDWAF_MATCH);
     EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_OK);
 
-    EXPECT_EQ(ddwaf_run(context1, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(
+        ddwaf_run(context1, ddwaf_object_clone(&parameter2, &tmp), nullptr, nullptr, LONG_TIME),
+        DDWAF_MATCH);
     EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-    ddwaf_object_free(&parameter1);
-    ddwaf_object_free(&parameter2);
 
     ddwaf_context_destroy(context1);
     ddwaf_destroy(handle1);
@@ -406,14 +407,13 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByID)
     ASSERT_NE(context3, nullptr);
 
     {
-        ddwaf_object tmp;
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context2);
@@ -463,14 +463,15 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByTags)
         ddwaf_object parameter2 = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter2, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter1, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter2, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter1);
-        ddwaf_object_free(&parameter2);
     }
 
     ddwaf_context_destroy(context1);
@@ -495,14 +496,15 @@ TEST(TestWafIntegration, UpdateDisableEnableRuleByTags)
         ddwaf_object parameter2 = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter2, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter1, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter1, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter2, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context3, &parameter2, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter1);
-        ddwaf_object_free(&parameter2);
     }
 
     ddwaf_context_destroy(context2);
@@ -566,10 +568,10 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(
@@ -597,10 +599,10 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(result2, {});
@@ -643,10 +645,10 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object result2;
         ddwaf_object result3;
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, &result2, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(
             result2, {{"block_request",
@@ -719,10 +721,10 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(
@@ -750,10 +752,10 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result1, {});
         EXPECT_ACTIONS(result2, {});
@@ -810,7 +812,9 @@ TEST(TestWafIntegration, UpdateTagsByID)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result1,
@@ -833,8 +837,6 @@ TEST(TestWafIntegration, UpdateTagsByID)
                     .highlight = "rule1"sv,
                     .args = {
                         {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -860,7 +862,9 @@ TEST(TestWafIntegration, UpdateTagsByID)
         ddwaf_object result3;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context3, ddwaf_object_clone(&parameter, &tmp), nullptr, &result3, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result3,
@@ -883,8 +887,6 @@ TEST(TestWafIntegration, UpdateTagsByID)
                     .highlight = "rule1"sv,
                     .args = {
                         {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_object_free(&result3);
         ddwaf_object_free(&result2);
@@ -940,10 +942,10 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_EVENTS(result1,
             {.id = "1",
@@ -987,10 +989,10 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_EVENTS(result1,
             {.id = "2",
@@ -1033,10 +1035,10 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_EVENTS(result1,
             {.id = "3",
@@ -1083,10 +1085,10 @@ TEST(TestWafIntegration, UpdateTagsByTags)
         ddwaf_object result3;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context3, ddwaf_object_clone(&parameter, &tmp), nullptr, &result3, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_EVENTS(result3,
             {.id = "3",
@@ -1162,7 +1164,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object result1;
         ddwaf_object result2;
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result1, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, &result1, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result1,
@@ -1195,8 +1199,6 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
 
-        ddwaf_object_free(&parameter);
-
         ddwaf_context_destroy(context1);
         ddwaf_context_destroy(context2);
     }
@@ -1226,7 +1228,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object result2;
         ddwaf_object result3;
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, &result2, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(result2,
@@ -1259,8 +1263,6 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object_free(&result2);
         ddwaf_object_free(&result3);
 
-        ddwaf_object_free(&parameter);
-
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
     }
@@ -1287,10 +1289,10 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context3, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context3);
         ddwaf_context_destroy(context4);
@@ -1380,22 +1382,26 @@ TEST(TestWafIntegration, UpdateRuleData)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
     }
 
     {
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "usr.id", ddwaf_object_string(&tmp, "paco"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -1446,10 +1452,10 @@ TEST(TestWafIntegration, UpdateAndRevertRuleData)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context1);
         ddwaf_context_destroy(context2);
@@ -1470,10 +1476,10 @@ TEST(TestWafIntegration, UpdateAndRevertRuleData)
         ddwaf_object_map_add(
             &parameter, "http.client_ip", ddwaf_object_string(&tmp, "192.168.1.1"));
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
@@ -1523,10 +1529,10 @@ TEST(TestWafIntegration, UpdateRuleExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1543,10 +1549,10 @@ TEST(TestWafIntegration, UpdateRuleExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1568,10 +1574,10 @@ TEST(TestWafIntegration, UpdateRuleExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context3);
         ddwaf_context_destroy(context2);
@@ -1620,10 +1626,10 @@ TEST(TestWafIntegration, UpdateInputExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1640,10 +1646,10 @@ TEST(TestWafIntegration, UpdateInputExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule2"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1660,10 +1666,10 @@ TEST(TestWafIntegration, UpdateInputExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule3"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1685,10 +1691,10 @@ TEST(TestWafIntegration, UpdateInputExclusions)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context3);
         ddwaf_context_destroy(context2);
@@ -1740,10 +1746,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1761,10 +1767,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.params", ddwaf_object_string(&tmp, "rule4"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context1, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context1);
@@ -1799,10 +1805,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result2;
         ddwaf_object result3;
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &result2, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, &result2, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result2, {});
         EXPECT_ACTIONS(
@@ -1828,10 +1834,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_map_add(
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context2, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context2);
         ddwaf_context_destroy(context3);
@@ -1867,10 +1873,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result3;
         ddwaf_object result4;
 
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &result3, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context3, ddwaf_object_clone(&parameter, &tmp), nullptr, &result3, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, &result4, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result3, {});
         EXPECT_ACTIONS(
@@ -1894,8 +1900,6 @@ TEST(TestWafIntegration, UpdateEverything)
             &parameter, "server.request.query", ddwaf_object_string(&tmp, "rule3"));
 
         EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context4);
     }
@@ -1930,10 +1934,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result4;
         ddwaf_object result5;
 
-        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, &result4, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context4, ddwaf_object_clone(&parameter, &tmp), nullptr, &result4, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(
             result4, {{"block_request",
@@ -1960,10 +1964,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
-        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context4, ddwaf_object_clone(&parameter, &tmp), nullptr, nullptr, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         ddwaf_context_destroy(context4);
         ddwaf_context_destroy(context5);
@@ -1984,10 +1988,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result4;
         ddwaf_object result5;
 
-        EXPECT_EQ(ddwaf_run(context4, &parameter, nullptr, &result4, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context4, ddwaf_object_clone(&parameter, &tmp), nullptr, &result4, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(
             result4, {{"block_request",
@@ -2031,10 +2035,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result5;
         ddwaf_object result6;
 
-        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context5, ddwaf_object_clone(&parameter, &tmp), nullptr, &result5, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, &result6, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result5, {});
         EXPECT_ACTIONS(
@@ -2063,10 +2067,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result5;
         ddwaf_object result6;
 
-        EXPECT_EQ(ddwaf_run(context5, &parameter, nullptr, &result5, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context5, ddwaf_object_clone(&parameter, &tmp), nullptr, &result5, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, &result6, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(
             result5, {{"block_request",
@@ -2093,8 +2097,6 @@ TEST(TestWafIntegration, UpdateEverything)
 
         EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
 
-        ddwaf_object_free(&parameter);
-
         ddwaf_context_destroy(context6);
     }
 
@@ -2120,10 +2122,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result6;
         ddwaf_object result7;
 
-        EXPECT_EQ(ddwaf_run(context6, &parameter, nullptr, &result6, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_run(context6, ddwaf_object_clone(&parameter, &tmp), nullptr, &result6, LONG_TIME),
+            DDWAF_OK);
         EXPECT_EQ(ddwaf_run(context7, &parameter, nullptr, &result7, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result6, {});
         EXPECT_ACTIONS(
@@ -2160,10 +2162,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result7;
         ddwaf_object result8;
 
-        EXPECT_EQ(ddwaf_run(context7, &parameter, nullptr, &result7, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context7, ddwaf_object_clone(&parameter, &tmp), nullptr, &result7, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(
             result7, {{"block_request",
@@ -2192,10 +2194,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result7;
         ddwaf_object result8;
 
-        EXPECT_EQ(ddwaf_run(context7, &parameter, nullptr, &result7, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context7, ddwaf_object_clone(&parameter, &tmp), nullptr, &result7, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(
             result7, {{"block_request",
@@ -2229,10 +2231,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result8;
         ddwaf_object result9;
 
-        EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context8, ddwaf_object_clone(&parameter, &tmp), nullptr, &result8, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context9, &parameter, nullptr, &result9, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result8, {});
         EXPECT_ACTIONS(result9, {});
@@ -2259,10 +2261,10 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object result8;
         ddwaf_object result9;
 
-        EXPECT_EQ(ddwaf_run(context8, &parameter, nullptr, &result8, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_run(context8, ddwaf_object_clone(&parameter, &tmp), nullptr, &result8, LONG_TIME),
+            DDWAF_MATCH);
         EXPECT_EQ(ddwaf_run(context9, &parameter, nullptr, &result9, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result9, {});
 

--- a/tests/integration/matchers/equals/test.cpp
+++ b/tests/integration/matchers/equals/test.cpp
@@ -29,7 +29,7 @@ TEST(TestEqualsMatcherIntegration, StringEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -64,7 +64,7 @@ TEST(TestEqualsMatcherIntegration, BoolEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -101,7 +101,7 @@ TEST(TestEqualsMatcherIntegration, SignedEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
@@ -136,7 +136,7 @@ TEST(TestEqualsMatcherIntegration, UnsignedEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "4",
@@ -173,7 +173,7 @@ TEST(TestEqualsMatcherIntegration, FloatEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "5",

--- a/tests/integration/matchers/equals/test.cpp
+++ b/tests/integration/matchers/equals/test.cpp
@@ -29,7 +29,7 @@ TEST(TestEqualsMatcherIntegration, StringEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -64,7 +64,7 @@ TEST(TestEqualsMatcherIntegration, BoolEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -101,7 +101,7 @@ TEST(TestEqualsMatcherIntegration, SignedEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "3",
@@ -136,7 +136,7 @@ TEST(TestEqualsMatcherIntegration, UnsignedEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "4",
@@ -173,7 +173,7 @@ TEST(TestEqualsMatcherIntegration, FloatEquals)
     ddwaf_object_map_add(&map, "input", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "5",

--- a/tests/integration/matchers/hidden_ascii_match/test.cpp
+++ b/tests/integration/matchers/hidden_ascii_match/test.cpp
@@ -39,7 +39,7 @@ TEST(TestHiddenAsciiMatchMatchIntegration, Match)
         ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, input.c_str()));
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+        auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -68,7 +68,7 @@ TEST(TestHiddenAsciiMatchMatchIntegration, Match)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+        auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/matchers/hidden_ascii_match/test.cpp
+++ b/tests/integration/matchers/hidden_ascii_match/test.cpp
@@ -39,7 +39,7 @@ TEST(TestHiddenAsciiMatchMatchIntegration, Match)
         ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, input.c_str()));
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -68,7 +68,7 @@ TEST(TestHiddenAsciiMatchMatchIntegration, Match)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/matchers/is_sqli/test.cpp
+++ b/tests/integration/matchers/is_sqli/test.cpp
@@ -32,7 +32,7 @@ TEST(TestIsSQLiIntegration, Match)
 
     ddwaf_object ret;
 
-    auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/matchers/is_sqli/test.cpp
+++ b/tests/integration/matchers/is_sqli/test.cpp
@@ -32,7 +32,7 @@ TEST(TestIsSQLiIntegration, Match)
 
     ddwaf_object ret;
 
-    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/matchers/is_xss/test.cpp
+++ b/tests/integration/matchers/is_xss/test.cpp
@@ -32,7 +32,7 @@ TEST(TestIsXSSIntegration, Match)
 
     ddwaf_object ret;
 
-    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/matchers/is_xss/test.cpp
+++ b/tests/integration/matchers/is_xss/test.cpp
@@ -32,7 +32,7 @@ TEST(TestIsXSSIntegration, Match)
 
     ddwaf_object ret;
 
-    auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/matchers/phrase_match/test.cpp
+++ b/tests/integration/matchers/phrase_match/test.cpp
@@ -29,7 +29,7 @@ TEST(TestPhraseMatchMatcherIntegration, Match)
     ddwaf_object_map_add(&map, "input1", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -65,7 +65,7 @@ TEST(TestPhraseMatchMatcherIntegration, MatchWordBound)
         ddwaf_object_map_add(&map, "input2", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(out, {.id = "2",
@@ -92,7 +92,7 @@ TEST(TestPhraseMatchMatcherIntegration, MatchWordBound)
         ddwaf_object_map_add(&map, "input2", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/matchers/phrase_match/test.cpp
+++ b/tests/integration/matchers/phrase_match/test.cpp
@@ -29,7 +29,7 @@ TEST(TestPhraseMatchMatcherIntegration, Match)
     ddwaf_object_map_add(&map, "input1", &value);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -65,7 +65,7 @@ TEST(TestPhraseMatchMatcherIntegration, MatchWordBound)
         ddwaf_object_map_add(&map, "input2", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
         EXPECT_EVENTS(out, {.id = "2",
@@ -92,7 +92,7 @@ TEST(TestPhraseMatchMatcherIntegration, MatchWordBound)
         ddwaf_object_map_add(&map, "input2", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/matchers/regex_match/test.cpp
+++ b/tests/integration/matchers/regex_match/test.cpp
@@ -34,7 +34,7 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -65,7 +65,7 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -99,7 +99,7 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -130,7 +130,7 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -174,7 +174,7 @@ TEST(TestRegexMatchIntegration, MinLength)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
         ddwaf_object_free(&ret);
 
@@ -193,7 +193,7 @@ TEST(TestRegexMatchIntegration, MinLength)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, &ret, LONG_TIME);
+        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",

--- a/tests/integration/matchers/regex_match/test.cpp
+++ b/tests/integration/matchers/regex_match/test.cpp
@@ -34,7 +34,7 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+        auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -65,7 +65,7 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+        auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -99,7 +99,7 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+        auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
@@ -130,7 +130,7 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+        auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",
@@ -174,7 +174,7 @@ TEST(TestRegexMatchIntegration, MinLength)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+        auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
         ddwaf_object_free(&ret);
 
@@ -193,7 +193,7 @@ TEST(TestRegexMatchIntegration, MinLength)
 
         ddwaf_object ret;
 
-        auto code = ddwaf_run(context, &param, nullptr, true, &ret, LONG_TIME);
+        auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "1",
                                .name = "rule1",

--- a/tests/integration/processors/extract_schema/test.cpp
+++ b/tests/integration/processors/extract_schema/test.cpp
@@ -43,7 +43,7 @@ TEST(TestExtractSchemaIntegration, Postprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -89,7 +89,7 @@ TEST(TestExtractSchemaIntegration, Preprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -146,7 +146,7 @@ TEST(TestExtractSchemaIntegration, Processor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -207,7 +207,7 @@ TEST(TestExtractSchemaIntegration, ProcessorWithScannerByTags)
     ASSERT_NE(context, nullptr);
 
     ddwaf_object out;
-    ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+    ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -257,7 +257,7 @@ TEST(TestExtractSchemaIntegration, ProcessorWithScannerByID)
     ASSERT_NE(context, nullptr);
 
     ddwaf_object out;
-    ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+    ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -311,7 +311,7 @@ TEST(TestExtractSchemaIntegration, ProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -354,7 +354,7 @@ TEST(TestExtractSchemaIntegration, ProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -409,7 +409,7 @@ TEST(TestExtractSchemaIntegration, ScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -453,7 +453,7 @@ TEST(TestExtractSchemaIntegration, ScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -510,7 +510,7 @@ TEST(TestExtractSchemaIntegration, ProcessorAndScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -553,7 +553,7 @@ TEST(TestExtractSchemaIntegration, ProcessorAndScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -609,7 +609,7 @@ TEST(TestExtractSchemaIntegration, EmptyScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -645,7 +645,7 @@ TEST(TestExtractSchemaIntegration, EmptyScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -699,7 +699,7 @@ TEST(TestExtractSchemaIntegration, EmptyProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -742,7 +742,7 @@ TEST(TestExtractSchemaIntegration, EmptyProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
+        ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -790,7 +790,8 @@ TEST(TestExtractSchemaIntegration, PostprocessorWithEphemeralMapping)
         ddwaf_object_map_add(&ephemeral, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(
+            ddwaf_context_eval(context, &persistent, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -811,7 +812,8 @@ TEST(TestExtractSchemaIntegration, PostprocessorWithEphemeralMapping)
         ddwaf_object_map_add(&ephemeral, "server.request.body", &map);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -861,7 +863,8 @@ TEST(TestExtractSchemaIntegration, PreprocessorWithEphemeralMapping)
         ddwaf_object_map_add(&ephemeral, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &persistent, &ephemeral, true, &out, LONG_TIME),
+            DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -889,7 +892,8 @@ TEST(TestExtractSchemaIntegration, PreprocessorWithEphemeralMapping)
         ddwaf_object_map_add(&ephemeral, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -949,7 +953,8 @@ TEST(TestExtractSchemaIntegration, ProcessorEphemeralExpression)
         ddwaf_object_map_add(&ephemeral, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(
+            ddwaf_context_eval(context, &persistent, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -968,7 +973,8 @@ TEST(TestExtractSchemaIntegration, ProcessorEphemeralExpression)
         ddwaf_object_map_add(&persistent, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &persistent, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(
+            ddwaf_context_eval(context, &persistent, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -986,7 +992,8 @@ TEST(TestExtractSchemaIntegration, ProcessorEphemeralExpression)
         ddwaf_object_map_add(&ephemeral, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(
+            ddwaf_context_eval(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/processors/extract_schema/test.cpp
+++ b/tests/integration/processors/extract_schema/test.cpp
@@ -43,7 +43,7 @@ TEST(TestExtractSchemaIntegration, Postprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -89,7 +89,7 @@ TEST(TestExtractSchemaIntegration, Preprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -146,7 +146,7 @@ TEST(TestExtractSchemaIntegration, Processor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -207,7 +207,7 @@ TEST(TestExtractSchemaIntegration, ProcessorWithScannerByTags)
     ASSERT_NE(context, nullptr);
 
     ddwaf_object out;
-    ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+    ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -257,7 +257,7 @@ TEST(TestExtractSchemaIntegration, ProcessorWithScannerByID)
     ASSERT_NE(context, nullptr);
 
     ddwaf_object out;
-    ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+    ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -311,7 +311,7 @@ TEST(TestExtractSchemaIntegration, ProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -354,7 +354,7 @@ TEST(TestExtractSchemaIntegration, ProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -409,7 +409,7 @@ TEST(TestExtractSchemaIntegration, ScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -453,7 +453,7 @@ TEST(TestExtractSchemaIntegration, ScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -510,7 +510,7 @@ TEST(TestExtractSchemaIntegration, ProcessorAndScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -553,7 +553,7 @@ TEST(TestExtractSchemaIntegration, ProcessorAndScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -609,7 +609,7 @@ TEST(TestExtractSchemaIntegration, EmptyScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -645,7 +645,7 @@ TEST(TestExtractSchemaIntegration, EmptyScannerUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -699,7 +699,7 @@ TEST(TestExtractSchemaIntegration, EmptyProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -742,7 +742,7 @@ TEST(TestExtractSchemaIntegration, EmptyProcessorUpdate)
         ASSERT_NE(context, nullptr);
 
         ddwaf_object out;
-        ddwaf_run(context, &map, nullptr, &out, LONG_TIME);
+        ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -790,7 +790,7 @@ TEST(TestExtractSchemaIntegration, PostprocessorWithEphemeralMapping)
         ddwaf_object_map_add(&ephemeral, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -811,7 +811,7 @@ TEST(TestExtractSchemaIntegration, PostprocessorWithEphemeralMapping)
         ddwaf_object_map_add(&ephemeral, "server.request.body", &map);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -861,7 +861,7 @@ TEST(TestExtractSchemaIntegration, PreprocessorWithEphemeralMapping)
         ddwaf_object_map_add(&ephemeral, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -889,7 +889,7 @@ TEST(TestExtractSchemaIntegration, PreprocessorWithEphemeralMapping)
         ddwaf_object_map_add(&ephemeral, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -949,7 +949,7 @@ TEST(TestExtractSchemaIntegration, ProcessorEphemeralExpression)
         ddwaf_object_map_add(&ephemeral, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &persistent, &ephemeral, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -968,7 +968,7 @@ TEST(TestExtractSchemaIntegration, ProcessorEphemeralExpression)
         ddwaf_object_map_add(&persistent, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &persistent, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &persistent, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -986,7 +986,7 @@ TEST(TestExtractSchemaIntegration, ProcessorEphemeralExpression)
         ddwaf_object_map_add(&ephemeral, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, nullptr, &ephemeral, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/processors/fingerprint/test.cpp
+++ b/tests/integration/processors/fingerprint/test.cpp
@@ -98,7 +98,7 @@ TEST(TestFingerprintIntegration, Postprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -181,7 +181,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -206,7 +206,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -229,7 +229,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -261,7 +261,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -282,7 +282,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -302,7 +302,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -410,7 +410,7 @@ TEST(TestFingerprintIntegration, Preprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -537,7 +537,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -580,7 +580,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -600,7 +600,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -641,7 +641,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -662,7 +662,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -779,7 +779,7 @@ TEST(TestFingerprintIntegration, Processor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -913,7 +913,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -962,7 +962,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -985,7 +985,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1031,7 +1031,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1055,7 +1055,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1118,7 +1118,7 @@ TEST(TestFingerprintIntegration, InvalidBodyType)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1165,7 +1165,7 @@ TEST(TestFingerprintIntegration, InvalidQueryType)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1212,7 +1212,7 @@ TEST(TestFingerprintIntegration, InvalidQueryAndBodyType)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1272,7 +1272,7 @@ TEST(TestFingerprintIntegration, InvalidHeader)
     ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1317,7 +1317,7 @@ TEST(TestFingerprintIntegration, InvalidCookies)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/processors/fingerprint/test.cpp
+++ b/tests/integration/processors/fingerprint/test.cpp
@@ -98,7 +98,7 @@ TEST(TestFingerprintIntegration, Postprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -181,7 +181,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -206,7 +206,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -229,7 +229,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -261,7 +261,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -282,7 +282,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "usr.id", ddwaf_object_string(&tmp, "admin"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -302,7 +302,7 @@ TEST(TestFingerprintIntegration, PostprocessorRegeneration)
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -410,7 +410,7 @@ TEST(TestFingerprintIntegration, Preprocessor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -537,7 +537,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -580,7 +580,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -600,7 +600,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -641,7 +641,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -662,7 +662,7 @@ TEST(TestFingerprintIntegration, PreprocessorRegeneration)
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -779,7 +779,7 @@ TEST(TestFingerprintIntegration, Processor)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -913,7 +913,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -962,7 +962,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.query", &query);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -985,7 +985,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.body", &body);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1031,7 +1031,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "server.request.cookies", &cookies);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1055,7 +1055,7 @@ TEST(TestFingerprintIntegration, ProcessorRegeneration)
         ddwaf_object_map_add(&map, "usr.session_id", ddwaf_object_string(&tmp, "ansd0182u2n"));
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1118,7 +1118,7 @@ TEST(TestFingerprintIntegration, InvalidBodyType)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1165,7 +1165,7 @@ TEST(TestFingerprintIntegration, InvalidQueryType)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1212,7 +1212,7 @@ TEST(TestFingerprintIntegration, InvalidQueryAndBodyType)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1272,7 +1272,7 @@ TEST(TestFingerprintIntegration, InvalidHeader)
     ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -1317,7 +1317,7 @@ TEST(TestFingerprintIntegration, InvalidCookies)
     ddwaf_object_map_add(&map, "waf.context.processor", &settings);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/processors/jwt_decode/test.cpp
+++ b/tests/integration/processors/jwt_decode/test.cpp
@@ -51,7 +51,7 @@ TEST(TestJwtDecoderIntegration, Preprocessor)
     ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -111,7 +111,7 @@ TEST(TestJwtDecoderIntegration, Postprocessor)
     ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -165,7 +165,7 @@ TEST(TestJwtDecoderIntegration, Processor)
     ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/processors/jwt_decode/test.cpp
+++ b/tests/integration/processors/jwt_decode/test.cpp
@@ -51,7 +51,7 @@ TEST(TestJwtDecoderIntegration, Preprocessor)
     ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -111,7 +111,7 @@ TEST(TestJwtDecoderIntegration, Postprocessor)
     ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -165,7 +165,7 @@ TEST(TestJwtDecoderIntegration, Processor)
     ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -42,7 +42,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersById)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -79,7 +79,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersById)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -127,7 +127,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersByTags)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -164,7 +164,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersByTags)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -212,7 +212,7 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -250,7 +250,7 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -288,7 +288,7 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -335,7 +335,7 @@ TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -373,7 +373,7 @@ TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -420,7 +420,7 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -457,7 +457,7 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -491,7 +491,7 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -538,7 +538,7 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -575,7 +575,7 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -609,7 +609,7 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -660,7 +660,7 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -708,7 +708,7 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -42,7 +42,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersById)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -79,7 +79,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersById)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -127,7 +127,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersByTags)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -164,7 +164,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersByTags)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -212,7 +212,7 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -250,7 +250,7 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -288,7 +288,7 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -335,7 +335,7 @@ TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -373,7 +373,7 @@ TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -420,7 +420,7 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -457,7 +457,7 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -491,7 +491,7 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -538,7 +538,7 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -575,7 +575,7 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -609,7 +609,7 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
         ddwaf_object_map_add(&map, "server.request.body", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -660,7 +660,7 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
@@ -708,7 +708,7 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
         ddwaf_object_map_add(&map, "server.request.headers", &value);
 
         ddwaf_object out;
-        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 

--- a/tests/integration/regressions/test.cpp
+++ b/tests/integration/regressions/test.cpp
@@ -30,7 +30,7 @@ TEST(TestRegressionsIntegration, DuplicateFlowMatches)
     ddwaf_object_map_add(&parameter, "param2", ddwaf_object_string(&tmp, "Duplicate"));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/regressions/test.cpp
+++ b/tests/integration/regressions/test.cpp
@@ -30,7 +30,7 @@ TEST(TestRegressionsIntegration, DuplicateFlowMatches)
     ddwaf_object_map_add(&parameter, "param2", ddwaf_object_string(&tmp, "Duplicate"));
 
     ddwaf_object ret;
-    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
+    EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &ret, LONG_TIME), DDWAF_MATCH);
 
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));

--- a/tests/integration/rules/attributes/test.cpp
+++ b/tests/integration/rules/attributes/test.cpp
@@ -34,7 +34,8 @@ TEST(TestRuleAttributesIntegration, SingleValueOutputNoEvent)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -89,7 +90,8 @@ TEST(TestRuleAttributesIntegration, SingleValueOutputAndEvent)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -147,7 +149,8 @@ TEST(TestRuleAttributesIntegration, SingleTargetOutputNoEvent)
         ddwaf_object_map_add(&parameter, "value3", ddwaf_object_string(&tmp, "rule3"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -202,7 +205,8 @@ TEST(TestRuleAttributesIntegration, MultipleValuesOutputNoEvent)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "rule4"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -275,7 +279,8 @@ TEST(TestRuleAttributesIntegration, AttributesWithActions)
         ddwaf_object_map_add(&parameter, "value5", ddwaf_object_string(&tmp, "rule5"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -339,7 +344,8 @@ TEST(TestRuleAttributesIntegration, MultipleAttributesAndActions)
         ddwaf_object_map_add(&parameter, "value6", ddwaf_object_string(&tmp, "rule6"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -422,7 +428,8 @@ TEST(TestRuleAttributesIntegration, AttributesAndMonitorRuleFilter)
         ddwaf_object_map_add(&parameter, "value7", ddwaf_object_string(&tmp, "rule7"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -482,7 +489,8 @@ TEST(TestRuleAttributesIntegration, AttributesAndBlockingRuleFilter)
         ddwaf_object_map_add(&parameter, "value8", ddwaf_object_string(&tmp, "rule8"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -546,7 +554,8 @@ TEST(TestRuleAttributesIntegration, AttributesAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule8"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -569,7 +578,8 @@ TEST(TestRuleAttributesIntegration, AttributesAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, nullptr, &parameter, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -593,7 +603,8 @@ TEST(TestRuleAttributesIntegration, AttributesAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -635,7 +646,8 @@ TEST(TestRuleAttributesIntegration, AttributesEventsAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule8"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -658,7 +670,8 @@ TEST(TestRuleAttributesIntegration, AttributesEventsAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, nullptr, &parameter, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -687,7 +700,8 @@ TEST(TestRuleAttributesIntegration, AttributesEventsAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, nullptr, &parameter, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 

--- a/tests/integration/rules/attributes/test.cpp
+++ b/tests/integration/rules/attributes/test.cpp
@@ -34,7 +34,7 @@ TEST(TestRuleAttributesIntegration, SingleValueOutputNoEvent)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -89,7 +89,7 @@ TEST(TestRuleAttributesIntegration, SingleValueOutputAndEvent)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -147,7 +147,7 @@ TEST(TestRuleAttributesIntegration, SingleTargetOutputNoEvent)
         ddwaf_object_map_add(&parameter, "value3", ddwaf_object_string(&tmp, "rule3"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -202,7 +202,7 @@ TEST(TestRuleAttributesIntegration, MultipleValuesOutputNoEvent)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "rule4"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -275,7 +275,7 @@ TEST(TestRuleAttributesIntegration, AttributesWithActions)
         ddwaf_object_map_add(&parameter, "value5", ddwaf_object_string(&tmp, "rule5"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -339,7 +339,7 @@ TEST(TestRuleAttributesIntegration, MultipleAttributesAndActions)
         ddwaf_object_map_add(&parameter, "value6", ddwaf_object_string(&tmp, "rule6"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -422,7 +422,7 @@ TEST(TestRuleAttributesIntegration, AttributesAndMonitorRuleFilter)
         ddwaf_object_map_add(&parameter, "value7", ddwaf_object_string(&tmp, "rule7"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -482,7 +482,7 @@ TEST(TestRuleAttributesIntegration, AttributesAndBlockingRuleFilter)
         ddwaf_object_map_add(&parameter, "value8", ddwaf_object_string(&tmp, "rule8"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -546,7 +546,7 @@ TEST(TestRuleAttributesIntegration, AttributesAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule8"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, &result, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -569,7 +569,7 @@ TEST(TestRuleAttributesIntegration, AttributesAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -593,7 +593,7 @@ TEST(TestRuleAttributesIntegration, AttributesAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, &result, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -635,7 +635,7 @@ TEST(TestRuleAttributesIntegration, AttributesEventsAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule8"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, &result, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_OK);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -658,7 +658,7 @@ TEST(TestRuleAttributesIntegration, AttributesEventsAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -687,7 +687,7 @@ TEST(TestRuleAttributesIntegration, AttributesEventsAndEphemeralMatches)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, nullptr, &parameter, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 

--- a/tests/integration/rules/custom_rules/test.cpp
+++ b/tests/integration/rules/custom_rules/test.cpp
@@ -36,14 +36,16 @@ TEST(TestCustomRulesIntegration, InitWithoutBaseRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "custom_rule1"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
     }
 
     {
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "custom_rule2"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
     }
 
     ddwaf_context_destroy(context1);
@@ -72,14 +74,16 @@ TEST(TestCustomRulesIntegration, InitWithBaseRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
     }
 
     {
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "custom_rule2"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context1, &parameter, nullptr, true, nullptr, LONG_TIME),
+            DDWAF_MATCH);
     }
 
     ddwaf_context_destroy(context1);
@@ -109,7 +113,8 @@ TEST(TestCustomRulesIntegration, RegularCustomRulesPrecedence)
         ddwaf_object_map_add(&parameter, "value3", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule3",
                                .name = "custom_rule3",
@@ -148,7 +153,8 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -192,7 +198,8 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -253,7 +260,8 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -274,7 +282,8 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -339,7 +348,8 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -360,7 +370,8 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule5",
                                .name = "custom_rule5",
@@ -445,7 +456,8 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -466,7 +478,8 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -531,7 +544,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -552,7 +566,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -631,7 +646,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -651,7 +667,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(
+            ddwaf_context_eval(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
     }
 
     {
@@ -659,7 +676,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context3, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -725,7 +743,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -746,7 +765,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -825,7 +845,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -849,7 +870,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule3",
                                .name = "rule3",
@@ -870,7 +892,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(
+            ddwaf_context_eval(context3, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule3",
                                .name = "custom_rule3",

--- a/tests/integration/rules/custom_rules/test.cpp
+++ b/tests/integration/rules/custom_rules/test.cpp
@@ -37,8 +37,6 @@ TEST(TestCustomRulesIntegration, InitWithoutBaseRules)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "custom_rule1"));
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -46,8 +44,6 @@ TEST(TestCustomRulesIntegration, InitWithoutBaseRules)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "custom_rule2"));
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -77,8 +73,6 @@ TEST(TestCustomRulesIntegration, InitWithBaseRules)
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -86,8 +80,6 @@ TEST(TestCustomRulesIntegration, InitWithBaseRules)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "custom_rule2"));
 
         EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
-
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -127,7 +119,6 @@ TEST(TestCustomRulesIntegration, RegularCustomRulesPrecedence)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value3"}}}}});
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -172,7 +163,6 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -216,7 +206,6 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -278,7 +267,6 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -300,7 +288,6 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -366,7 +353,6 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -385,7 +371,6 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -474,7 +459,6 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -496,7 +480,6 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -562,7 +545,6 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -584,7 +566,6 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -664,7 +645,6 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -672,8 +652,6 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
         EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
-
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -695,7 +673,6 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -762,7 +739,6 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -784,7 +760,6 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);
@@ -867,7 +842,6 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                                    {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -889,7 +863,6 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                    }}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     {
@@ -911,7 +884,6 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                    }}}}});
 
         ddwaf_object_free(&res);
-        ddwaf_object_free(&parameter);
     }
 
     ddwaf_context_destroy(context1);

--- a/tests/integration/rules/custom_rules/test.cpp
+++ b/tests/integration/rules/custom_rules/test.cpp
@@ -19,7 +19,7 @@ TEST(TestCustomRulesIntegration, InitWithoutBaseRules)
     auto rule = read_file<ddwaf_object>("custom_rules.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -55,7 +55,7 @@ TEST(TestCustomRulesIntegration, InitWithBaseRules)
     auto rule = read_file<ddwaf_object>("custom_rules_and_rules.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -91,7 +91,7 @@ TEST(TestCustomRulesIntegration, RegularCustomRulesPrecedence)
     auto rule = read_file<ddwaf_object>("custom_rules_and_rules.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -130,7 +130,7 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
     auto rule = read_file<ddwaf_object>("custom_rules_and_rules.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -174,7 +174,7 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
     auto rule = read_file<ddwaf_object>("custom_rules_and_rules.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
 
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
     ASSERT_NE(handle, nullptr);
@@ -214,7 +214,7 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
 // Custom rules can be updated when base rules exist
 TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -299,7 +299,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
 // Custom rules can be updated when custom rules already exist
 TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -382,7 +382,7 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
 // Remove all custom rules when no other rules are available
 TEST(TestCustomRulesIntegration, UpdateWithEmptyRules)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     auto rule = read_file<ddwaf_object>("custom_rules.yaml", base_dir);
@@ -406,7 +406,7 @@ TEST(TestCustomRulesIntegration, UpdateWithEmptyRules)
 // Remove all custom rules when base rules are available
 TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -491,7 +491,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
 // Ensure that existing custom rules are unaffected by overrides
 TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -577,7 +577,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
 // Ensure that custom rules are unaffected by overrides after an update
 TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -685,7 +685,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
 // Ensure that existing custom rules are unaffected by overrides
 TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {
@@ -771,7 +771,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
 // Ensure that custom rules are affected by overrides after an update
 TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
 {
-    ddwaf_config config{{nullptr, nullptr}, nullptr};
+    ddwaf_config config{{nullptr, nullptr}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     {

--- a/tests/integration/rules/custom_rules/test.cpp
+++ b/tests/integration/rules/custom_rules/test.cpp
@@ -36,14 +36,14 @@ TEST(TestCustomRulesIntegration, InitWithoutBaseRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "custom_rule1"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
     }
 
     {
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "custom_rule2"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
     }
 
     ddwaf_context_destroy(context1);
@@ -72,14 +72,14 @@ TEST(TestCustomRulesIntegration, InitWithBaseRules)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
     }
 
     {
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "custom_rule2"));
 
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_MATCH);
     }
 
     ddwaf_context_destroy(context1);
@@ -109,7 +109,7 @@ TEST(TestCustomRulesIntegration, RegularCustomRulesPrecedence)
         ddwaf_object_map_add(&parameter, "value3", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule3",
                                .name = "custom_rule3",
@@ -148,7 +148,7 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -192,7 +192,7 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -253,7 +253,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -274,7 +274,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -339,7 +339,7 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -360,7 +360,7 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule5",
                                .name = "custom_rule5",
@@ -445,7 +445,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -466,7 +466,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -531,7 +531,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -552,7 +552,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -631,7 +631,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -651,7 +651,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object parameter = DDWAF_OBJECT_MAP;
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, nullptr, LONG_TIME), DDWAF_OK);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
     }
 
     {
@@ -659,7 +659,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
         ddwaf_object_map_add(&parameter, "value4", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -725,7 +725,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
@@ -746,7 +746,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -825,7 +825,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context1, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
@@ -849,7 +849,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context2, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "rule3",
                                .name = "rule3",
@@ -870,7 +870,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
         ddwaf_object_map_add(&parameter, "value34", ddwaf_object_string(&tmp, "custom_rule"));
 
         ddwaf_object res;
-        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context3, &parameter, nullptr, true, &res, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EVENTS(res, {.id = "custom_rule3",
                                .name = "custom_rule3",

--- a/tests/integration/rules/rules_compat/test.cpp
+++ b/tests/integration/rules/rules_compat/test.cpp
@@ -38,7 +38,8 @@ TEST(TestRulesCompatIntegration, VerifyBothBaseAndCompat)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -149,7 +150,8 @@ TEST(TestRulesCompatIntegration, DuplicateRules)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, LONG_TIME),
+            DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 

--- a/tests/integration/rules/rules_compat/test.cpp
+++ b/tests/integration/rules/rules_compat/test.cpp
@@ -38,7 +38,7 @@ TEST(TestRulesCompatIntegration, VerifyBothBaseAndCompat)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 
@@ -149,7 +149,7 @@ TEST(TestRulesCompatIntegration, DuplicateRules)
         ddwaf_object_map_add(&parameter, "value2", ddwaf_object_string(&tmp, "rule2"));
 
         ddwaf_object result;
-        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &result, LONG_TIME), DDWAF_MATCH);
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
         EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_MAP);
 

--- a/tests/integration/transformers/test.cpp
+++ b/tests/integration/transformers/test.cpp
@@ -29,7 +29,7 @@ TEST(TestTransformers, Base64Decode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -61,7 +61,7 @@ TEST(TestTransformers, Base64DecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -93,7 +93,7 @@ TEST(TestTransformers, Base64UrlDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -125,7 +125,7 @@ TEST(TestTransformers, Base64Encode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -158,7 +158,7 @@ TEST(TestTransformers, Base64EncodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -191,7 +191,7 @@ TEST(TestTransformers, CompressWhitespace)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -224,7 +224,7 @@ TEST(TestTransformers, CompressWhitespaceAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -257,7 +257,7 @@ TEST(TestTransformers, CssDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -291,7 +291,7 @@ TEST(TestTransformers, CssDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -325,7 +325,7 @@ TEST(TestTransformers, HtmlEntityDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -359,7 +359,7 @@ TEST(TestTransformers, HtmlEntityDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -393,7 +393,7 @@ TEST(TestTransformers, JsDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -427,7 +427,7 @@ TEST(TestTransformers, JsDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -461,7 +461,7 @@ TEST(TestTransformers, Lowercase)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -494,7 +494,7 @@ TEST(TestTransformers, NormalizePath)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -527,7 +527,7 @@ TEST(TestTransformers, NormalizePathAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -560,7 +560,7 @@ TEST(TestTransformers, NormalizePathWin)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -593,7 +593,7 @@ TEST(TestTransformers, NormalizePathAliasWin)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -626,7 +626,7 @@ TEST(TestTransformers, RemoveComments)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -659,7 +659,7 @@ TEST(TestTransformers, RemoveCommentsAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -692,7 +692,7 @@ TEST(TestTransformers, RemoveNulls)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -725,7 +725,7 @@ TEST(TestTransformers, RemoveNullsAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -758,7 +758,7 @@ TEST(TestTransformers, ShellUnescape)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -791,7 +791,7 @@ TEST(TestTransformers, ShellUnescapeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -824,7 +824,7 @@ TEST(TestTransformers, UnicodeNormalize)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -857,7 +857,7 @@ TEST(TestTransformers, UrlBasename)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -890,7 +890,7 @@ TEST(TestTransformers, UrlBasenameAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -923,7 +923,7 @@ TEST(TestTransformers, UrlDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -956,7 +956,7 @@ TEST(TestTransformers, UrlDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -989,7 +989,7 @@ TEST(TestTransformers, UrlDecodeIis)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -1022,7 +1022,7 @@ TEST(TestTransformers, UrlDecodeIisAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -1055,7 +1055,7 @@ TEST(TestTransformers, UrlPath)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -1088,7 +1088,7 @@ TEST(TestTransformers, UrlPathAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -1121,7 +1121,7 @@ TEST(TestTransformers, UrlQuerystring)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -1154,7 +1154,7 @@ TEST(TestTransformers, UrlQuerystringAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -1187,7 +1187,7 @@ TEST(TestTransformers, Mixed)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(

--- a/tests/integration/transformers/test.cpp
+++ b/tests/integration/transformers/test.cpp
@@ -29,7 +29,7 @@ TEST(TestTransformers, Base64Decode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -61,7 +61,7 @@ TEST(TestTransformers, Base64DecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -93,7 +93,7 @@ TEST(TestTransformers, Base64UrlDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -125,7 +125,7 @@ TEST(TestTransformers, Base64Encode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -158,7 +158,7 @@ TEST(TestTransformers, Base64EncodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -191,7 +191,7 @@ TEST(TestTransformers, CompressWhitespace)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -224,7 +224,7 @@ TEST(TestTransformers, CompressWhitespaceAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -257,7 +257,7 @@ TEST(TestTransformers, CssDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -291,7 +291,7 @@ TEST(TestTransformers, CssDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -325,7 +325,7 @@ TEST(TestTransformers, HtmlEntityDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -359,7 +359,7 @@ TEST(TestTransformers, HtmlEntityDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -393,7 +393,7 @@ TEST(TestTransformers, JsDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -427,7 +427,7 @@ TEST(TestTransformers, JsDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(
@@ -461,7 +461,7 @@ TEST(TestTransformers, Lowercase)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -494,7 +494,7 @@ TEST(TestTransformers, NormalizePath)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -527,7 +527,7 @@ TEST(TestTransformers, NormalizePathAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -560,7 +560,7 @@ TEST(TestTransformers, NormalizePathWin)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -593,7 +593,7 @@ TEST(TestTransformers, NormalizePathAliasWin)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -626,7 +626,7 @@ TEST(TestTransformers, RemoveComments)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -659,7 +659,7 @@ TEST(TestTransformers, RemoveCommentsAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -692,7 +692,7 @@ TEST(TestTransformers, RemoveNulls)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -725,7 +725,7 @@ TEST(TestTransformers, RemoveNullsAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -758,7 +758,7 @@ TEST(TestTransformers, ShellUnescape)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -791,7 +791,7 @@ TEST(TestTransformers, ShellUnescapeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -824,7 +824,7 @@ TEST(TestTransformers, UnicodeNormalize)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -857,7 +857,7 @@ TEST(TestTransformers, UrlBasename)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -890,7 +890,7 @@ TEST(TestTransformers, UrlBasenameAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -923,7 +923,7 @@ TEST(TestTransformers, UrlDecode)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -956,7 +956,7 @@ TEST(TestTransformers, UrlDecodeAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -989,7 +989,7 @@ TEST(TestTransformers, UrlDecodeIis)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -1022,7 +1022,7 @@ TEST(TestTransformers, UrlDecodeIisAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -1055,7 +1055,7 @@ TEST(TestTransformers, UrlPath)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -1088,7 +1088,7 @@ TEST(TestTransformers, UrlPathAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -1121,7 +1121,7 @@ TEST(TestTransformers, UrlQuerystring)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "1",
@@ -1154,7 +1154,7 @@ TEST(TestTransformers, UrlQuerystringAlias)
     ddwaf_object_map_add(&map, "value2", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(out, {.id = "2",
@@ -1187,7 +1187,7 @@ TEST(TestTransformers, Mixed)
     ddwaf_object_map_add(&map, "value1", &string);
 
     ddwaf_object out;
-    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
     EXPECT_EVENTS(

--- a/tests/unit/context_test.cpp
+++ b/tests/unit/context_test.cpp
@@ -16,33 +16,10 @@
 
 #include <gmock/gmock.h>
 
-using ::testing::_;
-using ::testing::Return;
-using ::testing::Sequence;
-
 using namespace ddwaf;
 using namespace std::literals;
 using namespace ddwaf::exclusion;
 using attribute = object_store::attribute;
-
-namespace ddwaf::test {
-class context : public ddwaf::context {
-public:
-    explicit context(std::shared_ptr<ddwaf::ruleset> ruleset) : ddwaf::context(std::move(ruleset))
-    {}
-
-    bool insert(object_view object, attribute attr = attribute::none)
-    {
-        return store_.insert(object, attr);
-    }
-
-    bool insert(owned_object object, attribute attr = attribute::none)
-    {
-        return store_.insert(std::move(object), attr);
-    }
-};
-
-} // namespace ddwaf::test
 
 namespace {
 
@@ -60,7 +37,7 @@ TEST(TestContext, MatchTimeout)
     rbuilder.insert_base_rule(core_rule{"id", "name", std::move(tags), builder.build()});
 
     ddwaf::timer deadline{0s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
@@ -83,7 +60,7 @@ TEST(TestContext, NoMatch)
     rbuilder.insert_base_rule(core_rule{"id", "name", std::move(tags), builder.build()});
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.2"}});
     ctx.insert(std::move(root));
@@ -107,7 +84,7 @@ TEST(TestContext, Match)
     rbuilder.insert_base_rule(core_rule{"id", "name", std::move(tags), builder.build()});
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
@@ -147,7 +124,7 @@ TEST(TestContext, MatchMultipleRulesInCollectionSingleRun)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
     ctx.insert(std::move(root));
@@ -210,7 +187,7 @@ TEST(TestContext, MatchMultipleRulesWithPrioritySingleRun)
 
     auto ruleset = rbuilder.build();
     {
-        ddwaf::test::context ctx(ruleset);
+        context ctx(ruleset);
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
@@ -230,7 +207,7 @@ TEST(TestContext, MatchMultipleRulesWithPrioritySingleRun)
     }
 
     {
-        ddwaf::test::context ctx(ruleset);
+        context ctx(ruleset);
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
@@ -282,7 +259,7 @@ TEST(TestContext, MatchMultipleRulesInCollectionDoubleRun)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
@@ -354,7 +331,7 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
@@ -449,7 +426,7 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
@@ -522,7 +499,7 @@ TEST(TestContext, MatchMultipleCollectionsSingleRun)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
     ctx.insert(std::move(root));
@@ -566,7 +543,7 @@ TEST(TestContext, MatchPriorityCollectionsSingleRun)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
     ctx.insert(std::move(root));
@@ -607,7 +584,7 @@ TEST(TestContext, MatchMultipleCollectionsDoubleRun)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"usr.id", "admin"}});
@@ -662,7 +639,7 @@ TEST(TestContext, MatchMultiplePriorityCollectionsDoubleRun)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"usr.id", "admin"}});
@@ -715,7 +692,7 @@ TEST(TestContext, RuleFilterWithCondition)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
     ctx.insert(std::move(root));
@@ -760,7 +737,7 @@ TEST(TestContext, RuleFilterWithEphemeralConditionMatch)
             rule_filter{"1", builder.build(), std::set<const core_rule *>{rule}});
     }
 
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto persistent = owned_object::make_map({{"usr.id", "admin"}});
@@ -769,14 +746,14 @@ TEST(TestContext, RuleFilterWithEphemeralConditionMatch)
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
         EXPECT_TRUE(ctx.insert(std::move(ephemeral), context::attribute::ephemeral));
 
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 
     {
         auto root = owned_object::make_map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
     }
 }
@@ -825,7 +802,7 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralBypassPersistentMonitor)
             exclusion::filter_mode::monitor});
     }
 
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto persistent = owned_object::make_map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
@@ -834,7 +811,7 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralBypassPersistentMonitor)
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
         EXPECT_TRUE(ctx.insert(std::move(ephemeral), context::attribute::ephemeral));
 
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 
@@ -842,7 +819,7 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralBypassPersistentMonitor)
         auto root = owned_object::make_map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
 
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
 
         EXPECT_TRUE(object_view{res}.find("actions").empty());
@@ -893,7 +870,7 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralMonitorPersistentBypass)
             rule_filter{"2", builder.build(), std::set<const core_rule *>{rule}});
     }
 
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto persistent = owned_object::make_map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
@@ -902,7 +879,7 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralMonitorPersistentBypass)
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
         EXPECT_TRUE(ctx.insert(std::move(ephemeral), context::attribute::ephemeral));
 
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 
@@ -910,7 +887,7 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralMonitorPersistentBypass)
         auto root = owned_object::make_map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
 
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 }
@@ -947,7 +924,7 @@ TEST(TestContext, RuleFilterTimeout)
     }
 
     ddwaf::timer deadline{0s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
@@ -987,7 +964,7 @@ TEST(TestContext, NoRuleFilterWithCondition)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.2"}});
     ctx.insert(std::move(root));
@@ -1020,7 +997,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRules)
     ddwaf::timer deadline{2s};
 
     {
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 0);
     }
@@ -1028,7 +1005,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRules)
     {
         rbuilder.insert_filter(rule_filter{"1", std::make_shared<expression>(),
             std::set<const core_rule *>{rules[0], rules[1], rules[2]}});
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 3);
@@ -1040,7 +1017,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRules)
     {
         rbuilder.insert_filter(rule_filter{"2", std::make_shared<expression>(),
             std::set<const core_rule *>{rules[3], rules[4], rules[5]}});
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 6);
@@ -1055,7 +1032,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRules)
     {
         rbuilder.insert_filter(rule_filter{"3", std::make_shared<expression>(),
             std::set<const core_rule *>{rules[6], rules[7], rules[8]}});
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 9);
@@ -1092,7 +1069,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRules)
     ddwaf::timer deadline{2s};
 
     {
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 0);
     }
@@ -1100,7 +1077,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRules)
     {
         rbuilder.insert_filter(rule_filter{"1", std::make_shared<expression>(),
             std::set<const core_rule *>{rules[0], rules[1], rules[2], rules[3]}});
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 4);
@@ -1113,7 +1090,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRules)
     {
         rbuilder.insert_filter(rule_filter{"2", std::make_shared<expression>(),
             std::set<const core_rule *>{rules[2], rules[3], rules[4]}});
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 5);
@@ -1127,7 +1104,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRules)
     {
         rbuilder.insert_filter(rule_filter{"3", std::make_shared<expression>(),
             std::set<const core_rule *>{rules[0], rules[5], rules[6]}});
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 7);
@@ -1143,7 +1120,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRules)
     {
         rbuilder.insert_filter(rule_filter{"4", std::make_shared<expression>(),
             std::set<const core_rule *>{rules[7], rules[8], rules[6]}});
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 9);
@@ -1162,7 +1139,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRules)
         rbuilder.insert_filter(rule_filter{"5", std::make_shared<expression>(),
             std::set<const core_rule *>{rules[0], rules[1], rules[2], rules[3], rules[4], rules[5],
                 rules[6], rules[7], rules[8]}});
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
         EXPECT_EQ(rules_to_exclude.size(), 9);
@@ -1218,7 +1195,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRulesWithConditions)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"usr.id", "admin"}});
@@ -1295,7 +1272,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRulesWithConditions)
     }
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
@@ -1352,7 +1329,7 @@ TEST(TestContext, InputFilterExclude)
         std::set<const core_rule *>{rule}, std::move(obj_filter)});
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
@@ -1386,26 +1363,26 @@ TEST(TestContext, InputFilterExcludeEphemeral)
     rbuilder.insert_filter(input_filter{"1", std::make_shared<expression>(),
         std::set<const core_rule *>{rule}, std::move(obj_filter)});
 
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 
     {
         auto root = owned_object::make_map({{"http.peer_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
     }
 }
@@ -1432,11 +1409,11 @@ TEST(TestContext, InputFilterExcludeEphemeral)
 /*rbuilder.insert_filter(input_filter{"1", std::make_shared<expression>(),*/
 /*std::set<const core_rule *>{rule}, std::move(obj_filter)});*/
 
-/*ddwaf::test::context ctx(rbuilder.build());*/
+/*context ctx(rbuilder.build());*/
 
 /*auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});*/
 /*    {*/
-/*auto [code, res] = ctx.run({}, std::move(root), LONG_TIME);*/
+/*auto [code, res] = ctx.eval({}, std::move(root), LONG_TIME);*/
 /*EXPECT_EQ(code, DDWAF_OK);*/
 /*}*/
 
@@ -1446,7 +1423,7 @@ TEST(TestContext, InputFilterExcludeEphemeral)
 /*root.array[0].parameterNameLength = peer_ip.size();*/
 
 /*{*/
-/*auto [code, res] = ctx.run({}, std::move(root), LONG_TIME);*/
+/*auto [code, res] = ctx.eval({}, std::move(root), LONG_TIME);*/
 /*EXPECT_EQ(code, DDWAF_MATCH);*/
 /*}*/
 /*}*/
@@ -1473,7 +1450,7 @@ TEST(TestContext, InputFilterExcludeRule)
         rule_filter{"1", std::make_shared<expression>(), std::set<const core_rule *>{rule}});
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
@@ -1515,7 +1492,7 @@ TEST(TestContext, InputFilterExcludeRuleEphemeral)
         rule_filter{"1", std::make_shared<expression>(), std::set<const core_rule *>{rule}});
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root), attribute::ephemeral);
@@ -1551,7 +1528,7 @@ TEST(TestContext, InputFilterMonitorRuleEphemeral)
         std::set<const core_rule *>{rule}, filter_mode::monitor});
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root), attribute::ephemeral);
@@ -1593,7 +1570,7 @@ TEST(TestContext, InputFilterExcluderRuleEphemeralAndPersistent)
         rule_filter{"1", std::make_shared<expression>(), std::set<const core_rule *>{rule}});
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
@@ -1637,7 +1614,7 @@ TEST(TestContext, InputFilterMonitorRuleEphemeralAndPersistent)
         std::set<const core_rule *>{rule}, filter_mode::monitor});
 
     ddwaf::timer deadline{2s};
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
@@ -1699,7 +1676,7 @@ TEST(TestContext, InputFilterWithCondition)
     // Without usr.id, nothing should be excluded
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
@@ -1714,7 +1691,7 @@ TEST(TestContext, InputFilterWithCondition)
     // With usr.id != admin, nothing should be excluded
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
@@ -1730,7 +1707,7 @@ TEST(TestContext, InputFilterWithCondition)
     // With usr.id == admin, there should be no matches
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
@@ -1777,21 +1754,21 @@ TEST(TestContext, InputFilterWithEphemeralCondition)
             input_filter{"1", builder.build(), std::move(eval_filters), std::move(obj_filter)});
     }
 
-    ddwaf::test::context ctx(rbuilder.build());
+    context ctx(rbuilder.build());
     {
         auto persistent = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
         auto ephemeral = owned_object::make_map({{"usr.id", "admin"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
         EXPECT_TRUE(ctx.insert(std::move(ephemeral), context::attribute::ephemeral));
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 
     {
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
-        auto [code, res] = ctx.run(LONG_TIME);
+        auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
     }
 }
@@ -1840,7 +1817,7 @@ TEST(TestContext, InputFilterMultipleRules)
     // Without usr.id, nothing should be excluded
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
@@ -1859,7 +1836,7 @@ TEST(TestContext, InputFilterMultipleRules)
     // With usr.id != admin, nothing should be excluded
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
@@ -1879,7 +1856,7 @@ TEST(TestContext, InputFilterMultipleRules)
     // With usr.id == admin, there should be no matches
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
@@ -1948,7 +1925,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
     // Without usr.id, nothing should be excluded
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
@@ -1968,7 +1945,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
     // With usr.id != admin, nothing should be excluded
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
@@ -1989,7 +1966,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
     // With usr.id == admin, there should be no matches
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
@@ -2089,7 +2066,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
 
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(object_view{root});
@@ -2109,7 +2086,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
 
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root = owned_object::make_map({{"usr.id", "admin"}});
         ctx.insert(object_view{root});
@@ -2129,7 +2106,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
 
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root = owned_object::make_map(
             {{"server.request.headers", owned_object::make_map({{"cookie", "mycookie"}})}});
@@ -2150,7 +2127,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
 
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root =
             owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
@@ -2171,7 +2148,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
 
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root = owned_object::make_map(
             {{"server.request.headers", owned_object::make_map({{"cookie", "mycookie"}})},
@@ -2193,7 +2170,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
 
     {
         ddwaf::timer deadline{2s};
-        ddwaf::test::context ctx(rbuilder.build());
+        context ctx(rbuilder.build());
 
         auto root = owned_object::make_map(
             {{"server.request.headers", owned_object::make_map({{"cookie", "mycookie"}})},

--- a/tests/unit/dynamic_string_test.cpp
+++ b/tests/unit/dynamic_string_test.cpp
@@ -19,15 +19,11 @@ TEST(TestDynamicString, DefaultConstructor)
 {
     dynamic_string str;
 
-    // +1 for nul-character
-    EXPECT_EQ(str.capacity(), 1);
+    EXPECT_EQ(str.capacity(), 0);
 
     EXPECT_EQ(str.size(), 0);
     EXPECT_TRUE(str.empty());
-    EXPECT_NE(str.data(), nullptr);
-    EXPECT_STREQ(str.data(), "");
-    EXPECT_STR(static_cast<std::string_view>(str), "");
-    EXPECT_STR(static_cast<std::string>(str), "");
+    EXPECT_EQ(str.data(), nullptr);
     EXPECT_EQ(str, str);
 }
 
@@ -35,15 +31,11 @@ TEST(TestDynamicString, PreallocatedConstructor)
 {
     dynamic_string str{20};
 
-    // +1 for nul-character
-    EXPECT_EQ(str.capacity(), 21);
+    EXPECT_EQ(str.capacity(), 20);
 
     EXPECT_EQ(str.size(), 0);
     EXPECT_TRUE(str.empty());
     EXPECT_NE(str.data(), nullptr);
-    EXPECT_STREQ(str.data(), "");
-    EXPECT_STR(static_cast<std::string_view>(str), "");
-    EXPECT_STR(static_cast<std::string>(str), "");
     EXPECT_EQ(str, str);
 }
 
@@ -51,13 +43,11 @@ TEST(TestDynamicString, StringViewConstructor)
 {
     dynamic_string str{"thisisastring"sv};
 
-    // +1 for nul-character
-    EXPECT_EQ(str.capacity(), 14);
+    EXPECT_EQ(str.capacity(), 13);
 
     EXPECT_EQ(str.size(), 13);
     EXPECT_FALSE(str.empty());
     EXPECT_NE(str.data(), nullptr);
-    EXPECT_STREQ(str.data(), "thisisastring");
     EXPECT_STR(static_cast<std::string_view>(str), "thisisastring");
     EXPECT_STR(static_cast<std::string>(str), "thisisastring");
     EXPECT_EQ(str, str);
@@ -67,13 +57,10 @@ TEST(TestDynamicString, StringConstructor)
 {
     dynamic_string str{"thisisastring"s};
 
-    // +1 for nul-character
-    EXPECT_EQ(str.capacity(), 14);
-
+    EXPECT_EQ(str.capacity(), 13);
     EXPECT_EQ(str.size(), 13);
     EXPECT_FALSE(str.empty());
     EXPECT_NE(str.data(), nullptr);
-    EXPECT_STREQ(str.data(), "thisisastring");
     EXPECT_STR(static_cast<std::string_view>(str), "thisisastring");
     EXPECT_STR(static_cast<std::string>(str), "thisisastring");
     EXPECT_EQ(str, str);
@@ -88,8 +75,8 @@ TEST(TestDynamicString, CopyConstructor)
     dynamic_string copy{str};
     EXPECT_NE(copy.data(), nullptr);
     EXPECT_NE(str.data(), copy.data());
-    EXPECT_STREQ(str.data(), "thisisastring");
-    EXPECT_STREQ(copy.data(), "thisisastring");
+    EXPECT_STR(static_cast<std::string_view>(str), "thisisastring");
+    EXPECT_STR(static_cast<std::string_view>(copy), "thisisastring");
     EXPECT_EQ(str, copy);
 }
 
@@ -99,12 +86,12 @@ TEST(TestDynamicString, CopyAssignment)
     EXPECT_NE(str.data(), nullptr);
 
     dynamic_string copy;
-    EXPECT_NE(copy.data(), nullptr);
+    EXPECT_EQ(copy.data(), nullptr);
 
     copy = str;
     EXPECT_NE(str.data(), copy.data());
-    EXPECT_STREQ(str.data(), "thisisastring");
-    EXPECT_STREQ(copy.data(), "thisisastring");
+    EXPECT_STR(static_cast<std::string_view>(str), "thisisastring");
+    EXPECT_STR(static_cast<std::string>(str), "thisisastring");
     EXPECT_EQ(str, copy);
 }
 
@@ -123,7 +110,7 @@ TEST(TestDynamicString, MoveConstructor)
 
     EXPECT_NE(copy.data(), nullptr);
     EXPECT_NE(str.data(), copy.data());
-    EXPECT_STREQ(copy.data(), "thisisastring");
+    EXPECT_STR(copy, "thisisastring");
     EXPECT_EQ(copy, copy);
 }
 
@@ -133,7 +120,7 @@ TEST(TestDynamicString, MoveAssignment)
     EXPECT_NE(str.data(), nullptr);
 
     dynamic_string copy;
-    EXPECT_NE(copy.data(), nullptr);
+    EXPECT_EQ(copy.data(), nullptr);
 
     copy = std::move(str);
     EXPECT_EQ(str.capacity(), 0);
@@ -143,7 +130,7 @@ TEST(TestDynamicString, MoveAssignment)
 
     EXPECT_NE(copy.data(), nullptr);
     EXPECT_NE(str.data(), copy.data());
-    EXPECT_STREQ(copy.data(), "thisisastring");
+    EXPECT_STR(copy, "thisisastring");
     EXPECT_EQ(copy, copy);
 }
 
@@ -169,50 +156,46 @@ TEST(TestDynamicString, AppendDefaultString)
 {
     dynamic_string str;
 
-    // +1 for nul-character
-    EXPECT_EQ(str.capacity(), 1);
+    EXPECT_EQ(str.capacity(), 0);
     EXPECT_EQ(str.size(), 0);
-    EXPECT_STREQ(str.data(), "");
+    EXPECT_STR(str, "");
 
     str.append('c');
-    EXPECT_GT(str.capacity(), 2);
+    EXPECT_GE(str.capacity(), 1);
     EXPECT_EQ(str.size(), 1);
-    EXPECT_STREQ(str.data(), "c");
+    EXPECT_STR(str, "c");
 
     str.append("string");
-    EXPECT_GT(str.capacity(), 8);
+    EXPECT_GE(str.capacity(), 7);
     EXPECT_EQ(str.size(), 7);
-    EXPECT_STREQ(str.data(), "cstring");
+    EXPECT_STR(str, "cstring");
 }
 
 TEST(TestDynamicString, AppendPreallocatedString)
 {
     dynamic_string str{20};
 
-    // +1 for nul-character
-    EXPECT_EQ(str.capacity(), 21);
+    EXPECT_EQ(str.capacity(), 20);
     EXPECT_EQ(str.size(), 0);
-    EXPECT_STREQ(str.data(), "");
+    EXPECT_STR(str, "");
 
     str.append('c');
-    EXPECT_EQ(str.capacity(), 21);
+    EXPECT_EQ(str.capacity(), 20);
     EXPECT_EQ(str.size(), 1);
-    EXPECT_STREQ(str.data(), "c");
+    EXPECT_STR(str, "c");
 
     str.append("string");
-    EXPECT_EQ(str.capacity(), 21);
+    EXPECT_EQ(str.capacity(), 20);
     EXPECT_EQ(str.size(), 7);
-    EXPECT_STREQ(str.data(), "cstring");
+    EXPECT_STR(str, "cstring");
 }
 
 TEST(TestDynamicString, AppendCharsAndStrings)
 {
     dynamic_string str;
 
-    // +1 for nul-character
-    EXPECT_EQ(str.capacity(), 1);
+    EXPECT_EQ(str.capacity(), 0);
     EXPECT_EQ(str.size(), 0);
-    EXPECT_STREQ(str.data(), "");
 
     str.append("this");
     str.append(' ');
@@ -229,7 +212,7 @@ TEST(TestDynamicString, AppendCharsAndStrings)
     str.append("ere");
 
     EXPECT_EQ(str.size(), 44);
-    EXPECT_STREQ(str.data(), "this is a string that has been appended here");
+    EXPECT_STR(str, "this is a string that has been appended here");
 }
 
 TEST(TestDynamicString, Equality)

--- a/tests/unit/transformer/cow_string_test.cpp
+++ b/tests/unit/transformer/cow_string_test.cpp
@@ -74,7 +74,7 @@ TEST(TestCoWString, TruncateUnmodified)
     str.truncate(4);
 
     EXPECT_EQ(str.length(), 4);
-    EXPECT_STREQ(str.data(), "valu");
+    EXPECT_STR(str, "valu");
 }
 
 TEST(TestCoWString, TruncateUnmodifiedMutableBuffer)
@@ -88,7 +88,7 @@ TEST(TestCoWString, TruncateUnmodifiedMutableBuffer)
     str.truncate(4);
 
     EXPECT_EQ(str.length(), 4);
-    EXPECT_STREQ(str.data(), "valu");
+    EXPECT_STR(str, "valu");
     EXPECT_EQ(str.data(), original.data());
 }
 
@@ -104,7 +104,7 @@ TEST(TestCoWString, WriteAndTruncate)
 
     str.truncate(4);
     EXPECT_EQ(str.length(), 4);
-    EXPECT_STREQ(str.data(), "vale");
+    EXPECT_STR(str, "vale");
 }
 
 TEST(TestCoWString, WriteAndTruncateMutableBuffer)
@@ -121,7 +121,7 @@ TEST(TestCoWString, WriteAndTruncateMutableBuffer)
 
     str.truncate(4);
     EXPECT_EQ(str.length(), 4);
-    EXPECT_STREQ(str.data(), "vale");
+    EXPECT_STR(str, "vale");
     EXPECT_EQ(str.data(), original.data());
 }
 
@@ -135,7 +135,7 @@ TEST(TestCoWString, EmptyString)
     EXPECT_EQ(str.length(), 0);
     EXPECT_TRUE(str.modified());
     EXPECT_NE(str.data(), nullptr);
-    EXPECT_STREQ(str.data(), "");
+    EXPECT_STR(str, "");
 }
 
 TEST(TestCoWString, NullString) { EXPECT_THROW(cow_string({}), std::runtime_error); }
@@ -151,9 +151,10 @@ TEST(TestCoWString, WriteAndMove)
     EXPECT_NE(str.data(), nullptr);
 
     auto [buffer, length] = str.move();
-    EXPECT_STREQ(buffer, "valee");
+    EXPECT_STR((std::string_view{buffer, length}), "valee");
     EXPECT_EQ(length, 5);
-    free(buffer);
+
+    str.alloc()->deallocate(buffer, length, alignof(char));
 
     EXPECT_EQ(str.length(), 0);
     EXPECT_FALSE(str.modified());
@@ -167,9 +168,9 @@ TEST(TestCoWString, MoveUnmodified)
     EXPECT_FALSE(str.modified());
 
     auto [buffer, length] = str.move();
-    EXPECT_STREQ(buffer, "value");
+    EXPECT_STR((std::string_view{buffer, length}), "value");
     EXPECT_EQ(length, 5);
-    free(buffer);
+    str.alloc()->deallocate(buffer, length, alignof(char));
 
     EXPECT_EQ(str.length(), 0);
     EXPECT_FALSE(str.modified());
@@ -185,9 +186,9 @@ TEST(TestCoWString, MoveAfterTruncate)
     str.truncate(4);
 
     auto [buffer, length] = str.move();
-    EXPECT_STREQ(buffer, "valu");
+    EXPECT_STR((std::string_view{buffer, length}), "valu");
     EXPECT_EQ(length, 4);
-    free(buffer);
+    str.alloc()->deallocate(buffer, length, alignof(char));
 
     EXPECT_EQ(str.length(), 0);
     EXPECT_FALSE(str.modified());

--- a/tests/unit/transformer/manager_test.cpp
+++ b/tests/unit/transformer/manager_test.cpp
@@ -33,15 +33,15 @@ namespace {
 std::optional<std::string> transform(std::string_view input, const std::vector<transformer_id> &ids)
 {
     auto src = owned_object::make_string_nocopy(input, nullptr);
-    owned_object dst;
 
-    auto res = transformer::manager::transform(src, dst, ids);
+    auto res = transformer::manager::transform(src, ids);
 
     if (!res) {
         return std::nullopt;
     }
 
-    return {object_view{dst}.as<std::string>()};
+    auto str = std::string{static_cast<std::string_view>(res.value())};
+    return {std::move(str)};
 }
 
 TEST(TestTransformerManager, InvalidTypes)
@@ -51,79 +51,79 @@ TEST(TestTransformerManager, InvalidTypes)
 
     {
         std::vector<transformer_id> ids{transformer_id::compress_whitespace};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::lowercase};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::normalize_path};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::normalize_path_win};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::remove_comments};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::remove_nulls};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::unicode_normalize};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::url_decode};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::url_decode_iis};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::base64_decode};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::base64url_decode};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::base64_encode};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::url_path};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::url_basename};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::url_querystring};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::shell_unescape};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::js_decode};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::html_entity_decode};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
     {
         std::vector<transformer_id> ids{transformer_id::css_decode};
-        EXPECT_FALSE(transformer::manager::transform(src, dst, ids));
+        EXPECT_FALSE(transformer::manager::transform(src, ids));
     }
 }
 

--- a/tests/unit/transformer/manager_test.cpp
+++ b/tests/unit/transformer/manager_test.cpp
@@ -32,7 +32,7 @@ namespace {
 
 std::optional<std::string> transform(std::string_view input, const std::vector<transformer_id> &ids)
 {
-    auto src = owned_object::make_string_nocopy(input, nullptr);
+    auto src = owned_object::make_string_literal(input.data(), input.size());
 
     auto res = transformer::manager::transform(src, ids);
 

--- a/tests/unit/transformer/transformer_utils.hpp
+++ b/tests/unit/transformer/transformer_utils.hpp
@@ -11,6 +11,8 @@
 #include <cow_string.hpp>
 #include <string_view>
 
+#include "common/gtest_utils.hpp"
+
 // NOLINTBEGIN(hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 //
 // https://stackoverflow.com/questions/33484233/
@@ -33,13 +35,13 @@ template <std::size_t N> constexpr std::array<char, N - 1> literal_to_array(cons
         {                                                                                          \
             cow_string str(std::string_view{source, sizeof(source) - 1});                          \
             EXPECT_TRUE(transformer::name::transform(str));                                        \
-            EXPECT_STREQ(str.data(), expected);                                                    \
+            EXPECT_STR(str, expected);                                                             \
         }                                                                                          \
         if constexpr (sizeof(source) > 1) {                                                        \
             std::array<char, sizeof(source) - 1> copy{literal_to_array(source)};                   \
             cow_string str(std::string_view{copy.data(), copy.size()});                            \
             EXPECT_TRUE(transformer::name::transform(str)) << "Non nul-terminated string";         \
-            EXPECT_STREQ(str.data(), expected) << "Non nul-terminated string";                     \
+            EXPECT_STR(str, expected) << "Non nul-terminated string";                              \
         }                                                                                          \
     }
 

--- a/tests/unit/transformer/unicode_normalize_test.cpp
+++ b/tests/unit/transformer/unicode_normalize_test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 TEST(TestUnicodeNormalize, NameAndID)
 {
-    EXPECT_STREQ(transformer::unicode_normalize::name().data(), "unicode_normalize");
+    EXPECT_STR(transformer::unicode_normalize::name(), "unicode_normalize");
     EXPECT_EQ(transformer::unicode_normalize::id(), transformer_id::unicode_normalize);
 }
 
@@ -51,7 +51,7 @@ TEST(TestUnicodeNormalize, ValidTransform)
 
         cow_string str(original);
         EXPECT_TRUE(transformer::unicode_normalize::transform(str));
-        EXPECT_STREQ(str.data(), result.c_str());
+        EXPECT_STR(str, result);
     }
 }
 

--- a/tests/unit/waf_test.cpp
+++ b/tests/unit/waf_test.cpp
@@ -52,7 +52,7 @@ TEST(TestWaf, BasicContextRun)
     auto *ctx = instance.create_context();
 
     EXPECT_TRUE(ctx->insert(std::move(root)));
-    auto [code, res] = ctx->run(LONG_TIME);
+    auto [code, res] = ctx->eval(LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     delete ctx;
 }

--- a/tests/unit/waf_test.cpp
+++ b/tests/unit/waf_test.cpp
@@ -22,7 +22,7 @@ ddwaf::waf build_instance(std::string_view rule_file)
     }
 
     raw_configuration ruleset{object};
-    waf_builder builder{ddwaf_object_free, std::make_shared<match_obfuscator>()};
+    waf_builder builder{std::make_shared<match_obfuscator>()};
 
     ddwaf::null_ruleset_info info;
     auto res = builder.add_or_update("default", ruleset, info);

--- a/tools/infer_schema.cpp
+++ b/tools/infer_schema.cpp
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     }
 
     ddwaf_result ret;
-    ddwaf_run(context, &input, nullptr, &ret, std::numeric_limits<uint32_t>::max());
+    ddwaf_context_eval(context, &input, nullptr, &ret, std::numeric_limits<uint32_t>::max());
     if (ddwaf_object_size(&ret.derivatives) > 0) {
         std::cout << object_to_json(ret.derivatives) << '\n';
     }

--- a/tools/ip_match_benchmark.cpp
+++ b/tools/ip_match_benchmark.cpp
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
 
 
                 auto start = std::chrono::system_clock::now();
-                ddwaf_run(context, &input, nullptr, nullptr, std::numeric_limits<uint32_t>::max());
+                ddwaf_context_eval(context, &input, nullptr, nullptr, std::numeric_limits<uint32_t>::max());
                 auto count = (std::chrono::system_clock::now() - start).count();
 
                 ddwaf_object_free(&input);

--- a/tools/verify_rule.cpp
+++ b/tools/verify_rule.cpp
@@ -39,7 +39,7 @@ bool runVectors(YAML::Node rule, ddwaf_handle handle, bool runPositiveMatches)
             auto root = vector->as<ddwaf_object>();
             if (root.type != DDWAF_OBJ_INVALID) {
                 ddwaf_context ctx = ddwaf_context_init(handle);
-                DDWAF_RET_CODE ret = ddwaf_run(ctx, &root, nullptr, true, nullptr, LONG_TIME);
+                DDWAF_RET_CODE ret = ddwaf_context_eval(ctx, &root, nullptr, true, nullptr, LONG_TIME);
 
                 bool hadError = ret < DDWAF_OK;
                 bool hadMatch = !hadError && ret != DDWAF_OK;

--- a/tools/verify_rule.cpp
+++ b/tools/verify_rule.cpp
@@ -39,7 +39,7 @@ bool runVectors(YAML::Node rule, ddwaf_handle handle, bool runPositiveMatches)
             auto root = vector->as<ddwaf_object>();
             if (root.type != DDWAF_OBJ_INVALID) {
                 ddwaf_context ctx = ddwaf_context_init(handle);
-                DDWAF_RET_CODE ret = ddwaf_run(ctx, &root, nullptr, nullptr, LONG_TIME);
+                DDWAF_RET_CODE ret = ddwaf_run(ctx, &root, nullptr, true, nullptr, LONG_TIME);
 
                 bool hadError = ret < DDWAF_OK;
                 bool hadMatch = !hadError && ret != DDWAF_OK;

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 
         ddwaf_object ret;
         auto code =
-            ddwaf_run(context, &persistent, &ephemeral, &ret, std::numeric_limits<uint64_t>::max());
+            ddwaf_run(context, &persistent, &ephemeral, true, &ret, std::numeric_limits<uint64_t>::max());
 
         if (code == DDWAF_MATCH) {
             YAML::Emitter out(std::cout);

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    const ddwaf_config config{{.key_regex=key_regex, .value_regex=value_regex}, ddwaf_object_free};
+    const ddwaf_config config{{.key_regex=key_regex, .value_regex=value_regex}};
     ddwaf_builder builder = ddwaf_builder_init(&config);
 
     std::size_t index = 0;

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 
         ddwaf_object ret;
         auto code =
-            ddwaf_run(context, &persistent, &ephemeral, true, &ret, std::numeric_limits<uint64_t>::max());
+            ddwaf_context_eval(context, &persistent, &ephemeral, true, &ret, std::numeric_limits<uint64_t>::max());
 
         if (code == DDWAF_MATCH) {
             YAML::Emitter out(std::cout);

--- a/validator/runner.cpp
+++ b/validator/runner.cpp
@@ -89,7 +89,8 @@ bool test_runner::run_test(const YAML::Node &runs)
                 ephemeral_ptr = &ephemeral;
             }
 
-            auto retval = ddwaf_run(ctx.get(), persistent_ptr, ephemeral_ptr, res.get(), timeout);
+            auto retval =
+                ddwaf_run(ctx.get(), persistent_ptr, ephemeral_ptr, false, res.get(), timeout);
 
             expect(retval, code);
             if (code == DDWAF_MATCH) {

--- a/validator/runner.cpp
+++ b/validator/runner.cpp
@@ -90,7 +90,7 @@ bool test_runner::run_test(const YAML::Node &runs)
             }
 
             auto retval =
-                ddwaf_run(ctx.get(), persistent_ptr, ephemeral_ptr, false, res.get(), timeout);
+                ddwaf_run(ctx.get(), persistent_ptr, ephemeral_ptr, true, res.get(), timeout);
 
             expect(retval, code);
             if (code == DDWAF_MATCH) {

--- a/validator/runner.cpp
+++ b/validator/runner.cpp
@@ -89,8 +89,8 @@ bool test_runner::run_test(const YAML::Node &runs)
                 ephemeral_ptr = &ephemeral;
             }
 
-            auto retval =
-                ddwaf_run(ctx.get(), persistent_ptr, ephemeral_ptr, true, res.get(), timeout);
+            auto retval = ddwaf_context_eval(
+                ctx.get(), persistent_ptr, ephemeral_ptr, true, res.get(), timeout);
 
             expect(retval, code);
             if (code == DDWAF_MATCH) {


### PR DESCRIPTION
This is the first PR in the process to introduce allocators, in a limited fashion, to the `libddwaf` interface. The main changes done here are the following:

- Renamed `ddwaf_run` to `ddwaf_context_eval`.
- Removed `ddwaf_object_free` from `ddwaf_config`, as a consequence benchmarks were failing so a temporary `free_objects` boolean has been added to `ddwaf_context_eval` until allocators can be passed to the context.
- All calls to `malloc` / `free` have been replaced with the use of a `std::pmr::new_delete_resource`. With this change, all allocated memory is accounted for and no capacity is needed for output strings.
- Output strings are no longer nul-terminated.
- A new function called `ddwaf_object_clone` has been added to the interface.

The use of allocators is rudimentary as the goal is to propagate an allocator directly from the context, rather than getting a default one, however the PR is already relatively large so those changes will be done in the next PR.

Remaining work (Next PRs):
- Update objects to use allocators more effectively.
- Check for allocator compatibility where relevant.
- Propagate allocator from the context.
- Have a clear distinction between input , output and internal allocators.
- Update interface:
  - Pass input / ouput allocators to `context_init`.
  - Pass allocators to memory-allocating `ddwaf_object` functions.