### PR TITLE
Release v1.25.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # libddwaf release
 
+## v1.25.2 ([unstable](https://github.com/DataDog/libddwaf/blob/master/README.md#versioning-semantics))
+#### Fixes
+- Add missing `ddwaf_builder_get_config_paths` export to windows shared libraries ([#421](https://github.com/DataDog/libddwaf/pull/421))
+
 ## v1.25.1 ([unstable](https://github.com/DataDog/libddwaf/blob/master/README.md#versioning-semantics))
 #### Fixes
 - Support backwards-incompatible rules through the `rules_compat` key ([#409](https://github.com/DataDog/libddwaf/pull/409))

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -5,6 +5,7 @@ EXPORTS
   ddwaf_builder_init
   ddwaf_builder_add_or_update_config
   ddwaf_builder_remove_config
+  ddwaf_builder_get_config_paths
   ddwaf_builder_build_instance
   ddwaf_builder_destroy
   ddwaf_known_addresses


### PR DESCRIPTION
Add missing `ddwaf_builder_get_config_paths` export to windows shared libraries and release.