### PR TITLE
[v2] Update interface and expose allocators

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
 
             ddwaf_config config{{}};
             ddwaf_handle handle = ddwaf_init(&ruleset, &config, nullptr);
-            ddwaf_object_free(&ruleset);
+            ddwaf_object_destroy(&ruleset, ddwaf_get_default_allocator());
             if (handle == nullptr) {
                 std::cerr << "Invalid ruleset file\n";
                 utils::exit_failure();

--- a/benchmark/run_fixture.cpp
+++ b/benchmark/run_fixture.cpp
@@ -20,7 +20,7 @@ run_fixture::run_fixture(ddwaf_handle handle, std::vector<ddwaf_object> &&object
 
 bool run_fixture::set_up()
 {
-    ctx_ = ddwaf_context_init(handle_);
+    ctx_ = ddwaf_context_init(handle_, ddwaf_get_default_allocator());
     return ctx_ != nullptr;
 }
 
@@ -32,14 +32,14 @@ void run_fixture::warmup()
         object_stack.emplace(&object, 0);
         while (!object_stack.empty()) {
             auto &[current, i] = object_stack.top();
-            for (; i < ddwaf_object_size(current); ++i) {
+            for (; i < ddwaf_object_get_size(current); ++i) {
                 const auto &next = *ddwaf_object_at_value(current, i);
                 if (object_stack.size() <= max_depth &&
                     (next.type == DDWAF_OBJ_ARRAY || next.type == DDWAF_OBJ_MAP)) {
                     break;
                 }
             }
-            if (i == ddwaf_object_size(current)) {
+            if (i == ddwaf_object_get_size(current)) {
                 object_stack.pop();
             } else {
                 object_stack.emplace(ddwaf_object_at_value(current, i++), 0);
@@ -67,7 +67,7 @@ uint64_t run_fixture::test_main()
 
         const auto *duration = ddwaf_object_find(&res, "duration", sizeof("duration") - 1);
         total_runtime += ddwaf_object_get_unsigned(duration);
-        ddwaf_object_free(&res);
+        ddwaf_object_destroy(&res, ddwaf_get_default_allocator());
     }
 
     return total_runtime;

--- a/benchmark/run_fixture.hpp
+++ b/benchmark/run_fixture.hpp
@@ -18,7 +18,7 @@ public:
     run_fixture(ddwaf_handle handle, std::vector<ddwaf_object> &&objects);
     ~run_fixture() override
     {
-        for (auto &o : objects_) { ddwaf_object_free(&o); }
+        for (auto &o : objects_) { ddwaf_object_destroy(&o, ddwaf_get_default_allocator()); }
     }
 
     run_fixture(const run_fixture &) = delete;

--- a/benchmark/utils.cpp
+++ b/benchmark/utils.cpp
@@ -63,11 +63,12 @@ void object_to_json_helper(
         output.SetDouble(ddwaf_object_get_float(&obj));
         break;
     case DDWAF_OBJ_STRING: {
-        output.SetString(ddwaf_object_get_string(&obj, nullptr), ddwaf_object_length(&obj), alloc);
+        output.SetString(
+            ddwaf_object_get_string(&obj, nullptr), ddwaf_object_get_length(&obj), alloc);
     } break;
     case DDWAF_OBJ_MAP:
         output.SetObject();
-        for (std::size_t i = 0; i < ddwaf_object_size(&obj); i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             rapidjson::Value key;
             rapidjson::Value value;
 
@@ -75,14 +76,14 @@ void object_to_json_helper(
             const auto *child_val = ddwaf_object_at_value(&obj, i);
             object_to_json_helper(*child_val, value, alloc);
 
-            key.SetString(
-                ddwaf_object_get_string(child_key, nullptr), ddwaf_object_length(child_key), alloc);
+            key.SetString(ddwaf_object_get_string(child_key, nullptr),
+                ddwaf_object_get_length(child_key), alloc);
             output.AddMember(key, value, alloc);
         }
         break;
     case DDWAF_OBJ_ARRAY:
         output.SetArray();
-        for (unsigned i = 0; i < ddwaf_object_size(&obj); i++) {
+        for (unsigned i = 0; i < ddwaf_object_get_size(&obj); i++) {
             rapidjson::Value value;
             const auto *child_val = ddwaf_object_at_value(&obj, i);
             object_to_json_helper(*child_val, value, alloc);
@@ -118,43 +119,47 @@ std::string object_to_string(const ddwaf_object &obj) noexcept
 // NOLINTNEXTLINE(misc-no-recursion)
 ddwaf_object object_dup(const ddwaf_object &o) noexcept
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     ddwaf_object copy{};
     switch (o.type) {
     case DDWAF_OBJ_INVALID:
-        ddwaf_object_invalid(&copy);
+        ddwaf_object_set_invalid(&copy);
         break;
     case DDWAF_OBJ_NULL:
-        ddwaf_object_null(&copy);
+        ddwaf_object_set_null(&copy);
         break;
     case DDWAF_OBJ_BOOL:
-        ddwaf_object_bool(&copy, ddwaf_object_get_bool(&o));
+        ddwaf_object_set_bool(&copy, ddwaf_object_get_bool(&o));
         break;
     case DDWAF_OBJ_SIGNED:
-        ddwaf_object_signed(&copy, ddwaf_object_get_signed(&o));
+        ddwaf_object_set_signed(&copy, ddwaf_object_get_signed(&o));
         break;
     case DDWAF_OBJ_UNSIGNED:
-        ddwaf_object_unsigned(&copy, ddwaf_object_get_unsigned(&o));
+        ddwaf_object_set_unsigned(&copy, ddwaf_object_get_unsigned(&o));
         break;
     case DDWAF_OBJ_FLOAT:
-        ddwaf_object_float(&copy, ddwaf_object_get_float(&o));
+        ddwaf_object_set_float(&copy, ddwaf_object_get_float(&o));
         break;
     case DDWAF_OBJ_STRING:
-        ddwaf_object_stringl(&copy, ddwaf_object_get_string(&o, nullptr), ddwaf_object_length(&o));
+        ddwaf_object_set_string(
+            &copy, ddwaf_object_get_string(&o, nullptr), ddwaf_object_get_length(&o), alloc);
         break;
     case DDWAF_OBJ_ARRAY:
-        ddwaf_object_array(&copy);
-        for (std::size_t i = 0; i < ddwaf_object_size(&o); i++) {
-            ddwaf_object child_copy = object_dup(*ddwaf_object_at_value(&o, i));
-            ddwaf_object_array_add(&copy, &child_copy);
+        ddwaf_object_set_array(&copy, ddwaf_object_get_size(&o), alloc);
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&o); i++) {
+            auto *child_copy = ddwaf_object_insert(&copy, alloc);
+            *child_copy = object_dup(*ddwaf_object_at_value(&o, i));
         }
         break;
     case DDWAF_OBJ_MAP:
-        ddwaf_object_map(&copy);
-        for (std::size_t i = 0; i < ddwaf_object_size(&o); i++) {
+        ddwaf_object_set_map(&copy, ddwaf_object_get_size(&o), alloc);
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&o); i++) {
             const auto *child_key = ddwaf_object_at_key(&o, i);
-            ddwaf_object child_copy = object_dup(*ddwaf_object_at_value(&o, i));
-            ddwaf_object_map_addl(&copy, ddwaf_object_get_string(child_key, nullptr),
-                ddwaf_object_length(child_key), &child_copy);
+            auto *child_copy =
+                ddwaf_object_insert_key(&copy, ddwaf_object_get_string(child_key, nullptr),
+                    ddwaf_object_get_length(child_key), alloc);
+            *child_copy = object_dup(*ddwaf_object_at_value(&o, i));
         }
         break;
     }

--- a/benchmark/yaml_helpers.cpp
+++ b/benchmark/yaml_helpers.cpp
@@ -12,68 +12,80 @@ namespace YAML {
 namespace {
 
 // NOLINTNEXTLINE(misc-no-recursion)
-ddwaf_object node_to_arg(const Node &node)
+void node_to_ddwaf_object(ddwaf_object *root, const Node &node)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     switch (node.Type()) {
     case NodeType::Sequence: {
-        ddwaf_object arg{};
-        ddwaf_object_array(&arg);
+        ddwaf_object_set_array(root, node.size(), alloc);
         for (auto it = node.begin(); it != node.end(); ++it) {
-            ddwaf_object child = node_to_arg(*it);
-            ddwaf_object_array_add(&arg, &child);
+            auto *child = ddwaf_object_insert(root, alloc);
+            node_to_ddwaf_object(child, *it);
         }
-        return arg;
+        return;
     }
     case NodeType::Map: {
-        ddwaf_object arg{};
-        ddwaf_object_map(&arg);
+        ddwaf_object_set_map(root, node.size(), alloc);
         for (auto it = node.begin(); it != node.end(); ++it) {
             auto key = it->first.as<std::string>();
-            ddwaf_object child = node_to_arg(it->second);
-            ddwaf_object_map_addl(&arg, key.c_str(), key.size(), &child);
+            auto *child = ddwaf_object_insert_key(root, key.data(), key.size(), alloc);
+            node_to_ddwaf_object(child, it->second);
         }
-        return arg;
+        return;
     }
     case NodeType::Scalar: {
-        ddwaf_object arg{};
+        const std::string &value = node.Scalar();
+
         if (node.Tag() == "?") {
             try {
-                ddwaf_object_unsigned(&arg, node.as<uint64_t>());
-                return arg;
+                ddwaf_object_set_unsigned(root, node.as<uint64_t>());
+                return;
             } catch (...) {}
 
             try {
-                ddwaf_object_signed(&arg, node.as<int64_t>());
-                return arg;
+                ddwaf_object_set_signed(root, node.as<int64_t>());
+                return;
             } catch (...) {}
 
             try {
-                ddwaf_object_float(&arg, node.as<double>());
-                return arg;
+                ddwaf_object_set_float(root, node.as<double>());
+                return;
             } catch (...) {}
 
             try {
-                ddwaf_object_bool(&arg, node.as<bool>());
-                return arg;
+                if (!value.empty() && value[0] != 'Y' && value[0] != 'y' && value[0] != 'n' &&
+                    value[0] != 'N') {
+                    // Skip the yes / no variants of boolean
+                    ddwaf_object_set_bool(root, node.as<bool>());
+                    return;
+                }
             } catch (...) {}
         }
 
-        const std::string &value = node.Scalar();
-        ddwaf_object_stringl(&arg, value.c_str(), value.size());
-        return arg;
+        ddwaf_object_set_string(root, value.data(), value.size(), alloc);
+        return;
     }
-    case NodeType::Null:
-    case NodeType::Undefined:
-        ddwaf_object arg{};
-        ddwaf_object_invalid(&arg);
-        return arg;
+    case NodeType::Null: {
+        ddwaf_object_set_null(root);
+        return;
+    }
+    case NodeType::Undefined: {
+        ddwaf_object_set_invalid(root);
+        return;
+    }
     }
 
     throw parsing_error("Invalid YAML node type");
 }
+
 } // namespace
 
-ddwaf_object as_if<ddwaf_object, void>::operator()() const { return node_to_arg(node); }
+ddwaf_object as_if<ddwaf_object, void>::operator()() const
+{
+    ddwaf_object object;
+    node_to_ddwaf_object(&object, node);
+    return object;
+}
 
 // NOLINTNEXTLINE(misc-no-recursion)
 YAML::Emitter &operator<<(YAML::Emitter &out, const ddwaf_object &o)
@@ -98,18 +110,18 @@ YAML::Emitter &operator<<(YAML::Emitter &out, const ddwaf_object &o)
     case DDWAF_OBJ_STRING:
     case DDWAF_OBJ_SMALL_STRING:
     case DDWAF_OBJ_LITERAL_STRING:
-        out << std::string{ddwaf_object_get_string(&o, nullptr), ddwaf_object_length(&o)};
+        out << std::string{ddwaf_object_get_string(&o, nullptr), ddwaf_object_get_length(&o)};
         break;
     case DDWAF_OBJ_ARRAY:
         out << YAML::BeginSeq;
-        for (std::size_t i = 0; i < ddwaf_object_size(&o); i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&o); i++) {
             out << *ddwaf_object_at_value(&o, i);
         }
         out << YAML::EndSeq;
         break;
     case DDWAF_OBJ_MAP:
         out << YAML::BeginMap;
-        for (std::size_t i = 0; i < ddwaf_object_size(&o); i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&o); i++) {
             out << YAML::Key << *ddwaf_object_at_key(&o, i);
             out << YAML::Value << *ddwaf_object_at_value(&o, i);
             ;

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -179,7 +179,7 @@ int main()
 
     auto rule = doc.as<ddwaf_object>(); //= convert_yaml_to_args(doc);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
     if (handle == nullptr) {
         return EXIT_FAILURE;
     }
@@ -207,7 +207,7 @@ int main()
         out << object_to_yaml(ret);
     }
 
-    ddwaf_object_free(&ret);
+    ddwaf_object_destroy(&ret, alloc);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);

--- a/fuzzer/global/src/helpers.cpp
+++ b/fuzzer/global/src/helpers.cpp
@@ -49,13 +49,13 @@ void _print_object(ddwaf_object entry, uint8_t depth)
 
     switch (entry.type) {
     case DDWAF_OBJ_MAP:
-        if (ddwaf_object_size(&entry) == 0) {
+        if (ddwaf_object_get_size(&entry) == 0) {
             std::cerr << "{}";
         } else {
 
             std::cerr << "{";
 
-            for (uint64_t i = 0; i < ddwaf_object_size(&entry); i++) {
+            for (uint64_t i = 0; i < ddwaf_object_get_size(&entry); i++) {
                 if (first) {
                     first = false;
                 } else {
@@ -79,13 +79,13 @@ void _print_object(ddwaf_object entry, uint8_t depth)
         break;
 
     case DDWAF_OBJ_ARRAY:
-        if (ddwaf_object_size(&entry) == 0) {
+        if (ddwaf_object_get_size(&entry) == 0) {
             indent(depth);
             std::cerr << "[]";
         } else {
             std::cerr << "[";
 
-            for (uint64_t i = 0; i < ddwaf_object_size(&entry); i++) {
+            for (uint64_t i = 0; i < ddwaf_object_get_size(&entry); i++) {
                 if (first) {
                     first = false;
                 } else {

--- a/fuzzer/global/src/interface.cpp
+++ b/fuzzer/global/src/interface.cpp
@@ -27,39 +27,66 @@ protected:
 
 namespace {
 // NOLINTNEXTLINE(misc-no-recursion)
-ddwaf_object yaml_to_object(const Node &node)
+void node_to_ddwaf_object(ddwaf_object *root, const Node &node)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     switch (node.Type()) {
     case NodeType::Sequence: {
-        ddwaf_object arg;
-        ddwaf_object_array(&arg);
+        ddwaf_object_set_array(root, node.size(), alloc);
         for (auto it = node.begin(); it != node.end(); ++it) {
-            ddwaf_object child = yaml_to_object(*it);
-            ddwaf_object_array_add(&arg, &child);
+            auto *child = ddwaf_object_insert(root, alloc);
+            node_to_ddwaf_object(child, *it);
         }
-        return arg;
+        return;
     }
     case NodeType::Map: {
-        ddwaf_object arg;
-        ddwaf_object_map(&arg);
+        ddwaf_object_set_map(root, node.size(), alloc);
         for (auto it = node.begin(); it != node.end(); ++it) {
             auto key = it->first.as<std::string>();
-            ddwaf_object child = yaml_to_object(it->second);
-            ddwaf_object_map_addl(&arg, key.c_str(), key.size(), &child);
+            auto *child = ddwaf_object_insert_key(root, key.data(), key.size(), alloc);
+            node_to_ddwaf_object(child, it->second);
         }
-        return arg;
+        return;
     }
     case NodeType::Scalar: {
         const std::string &value = node.Scalar();
-        ddwaf_object arg;
-        ddwaf_object_stringl(&arg, value.c_str(), value.size());
-        return arg;
+
+        if (node.Tag() == "?") {
+            try {
+                ddwaf_object_set_unsigned(root, node.as<uint64_t>());
+                return;
+            } catch (...) {}
+
+            try {
+                ddwaf_object_set_signed(root, node.as<int64_t>());
+                return;
+            } catch (...) {}
+
+            try {
+                ddwaf_object_set_float(root, node.as<double>());
+                return;
+            } catch (...) {}
+
+            try {
+                if (!value.empty() && value[0] != 'Y' && value[0] != 'y' && value[0] != 'n' &&
+                    value[0] != 'N') {
+                    // Skip the yes / no variants of boolean
+                    ddwaf_object_set_bool(root, node.as<bool>());
+                    return;
+                }
+            } catch (...) {}
+        }
+
+        ddwaf_object_set_string(root, value.data(), value.size(), alloc);
+        return;
     }
-    case NodeType::Null:
+    case NodeType::Null: {
+        ddwaf_object_set_null(root);
+        return;
+    }
     case NodeType::Undefined: {
-        ddwaf_object arg;
-        ddwaf_object_invalid(&arg);
-        return arg;
+        ddwaf_object_set_invalid(root);
+        return;
     }
     }
 
@@ -72,7 +99,9 @@ template <> as_if<ddwaf_object, void>::as_if(const Node &node_) : node(node_) {}
 
 template <> ddwaf_object as_if<ddwaf_object, void>::operator()() const
 {
-    return yaml_to_object(node);
+    ddwaf_object object;
+    node_to_ddwaf_object(&object, node);
+    return object;
 }
 
 } // namespace YAML
@@ -96,16 +125,18 @@ ddwaf_handle init_waf()
     ddwaf_object rule = file_to_object("sample_rules.yml");
     ddwaf_object ruleset_info;
     ddwaf_handle handle = ddwaf_init(&rule, &config, &ruleset_info);
-    ddwaf_object_free(&rule);
-    ddwaf_object_free(&ruleset_info);
+    ddwaf_object_destroy(&rule, ddwaf_get_default_allocator());
+    ddwaf_object_destroy(&ruleset_info, ddwaf_get_default_allocator());
     return handle;
 }
 
 void run_waf(ddwaf_handle handle, ddwaf_object args, bool ephemeral, size_t timeLeftInUs)
 {
-    ddwaf_context context = ddwaf_context_init(handle);
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     if (context == nullptr) {
-        ddwaf_object_free(&args);
+        ddwaf_object_destroy(&args, alloc);
         return;
     }
 
@@ -118,6 +149,6 @@ void run_waf(ddwaf_handle handle, ddwaf_object args, bool ephemeral, size_t time
 
     // TODO split input in several ddwaf_object, and call ddwaf_context_eval on the same context
 
-    ddwaf_object_free(&res);
+    ddwaf_object_destroy(&res, alloc);
     ddwaf_context_destroy(context);
 }

--- a/fuzzer/global/src/main.cpp
+++ b/fuzzer/global/src/main.cpp
@@ -104,7 +104,7 @@ public:
             auto [object, ephemeral, timeout] = objects_.front();
             objects_.pop_front();
 
-            ddwaf_object_free(&object);
+            ddwaf_object_destroy(&object, ddwaf_get_default_allocator());
         }
         ddwaf_destroy(handle_);
     }

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -544,6 +544,9 @@ ddwaf_object* ddwaf_object_set_string_literal(ddwaf_object *object, const char *
  * @param length Length of the string.
  *
  * @return A pointer to the passed object or NULL if the operation failed.
+ *
+ * @note The provided string must have been allocated with the same allocator used
+ * with ddwaf_object_destroy.
  **/
 ddwaf_object* ddwaf_object_set_string_nocopy(ddwaf_object *object, const char *string, uint32_t length);
 /**
@@ -678,6 +681,9 @@ ddwaf_object *ddwaf_object_insert_literal_key(ddwaf_object *map, const char *key
  * @param alloc Allocator to use for memory allocation. (nonnull)
  *
  * @return A pointer to the newly inserted object or NULL if the operation failed.
+ *
+ * @note The provided string must have been allocated with the same allocator used
+ * with ddwaf_object_destroy.
  **/
 ddwaf_object *ddwaf_object_insert_key_nocopy(ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc);
 
@@ -819,10 +825,11 @@ const ddwaf_object* ddwaf_object_find(const ddwaf_object *object, const char *ke
  *
  * @param source The source object to clone from. (nonnull)
  * @param destination The destination object to clone into. (nonnull)
+ * @param alloc Allocator to use for memory allocation. (nonnull)
  *
  * @return A pointer to the destination object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_clone(const ddwaf_object *source, ddwaf_object *destination);
+ddwaf_object* ddwaf_object_clone(const ddwaf_object *source, ddwaf_object *destination, ddwaf_allocator alloc);
 
 /**
  * ddwaf_object_is_invalid

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -13,9 +13,11 @@ class waf;
 class context_wrapper;
 class waf_builder;
 } // namespace ddwaf
+
 using ddwaf_handle = ddwaf::waf *;
 using ddwaf_context = ddwaf::context_wrapper *;
 using ddwaf_builder = ddwaf::waf_builder *;
+using ddwaf_allocator = void *;
 
 extern "C"
 {
@@ -88,6 +90,7 @@ typedef enum
 typedef struct _ddwaf_handle* ddwaf_handle;
 typedef struct _ddwaf_context* ddwaf_context;
 typedef struct _ddwaf_builder* ddwaf_builder;
+typedef struct _ddwaf_allocator* ddwaf_allocator;
 #endif
 
 typedef struct _ddwaf_config ddwaf_config;
@@ -288,7 +291,7 @@ const char *const *ddwaf_known_actions(const ddwaf_handle handle, uint32_t *size
  *
  * @note The WAF instance needs to be valid for the lifetime of the context.
  **/
-ddwaf_context ddwaf_context_init(const ddwaf_handle handle);
+ddwaf_context ddwaf_context_init(const ddwaf_handle handle, ddwaf_allocator output_alloc);
 
 /**
  * ddwaf_context_eval
@@ -471,7 +474,16 @@ uint32_t ddwaf_builder_get_config_paths(ddwaf_builder builder, ddwaf_object *pat
 void ddwaf_builder_destroy(ddwaf_builder builder);
 
 /**
- * ddwaf_object_invalid
+ * ddwaf_get_default_allocator
+ *
+ * Returns the default allocator used by the library.
+ *
+ * @return The default allocator.
+ **/
+ddwaf_allocator ddwaf_get_default_allocator();
+
+/**
+ * ddwaf_object_set_invalid
  *
  * Creates an invalid object.
  *
@@ -479,10 +491,10 @@ void ddwaf_builder_destroy(ddwaf_builder builder);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_invalid(ddwaf_object *object);
+ddwaf_object* ddwaf_object_set_invalid(ddwaf_object *object);
 
 /**
- * ddwaf_object_null
+ * ddwaf_object_set_null
  *
  * Creates an null object. Provides a different semantical value to invalid as
  * it can be used to signify that a value is null rather than of an unknown type.
@@ -491,76 +503,51 @@ ddwaf_object* ddwaf_object_invalid(ddwaf_object *object);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_null(ddwaf_object *object);
+ddwaf_object* ddwaf_object_set_null(ddwaf_object *object);
 
 /**
- * ddwaf_object_string
+ * ddwaf_object_set_string
  *
  * Creates an object from a string.
  *
  * @param object Object to perform the operation on. (nonnull)
- * @param string String to initialise the object with, this string will be copied
- *               and its length will be calculated using strlen(string). (nonnull)
+ * @param string String to initialise the object with, this string will be copied. (nonnull)
+ * @param length Length of the string.
+ * @param alloc Allocator to use for memory allocation. (nonnull)
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_string(ddwaf_object *object, const char *string);
+ddwaf_object* ddwaf_object_set_string(ddwaf_object *object, const char *string, uint32_t length, ddwaf_allocator alloc);
 
 /**
- * ddwaf_object_stringl
+ * ddwaf_object_set_string_literal
  *
- * Creates an object from a string and its length.
+ * Creates an object from a literal string and its length.
  *
  * @param object Object to perform the operation on. (nonnull)
- * @param string String to initialise the object with, this string will be
- *               copied. (nonnull)
+ * @param string Literal string to initialise the object with, this string will not be copied
+ *               and must remain valid for the lifetime of the object. (nonnull)
  * @param length Length of the string.
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_stringl(ddwaf_object *object, const char *string, size_t length);
+ddwaf_object* ddwaf_object_set_string_literal(ddwaf_object *object, const char *string, uint32_t length);
 
 /**
- * ddwaf_object_stringl_nc
+ * ddwaf_object_set_string_nocopy
  *
- * Creates an object with the string pointer and length provided.
+ * Creates an object with the string pointer and length provided, without copying the string.
  *
  * @param object Object to perform the operation on. (nonnull)
- * @param string String pointer to initialise the object with.
+ * @param string String pointer to initialise the object with, this string will not be copied
+ *               and must remain valid for the lifetime of the object. (nonnull)
  * @param length Length of the string.
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_stringl_nc(ddwaf_object *object, const char *string, size_t length);
-
+ddwaf_object* ddwaf_object_set_string_nocopy(ddwaf_object *object, const char *string, uint32_t length);
 /**
- * ddwaf_object_string_from_unsigned
- *
- * Creates an object using an unsigned integer (64-bit). The resulting object
- * will contain a string created using the integer provided.
- *
- * @param object Object to perform the operation on. (nonnull)
- * @param value Integer to initialise the object with.
- *
- * @return A pointer to the passed object or NULL if the operation failed.
- **/
-ddwaf_object* ddwaf_object_string_from_unsigned(ddwaf_object *object, uint64_t value);
-
-/**
- * ddwaf_object_string_from_signed
- *
- * Creates an object using a signed integer (64-bit). The resulting object
- * will contain a string created using the integer provided.
- *
- * @param object Object to perform the operation on. (nonnull)
- * @param value Integer to initialise the object with.
- *
- * @return A pointer to the passed object or NULL if the operation failed.
- **/
-ddwaf_object* ddwaf_object_string_from_signed(ddwaf_object *object, int64_t value);
-
-/**
- * ddwaf_object_unsigned_force
+ * ddwaf_object_set_unsigned
  *
  * Creates an object using an unsigned integer (64-bit). The resulting object
  * will contain an unsigned integer as opposed to a string.
@@ -570,10 +557,10 @@ ddwaf_object* ddwaf_object_string_from_signed(ddwaf_object *object, int64_t valu
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_unsigned(ddwaf_object *object, uint64_t value);
+ddwaf_object* ddwaf_object_set_unsigned(ddwaf_object *object, uint64_t value);
 
 /**
- * ddwaf_object_signed_force
+ * ddwaf_object_set_signed
  *
  * Creates an object using a signed integer (64-bit). The resulting object
  * will contain a signed integer as opposed to a string.
@@ -583,10 +570,10 @@ ddwaf_object* ddwaf_object_unsigned(ddwaf_object *object, uint64_t value);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_signed(ddwaf_object *object, int64_t value);
+ddwaf_object* ddwaf_object_set_signed(ddwaf_object *object, int64_t value);
 
 /**
- * ddwaf_object_bool
+ * ddwaf_object_set_bool
  *
  * Creates an object using a boolean, the resulting object will contain a
  * boolean as opposed to a string.
@@ -596,10 +583,10 @@ ddwaf_object* ddwaf_object_signed(ddwaf_object *object, int64_t value);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_bool(ddwaf_object *object, bool value);
+ddwaf_object* ddwaf_object_set_bool(ddwaf_object *object, bool value);
 
 /**
- * ddwaf_object_float
+ * ddwaf_object_set_float
  *
  * Creates an object using a double, the resulting object will contain a
  * double as opposed to a string.
@@ -609,87 +596,93 @@ ddwaf_object* ddwaf_object_bool(ddwaf_object *object, bool value);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_float(ddwaf_object *object, double value);
+ddwaf_object* ddwaf_object_set_float(ddwaf_object *object, double value);
 
 /**
- * ddwaf_object_array
+ * ddwaf_object_set_array
  *
  * Creates an array object, for sequential storage.
  *
  * @param object Object to perform the operation on. (nonnull)
+ * @param capacity Initial capacity of the array.
+ * @param alloc Allocator to use for memory allocation. (nonnull)
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_array(ddwaf_object *object);
+ddwaf_object* ddwaf_object_set_array(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc);
 
 /**
- * ddwaf_object_map
+ * ddwaf_object_set_map
  *
  * Creates a map object, for key-value storage.
  *
  * @param object Object to perform the operation on. (nonnull)
+ * @param capacity Initial capacity of the map.
+ * @param alloc Allocator to use for memory allocation. (nonnull)
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_map(ddwaf_object *object);
+ddwaf_object* ddwaf_object_set_map(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc);
 
 /**
- * ddwaf_object_array_add
+ * ddwaf_object_insert
  *
- * Inserts an object into an array object.
+ * Inserts a new object into an array object.
  *
  * @param array Array in which to insert the object. (nonnull)
- * @param object Object to insert into the array. (nonnull)
+ * @param alloc Allocator to use for memory allocation. (nonnull)
  *
- * @return The success or failure of the operation.
+ * @return A pointer to the newly inserted object or NULL if the operation failed.
  **/
-bool ddwaf_object_array_add(ddwaf_object *array, ddwaf_object *object);
+
+ddwaf_object *ddwaf_object_insert(ddwaf_object *array, ddwaf_allocator alloc);
 
 /**
- * ddwaf_object_map_add
+ * ddwaf_object_insert_key
  *
- * Inserts an object into an map object, using a key.
- *
- * @param map Map in which to insert the object. (nonnull)
- * @param key The key for indexing purposes, this string will be copied and its
- *            length will be calcualted using strlen(key). (nonnull)
- * @param object Object to insert into the array. (nonnull)
- *
- * @return The success or failure of the operation.
- **/
-bool ddwaf_object_map_add(ddwaf_object *map, const char *key, ddwaf_object *object);
-
-/**
- * ddwaf_object_map_addl
- *
- * Inserts an object into an map object, using a key and its length.
+ * Inserts a new object into a map object, using a key.
  *
  * @param map Map in which to insert the object. (nonnull)
- * @param key The key for indexing purposes, this string will be copied (nonnull)
+ * @param key The key for indexing purposes, this string will be copied. (nonnull)
  * @param length Length of the key.
- * @param object Object to insert into the array. (nonnull)
+ * @param alloc Allocator to use for memory allocation. (nonnull)
  *
- * @return The success or failure of the operation.
+ * @return A pointer to the newly inserted object or NULL if the operation failed.
  **/
-bool ddwaf_object_map_addl(ddwaf_object *map, const char *key, size_t length, ddwaf_object *object);
+ddwaf_object *ddwaf_object_insert_key(ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc);
 
 /**
- * ddwaf_object_map_addl_nc
+ * ddwaf_object_insert_literal_key
  *
- * Inserts an object into an map object, using a key and its length, but without
+ * Inserts a new object into a map object, using a literal key.
+ *
+ * @param map Map in which to insert the object. (nonnull)
+ * @param key The key for indexing purposes, this string will not be copied. (nonnull)
+ * @param length Length of the key.
+ * @param alloc Allocator to use for memory allocation. (nonnull)
+ *
+ * @return A pointer to the newly inserted object or NULL if the operation failed.
+ **/
+ddwaf_object *ddwaf_object_insert_literal_key(ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc);
+
+
+/**
+ * ddwaf_object_insert_key_nocopy
+ *
+ * Inserts a new object into a map object, using a key and its length, but without
  * creating a copy of the key.
  *
  * @param map Map in which to insert the object. (nonnull)
- * @param key The key for indexing purposes, this string will be copied (nonnull)
+ * @param key The key for indexing purposes, this string will not be copied. (nonnull)
  * @param length Length of the key.
- * @param object Object to insert into the array. (nonnull)
+ * @param alloc Allocator to use for memory allocation. (nonnull)
  *
- * @return The success or failure of the operation.
+ * @return A pointer to the newly inserted object or NULL if the operation failed.
  **/
-bool ddwaf_object_map_addl_nc(ddwaf_object *map, const char *key, size_t length, ddwaf_object *object);
+ddwaf_object *ddwaf_object_insert_key_nocopy(ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc);
 
 /**
- * ddwaf_object_type
+ * ddwaf_object_get_type
  *
  * Returns the type of the object.
  *
@@ -697,10 +690,10 @@ bool ddwaf_object_map_addl_nc(ddwaf_object *map, const char *key, size_t length,
  *
  * @return The object type of DDWAF_OBJ_INVALID if NULL.
  **/
-DDWAF_OBJ_TYPE ddwaf_object_type(const ddwaf_object *object);
+DDWAF_OBJ_TYPE ddwaf_object_get_type(const ddwaf_object *object);
 
 /**
- * ddwaf_object_size
+ * ddwaf_object_get_size
  *
  * Returns the size of the container object.
  *
@@ -708,10 +701,10 @@ DDWAF_OBJ_TYPE ddwaf_object_type(const ddwaf_object *object);
  *
  * @return The object size or 0 if the object is not a container (array, map).
  **/
-size_t ddwaf_object_size(const ddwaf_object *object);
+size_t ddwaf_object_get_size(const ddwaf_object *object);
 
 /**
- * ddwaf_object_length
+ * ddwaf_object_get_length
  *
  * Returns the length of the string object.
  *
@@ -719,7 +712,7 @@ size_t ddwaf_object_size(const ddwaf_object *object);
  *
  * @return The string length or 0 if the object is not a string.
  **/
-size_t ddwaf_object_length(const ddwaf_object *object);
+size_t ddwaf_object_get_length(const ddwaf_object *object);
 
 /**
  * ddwaf_object_get_string
@@ -821,15 +814,124 @@ const ddwaf_object* ddwaf_object_find(const ddwaf_object *object, const char *ke
 
 /**
  * ddwaf_object_clone
+ *
+ * Creates a deep copy of the source object into the destination object.
+ *
+ * @param source The source object to clone from. (nonnull)
+ * @param destination The destination object to clone into. (nonnull)
+ *
+ * @return A pointer to the destination object or NULL if the operation failed.
  **/
 ddwaf_object* ddwaf_object_clone(const ddwaf_object *source, ddwaf_object *destination);
 
 /**
- * ddwaf_object_free
+ * ddwaf_object_is_invalid
  *
- * @param object Object to free. (nonnull)
+ * Returns true if the object is invalid.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is invalid, false otherwise.
  **/
-void ddwaf_object_free(ddwaf_object *object);
+bool ddwaf_object_is_invalid(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_is_null
+ *
+ * Returns true if the object is null.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is null, false otherwise.
+ **/
+bool ddwaf_object_is_null(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_is_bool
+ *
+ * Returns true if the object is a boolean.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is a boolean, false otherwise.
+ **/
+bool ddwaf_object_is_bool(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_is_signed
+ *
+ * Returns true if the object is a signed integer.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is a signed integer, false otherwise.
+ **/
+bool ddwaf_object_is_signed(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_is_unsigned
+ *
+ * Returns true if the object is an unsigned integer.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is an unsigned integer, false otherwise.
+ **/
+bool ddwaf_object_is_unsigned(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_is_float
+ *
+ * Returns true if the object is a float.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is a float, false otherwise.
+ **/
+bool ddwaf_object_is_float(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_is_string
+ *
+ * Returns true if the object is a string.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is a string, false otherwise.
+ **/
+bool ddwaf_object_is_string(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_is_array
+ *
+ * Returns true if the object is an array.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is an array, false otherwise.
+ **/
+bool ddwaf_object_is_array(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_is_map
+ *
+ * Returns true if the object is a map.
+ *
+ * @param object The object from which to get the type.
+ *
+ * @return True if the object is a map, false otherwise.
+ **/
+bool ddwaf_object_is_map(const ddwaf_object *object);
+
+/**
+ * ddwaf_object_destroy
+ *
+ * Frees the memory contained within the object.
+ *
+ * @param object Object to destroy. (nonnull)
+ * @param alloc Allocator to use for memory reclamation. (nonnull)
+ **/
+void ddwaf_object_destroy(ddwaf_object *object, ddwaf_allocator alloc);
 
 /**
  * ddwaf_get_version

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -12,36 +12,43 @@ EXPORTS
   ddwaf_context_init
   ddwaf_context_eval
   ddwaf_context_destroy
-  ddwaf_object_invalid
-  ddwaf_object_null
-  ddwaf_object_string
-  ddwaf_object_stringl
-  ddwaf_object_stringl_nc
-  ddwaf_object_string_from_unsigned
-  ddwaf_object_string_from_signed
-  ddwaf_object_unsigned
-  ddwaf_object_signed
-  ddwaf_object_bool
-  ddwaf_object_float
-  ddwaf_object_array
-  ddwaf_object_map
-  ddwaf_object_array_add
-  ddwaf_object_map_add
-  ddwaf_object_map_addl
-  ddwaf_object_map_addl_nc
-  ddwaf_object_type
-  ddwaf_object_size
-  ddwaf_object_length
-  ddwaf_object_get_string
-  ddwaf_object_get_unsigned
-  ddwaf_object_get_signed
-  ddwaf_object_get_float
-  ddwaf_object_at_key
-  ddwaf_object_at_value
-  ddwaf_object_get_bool
-  ddwaf_object_free
+  ddwaf_object_destroy
   ddwaf_get_version
   ddwaf_set_log_cb
   ddwaf_known_actions
+  ddwaf_get_default_allocator
+  ddwaf_object_set_invalid
+  ddwaf_object_set_null
+  ddwaf_object_set_bool
+  ddwaf_object_set_signed
+  ddwaf_object_set_unsigned
+  ddwaf_object_set_float
+  ddwaf_object_set_string
+  ddwaf_object_set_string_literal
+  ddwaf_object_set_array
+  ddwaf_object_set_map
+  ddwaf_object_insert
+  ddwaf_object_insert_key
+  ddwaf_object_insert_key_nocopy
+  ddwaf_object_insert_literal_key
+  ddwaf_object_get_type
+  ddwaf_object_get_size
+  ddwaf_object_get_length
+  ddwaf_object_get_bool
+  ddwaf_object_get_signed
+  ddwaf_object_get_unsigned
+  ddwaf_object_get_float
+  ddwaf_object_get_string
+  ddwaf_object_at_key
+  ddwaf_object_at_value
   ddwaf_object_find
   ddwaf_object_clone
+  ddwaf_object_is_invalid
+  ddwaf_object_is_null
+  ddwaf_object_is_bool
+  ddwaf_object_is_signed
+  ddwaf_object_is_unsigned
+  ddwaf_object_is_float
+  ddwaf_object_is_string
+  ddwaf_object_is_array
+  ddwaf_object_is_map

--- a/src/attribute_collector.hpp
+++ b/src/attribute_collector.hpp
@@ -39,8 +39,8 @@ public:
     {}
     attribute_collector(const attribute_collector &) = delete;
     attribute_collector &operator=(const attribute_collector &) = delete;
-    attribute_collector(attribute_collector &&other) noexcept = delete;
-    attribute_collector &operator=(attribute_collector &&other) noexcept = delete;
+    attribute_collector(attribute_collector &&other) noexcept = default;
+    attribute_collector &operator=(attribute_collector &&other) noexcept = default;
     ~attribute_collector() = default;
 
     template <typename T> bool insert(std::string_view key, T &&value)

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -29,6 +28,7 @@
 #include "object.hpp"
 #include "object_store.hpp"
 #include "object_type.hpp"
+#include "pointer.hpp"
 #include "re2.h"
 #include "ruleset_info.hpp"
 #include "utils.hpp"
@@ -153,9 +153,6 @@ std::shared_ptr<ddwaf::match_obfuscator> obfuscator_from_config(const ddwaf_conf
     return std::make_shared<ddwaf::match_obfuscator>(key_regex, value_regex);
 }
 
-// Maximum number of characters required to represent a 64 bit integer as a string
-// 20 bytes for UINT64_MAX or INT64_MIN + null byte
-constexpr size_t UINT64_CHARS = 21;
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
 detail::object *to_ptr(ddwaf_object *ptr) { return reinterpret_cast<detail::object *>(ptr); }
 const detail::object *to_ptr(const ddwaf_object *ptr)
@@ -167,11 +164,18 @@ const detail::object *to_ptr(const ddwaf_object *ptr)
 detail::object &to_ref(ddwaf_object *ptr) { return *to_ptr(ptr); }
 const detail::object &to_ref(const ddwaf_object *ptr) { return *to_ptr(ptr); }
 
-borrowed_object to_borrowed(ddwaf_object *ptr)
+borrowed_object to_borrowed(ddwaf_object *ptr, nonnull_ptr<memory::memory_resource> alloc)
 {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return borrowed_object{reinterpret_cast<detail::object *>(ptr)};
+    return borrowed_object{reinterpret_cast<detail::object *>(ptr), alloc};
 }
+
+memory::memory_resource *to_alloc_ptr(ddwaf_allocator alloc)
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<memory::memory_resource *>(alloc);
+}
+
 } // namespace
 
 // explicit instantiation declaration to suppress warning
@@ -254,11 +258,11 @@ const char *const *ddwaf_known_actions(ddwaf::waf *handle, uint32_t *size)
     return action_types.data();
 }
 
-ddwaf_context ddwaf_context_init(ddwaf::waf *handle)
+ddwaf_context ddwaf_context_init(ddwaf::waf *handle, ddwaf_allocator output_alloc)
 {
     try {
-        if (handle != nullptr) {
-            return handle->create_context();
+        if (handle != nullptr && output_alloc != nullptr) {
+            return handle->create_context(to_alloc_ptr(output_alloc));
         }
     } catch (const std::exception &e) {
         DDWAF_ERROR("{}", e.what());
@@ -445,12 +449,9 @@ uint32_t ddwaf_builder_get_config_paths(
         }
 
         if (paths != nullptr) {
-            ddwaf_object_array(paths);
-            for (const auto &value : config_paths) {
-                ddwaf_object tmp{};
-                ddwaf_object_array_add(
-                    paths, ddwaf_object_stringl(&tmp, value.data(), value.size()));
-            }
+            auto object = owned_object::make_array(config_paths.size());
+            for (const auto &value : config_paths) { object.emplace_back(value); }
+            to_ref(paths) = object.move();
         }
         return config_paths.size();
     } catch (const std::exception &e) {
@@ -464,7 +465,9 @@ uint32_t ddwaf_builder_get_config_paths(
 
 void ddwaf_builder_destroy(ddwaf_builder builder) { delete builder; }
 
-ddwaf_object *ddwaf_object_invalid(ddwaf_object *object)
+ddwaf_allocator ddwaf_get_default_allocator() { return memory::get_default_resource(); }
+
+ddwaf_object *ddwaf_object_set_invalid(ddwaf_object *object)
 {
     if (object == nullptr) {
         return nullptr;
@@ -475,7 +478,12 @@ ddwaf_object *ddwaf_object_invalid(ddwaf_object *object)
     return object;
 }
 
-ddwaf_object *ddwaf_object_null(ddwaf_object *object)
+ddwaf_object *ddwaf_object_invalid(ddwaf_object *object)
+{
+    return ddwaf_object_set_invalid(object);
+}
+
+ddwaf_object *ddwaf_object_set_null(ddwaf_object *object)
 {
     if (object == nullptr) {
         return nullptr;
@@ -486,69 +494,54 @@ ddwaf_object *ddwaf_object_null(ddwaf_object *object)
     return object;
 }
 
-ddwaf_object *ddwaf_object_string(ddwaf_object *object, const char *string)
+ddwaf_object *ddwaf_object_null(ddwaf_object *object) { return ddwaf_object_set_null(object); }
+
+ddwaf_object *ddwaf_object_set_string(
+    ddwaf_object *object, const char *string, uint32_t length, ddwaf_allocator alloc)
+{
+    if (object == nullptr || string == nullptr || alloc == nullptr) {
+        return nullptr;
+    }
+    to_ref(object) = owned_object{string, length, to_alloc_ptr(alloc)}.move();
+    return object;
+}
+
+ddwaf_object *ddwaf_object_set_string_nocopy(
+    ddwaf_object *object, const char *string, uint32_t length)
 {
     if (object == nullptr || string == nullptr) {
         return nullptr;
     }
-    to_ref(object) = owned_object{string}.move();
+    to_ref(object) = owned_object::make_string_nocopy(string, length).move();
     return object;
 }
 
-ddwaf_object *ddwaf_object_stringl(ddwaf_object *object, const char *string, size_t length)
+ddwaf_object *ddwaf_object_set_string_literal(
+    ddwaf_object *object, const char *string, uint32_t length)
 {
     if (object == nullptr || string == nullptr) {
         return nullptr;
     }
-
-    to_ref(object) = owned_object{string, static_cast<uint32_t>(length)}.move();
+    to_ref(object) = owned_object::make_string_literal(string, length).move();
     return object;
 }
 
-ddwaf_object *ddwaf_object_stringl_nc(ddwaf_object *object, const char *string, size_t length)
-{
-    if (object == nullptr || string == nullptr) {
-        return nullptr;
-    }
-
-    to_ref(object) = owned_object::make_string_nocopy(string, static_cast<uint32_t>(length)).move();
-    return object;
-}
-
-// TODO: deprecate
-ddwaf_object *ddwaf_object_string_from_signed(ddwaf_object *object, int64_t value)
+ddwaf_object *ddwaf_object_set_unsigned(ddwaf_object *object, uint64_t value)
 {
     if (object == nullptr) {
         return nullptr;
     }
 
-    // INT64_MIN is 20 char long
-    char container[UINT64_CHARS] = {0};
-    const auto length = static_cast<std::size_t>(
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        snprintf(container, sizeof(container), "%" PRId64, value));
-
-    return ddwaf_object_stringl(object, container, length);
-}
-
-// TODO: deprecate
-ddwaf_object *ddwaf_object_string_from_unsigned(ddwaf_object *object, uint64_t value)
-{
-    if (object == nullptr) {
-        return nullptr;
-    }
-
-    // UINT64_MAX is 20 char long
-    char container[UINT64_CHARS] = {0};
-
-    const auto length = static_cast<size_t>(
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-        snprintf(container, sizeof(container), "%" PRIu64, value));
-
-    return ddwaf_object_stringl(object, container, length);
+    to_ref(object) = owned_object{value}.move();
+    return object;
 }
 
 ddwaf_object *ddwaf_object_unsigned(ddwaf_object *object, uint64_t value)
+{
+    return ddwaf_object_set_unsigned(object, value);
+}
+
+ddwaf_object *ddwaf_object_set_signed(ddwaf_object *object, int64_t value)
 {
     if (object == nullptr) {
         return nullptr;
@@ -560,15 +553,24 @@ ddwaf_object *ddwaf_object_unsigned(ddwaf_object *object, uint64_t value)
 
 ddwaf_object *ddwaf_object_signed(ddwaf_object *object, int64_t value)
 {
+    return ddwaf_object_set_signed(object, value);
+}
+
+ddwaf_object *ddwaf_object_set_bool(ddwaf_object *object, bool value)
+{
     if (object == nullptr) {
         return nullptr;
     }
-
     to_ref(object) = owned_object{value}.move();
     return object;
 }
 
 ddwaf_object *ddwaf_object_bool(ddwaf_object *object, bool value)
+{
+    return ddwaf_object_set_bool(object, value);
+}
+
+ddwaf_object *ddwaf_object_set_float(ddwaf_object *object, double value)
 {
     if (object == nullptr) {
         return nullptr;
@@ -579,100 +581,102 @@ ddwaf_object *ddwaf_object_bool(ddwaf_object *object, bool value)
 
 ddwaf_object *ddwaf_object_float(ddwaf_object *object, double value)
 {
-    if (object == nullptr) {
+    return ddwaf_object_set_float(object, value);
+}
+
+ddwaf_object *ddwaf_object_set_array(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc)
+{
+    if (object == nullptr || alloc == nullptr) {
         return nullptr;
     }
-    to_ref(object) = owned_object{value}.move();
+    to_ref(object) = owned_object::make_array(capacity, to_alloc_ptr(alloc)).move();
     return object;
 }
 
-ddwaf_object *ddwaf_object_array(ddwaf_object *object)
+ddwaf_object *ddwaf_object_set_map(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc)
 {
-    if (object == nullptr) {
-        return nullptr;
-    }
-    to_ref(object) = owned_object::make_array().move();
-    return object;
-}
-
-ddwaf_object *ddwaf_object_map(ddwaf_object *object)
-{
-    if (object == nullptr) {
+    if (object == nullptr || alloc == nullptr) {
         return nullptr;
     }
 
-    to_ref(object) = owned_object::make_map().move();
+    to_ref(object) = owned_object::make_map(capacity, to_alloc_ptr(alloc)).move();
     return object;
 }
 
-bool ddwaf_object_array_add(ddwaf_object *array, ddwaf_object *object)
+ddwaf_object *ddwaf_object_insert(ddwaf_object *array, ddwaf_allocator alloc)
 {
-    if (array == nullptr || array->type != DDWAF_OBJ_ARRAY || object == nullptr) {
-        return false;
+    if (array == nullptr || array->type != DDWAF_OBJ_ARRAY || alloc == nullptr) {
+        return nullptr;
     }
 
     try {
-        to_borrowed(array).emplace_back(owned_object{to_ref(object)});
-        return true;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return reinterpret_cast<ddwaf_object *>(
+            to_borrowed(array, to_alloc_ptr(alloc)).emplace_back({}).ptr());
     } catch (...) {} // NOLINT(bugprone-empty-catch)
-    return false;
+    return nullptr;
 }
-
-bool ddwaf_object_map_add(ddwaf_object *map, const char *key, ddwaf_object *object)
+ddwaf_object *ddwaf_object_insert_key(
+    ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc)
 {
-    if (map == nullptr || map->type != DDWAF_OBJ_MAP || key == nullptr || object == nullptr) {
-        return false;
+    if (map == nullptr || map->type != DDWAF_OBJ_MAP || alloc == nullptr) {
+        return nullptr;
     }
 
     try {
-        to_borrowed(map).emplace(std::string_view{key}, owned_object{to_ref(object)});
-        return true;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return reinterpret_cast<ddwaf_object *>(
+            to_borrowed(map, to_alloc_ptr(alloc)).emplace(std::string_view{key, length}, {}).ptr());
     } catch (...) {} // NOLINT(bugprone-empty-catch)
-    return false;
+    return nullptr;
 }
 
-bool ddwaf_object_map_addl(ddwaf_object *map, const char *key, size_t length, ddwaf_object *object)
+ddwaf_object *ddwaf_object_insert_key_nocopy(
+    ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc)
 {
-    if (map == nullptr || map->type != DDWAF_OBJ_MAP || key == nullptr || object == nullptr) {
-        return false;
+    if (map == nullptr || map->type != DDWAF_OBJ_MAP || alloc == nullptr) {
+        return nullptr;
     }
 
     try {
-        to_borrowed(map).emplace(std::string_view{key, length}, owned_object{to_ref(object)});
-        return true;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return reinterpret_cast<ddwaf_object *>(
+            to_borrowed(map, to_alloc_ptr(alloc))
+                .emplace(owned_object::make_string_nocopy(key, length), {})
+                .ptr());
     } catch (...) {} // NOLINT(bugprone-empty-catch)
-    return false;
+    return nullptr;
 }
 
-bool ddwaf_object_map_addl_nc(
-    ddwaf_object *map, const char *key, size_t length, ddwaf_object *object)
+ddwaf_object *ddwaf_object_insert_literal_key(
+    ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc)
 {
-    if (map == nullptr || map->type != DDWAF_OBJ_MAP || key == nullptr || object == nullptr) {
-        return false;
+    if (map == nullptr || map->type != DDWAF_OBJ_MAP || alloc == nullptr) {
+        return nullptr;
     }
 
     try {
-        to_borrowed(map).emplace(
-            owned_object::make_string_nocopy(key, static_cast<uint32_t>(length)),
-            owned_object{to_ref(object)});
-        return true;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return reinterpret_cast<ddwaf_object *>(
+            to_borrowed(map, to_alloc_ptr(alloc))
+                .emplace(owned_object::make_string_literal(key, length), {})
+                .ptr());
     } catch (...) {} // NOLINT(bugprone-empty-catch)
-    return false;
+    return nullptr;
 }
 
-// NOLINTNEXTLINE(misc-no-recursion)
-void ddwaf_object_free(ddwaf_object *object)
+void ddwaf_object_destroy(ddwaf_object *object, ddwaf_allocator alloc)
 {
     if (object == nullptr) {
         return;
     }
 
-    detail::object_destroy(to_ref(object), memory::get_default_resource());
+    detail::object_destroy(to_ref(object), to_alloc_ptr(alloc));
 
     ddwaf_object_invalid(object);
 }
 
-DDWAF_OBJ_TYPE ddwaf_object_type(const ddwaf_object *object)
+DDWAF_OBJ_TYPE ddwaf_object_get_type(const ddwaf_object *object)
 {
     const object_view view{to_ptr(object)};
     if (!view.has_value()) {
@@ -682,7 +686,7 @@ DDWAF_OBJ_TYPE ddwaf_object_type(const ddwaf_object *object)
     return static_cast<DDWAF_OBJ_TYPE>(view.type());
 }
 
-size_t ddwaf_object_size(const ddwaf_object *object)
+size_t ddwaf_object_get_size(const ddwaf_object *object)
 {
     const object_view view{to_ptr(object)};
     if (!view.has_value() || !view.is_container()) {
@@ -692,7 +696,7 @@ size_t ddwaf_object_size(const ddwaf_object *object)
     return view.size();
 }
 
-size_t ddwaf_object_length(const ddwaf_object *object)
+size_t ddwaf_object_get_length(const ddwaf_object *object)
 {
     const object_view view{to_ptr(object)};
     if (!view.has_value() || !view.is_string()) {
@@ -794,5 +798,51 @@ ddwaf_object *ddwaf_object_clone(const ddwaf_object *source, ddwaf_object *desti
 
     to_ref(destination) = view.clone().move();
     return destination;
+}
+
+bool ddwaf_object_is_invalid(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.is_invalid();
+}
+bool ddwaf_object_is_null(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.type() == object_type::null;
+}
+bool ddwaf_object_is_bool(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.type() == object_type::boolean;
+}
+bool ddwaf_object_is_signed(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.type() == object_type::int64;
+}
+bool ddwaf_object_is_unsigned(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.type() == object_type::uint64;
+}
+bool ddwaf_object_is_float(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.type() == object_type::float64;
+}
+bool ddwaf_object_is_string(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.is_string();
+}
+bool ddwaf_object_is_array(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.is_array();
+}
+bool ddwaf_object_is_map(const ddwaf_object *object)
+{
+    const object_view view{to_ptr(object)};
+    return view.has_value() && view.is_map();
 }
 }

--- a/src/waf.hpp
+++ b/src/waf.hpp
@@ -9,6 +9,7 @@
 
 #include "configuration/common/raw_configuration.hpp"
 #include "context.hpp"
+#include "memory_resource.hpp"
 #include "ruleset.hpp"
 #include "ruleset_info.hpp"
 #include "utils.hpp"
@@ -25,7 +26,11 @@ public:
     waf &operator=(waf &&) = default;
     ~waf() = default;
 
-    ddwaf::context_wrapper *create_context() { return new context_wrapper(ruleset_); }
+    ddwaf::context_wrapper *create_context(
+        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource())
+    {
+        return new context_wrapper(ruleset_, alloc);
+    }
 
     [[nodiscard]] const std::vector<const char *> &get_root_addresses() const
     {

--- a/tests/common/base_utils.hpp
+++ b/tests/common/base_utils.hpp
@@ -15,24 +15,6 @@
 #define LONG_TIME 1000000
 #define SHORT_TIME 1
 
-#define DDWAF_OBJECT_INVALID                                                                       \
-    {                                                                                              \
-        .type = DDWAF_OBJ_INVALID                                                                  \
-    }
-#define DDWAF_OBJECT_MAP                                                                           \
-    {                                                                                              \
-        .via                                                                                       \
-        {                                                                                          \
-            .map { .type = DDWAF_OBJ_MAP, .size = 0, .capacity = 0, .ptr = NULL }                  \
-        }                                                                                          \
-    }
-#define DDWAF_OBJECT_ARRAY                                                                         \
-    {                                                                                              \
-        .via                                                                                       \
-        {                                                                                          \
-            .array { .type = DDWAF_OBJ_ARRAY, .size = 0, .capacity = 0, .ptr = NULL }              \
-        }                                                                                          \
-    }
 #define LSTRARG(value) value, sizeof(value) - 1
 
 namespace ddwaf::test {

--- a/tests/integration/conditions/exists/test.cpp
+++ b/tests/integration/conditions/exists/test.cpp
@@ -5,6 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 
 #include "common/gtest_utils.hpp"
+#include "ddwaf.h"
 
 using namespace ddwaf;
 using namespace std::literals;
@@ -14,18 +15,20 @@ constexpr std::string_view base_dir = "integration/conditions/exists";
 
 TEST(TestConditionExistsIntegration, AddressAvailable)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&map, "input-1", ddwaf_object_invalid(&value));
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_insert_key(&map, STRL("input-1"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -41,49 +44,54 @@ TEST(TestConditionExistsIntegration, AddressAvailable)
                                    .address = "input-1",
                                }}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsIntegration, AddressNotAvailable)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&map, "input", ddwaf_object_invalid(&value));
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_insert_key(&map, STRL("input"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsIntegration, KeyPathAvailable)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object intermediate = DDWAF_OBJECT_MAP;
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&intermediate, "path", ddwaf_object_invalid(&value));
-    ddwaf_object_map_add(&map, "input-2", &intermediate);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+
+    auto *intermediate = ddwaf_object_insert_key(&map, STRL("input-2"), alloc);
+    ddwaf_object_set_map(intermediate, 1, alloc);
+    ddwaf_object_insert_key(intermediate, STRL("path"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -96,50 +104,55 @@ TEST(TestConditionExistsIntegration, KeyPathAvailable)
                                .highlight = ""sv,
                                .args = {{.address = "input-2", .path = {"path"}}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsIntegration, KeyPathNotAvailable)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object intermediate = DDWAF_OBJECT_MAP;
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&intermediate, "poth", ddwaf_object_invalid(&value));
-    ddwaf_object_map_add(&map, "input-2", &intermediate);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+
+    auto *intermediate = ddwaf_object_insert_key(&map, STRL("input-2"), alloc);
+    ddwaf_object_set_map(intermediate, 1, alloc);
+    ddwaf_object_insert_key(intermediate, STRL("poth"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsIntegration, AddressAvailableVariadicRule)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&map, "input-3-1", ddwaf_object_invalid(&value));
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_insert_key(&map, STRL("input-3-1"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -154,27 +167,30 @@ TEST(TestConditionExistsIntegration, AddressAvailableVariadicRule)
                                    .address = "input-3-1",
                                }}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsIntegration, KeyPathAvailableVariadicRule)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object intermediate = DDWAF_OBJECT_MAP;
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&intermediate, "path", ddwaf_object_invalid(&value));
-    ddwaf_object_map_add(&map, "input-3-2", &intermediate);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+
+    auto *intermediate = ddwaf_object_insert_key(&map, STRL("input-3-2"), alloc);
+    ddwaf_object_set_map(intermediate, 1, alloc);
+    ddwaf_object_insert_key(intermediate, STRL("path"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -187,28 +203,32 @@ TEST(TestConditionExistsIntegration, KeyPathAvailableVariadicRule)
                                .highlight = ""sv,
                                .args = {{.address = "input-3-2", .path = {"path"}}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsIntegration, AddressAvailableKeyPathNotAvailableVariadicRule)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object intermediate = DDWAF_OBJECT_MAP;
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&intermediate, "poth", ddwaf_object_invalid(&value));
-    ddwaf_object_map_add(&map, "input-3-2", &intermediate);
-    ddwaf_object_map_add(&map, "input-3-1", ddwaf_object_invalid(&value));
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+
+    auto *intermediate = ddwaf_object_insert_key(&map, STRL("input-3-2"), alloc);
+    ddwaf_object_set_map(intermediate, 1, alloc);
+    ddwaf_object_insert_key(intermediate, STRL("poth"), alloc);
+
+    ddwaf_object_insert_key(&map, STRL("input-3-1"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -223,48 +243,52 @@ TEST(TestConditionExistsIntegration, AddressAvailableKeyPathNotAvailableVariadic
                                    .address = "input-3-1",
                                }}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsNegatedIntegration, AddressAvailable)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists_negated.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&map, "input-1", ddwaf_object_invalid(&value));
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_insert_key(&map, STRL("input-1"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsNegatedIntegration, AddressNotAvailable)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists_negated.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&map, "input", ddwaf_object_invalid(&value));
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_insert_key(&map, STRL("input"), alloc);
 
     // Even though the address isn't present, this test shouldn't result in a match
     // as the !exists operator only supports address + key path, since we can't
@@ -272,27 +296,31 @@ TEST(TestConditionExistsNegatedIntegration, AddressNotAvailable)
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsNegatedIntegration, KeyPathNotAvailable)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists_negated.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object intermediate = DDWAF_OBJECT_MAP;
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&intermediate, "poth", ddwaf_object_invalid(&value));
-    ddwaf_object_map_add(&map, "input-2", &intermediate);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+
+    auto *intermediate = ddwaf_object_insert_key(&map, STRL("input-2"), alloc);
+
+    ddwaf_object_set_map(intermediate, 1, alloc);
+    ddwaf_object_insert_key(intermediate, STRL("poth"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -305,32 +333,36 @@ TEST(TestConditionExistsNegatedIntegration, KeyPathNotAvailable)
                                .highlight = ""sv,
                                .args = {{.address = "input-2", .path = {"path"}}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestConditionExistsNegatedIntegration, KeyPathAvailable)
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     auto rule = read_file<ddwaf_object>("exists_negated.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object intermediate = DDWAF_OBJECT_MAP;
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_map_add(&intermediate, "path", ddwaf_object_invalid(&value));
-    ddwaf_object_map_add(&map, "input-2", &intermediate);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+
+    auto *intermediate = ddwaf_object_insert_key(&map, STRL("input-2"), alloc);
+
+    ddwaf_object_set_map(intermediate, 1, alloc);
+    ddwaf_object_insert_key(intermediate, STRL("path"), alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }

--- a/tests/integration/exclusion/rule_filter/test.cpp
+++ b/tests/integration/exclusion/rule_filter/test.cpp
@@ -15,20 +15,21 @@ constexpr std::string_view base_dir = "integration/exclusion/rule_filter/";
 
 TEST(TestRuleFilterIntegration, ExcludeSingleRule)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_one_rule.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -41,27 +42,28 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRule)
                                    .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestRuleFilterIntegration, ExcludeByType)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_by_type.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -74,52 +76,54 @@ TEST(TestRuleFilterIntegration, ExcludeByType)
                                    .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestRuleFilterIntegration, ExcludeByCategory)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_by_category.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestRuleFilterIntegration, ExcludeByTags)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_by_tags.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -132,45 +136,49 @@ TEST(TestRuleFilterIntegration, ExcludeByTags)
                                    .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_all_with_condition.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
-        ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
+        ddwaf_object_set_map(&root, 2, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
+        ddwaf_object_set_string(
+            ddwaf_object_insert_key(&root, STRL("usr.id"), alloc), STRL("admin"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -193,7 +201,7 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
                         .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -201,22 +209,25 @@ TEST(TestRuleFilterIntegration, ExcludeAllWithCondition)
 
 TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_one_rule_with_condition.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
-        ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
+        ddwaf_object_set_map(&root, 2, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
+        ddwaf_object_set_string(
+            ddwaf_object_insert_key(&root, STRL("usr.id"), alloc), STRL("admin"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -230,18 +241,19 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -264,7 +276,7 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
                         .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -272,23 +284,26 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithCondition)
 
 TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule =
         read_file<ddwaf_object>("exclude_one_rule_with_condition_and_transformers.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
-        ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "AD      MIN"));
+        ddwaf_object_set_map(&root, 2, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
+        ddwaf_object_set_string(
+            ddwaf_object_insert_key(&root, STRL("usr.id"), alloc), STRL("AD      MIN"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -302,18 +317,19 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -336,29 +352,32 @@ TEST(TestRuleFilterIntegration, ExcludeSingleRuleWithConditionAndTransformers)
                         .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
 }
 TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_by_type_with_condition.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
-        ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
+        ddwaf_object_set_map(&root, 2, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
+        ddwaf_object_set_string(
+            ddwaf_object_insert_key(&root, STRL("usr.id"), alloc), STRL("admin"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -372,18 +391,19 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -406,7 +426,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
                         .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -414,38 +434,42 @@ TEST(TestRuleFilterIntegration, ExcludeByTypeWithCondition)
 
 TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_by_category_with_condition.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
-        ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
+        ddwaf_object_set_map(&root, 2, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
+        ddwaf_object_set_string(
+            ddwaf_object_insert_key(&root, STRL("usr.id"), alloc), STRL("admin"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_OK);
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -468,7 +492,7 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
                         .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -476,22 +500,25 @@ TEST(TestRuleFilterIntegration, ExcludeByCategoryWithCondition)
 
 TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_by_tags_with_condition.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
-        ddwaf_object_map_add(&root, "usr.id", ddwaf_object_string(&tmp, "admin"));
+        ddwaf_object_set_map(&root, 2, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
+        ddwaf_object_set_string(
+            ddwaf_object_insert_key(&root, STRL("usr.id"), alloc), STRL("admin"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -505,18 +532,19 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
                                        .address = "http.client_ip",
                                    }}}}});
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -539,7 +567,7 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
                         .value = "192.168.0.1"sv,
                         .address = "http.client_ip",
                     }}}}});
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -547,20 +575,21 @@ TEST(TestRuleFilterIntegration, ExcludeByTagsWithCondition)
 
 TEST(TestRuleFilterIntegration, MonitorSingleRule)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("monitor_one_rule.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -576,27 +605,28 @@ TEST(TestRuleFilterIntegration, MonitorSingleRule)
                                }}}}});
     EXPECT_ACTIONS(out, {});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestRuleFilterIntegration, AvoidHavingTwoMonitorOnActions)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("multiple_monitor_on_match.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -612,27 +642,28 @@ TEST(TestRuleFilterIntegration, AvoidHavingTwoMonitorOnActions)
                                }}}}});
     EXPECT_ACTIONS(out, {});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestRuleFilterIntegration, MonitorBypassFilterModePrecedence)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("monitor_bypass_precedence.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
     ddwaf_context_destroy(context);
@@ -641,20 +672,21 @@ TEST(TestRuleFilterIntegration, MonitorBypassFilterModePrecedence)
 
 TEST(TestRuleFilterIntegration, MonitorCustomFilterModePrecedence)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("monitor_custom_precedence.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -670,27 +702,28 @@ TEST(TestRuleFilterIntegration, MonitorCustomFilterModePrecedence)
                                }}}}});
     EXPECT_ACTIONS(out, {});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestRuleFilterIntegration, BypassCustomFilterModePrecedence)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("bypass_custom_precedence.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, nullptr, LONG_TIME), DDWAF_OK);
 
@@ -700,20 +733,21 @@ TEST(TestRuleFilterIntegration, BypassCustomFilterModePrecedence)
 
 TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_with_custom_action.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -730,28 +764,30 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
     EXPECT_ACTIONS(out,
         {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}})
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("exclude_with_custom_action_and_condition.yaml", base_dir);
     ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -768,18 +804,19 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}})
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.2"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.2"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -794,7 +831,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
                                    }}}}});
         EXPECT_ACTIONS(out, {})
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
     ddwaf_destroy(handle);
@@ -802,26 +839,28 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
 
 TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_builder builder = ddwaf_builder_init(nullptr);
 
     {
         auto rule = read_file<ddwaf_object>("exclude_with_unknown_action.yaml", base_dir);
         ASSERT_NE(rule.type, DDWAF_OBJ_INVALID);
         ddwaf_builder_add_or_update_config(builder, LSTRARG("default"), &rule, nullptr);
-        ddwaf_object_free(&rule);
+        ddwaf_object_destroy(&rule, alloc);
     }
 
     auto *handle1 = ddwaf_builder_build_instance(builder);
     ASSERT_NE(handle1, nullptr);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle1);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle1, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -836,7 +875,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
                                    }}}}});
         EXPECT_ACTIONS(out, {});
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
@@ -844,20 +883,21 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         auto actions = yaml_to_object<ddwaf_object>(
             R"({actions: [{id: block2, type: block_request, parameters: {}}]})");
         ddwaf_builder_add_or_update_config(builder, LSTRARG("actions"), &actions, nullptr);
-        ddwaf_object_free(&actions);
+        ddwaf_object_destroy(&actions, alloc);
     }
 
     auto *handle2 = ddwaf_builder_build_instance(builder);
     ASSERT_NE(handle1, nullptr);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle2);
+        auto *alloc = ddwaf_get_default_allocator();
+        ddwaf_context context = ddwaf_context_init(handle2, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object root;
-        ddwaf_object tmp;
-        ddwaf_object_map(&root);
-        ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+        ddwaf_object_set_map(&root, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc),
+            STRL("192.168.0.1"), alloc);
 
         ddwaf_object out;
         EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -874,7 +914,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
                                                    {"type", "auto"}}}})
 
-        ddwaf_object_free(&out);
+        ddwaf_object_destroy(&out, alloc);
         ddwaf_context_destroy(context);
     }
 
@@ -885,6 +925,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
 
 TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     // In this test, the ruleset contains a rule filter with the action
     // generate_stack, which is neither a blocking, redirecting or monitoring
     // action, hence its ignored.
@@ -893,15 +934,15 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
 
     auto *handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "http.client_ip", ddwaf_object_string(&tmp, "192.168.0.1"));
+    ddwaf_object_set_map(&root, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("http.client_ip"), alloc), STRL("192.168.0.1"), alloc);
 
     ddwaf_object out;
     EXPECT_EQ(ddwaf_context_eval(context, &root, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -918,7 +959,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
     EXPECT_ACTIONS(out,
         {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}})
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
 
     ddwaf_destroy(handle);

--- a/tests/integration/interface/context/result/test.cpp
+++ b/tests/integration/interface/context/result/test.cpp
@@ -15,50 +15,53 @@ constexpr std::string_view base_dir = "integration/interface/context/result/";
 
 TEST(TestContextResultIntegration, ResultInvalidArgumentNullContext)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_object tmp;
-    ddwaf_object persistent = DDWAF_OBJECT_MAP;
-    ddwaf_object_map_add(&persistent, "value1", ddwaf_object_string(&tmp, "rule1"));
+    ddwaf_object persistent;
+    ddwaf_object_set_map(&persistent, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&persistent, STRL("value1"), alloc), STRL("rule1"), alloc);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
 
     EXPECT_EQ(ddwaf_context_eval(nullptr, &persistent, nullptr, true, &result, LONG_TIME),
         DDWAF_ERR_INVALID_ARGUMENT);
 
     // The result object must be unchanged
-    EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
+    EXPECT_EQ(ddwaf_object_get_type(&result), DDWAF_OBJ_INVALID);
 
-    ddwaf_object_free(&persistent);
+    ddwaf_object_destroy(&persistent, alloc);
     ddwaf_destroy(handle);
 }
 
 TEST(TestContextResultIntegration, ResultInvalidArgumentNoData)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
 
     EXPECT_EQ(ddwaf_context_eval(context, nullptr, nullptr, true, &result, LONG_TIME),
         DDWAF_ERR_INVALID_ARGUMENT);
 
     // The result object must be unchanged
-    EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
+    EXPECT_EQ(ddwaf_object_get_type(&result), DDWAF_OBJ_INVALID);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
@@ -66,28 +69,29 @@ TEST(TestContextResultIntegration, ResultInvalidArgumentNoData)
 
 TEST(TestContextResultIntegration, ResultInvalidObjectInvalidPersistentDataSchema)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object tmp;
-    ddwaf_object persistent = DDWAF_OBJECT_ARRAY;
-    ddwaf_object_array_add(&persistent, ddwaf_object_string(&tmp, "rule1"));
+    ddwaf_object persistent;
+    ddwaf_object_set_array(&persistent, 1, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert(&persistent, alloc), STRL("rule1"), alloc);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
 
     EXPECT_EQ(ddwaf_context_eval(context, &persistent, nullptr, true, &result, LONG_TIME),
         DDWAF_ERR_INVALID_OBJECT);
 
     // The result object must be unchanged
-    EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
+    EXPECT_EQ(ddwaf_object_get_type(&result), DDWAF_OBJ_INVALID);
 
     // The persistent object, even though invalid, is freed on context destruction
     ddwaf_context_destroy(context);
@@ -96,28 +100,29 @@ TEST(TestContextResultIntegration, ResultInvalidObjectInvalidPersistentDataSchem
 
 TEST(TestContextResultIntegration, ResultInvalidObjectInvalidEphemeralDataSchema)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object tmp;
-    ddwaf_object ephemeral = DDWAF_OBJECT_ARRAY;
-    ddwaf_object_array_add(&ephemeral, ddwaf_object_string(&tmp, "rule1"));
+    ddwaf_object ephemeral;
+    ddwaf_object_set_array(&ephemeral, 1, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert(&ephemeral, alloc), STRL("rule1"), alloc);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
 
     EXPECT_EQ(ddwaf_context_eval(context, nullptr, &ephemeral, true, &result, LONG_TIME),
         DDWAF_ERR_INVALID_OBJECT);
 
     // The result object must be unchanged
-    EXPECT_EQ(ddwaf_object_type(&result), DDWAF_OBJ_INVALID);
+    EXPECT_EQ(ddwaf_object_get_type(&result), DDWAF_OBJ_INVALID);
 
     // The ephemeral object, even though invalid, is freed on context destruction
     ddwaf_context_destroy(context);
@@ -126,355 +131,365 @@ TEST(TestContextResultIntegration, ResultInvalidObjectInvalidEphemeralDataSchema
 
 TEST(TestContextResultIntegration, ResultOk)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     // Destroying the handle should not invalidate it
     ddwaf_destroy(handle);
 
-    ddwaf_object tmp;
-    ddwaf_object parameter = DDWAF_OBJECT_MAP;
-    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_invalid(&tmp));
+    ddwaf_object parameter;
+    ddwaf_object_set_map(&parameter, 1, alloc);
+    ddwaf_object_insert_key(&parameter, STRL("value1"), alloc);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
     EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
-    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(events), 0);
+    EXPECT_EQ(ddwaf_object_get_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_size(events), 0);
 
     const auto *actions = ddwaf_object_find(&result, STRL("actions"));
     ASSERT_NE(actions, nullptr);
-    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(actions), 0);
+    EXPECT_EQ(ddwaf_object_get_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(actions), 0);
 
     const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
     ASSERT_NE(timeout, nullptr);
-    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(timeout), DDWAF_OBJ_BOOL);
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
     const auto *duration = ddwaf_object_find(&result, STRL("duration"));
     ASSERT_NE(duration, nullptr);
-    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(duration), DDWAF_OBJ_UNSIGNED);
     EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
 
     const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
     ASSERT_NE(attributes, nullptr);
-    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+    EXPECT_EQ(ddwaf_object_get_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 0);
 
     const auto *keep = ddwaf_object_find(&result, STRL("keep"));
     ASSERT_NE(keep, nullptr);
-    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(keep), DDWAF_OBJ_BOOL);
     EXPECT_FALSE(ddwaf_object_get_bool(keep));
 
-    ddwaf_object_free(&result);
+    ddwaf_object_destroy(&result, alloc);
     ddwaf_context_destroy(context);
 }
 
 TEST(TestContextResultIntegration, ResultOkWithAttributes)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     // Destroying the handle should not invalidate it
     ddwaf_destroy(handle);
 
-    ddwaf_object tmp;
-    ddwaf_object parameter = DDWAF_OBJECT_MAP;
-    ddwaf_object_map_add(&parameter, "server.request.body", ddwaf_object_invalid(&tmp));
+    ddwaf_object parameter;
+    ddwaf_object_set_map(&parameter, 2, alloc);
+    ddwaf_object_set_invalid(
+        ddwaf_object_insert_key(&parameter, STRL("server.request.body"), alloc));
+    // Move the settings object to the parameter
+    auto *settings = ddwaf_object_insert_key(&parameter, STRL("waf.context.processor"), alloc);
 
-    ddwaf_object settings;
-    ddwaf_object_map(&settings);
-    ddwaf_object_map_add(&settings, "extract-schema", ddwaf_object_bool(&tmp, true));
-    ddwaf_object_map_add(&parameter, "waf.context.processor", &settings);
+    ddwaf_object_set_map(settings, 1, alloc);
+    ddwaf_object_set_bool(ddwaf_object_insert_key(settings, STRL("extract-schema"), alloc), true);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
     EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
-    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(events), 0);
+    EXPECT_EQ(ddwaf_object_get_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_size(events), 0);
 
     const auto *actions = ddwaf_object_find(&result, STRL("actions"));
     ASSERT_NE(actions, nullptr);
-    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(actions), 0);
+    EXPECT_EQ(ddwaf_object_get_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(actions), 0);
 
     const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
     ASSERT_NE(timeout, nullptr);
-    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(timeout), DDWAF_OBJ_BOOL);
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
     const auto *duration = ddwaf_object_find(&result, STRL("duration"));
     ASSERT_NE(duration, nullptr);
-    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(duration), DDWAF_OBJ_UNSIGNED);
     EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
 
     const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
     ASSERT_NE(attributes, nullptr);
-    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+    EXPECT_EQ(ddwaf_object_get_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 1);
 
     const auto *keep = ddwaf_object_find(&result, STRL("keep"));
     ASSERT_NE(keep, nullptr);
-    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(keep), DDWAF_OBJ_BOOL);
     EXPECT_FALSE(ddwaf_object_get_bool(keep));
 
-    ddwaf_object_free(&result);
+    ddwaf_object_destroy(&result, alloc);
     ddwaf_context_destroy(context);
 }
 
 TEST(TestContextResultIntegration, ResultOkWithTimeout)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     // Destroying the handle should not invalidate it
     ddwaf_destroy(handle);
 
-    ddwaf_object tmp;
-    ddwaf_object parameter = DDWAF_OBJECT_MAP;
-    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_invalid(&tmp));
+    ddwaf_object parameter;
+    ddwaf_object_set_map(&parameter, 1, alloc);
+    ddwaf_object_insert_key(&parameter, STRL("value1"), alloc);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
     EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, 0), DDWAF_OK);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
-    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(events), 0);
+    EXPECT_EQ(ddwaf_object_get_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_size(events), 0);
 
     const auto *actions = ddwaf_object_find(&result, STRL("actions"));
     ASSERT_NE(actions, nullptr);
-    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(actions), 0);
+    EXPECT_EQ(ddwaf_object_get_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(actions), 0);
 
     const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
     ASSERT_NE(timeout, nullptr);
-    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(timeout), DDWAF_OBJ_BOOL);
     EXPECT_TRUE(ddwaf_object_get_bool(timeout));
 
     const auto *duration = ddwaf_object_find(&result, STRL("duration"));
     ASSERT_NE(duration, nullptr);
-    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(duration), DDWAF_OBJ_UNSIGNED);
     EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
 
     const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
     ASSERT_NE(attributes, nullptr);
-    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+    EXPECT_EQ(ddwaf_object_get_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 0);
 
     const auto *keep = ddwaf_object_find(&result, STRL("keep"));
     ASSERT_NE(keep, nullptr);
-    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(keep), DDWAF_OBJ_BOOL);
     EXPECT_FALSE(ddwaf_object_get_bool(keep));
 
-    ddwaf_object_free(&result);
+    ddwaf_object_destroy(&result, alloc);
     ddwaf_context_destroy(context);
 }
 
 TEST(TestContextResultIntegration, ResultMatch)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     // Destroying the handle should not invalidate it
     ddwaf_destroy(handle);
 
-    ddwaf_object tmp;
-    ddwaf_object parameter = DDWAF_OBJECT_MAP;
-    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+    ddwaf_object parameter;
+    ddwaf_object_set_map(&parameter, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&parameter, STRL("value1"), alloc), STRL("rule1"), alloc);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
     EXPECT_EQ(
         ddwaf_context_eval(context, &parameter, nullptr, true, &result, LONG_TIME), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
-    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(events), 1);
+    EXPECT_EQ(ddwaf_object_get_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_size(events), 1);
 
     const auto *actions = ddwaf_object_find(&result, STRL("actions"));
     ASSERT_NE(actions, nullptr);
-    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(actions), 0);
+    EXPECT_EQ(ddwaf_object_get_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(actions), 0);
 
     const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
     ASSERT_NE(timeout, nullptr);
-    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(timeout), DDWAF_OBJ_BOOL);
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
     const auto *duration = ddwaf_object_find(&result, STRL("duration"));
     ASSERT_NE(duration, nullptr);
-    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(duration), DDWAF_OBJ_UNSIGNED);
     EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
 
     const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
     ASSERT_NE(attributes, nullptr);
-    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+    EXPECT_EQ(ddwaf_object_get_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 0);
 
     const auto *keep = ddwaf_object_find(&result, STRL("keep"));
     ASSERT_NE(keep, nullptr);
-    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(keep), DDWAF_OBJ_BOOL);
     EXPECT_TRUE(ddwaf_object_get_bool(keep));
 
-    ddwaf_object_free(&result);
+    ddwaf_object_destroy(&result, alloc);
     ddwaf_context_destroy(context);
 }
 
 TEST(TestContextResultIntegration, ResultMatchWithTimeout)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     // Destroying the handle should not invalidate it
     ddwaf_destroy(handle);
 
-    ddwaf_object tmp;
-    ddwaf_object parameter = DDWAF_OBJECT_MAP;
-    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
+    ddwaf_object parameter;
+    ddwaf_object_set_map(&parameter, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&parameter, STRL("value1"), alloc), STRL("rule1"), alloc);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
     EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, 0), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
-    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(events), 1);
+    EXPECT_EQ(ddwaf_object_get_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_size(events), 1);
 
     const auto *actions = ddwaf_object_find(&result, STRL("actions"));
     ASSERT_NE(actions, nullptr);
-    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(actions), 0);
+    EXPECT_EQ(ddwaf_object_get_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(actions), 0);
 
     const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
     ASSERT_NE(timeout, nullptr);
-    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(timeout), DDWAF_OBJ_BOOL);
     EXPECT_TRUE(ddwaf_object_get_bool(timeout));
 
     const auto *duration = ddwaf_object_find(&result, STRL("duration"));
     ASSERT_NE(duration, nullptr);
-    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(duration), DDWAF_OBJ_UNSIGNED);
     EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
 
     const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
     ASSERT_NE(attributes, nullptr);
-    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+    EXPECT_EQ(ddwaf_object_get_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 0);
 
     const auto *keep = ddwaf_object_find(&result, STRL("keep"));
     ASSERT_NE(keep, nullptr);
-    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(keep), DDWAF_OBJ_BOOL);
     EXPECT_TRUE(ddwaf_object_get_bool(keep));
 
-    ddwaf_object_free(&result);
+    ddwaf_object_destroy(&result, alloc);
     ddwaf_context_destroy(context);
 }
 
 TEST(TestContextResultIntegration, ResultMatchWithTimeoutOnPreprocessor)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("interface.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     // Destroying the handle should not invalidate it
     ddwaf_destroy(handle);
 
-    ddwaf_object tmp;
-    ddwaf_object settings;
-    ddwaf_object_map(&settings);
-    ddwaf_object_map_add(&settings, "extract-schema", ddwaf_object_bool(&tmp, true));
-
-    ddwaf_object parameter = DDWAF_OBJECT_MAP;
-    ddwaf_object_map_add(&parameter, "value1", ddwaf_object_string(&tmp, "rule1"));
-    ddwaf_object_map_add(&parameter, "server.request.body", ddwaf_object_invalid(&tmp));
-    ddwaf_object_map_add(&parameter, "waf.context.processor", &settings);
+    ddwaf_object parameter;
+    ddwaf_object_set_map(&parameter, 3, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&parameter, STRL("value1"), alloc), STRL("rule1"), alloc);
+    ddwaf_object_set_invalid(
+        ddwaf_object_insert_key(&parameter, STRL("server.request.body"), alloc));
+    // Move the settings object to the parameter
+    auto *settings = ddwaf_object_insert_key(&parameter, STRL("waf.context.processor"), alloc);
+    ddwaf_object_set_map(settings, 1, alloc);
+    ddwaf_object_set_bool(ddwaf_object_insert_key(settings, STRL("extract-schema"), alloc), true);
 
     ddwaf_object result;
-    ddwaf_object_invalid(&result);
+    ddwaf_object_set_invalid(&result);
     EXPECT_EQ(ddwaf_context_eval(context, &parameter, nullptr, true, &result, 0), DDWAF_MATCH);
 
     const auto *events = ddwaf_object_find(&result, STRL("events"));
     ASSERT_NE(events, nullptr);
-    EXPECT_EQ(ddwaf_object_type(events), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(events), 1);
+    EXPECT_EQ(ddwaf_object_get_type(events), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_size(events), 1);
 
     const auto *actions = ddwaf_object_find(&result, STRL("actions"));
     ASSERT_NE(actions, nullptr);
-    EXPECT_EQ(ddwaf_object_type(actions), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(actions), 0);
+    EXPECT_EQ(ddwaf_object_get_type(actions), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(actions), 0);
 
     const auto *timeout = ddwaf_object_find(&result, STRL("timeout"));
     ASSERT_NE(timeout, nullptr);
-    EXPECT_EQ(ddwaf_object_type(timeout), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(timeout), DDWAF_OBJ_BOOL);
     EXPECT_TRUE(ddwaf_object_get_bool(timeout));
 
     const auto *duration = ddwaf_object_find(&result, STRL("duration"));
     ASSERT_NE(duration, nullptr);
-    EXPECT_EQ(ddwaf_object_type(duration), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(duration), DDWAF_OBJ_UNSIGNED);
     EXPECT_GT(ddwaf_object_get_unsigned(duration), 0);
 
     const auto *attributes = ddwaf_object_find(&result, STRL("attributes"));
     ASSERT_NE(attributes, nullptr);
-    EXPECT_EQ(ddwaf_object_type(attributes), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+    EXPECT_EQ(ddwaf_object_get_type(attributes), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 0);
 
     const auto *keep = ddwaf_object_find(&result, STRL("keep"));
     ASSERT_NE(keep, nullptr);
-    EXPECT_EQ(ddwaf_object_type(keep), DDWAF_OBJ_BOOL);
+    EXPECT_EQ(ddwaf_object_get_type(keep), DDWAF_OBJ_BOOL);
     EXPECT_TRUE(ddwaf_object_get_bool(keep));
 
-    ddwaf_object_free(&result);
+    ddwaf_object_destroy(&result, alloc);
     ddwaf_context_destroy(context);
 }
 

--- a/tests/integration/interface/object/test.cpp
+++ b/tests/integration/interface/object/test.cpp
@@ -26,333 +26,278 @@ std::string_view object_to_view(const ddwaf_object &o)
 TEST(TestObjectIntegration, TestCreateInvalid)
 {
     ddwaf_object object;
-    ddwaf_object_invalid(&object);
-    EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_INVALID);
+    ddwaf_object_set_invalid(&object);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_INVALID);
 
     // Getters
-    EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_INVALID);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_INVALID);
 }
 
 TEST(TestObjectIntegration, TestInvalidString)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object object;
-    EXPECT_EQ(ddwaf_object_string(&object, nullptr), nullptr);
-    EXPECT_EQ(ddwaf_object_stringl(&object, nullptr, 0), nullptr);
+    EXPECT_EQ(ddwaf_object_set_string(&object, nullptr, 0, alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_set_string(&object, nullptr, 0, alloc), nullptr);
 }
 
 TEST(TestObjectIntegration, TestString)
 {
+    auto *alloc = ddwaf_get_default_allocator();
 
     ddwaf_object object;
-    ddwaf_object_string(&object, "Sqreen");
+    ddwaf_object_set_string(&object, STRL("Sqreen"), alloc);
 
-    EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_EQ(ddwaf_object_length(&object), 6);
+    EXPECT_TRUE((ddwaf_object_get_type(&object) & DDWAF_OBJ_STRING) != 0);
+    EXPECT_EQ(ddwaf_object_get_length(&object), 6);
     EXPECT_STRV(object_to_view(object), "Sqreen");
 
     // Getters
-    EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
+    EXPECT_TRUE((ddwaf_object_get_type(&object) & DDWAF_OBJ_STRING) != 0);
     EXPECT_STRV(object_to_view(object), "Sqreen");
-    EXPECT_EQ(ddwaf_object_length(&object), 6);
-    EXPECT_EQ(ddwaf_object_size(&object), 0);
+    EXPECT_EQ(ddwaf_object_get_length(&object), 6);
+    EXPECT_EQ(ddwaf_object_get_size(&object), 0);
 
-    ddwaf_object_free(&object);
+    ddwaf_object_destroy(&object, alloc);
 }
 
 TEST(TestObjectIntegration, TestCreateStringl)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object object;
-    ddwaf_object_stringl(&object, "Sqreen", sizeof("Sqreen") - 1);
+    ddwaf_object_set_string(&object, "Sqreen", sizeof("Sqreen") - 1, alloc);
 
-    EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_EQ(ddwaf_object_length(&object), 6);
+    EXPECT_TRUE((ddwaf_object_get_type(&object) & DDWAF_OBJ_STRING) != 0);
+    EXPECT_EQ(ddwaf_object_get_length(&object), 6);
     EXPECT_STRV(object_to_view(object), "Sqreen");
 
     // Getters
-    EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
+    EXPECT_TRUE((ddwaf_object_get_type(&object) & DDWAF_OBJ_STRING) != 0);
     EXPECT_STRV(object_to_view(object), "Sqreen");
-    EXPECT_EQ(ddwaf_object_length(&object), 6);
-    EXPECT_EQ(ddwaf_object_size(&object), 0);
+    EXPECT_EQ(ddwaf_object_get_length(&object), 6);
+    EXPECT_EQ(ddwaf_object_get_size(&object), 0);
 
-    ddwaf_object_free(&object);
+    ddwaf_object_destroy(&object, alloc);
 }
 
 TEST(TestObjectIntegration, TestCreateInt)
 {
-    {
-        ddwaf_object object;
-        ddwaf_object_string_from_signed(&object, INT64_MIN);
-
-        EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
-        EXPECT_EQ(ddwaf_object_length(&object), 20);
-        EXPECT_STRV(object_to_view(object), "-9223372036854775808");
-
-        // Getters
-        EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
-        EXPECT_EQ(ddwaf_object_length(&object), 20);
-
-        EXPECT_STRV(object_to_view(object), "-9223372036854775808");
-        EXPECT_EQ(ddwaf_object_get_signed(&object), 0);
-        EXPECT_EQ(ddwaf_object_get_unsigned(&object), 0);
-        EXPECT_EQ(ddwaf_object_get_bool(&object), false);
-
-        ddwaf_object_free(&object);
-    }
-
-    {
-        ddwaf_object object;
-        ddwaf_object_string_from_signed(&object, INT64_MAX);
-
-        EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
-        EXPECT_EQ(ddwaf_object_length(&object), 19);
-        EXPECT_STRV(object_to_view(object), "9223372036854775807");
-
-        // Getters
-        EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
-        EXPECT_EQ(ddwaf_object_length(&object), 19);
-        EXPECT_STRV(object_to_view(object), "9223372036854775807");
-        EXPECT_EQ(ddwaf_object_get_signed(&object), 0);
-        EXPECT_EQ(ddwaf_object_get_unsigned(&object), 0);
-        EXPECT_EQ(ddwaf_object_get_bool(&object), false);
-
-        ddwaf_object_free(&object);
-    }
-}
-
-TEST(TestObjectIntegration, TestCreateIntForce)
-{
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object object;
-    ddwaf_object_signed(&object, INT64_MIN);
+    ddwaf_object_set_signed(&object, INT64_MIN);
 
-    EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_SIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
 
     // Getters
-    EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_SIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
     EXPECT_EQ(ddwaf_object_get_signed(&object), INT64_MIN);
     EXPECT_EQ(ddwaf_object_get_unsigned(&object), 0);
     EXPECT_EQ(ddwaf_object_get_bool(&object), false);
 
-    ddwaf_object_free(&object);
+    ddwaf_object_destroy(&object, alloc);
 }
 
 TEST(TestObjectIntegration, TestCreateUint)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object object;
-    ddwaf_object_string_from_unsigned(&object, UINT64_MAX);
+    ddwaf_object_set_unsigned(&object, UINT64_MAX);
 
-    EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_EQ(ddwaf_object_length(&object), 20);
-    EXPECT_STRV(object_to_view(object), "18446744073709551615");
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_UNSIGNED);
 
     // Getters
-    EXPECT_TRUE((ddwaf_object_type(&object) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_EQ(ddwaf_object_length(&object), 20);
-    EXPECT_STRV(object_to_view(object), "18446744073709551615");
-    EXPECT_EQ(ddwaf_object_get_signed(&object), 0);
-    EXPECT_EQ(ddwaf_object_get_unsigned(&object), 0);
-    EXPECT_EQ(ddwaf_object_get_bool(&object), false);
-
-    ddwaf_object_free(&object);
-}
-
-TEST(TestObjectIntegration, TestCreateUintForce)
-{
-    ddwaf_object object;
-    ddwaf_object_unsigned(&object, UINT64_MAX);
-
-    EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_UNSIGNED);
-
-    // Getters
-    EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_UNSIGNED);
     EXPECT_EQ(ddwaf_object_get_signed(&object), 0);
     EXPECT_EQ(ddwaf_object_get_unsigned(&object), UINT64_MAX);
     EXPECT_EQ(ddwaf_object_get_bool(&object), false);
 
-    ddwaf_object_free(&object);
+    ddwaf_object_destroy(&object, alloc);
 }
 
 TEST(TestObjectIntegration, TestCreateBool)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     {
         ddwaf_object object;
-        ddwaf_object_bool(&object, true);
+        ddwaf_object_set_bool(&object, true);
 
-        EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_BOOL);
+        EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_BOOL);
 
         // Getters
-        EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_BOOL);
+        EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_BOOL);
         EXPECT_EQ(ddwaf_object_get_signed(&object), 0);
         EXPECT_EQ(ddwaf_object_get_unsigned(&object), 0);
         EXPECT_EQ(ddwaf_object_get_bool(&object), true);
 
-        ddwaf_object_free(&object);
+        ddwaf_object_destroy(&object, alloc);
     }
 
     {
         ddwaf_object object;
-        ddwaf_object_bool(&object, false);
+        ddwaf_object_set_bool(&object, false);
 
-        EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_BOOL);
+        EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_BOOL);
 
         // Getters
-        EXPECT_EQ(ddwaf_object_type(&object), DDWAF_OBJ_BOOL);
+        EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_BOOL);
         EXPECT_EQ(ddwaf_object_get_signed(&object), 0);
         EXPECT_EQ(ddwaf_object_get_unsigned(&object), 0);
         EXPECT_EQ(ddwaf_object_get_bool(&object), false);
 
-        ddwaf_object_free(&object);
+        ddwaf_object_destroy(&object, alloc);
     }
 }
 
 TEST(TestObjectIntegration, TestCreateArray)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object container;
-    ddwaf_object_array(&container);
+    ddwaf_object_set_array(&container, 0, alloc);
 
     EXPECT_EQ(container.type, DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(&container), 0);
+    EXPECT_EQ(ddwaf_object_get_size(&container), 0);
 
     // Getters
-    EXPECT_EQ(ddwaf_object_type(&container), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_length(&container), 0);
-    EXPECT_EQ(ddwaf_object_size(&container), 0);
+    EXPECT_EQ(ddwaf_object_get_type(&container), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_length(&container), 0);
+    EXPECT_EQ(ddwaf_object_get_size(&container), 0);
     EXPECT_EQ(ddwaf_object_at_value(&container, 0), nullptr);
 
-    ddwaf_object_free(&container);
+    ddwaf_object_destroy(&container, alloc);
 }
 
 TEST(TestObjectIntegration, TestCreateMap)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object container;
-    ddwaf_object_map(&container);
+    ddwaf_object_set_map(&container, 0, alloc);
 
     EXPECT_EQ(container.type, DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_size(&container), 0);
+    EXPECT_EQ(ddwaf_object_get_size(&container), 0);
 
     // Getters
-    EXPECT_EQ(ddwaf_object_type(&container), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_length(&container), 0);
-    EXPECT_EQ(ddwaf_object_size(&container), 0);
+    EXPECT_EQ(ddwaf_object_get_type(&container), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_length(&container), 0);
+    EXPECT_EQ(ddwaf_object_get_size(&container), 0);
     EXPECT_EQ(ddwaf_object_at_value(&container, 0), nullptr);
 
-    ddwaf_object_free(&container);
+    ddwaf_object_destroy(&container, alloc);
 }
 
 TEST(TestObjectIntegration, TestAddArray)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object container;
-    ddwaf_object_array(&container);
+    ddwaf_object_set_array(&container, 3, alloc);
 
     ddwaf_object object;
-    ddwaf_object_invalid(&object);
+    ddwaf_object_set_invalid(&object);
 
-    EXPECT_FALSE(ddwaf_object_array_add(nullptr, &object));
-    EXPECT_FALSE(ddwaf_object_array_add(&object, &container));
+    // Test invalid parameters - these operations should be safe but have no effect
+    // The new API doesn't have direct equivalents to these failure cases
+    // but we can test similar scenarios
 
-    EXPECT_TRUE(ddwaf_object_array_add(&container, &object));
-    EXPECT_TRUE(ddwaf_object_array_add(&container, ddwaf_object_string_from_signed(&object, 42)));
-    EXPECT_TRUE(ddwaf_object_array_add(&container, ddwaf_object_string_from_unsigned(&object, 43)));
+    ddwaf_object_insert(&container, alloc);
+    ddwaf_object_set_signed(ddwaf_object_insert(&container, alloc), 42);
+    ddwaf_object_set_unsigned(ddwaf_object_insert(&container, alloc), 43);
 
     EXPECT_EQ(container.type, DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_size(&container), 3);
+    EXPECT_EQ(ddwaf_object_get_size(&container), 3);
 
-    EXPECT_EQ(ddwaf_object_type(ddwaf_object_at_value(&container, 0)), DDWAF_OBJ_INVALID);
+    EXPECT_EQ(ddwaf_object_get_type(ddwaf_object_at_value(&container, 0)), DDWAF_OBJ_INVALID);
 
-    EXPECT_TRUE((ddwaf_object_type(ddwaf_object_at_value(&container, 1)) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_STRV(object_to_view(*ddwaf_object_at_value(&container, 1)), "42");
+    EXPECT_TRUE(
+        (ddwaf_object_get_type(ddwaf_object_at_value(&container, 1)) & DDWAF_OBJ_SIGNED) != 0);
+    EXPECT_EQ(ddwaf_object_get_signed(ddwaf_object_at_value(&container, 1)), 42);
 
-    EXPECT_TRUE((ddwaf_object_type(ddwaf_object_at_value(&container, 2)) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_STRV(object_to_view(*ddwaf_object_at_value(&container, 2)), "43");
+    EXPECT_TRUE(
+        (ddwaf_object_get_type(ddwaf_object_at_value(&container, 2)) & DDWAF_OBJ_UNSIGNED) != 0);
+    EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_at_value(&container, 2)), 43);
 
     // Getters
-    EXPECT_EQ(ddwaf_object_type(&container), DDWAF_OBJ_ARRAY);
-    EXPECT_EQ(ddwaf_object_length(&container), 0);
-    EXPECT_EQ(ddwaf_object_size(&container), 3);
+    EXPECT_EQ(ddwaf_object_get_type(&container), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_length(&container), 0);
+    EXPECT_EQ(ddwaf_object_get_size(&container), 3);
 
     const auto *internal = ddwaf_object_at_value(&container, 0);
-    EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_INVALID);
+    EXPECT_EQ(ddwaf_object_get_type(internal), DDWAF_OBJ_INVALID);
 
     internal = ddwaf_object_at_value(&container, 1);
-    EXPECT_TRUE((ddwaf_object_type(internal) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_STRV(object_to_view(*internal), "42");
+    EXPECT_TRUE((ddwaf_object_get_type(internal) & DDWAF_OBJ_SIGNED) != 0);
+    EXPECT_EQ(ddwaf_object_get_signed(internal), 42);
 
     internal = ddwaf_object_at_value(&container, 2);
-    EXPECT_TRUE((ddwaf_object_type(internal) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_STRV(object_to_view(*internal), "43");
+    EXPECT_TRUE((ddwaf_object_get_type(internal) & DDWAF_OBJ_UNSIGNED) != 0);
+    EXPECT_EQ(ddwaf_object_get_unsigned(internal), 43);
 
     EXPECT_EQ(ddwaf_object_at_value(&container, 3), nullptr);
 
-    ddwaf_object_free(&container);
+    ddwaf_object_destroy(&container, alloc);
 }
 
 TEST(TestObjectIntegration, TestAddMap)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object map;
     ddwaf_object array;
-    ddwaf_object tmp;
 
-    ddwaf_object_map(&map);
-    ddwaf_object_array(&array);
+    ddwaf_object_set_map(&map, 4, alloc);
+    ddwaf_object_set_array(&array, 0, alloc);
 
-    EXPECT_FALSE(ddwaf_object_map_add(nullptr, "key", ddwaf_object_string_from_signed(&tmp, 42)));
-    ddwaf_object_free(&tmp);
-    EXPECT_FALSE(ddwaf_object_map_add(&array, "key", ddwaf_object_string_from_signed(&tmp, 42)));
-    ddwaf_object_free(&tmp);
-    EXPECT_FALSE(ddwaf_object_map_add(&map, nullptr, ddwaf_object_string_from_signed(&tmp, 42)));
-    ddwaf_object_free(&tmp);
-
-    EXPECT_FALSE(ddwaf_object_map_add(&map, "key", nullptr));
-
-    EXPECT_TRUE(ddwaf_object_map_add(&map, "key", ddwaf_object_invalid(&tmp)));
+    // Test setting values with the new API
+    ddwaf_object_insert_key(&map, STRL("key"), alloc);
     EXPECT_STRV(object_to_view(map.via.map.ptr[0].key), "key");
 
-    ASSERT_TRUE(ddwaf_object_map_add(&map, "key", ddwaf_object_string_from_signed(&tmp, 42)));
+    ddwaf_object_set_signed(ddwaf_object_insert_key(&map, STRL("key"), alloc), 42);
     EXPECT_STRV(object_to_view(map.via.map.ptr[1].key), "key");
 
-    ASSERT_TRUE(ddwaf_object_map_addl(&map, "key2", 4, ddwaf_object_string_from_signed(&tmp, 43)));
+    ddwaf_object_set_signed(ddwaf_object_insert_key(&map, "key2", 4, alloc), 43);
     EXPECT_STRV(object_to_view(map.via.map.ptr[2].key), "key2");
 
     char *str = static_cast<char *>(std::pmr::get_default_resource()->allocate(4, alignof(char)));
     // NOLINTNEXTLINE(bugprone-not-null-terminated-result)
     memcpy(str, "key3", 4);
-    ASSERT_TRUE(ddwaf_object_map_addl_nc(&map, str, 4, ddwaf_object_string_from_signed(&tmp, 44)));
+    ddwaf_object_set_signed(ddwaf_object_insert_key_nocopy(&map, str, 4, alloc), 44);
     EXPECT_EQ(object_to_view(map.via.map.ptr[3].key), "key3");
 
     // Getters
-    EXPECT_EQ(ddwaf_object_type(&map), DDWAF_OBJ_MAP);
-    EXPECT_EQ(ddwaf_object_length(&map), 0);
-    EXPECT_EQ(ddwaf_object_size(&map), 4);
+    EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_length(&map), 0);
+    EXPECT_EQ(ddwaf_object_get_size(&map), 4);
 
     // size_t length;
     const auto *internal = ddwaf_object_at_value(&map, 0);
-    EXPECT_EQ(ddwaf_object_type(internal), DDWAF_OBJ_INVALID);
+    EXPECT_EQ(ddwaf_object_get_type(internal), DDWAF_OBJ_INVALID);
     // EXPECT_STRV(ddwaf_object_get_key(internal, &length), "key");
 
     internal = ddwaf_object_at_value(&map, 1);
-    EXPECT_TRUE((ddwaf_object_type(internal) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_STRV(object_to_view(*internal), "42");
+    EXPECT_TRUE((ddwaf_object_get_type(internal) & DDWAF_OBJ_SIGNED) != 0);
+    EXPECT_EQ(ddwaf_object_get_signed(internal), 42);
     // EXPECT_STRV(ddwaf_object_get_key(internal, &length), "key");
     // EXPECT_EQ(length, 3);
 
     internal = ddwaf_object_at_value(&map, 2);
-    EXPECT_TRUE((ddwaf_object_type(internal) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_STRV(object_to_view(*internal), "43");
+    EXPECT_TRUE((ddwaf_object_get_type(internal) & DDWAF_OBJ_SIGNED) != 0);
+    EXPECT_EQ(ddwaf_object_get_signed(internal), 43);
     ////EXPECT_STRV(ddwaf_object_get_key(internal, &length), "key2");
     // EXPECT_EQ(length, 4);
 
     internal = ddwaf_object_at_value(&map, 3);
-    EXPECT_TRUE((ddwaf_object_type(internal) & DDWAF_OBJ_STRING) != 0);
-    EXPECT_STRV(object_to_view(*internal), "44");
+    EXPECT_TRUE((ddwaf_object_get_type(internal) & DDWAF_OBJ_SIGNED) != 0);
+    EXPECT_EQ(ddwaf_object_get_signed(internal), 44);
     // EXPECT_STRV(ddwaf_object_get_key(internal, &length), "key3");
     // EXPECT_EQ(length, 4);
 
     EXPECT_EQ(ddwaf_object_at_value(&map, 4), nullptr);
 
-    ddwaf_object_free(&map);
-    ddwaf_object_free(&array);
+    ddwaf_object_destroy(&map, alloc);
+    ddwaf_object_destroy(&array, alloc);
 }
 
-TEST(TestObjectIntegration, NullFree) { ddwaf_object_free(nullptr); }
+TEST(TestObjectIntegration, NullFree)
+{
+    ddwaf_object_destroy(nullptr, ddwaf_get_default_allocator());
+}
 
 TEST(TestObjectIntegration, FindNullObject)
 {
@@ -361,42 +306,42 @@ TEST(TestObjectIntegration, FindNullObject)
 
 TEST(TestObjectIntegration, FindInvalidKey)
 {
-    ddwaf_object tmp;
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object map;
-    ddwaf_object_map(&map);
-    ddwaf_object_map_add(&map, "key", ddwaf_object_invalid(&tmp));
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_insert_key(&map, STRL("key"), alloc);
 
     EXPECT_EQ(ddwaf_object_find(&map, nullptr, 1), nullptr);
     EXPECT_EQ(ddwaf_object_find(&map, "", 0), nullptr);
 
-    ddwaf_object_free(&map);
+    ddwaf_object_destroy(&map, alloc);
 }
 
 TEST(TestObjectIntegration, FindNotMap)
 {
-    ddwaf_object tmp;
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object array;
-    ddwaf_object_array(&array);
-    ddwaf_object_array_add(&array, ddwaf_object_invalid(&tmp));
+    ddwaf_object_set_array(&array, 1, alloc);
+    ddwaf_object_insert(&array, alloc);
 
     EXPECT_EQ(ddwaf_object_find(&array, STRL("key")), nullptr);
 
-    ddwaf_object_free(&array);
+    ddwaf_object_destroy(&array, alloc);
 }
 
 TEST(TestObjectIntegration, FindEmptyMap)
 {
-    ddwaf_object tmp;
+    auto *alloc = ddwaf_get_default_allocator();
     ddwaf_object map;
-    ddwaf_object_map(&map);
-    ddwaf_object_map_add(&map, "key", ddwaf_object_unsigned(&tmp, 42));
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_unsigned(ddwaf_object_insert_key(&map, STRL("key"), alloc), 42);
 
     const auto *object = ddwaf_object_find(&map, STRL("key"));
     ASSERT_NE(object, nullptr);
-    EXPECT_EQ(ddwaf_object_type(object), DDWAF_OBJ_UNSIGNED);
+    EXPECT_EQ(ddwaf_object_get_type(object), DDWAF_OBJ_UNSIGNED);
     EXPECT_EQ(ddwaf_object_get_unsigned(object), 42);
 
-    ddwaf_object_free(&map);
+    ddwaf_object_destroy(&map, alloc);
 }
 
 } // namespace

--- a/tests/integration/matchers/equals/test.cpp
+++ b/tests/integration/matchers/equals/test.cpp
@@ -14,19 +14,20 @@ constexpr std::string_view base_dir = "integration/matchers/equals/";
 
 TEST(TestEqualsMatcherIntegration, StringEquals)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("equals.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_string(&value, "arachni");
-    ddwaf_object_map_add(&map, "input", &value);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("input"), alloc), STRL("arachni"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -42,26 +43,26 @@ TEST(TestEqualsMatcherIntegration, StringEquals)
                                    .address = "input",
                                }}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestEqualsMatcherIntegration, BoolEquals)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("equals.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_bool(&value, false);
-    ddwaf_object_map_add(&map, "input", &value);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_bool(ddwaf_object_insert_key(&map, STRL("input"), alloc), false);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -79,26 +80,26 @@ TEST(TestEqualsMatcherIntegration, BoolEquals)
                                }},
                            }}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestEqualsMatcherIntegration, SignedEquals)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("equals.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_signed(&value, -42);
-    ddwaf_object_map_add(&map, "input", &value);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_signed(ddwaf_object_insert_key(&map, STRL("input"), alloc), -42);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -114,26 +115,26 @@ TEST(TestEqualsMatcherIntegration, SignedEquals)
                                    .address = "input",
                                }}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestEqualsMatcherIntegration, UnsignedEquals)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("equals.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_unsigned(&value, 42);
-    ddwaf_object_map_add(&map, "input", &value);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_unsigned(ddwaf_object_insert_key(&map, STRL("input"), alloc), 42);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -151,26 +152,26 @@ TEST(TestEqualsMatcherIntegration, UnsignedEquals)
                                }},
                            }}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestEqualsMatcherIntegration, FloatEquals)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("equals.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object value;
-    ddwaf_object_float(&value, 42.01);
-    ddwaf_object_map_add(&map, "input", &value);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_float(ddwaf_object_insert_key(&map, STRL("input"), alloc), 42.01);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -188,7 +189,7 @@ TEST(TestEqualsMatcherIntegration, FloatEquals)
                                }},
                            }}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }

--- a/tests/integration/matchers/hidden_ascii_match/test.cpp
+++ b/tests/integration/matchers/hidden_ascii_match/test.cpp
@@ -13,6 +13,7 @@ namespace {
 
 TEST(TestHiddenAsciiMatchMatchIntegration, Match)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     // Initialize a WAF rule
     auto rule = yaml_to_object<ddwaf_object>(
         R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: hidden_ascii_match, parameters: {inputs: [{address: arg1}]}}]}]})");
@@ -20,10 +21,10 @@ TEST(TestHiddenAsciiMatchMatchIntegration, Match)
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         std::string input =
@@ -34,9 +35,9 @@ TEST(TestHiddenAsciiMatchMatchIntegration, Match)
             "\xF3\xA0\x81\xA1\xF3\xA0\x81\xB3\xF3\xA0\x81\xA3\xF3\xA0\x81\xA9\xF3\xA0\x81\xA9";
 
         ddwaf_object param;
-        ddwaf_object tmp;
-        ddwaf_object_map(&param);
-        ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, input.c_str()));
+        ddwaf_object_set_map(&param, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&param, STRL("arg1"), alloc), input.data(),
+            input.size(), alloc);
         ddwaf_object ret;
 
         auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
@@ -52,19 +53,19 @@ TEST(TestHiddenAsciiMatchMatchIntegration, Match)
                                        .value = input,
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_object_free(&ret);
+        ddwaf_object_destroy(&ret, alloc);
 
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object param;
-        ddwaf_object tmp;
-        ddwaf_object_map(&param);
-        ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "normal text"));
+        ddwaf_object_set_map(&param, 1, alloc);
+        ddwaf_object_set_string(
+            ddwaf_object_insert_key(&param, STRL("arg1"), alloc), STRL("normal text"), alloc);
 
         ddwaf_object ret;
 
@@ -72,7 +73,7 @@ TEST(TestHiddenAsciiMatchMatchIntegration, Match)
         EXPECT_EQ(code, DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
-        ddwaf_object_free(&ret);
+        ddwaf_object_destroy(&ret, alloc);
 
         ddwaf_context_destroy(context);
     }

--- a/tests/integration/matchers/is_sqli/test.cpp
+++ b/tests/integration/matchers/is_sqli/test.cpp
@@ -13,6 +13,7 @@ namespace {
 
 TEST(TestIsSQLiIntegration, Match)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     // Initialize a WAF rule
     auto rule = yaml_to_object<ddwaf_object>(
         R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: is_sqli, parameters: {inputs: [{address: arg1}]}}]}]})");
@@ -20,15 +21,15 @@ TEST(TestIsSQLiIntegration, Match)
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
     ddwaf_object param;
-    ddwaf_object tmp;
-    ddwaf_object_map(&param);
-    ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "'OR 1=1/*"));
+    ddwaf_object_set_map(&param, 1, alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&param, STRL("arg1"), alloc), STRL("'OR 1=1/*"), alloc);
 
     ddwaf_object ret;
 
@@ -45,7 +46,7 @@ TEST(TestIsSQLiIntegration, Match)
                                    .value = "'OR 1=1/*"sv,
                                    .address = "arg1",
                                }}}}});
-    ddwaf_object_free(&ret);
+    ddwaf_object_destroy(&ret, alloc);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);

--- a/tests/integration/matchers/is_xss/test.cpp
+++ b/tests/integration/matchers/is_xss/test.cpp
@@ -5,6 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 
 #include "common/gtest_utils.hpp"
+#include "ddwaf.h"
 
 using namespace ddwaf::matcher;
 using namespace std::literals;
@@ -13,6 +14,7 @@ namespace {
 
 TEST(TestIsXSSIntegration, Match)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     // Initialize a WAF rule
     auto rule = yaml_to_object<ddwaf_object>(
         R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: is_xss, parameters: {inputs: [{address: arg1}]}}]}]})");
@@ -20,18 +22,18 @@ TEST(TestIsXSSIntegration, Match)
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
     ddwaf_object param;
-    ddwaf_object tmp;
-    ddwaf_object_map(&param);
-    ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "<script>alert(1);</script>"));
+    ddwaf_object_set_map(&param, 1, alloc);
+
+    auto *child = ddwaf_object_insert_key(&param, STRL("arg1"), alloc);
+    ddwaf_object_set_string(child, STRL("<script>alert(1);</script>"), alloc);
 
     ddwaf_object ret;
-
     auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
     EXPECT_EQ(code, DDWAF_MATCH);
     const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
@@ -44,7 +46,7 @@ TEST(TestIsXSSIntegration, Match)
                                    .value = "<script>alert(1);</script>"sv,
                                    .address = "arg1",
                                }}}}});
-    ddwaf_object_free(&ret);
+    ddwaf_object_destroy(&ret, alloc);
 
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);

--- a/tests/integration/matchers/regex_match/test.cpp
+++ b/tests/integration/matchers/regex_match/test.cpp
@@ -13,6 +13,7 @@ namespace {
 
 TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     // Initialize a WAF rule
     auto rule = yaml_to_object<ddwaf_object>(
         R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: alert, options: {case_sensitive: true}}}]}]})");
@@ -20,17 +21,16 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object param;
-        ddwaf_object tmp;
-        ddwaf_object_map(&param);
-        ddwaf_object_map_add(
-            &param, "arg1", ddwaf_object_string(&tmp, "<script>alert(1);</script>"));
+        ddwaf_object_set_map(&param, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&param, STRL("arg1"), alloc),
+            STRL("<script>alert(1);</script>"), alloc);
 
         ddwaf_object ret;
 
@@ -48,20 +48,19 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
                                        .value = "<script>alert(1);</script>"sv,
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_object_free(&ret);
+        ddwaf_object_destroy(&ret, alloc);
 
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object param;
-        ddwaf_object tmp;
-        ddwaf_object_map(&param);
-        ddwaf_object_map_add(
-            &param, "arg1", ddwaf_object_string(&tmp, "<script>AlErT(1);</script>"));
+        ddwaf_object_set_map(&param, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&param, STRL("arg1"), alloc),
+            STRL("<script>AlErT(1);</script>"), alloc);
 
         ddwaf_object ret;
 
@@ -69,7 +68,7 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
         EXPECT_EQ(code, DDWAF_OK);
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
-        ddwaf_object_free(&ret);
+        ddwaf_object_destroy(&ret, alloc);
 
         ddwaf_context_destroy(context);
     }
@@ -78,6 +77,7 @@ TEST(TestRegexMatchIntegration, CaseSensitiveMatch)
 
 TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     // Initialize a WAF rule
     auto rule = yaml_to_object<ddwaf_object>(
         R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: alert, options: {case_sensitive: false}}}]}]})");
@@ -85,17 +85,16 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object param;
-        ddwaf_object tmp;
-        ddwaf_object_map(&param);
-        ddwaf_object_map_add(
-            &param, "arg1", ddwaf_object_string(&tmp, "<script>alert(1);</script>"));
+        ddwaf_object_set_map(&param, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&param, STRL("arg1"), alloc),
+            STRL("<script>alert(1);</script>"), alloc);
 
         ddwaf_object ret;
 
@@ -113,20 +112,19 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
                                        .value = "<script>alert(1);</script>"sv,
                                        .address = "arg1",
                                    }}}}});
-        ddwaf_object_free(&ret);
+        ddwaf_object_destroy(&ret, alloc);
 
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object param;
-        ddwaf_object tmp;
-        ddwaf_object_map(&param);
-        ddwaf_object_map_add(
-            &param, "arg1", ddwaf_object_string(&tmp, "<script>AlErT(1);</script>"));
+        ddwaf_object_set_map(&param, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&param, STRL("arg1"), alloc),
+            STRL("<script>AlErT(1);</script>"), alloc);
 
         ddwaf_object ret;
 
@@ -145,7 +143,7 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
 
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
-        ddwaf_object_free(&ret);
+        ddwaf_object_destroy(&ret, alloc);
 
         ddwaf_context_destroy(context);
     }
@@ -154,6 +152,7 @@ TEST(TestRegexMatchIntegration, CaseInsensitiveMatch)
 
 TEST(TestRegexMatchIntegration, MinLength)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     // Initialize a WAF rule
     auto rule = yaml_to_object<ddwaf_object>(
         R"({version: '2.1', rules: [{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: match_regex, parameters: {inputs: [{address: arg1}], regex: alert, options: {min_length: 10}}}]}]})");
@@ -161,35 +160,34 @@ TEST(TestRegexMatchIntegration, MinLength)
 
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object param;
-        ddwaf_object tmp;
-        ddwaf_object_map(&param);
-        ddwaf_object_map_add(&param, "arg1", ddwaf_object_string(&tmp, "alert("));
+        ddwaf_object_set_map(&param, 1, alloc);
+        ddwaf_object_set_string(
+            ddwaf_object_insert_key(&param, STRL("arg1"), alloc), STRL("alert("), alloc);
 
         ddwaf_object ret;
 
         auto code = ddwaf_context_eval(context, &param, nullptr, true, &ret, LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
-        ddwaf_object_free(&ret);
+        ddwaf_object_destroy(&ret, alloc);
 
         ddwaf_context_destroy(context);
     }
 
     {
-        ddwaf_context context = ddwaf_context_init(handle);
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
         ASSERT_NE(context, nullptr);
 
         ddwaf_object param;
-        ddwaf_object tmp;
-        ddwaf_object_map(&param);
-        ddwaf_object_map_add(
-            &param, "arg1", ddwaf_object_string(&tmp, "<script>AlErT(1);</script>"));
+        ddwaf_object_set_map(&param, 1, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&param, STRL("arg1"), alloc),
+            STRL("<script>AlErT(1);</script>"), alloc);
 
         ddwaf_object ret;
 
@@ -208,7 +206,7 @@ TEST(TestRegexMatchIntegration, MinLength)
 
         const auto *timeout = ddwaf_object_find(&ret, STRL("timeout"));
         EXPECT_FALSE(ddwaf_object_get_bool(timeout));
-        ddwaf_object_free(&ret);
+        ddwaf_object_destroy(&ret, alloc);
 
         ddwaf_context_destroy(context);
     }

--- a/tests/integration/processors/jwt_decode/test.cpp
+++ b/tests/integration/processors/jwt_decode/test.cpp
@@ -14,11 +14,12 @@ constexpr std::string_view base_dir = "integration/processors/jwt_decode";
 
 TEST(TestJwtDecoderIntegration, Preprocessor)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_json_file("preprocessor.json", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     uint32_t size;
     const char *const *addresses = ddwaf_known_addresses(handle, &size);
@@ -27,28 +28,25 @@ TEST(TestJwtDecoderIntegration, Preprocessor)
     EXPECT_TRUE(address_set.contains("server.request.headers.no_cookies"));
     EXPECT_TRUE(address_set.contains("server.request.jwt"));
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object tmp;
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-
-    ddwaf_object headers;
-    ddwaf_object_map(&headers);
-    ddwaf_object_map_add(&headers, "authorization",
-        ddwaf_object_string(&tmp,
-            "Bearer "
-            "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
-            "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
-            "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
-            "8B48NpATozzMHn0j3rE0xVUldxShzy0xeJ7vYAccVXu2Gs9rnTVqouc-UZu_wJHkZiKBL67j8_"
-            "61L6SXswzPAQu4kVDwAefGf5hyYBUM-80vYZwWPEpLI8K4yCBsF6I9N1yQaZAJmkMp_"
-            "Iw371Menae4Mp4JusvBJS-s6LrmG2QbiZaFaxVJiW8KlUkWyUCns8-"
-            "qFl5OMeYlgGFsyvvSHvXCzQrsEXqyCdS4tQJd73ayYA4SPtCb9clz76N1zE5WsV4Z0BYrxeb77oA7jJh"
-            "h994RAPzCG0hmQ"));
-
-    ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
+    auto *headers = ddwaf_object_insert_key(&map, STRL("server.request.headers.no_cookies"), alloc);
+    ddwaf_object_set_map(headers, 1, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(headers, STRL("authorization"), alloc),
+        STRL("Bearer "
+             "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
+             "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
+             "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
+             "8B48NpATozzMHn0j3rE0xVUldxShzy0xeJ7vYAccVXu2Gs9rnTVqouc-UZu_wJHkZiKBL67j8_"
+             "61L6SXswzPAQu4kVDwAefGf5hyYBUM-80vYZwWPEpLI8K4yCBsF6I9N1yQaZAJmkMp_"
+             "Iw371Menae4Mp4JusvBJS-s6LrmG2QbiZaFaxVJiW8KlUkWyUCns8-"
+             "qFl5OMeYlgGFsyvvSHvXCzQrsEXqyCdS4tQJd73ayYA4SPtCb9clz76N1zE5WsV4Z0BYrxeb77oA7jJh"
+             "h994RAPzCG0hmQ"),
+        alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -66,20 +64,21 @@ TEST(TestJwtDecoderIntegration, Preprocessor)
                                }}}}});
 
     const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
-    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 0);
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestJwtDecoderIntegration, Postprocessor)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_json_file("postprocessor.json", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     uint32_t size;
     const char *const *addresses = ddwaf_known_addresses(handle, &size);
@@ -87,28 +86,25 @@ TEST(TestJwtDecoderIntegration, Postprocessor)
     std::unordered_set<std::string_view> address_set(addresses, addresses + size);
     EXPECT_TRUE(address_set.contains("server.request.headers.no_cookies"));
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object tmp;
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-
-    ddwaf_object headers;
-    ddwaf_object_map(&headers);
-    ddwaf_object_map_add(&headers, "authorization",
-        ddwaf_object_string(&tmp,
-            "Bearer "
-            "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
-            "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
-            "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
-            "8B48NpATozzMHn0j3rE0xVUldxShzy0xeJ7vYAccVXu2Gs9rnTVqouc-UZu_wJHkZiKBL67j8_"
-            "61L6SXswzPAQu4kVDwAefGf5hyYBUM-80vYZwWPEpLI8K4yCBsF6I9N1yQaZAJmkMp_"
-            "Iw371Menae4Mp4JusvBJS-s6LrmG2QbiZaFaxVJiW8KlUkWyUCns8-"
-            "qFl5OMeYlgGFsyvvSHvXCzQrsEXqyCdS4tQJd73ayYA4SPtCb9clz76N1zE5WsV4Z0BYrxeb77oA7jJh"
-            "h994RAPzCG0hmQ"));
-
-    ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
+    auto *headers = ddwaf_object_insert_key(&map, STRL("server.request.headers.no_cookies"), alloc);
+    ddwaf_object_set_map(headers, 1, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(headers, STRL("authorization"), alloc),
+        STRL("Bearer "
+             "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
+             "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
+             "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
+             "8B48NpATozzMHn0j3rE0xVUldxShzy0xeJ7vYAccVXu2Gs9rnTVqouc-UZu_wJHkZiKBL67j8_"
+             "61L6SXswzPAQu4kVDwAefGf5hyYBUM-80vYZwWPEpLI8K4yCBsF6I9N1yQaZAJmkMp_"
+             "Iw371Menae4Mp4JusvBJS-s6LrmG2QbiZaFaxVJiW8KlUkWyUCns8-"
+             "qFl5OMeYlgGFsyvvSHvXCzQrsEXqyCdS4tQJd73ayYA4SPtCb9clz76N1zE5WsV4Z0BYrxeb77oA7jJh"
+             "h994RAPzCG0hmQ"),
+        alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_OK);
@@ -116,23 +112,24 @@ TEST(TestJwtDecoderIntegration, Postprocessor)
     EXPECT_FALSE(ddwaf_object_get_bool(timeout));
 
     const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
-    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 1);
 
     EXPECT_JSON(*attributes,
         R"({"server.request.jwt":{"header":{"alg":"RS384","typ":"JWT"},"payload":{"sub":"1234567890","name":"John Doe","admin":true,"iat":1516239022},"signature":{"available":true}}})");
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestJwtDecoderIntegration, Processor)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_json_file("processor.json", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
     uint32_t size;
     const char *const *addresses = ddwaf_known_addresses(handle, &size);
@@ -141,28 +138,25 @@ TEST(TestJwtDecoderIntegration, Processor)
     EXPECT_TRUE(address_set.contains("server.request.headers.no_cookies"));
     EXPECT_TRUE(address_set.contains("server.request.jwt"));
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object tmp;
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-
-    ddwaf_object headers;
-    ddwaf_object_map(&headers);
-    ddwaf_object_map_add(&headers, "authorization",
-        ddwaf_object_string(&tmp,
-            "Bearer "
-            "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
-            "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
-            "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
-            "8B48NpATozzMHn0j3rE0xVUldxShzy0xeJ7vYAccVXu2Gs9rnTVqouc-UZu_wJHkZiKBL67j8_"
-            "61L6SXswzPAQu4kVDwAefGf5hyYBUM-80vYZwWPEpLI8K4yCBsF6I9N1yQaZAJmkMp_"
-            "Iw371Menae4Mp4JusvBJS-s6LrmG2QbiZaFaxVJiW8KlUkWyUCns8-"
-            "qFl5OMeYlgGFsyvvSHvXCzQrsEXqyCdS4tQJd73ayYA4SPtCb9clz76N1zE5WsV4Z0BYrxeb77oA7jJh"
-            "h994RAPzCG0hmQ"));
-
-    ddwaf_object_map_add(&map, "server.request.headers.no_cookies", &headers);
+    auto *headers = ddwaf_object_insert_key(&map, STRL("server.request.headers.no_cookies"), alloc);
+    ddwaf_object_set_map(headers, 1, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(headers, STRL("authorization"), alloc),
+        STRL("Bearer "
+             "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
+             "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
+             "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
+             "8B48NpATozzMHn0j3rE0xVUldxShzy0xeJ7vYAccVXu2Gs9rnTVqouc-UZu_wJHkZiKBL67j8_"
+             "61L6SXswzPAQu4kVDwAefGf5hyYBUM-80vYZwWPEpLI8K4yCBsF6I9N1yQaZAJmkMp_"
+             "Iw371Menae4Mp4JusvBJS-s6LrmG2QbiZaFaxVJiW8KlUkWyUCns8-"
+             "qFl5OMeYlgGFsyvvSHvXCzQrsEXqyCdS4tQJd73ayYA4SPtCb9clz76N1zE5WsV4Z0BYrxeb77oA7jJh"
+             "h994RAPzCG0hmQ"),
+        alloc);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -180,12 +174,12 @@ TEST(TestJwtDecoderIntegration, Processor)
                                }}}}});
 
     const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
-    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+    EXPECT_EQ(ddwaf_object_get_size(attributes), 1);
 
     EXPECT_JSON(*attributes,
         R"({"server.request.jwt":{"header":{"alg":"RS384","typ":"JWT"},"payload":{"sub":"1234567890","name":"John Doe","admin":true,"iat":1516239022},"signature":{"available":true}}})");
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }

--- a/tests/integration/transformers/test.cpp
+++ b/tests/integration/transformers/test.cpp
@@ -14,19 +14,20 @@ constexpr std::string_view base_dir = "integration/transformers/";
 
 TEST(TestTransformers, Base64Decode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("base64_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "J09SIDE9MS8q");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("J09SIDE9MS8q"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -39,26 +40,27 @@ TEST(TestTransformers, Base64Decode)
                                .highlight = "s&1c"sv,
                                .args = {{.value = "'OR 1=1/*"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, Base64DecodeAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("base64_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "J09SIDE9MS8q");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("J09SIDE9MS8q"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -71,26 +73,27 @@ TEST(TestTransformers, Base64DecodeAlias)
                                .highlight = "s&1c"sv,
                                .args = {{.value = "'OR 1=1/*"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, Base64UrlDecode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("base64url_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "J09SIDE9MS8q");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("J09SIDE9MS8q"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -103,26 +106,27 @@ TEST(TestTransformers, Base64UrlDecode)
                                .highlight = "s&1c"sv,
                                .args = {{.value = "'OR 1=1/*"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, Base64Encode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("base64_encode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "'OR 1=1/*");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("'OR 1=1/*"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -136,26 +140,27 @@ TEST(TestTransformers, Base64Encode)
                                .highlight = "J09SIDE9MS8q"sv,
                                .args = {{.value = "J09SIDE9MS8q"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, Base64EncodeAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("base64_encode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "'OR 1=1/*");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("'OR 1=1/*"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -169,26 +174,27 @@ TEST(TestTransformers, Base64EncodeAlias)
                                .highlight = "J09SIDE9MS8q"sv,
                                .args = {{.value = "J09SIDE9MS8q"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, CompressWhitespace)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("compress_whitespace.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "attack      value");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("attack      value"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -202,26 +208,27 @@ TEST(TestTransformers, CompressWhitespace)
                                .highlight = "attack value"sv,
                                .args = {{.value = "attack value"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, CompressWhitespaceAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("compress_whitespace.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "attack      value");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("attack      value"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -235,26 +242,27 @@ TEST(TestTransformers, CompressWhitespaceAlias)
                                .highlight = "attack value"sv,
                                .args = {{.value = "attack value"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, CssDecode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("css_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "CSS\\\n tran\\sformations");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("CSS\\\n tran\\sformations"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -269,26 +277,27 @@ TEST(TestTransformers, CssDecode)
                      .highlight = "CSS transformations"sv,
                      .args = {{.value = "CSS transformations"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, CssDecodeAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("css_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "CSS\\\n tran\\sformations");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("CSS\\\n tran\\sformations"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -303,26 +312,27 @@ TEST(TestTransformers, CssDecodeAlias)
                      .highlight = "CSS transformations"sv,
                      .args = {{.value = "CSS transformations"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, HtmlEntityDecode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("html_entity_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "HTML &#x0000000000000000000000000000041 &#x41; transformation");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(ddwaf_object_insert_key(&map, STRL("value1"), alloc),
+        STRL("HTML &#x0000000000000000000000000000041 &#x41; transformation"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -337,26 +347,27 @@ TEST(TestTransformers, HtmlEntityDecode)
                      .highlight = "HTML A A transformation"sv,
                      .args = {{.value = "HTML A A transformation"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, HtmlEntityDecodeAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("html_entity_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "HTML &#x0000000000000000000000000000041 &#x41; transformation");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(ddwaf_object_insert_key(&map, STRL("value2"), alloc),
+        STRL("HTML &#x0000000000000000000000000000041 &#x41; transformation"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -371,26 +382,27 @@ TEST(TestTransformers, HtmlEntityDecodeAlias)
                      .highlight = "HTML A A transformation"sv,
                      .args = {{.value = "HTML A A transformation"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, JsDecode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("js_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, R"(\x41\x20\x4aS\x20transf\x6Frmation)");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(ddwaf_object_insert_key(&map, STRL("value1"), alloc),
+        STRL(R"(\x41\x20\x4aS\x20transf\x6Frmation)"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -405,26 +417,27 @@ TEST(TestTransformers, JsDecode)
                      .highlight = "A JS transformation"sv,
                      .args = {{.value = "A JS transformation"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, JsDecodeAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("js_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, R"(\x41\x20\x4aS\x20transf\x6Frmation)");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(ddwaf_object_insert_key(&map, STRL("value2"), alloc),
+        STRL(R"(\x41\x20\x4aS\x20transf\x6Frmation)"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -439,26 +452,27 @@ TEST(TestTransformers, JsDecodeAlias)
                      .highlight = "A JS transformation"sv,
                      .args = {{.value = "A JS transformation"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, Lowercase)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("lowercase.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "ArAcHnI");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("ArAcHnI"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -472,26 +486,27 @@ TEST(TestTransformers, Lowercase)
                                .highlight = "arachni"sv,
                                .args = {{.value = "arachni"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, NormalizePath)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("normalize_path.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/etc/dir1/dir2/../../passwd");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("/etc/dir1/dir2/../../passwd"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -505,26 +520,27 @@ TEST(TestTransformers, NormalizePath)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, NormalizePathAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("normalize_path.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/etc/dir1/dir2/../../passwd");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("/etc/dir1/dir2/../../passwd"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -538,26 +554,27 @@ TEST(TestTransformers, NormalizePathAlias)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, NormalizePathWin)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("normalize_path_win.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, R"(\etc\dir1\dir2\..\..\passwd)");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(ddwaf_object_insert_key(&map, STRL("value1"), alloc),
+        STRL(R"(\etc\dir1\dir2\..\..\passwd)"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -571,26 +588,27 @@ TEST(TestTransformers, NormalizePathWin)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, NormalizePathAliasWin)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("normalize_path_win.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, R"(\etc\dir1\dir2\..\..\passwd)");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(ddwaf_object_insert_key(&map, STRL("value2"), alloc),
+        STRL(R"(\etc\dir1\dir2\..\..\passwd)"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -604,26 +622,27 @@ TEST(TestTransformers, NormalizePathAliasWin)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, RemoveComments)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("remove_comments.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "passwd#asdsd");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("passwd#asdsd"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -637,26 +656,27 @@ TEST(TestTransformers, RemoveComments)
                                .highlight = "passwd"sv,
                                .args = {{.value = "passwd"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, RemoveCommentsAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("remove_comments.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "passwd#asdsd");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("passwd#asdsd"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -670,26 +690,27 @@ TEST(TestTransformers, RemoveCommentsAlias)
                                .highlight = "passwd"sv,
                                .args = {{.value = "passwd"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, RemoveNulls)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("remove_nulls.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_stringl(&string, "/etc/\0passwd", sizeof("/etc/\0passwd") - 1);
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("/etc/\0passwd"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -703,26 +724,27 @@ TEST(TestTransformers, RemoveNulls)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, RemoveNullsAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("remove_nulls.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_stringl(&string, "/etc/\0passwd", sizeof("/etc/\0passwd") - 1);
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(ddwaf_object_insert_key(&map, STRL("value2"), alloc),
+        "/etc/\0passwd", sizeof("/etc/\0passwd") - 1);
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -736,26 +758,27 @@ TEST(TestTransformers, RemoveNullsAlias)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, ShellUnescape)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("shell_unescape.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/\\etc/\"pass^wd");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("/\\etc/\"pass^wd"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -769,26 +792,27 @@ TEST(TestTransformers, ShellUnescape)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, ShellUnescapeAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("shell_unescape.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/\\etc/\"pass^wd");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("/\\etc/\"pass^wd"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -802,26 +826,27 @@ TEST(TestTransformers, ShellUnescapeAlias)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UnicodeNormalize)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("unicode_normalize.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/étc/p𝑎ßwd");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("/étc/p𝑎ßwd"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -835,26 +860,27 @@ TEST(TestTransformers, UnicodeNormalize)
                                .highlight = "/etc/passwd"sv,
                                .args = {{.value = "/etc/passwd"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlBasename)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_basename.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("/path/to/index.php?a=b#frag"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -868,26 +894,27 @@ TEST(TestTransformers, UrlBasename)
                                .highlight = "index.php"sv,
                                .args = {{.value = "index.php"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlBasenameAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_basename.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("/path/to/index.php?a=b#frag"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -901,26 +928,27 @@ TEST(TestTransformers, UrlBasenameAlias)
                                .highlight = "index.php"sv,
                                .args = {{.value = "index.php"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlDecode)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "%61n+%61ttack%20valu%65");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("%61n+%61ttack%20valu%65"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -934,26 +962,27 @@ TEST(TestTransformers, UrlDecode)
                                .highlight = "an attack value"sv,
                                .args = {{.value = "an attack value"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlDecodeAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_decode.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "%61n+%61ttack%20valu%65");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("%61n+%61ttack%20valu%65"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -967,26 +996,27 @@ TEST(TestTransformers, UrlDecodeAlias)
                                .highlight = "an attack value"sv,
                                .args = {{.value = "an attack value"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlDecodeIis)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_decode_iis.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "%61n+%61ttack%20valu%65");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("%61n+%61ttack%20valu%65"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -1000,26 +1030,27 @@ TEST(TestTransformers, UrlDecodeIis)
                                .highlight = "an attack value"sv,
                                .args = {{.value = "an attack value"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlDecodeIisAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_decode_iis.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "%61n+%61ttack%20valu%65");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("%61n+%61ttack%20valu%65"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -1033,26 +1064,27 @@ TEST(TestTransformers, UrlDecodeIisAlias)
                                .highlight = "an attack value"sv,
                                .args = {{.value = "an attack value"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlPath)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_path.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("/path/to/index.php?a=b#frag"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -1066,26 +1098,27 @@ TEST(TestTransformers, UrlPath)
                                .highlight = "/path/to/index.php"sv,
                                .args = {{.value = "/path/to/index.php"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlPathAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_path.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("/path/to/index.php?a=b#frag"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -1099,26 +1132,27 @@ TEST(TestTransformers, UrlPathAlias)
                                .highlight = "/path/to/index.php"sv,
                                .args = {{.value = "/path/to/index.php"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlQuerystring)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_querystring.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value1"), alloc), STRL("/path/to/index.php?a=b#frag"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -1132,26 +1166,27 @@ TEST(TestTransformers, UrlQuerystring)
                                .highlight = "a=b"sv,
                                .args = {{.value = "a=b"sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, UrlQuerystringAlias)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("url_querystring.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "/path/to/index.php?a=b#frag");
-    ddwaf_object_map_add(&map, "value2", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(
+        ddwaf_object_insert_key(&map, STRL("value2"), alloc), STRL("/path/to/index.php?a=b#frag"));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -1165,26 +1200,27 @@ TEST(TestTransformers, UrlQuerystringAlias)
                                .highlight = "a=b"sv,
                                .args = {{.value = "a=b"sv, .address = "value2"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }
 
 TEST(TestTransformers, Mixed)
 {
+    auto *alloc = ddwaf_get_default_allocator();
     auto rule = read_file<ddwaf_object>("mixed.yaml", base_dir);
     ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
     ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
     ASSERT_NE(handle, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, ddwaf_get_default_allocator());
     ASSERT_NE(context, nullptr);
 
-    ddwaf_object map = DDWAF_OBJECT_MAP;
-    ddwaf_object string;
-    ddwaf_object_string(&string, "L3AgIGEgIHRIL3QgIE8vRmlsRS5QSFA/YT1iI2ZyYWc=");
-    ddwaf_object_map_add(&map, "value1", &string);
+    ddwaf_object map;
+    ddwaf_object_set_map(&map, 1, alloc);
+    ddwaf_object_set_string_literal(ddwaf_object_insert_key(&map, STRL("value1"), alloc),
+        STRL("L3AgIGEgIHRIL3QgIE8vRmlsRS5QSFA/YT1iI2ZyYWc="));
 
     ddwaf_object out;
     ASSERT_EQ(ddwaf_context_eval(context, &map, nullptr, true, &out, LONG_TIME), DDWAF_MATCH);
@@ -1199,7 +1235,7 @@ TEST(TestTransformers, Mixed)
                      .highlight = "L3AgYSB0aC90IG8vZmlsZS5waHA="sv,
                      .args = {{.value = "L3AgYSB0aC90IG8vZmlsZS5waHA="sv, .address = "value1"}}}}});
 
-    ddwaf_object_free(&out);
+    ddwaf_object_destroy(&out, alloc);
     ddwaf_context_destroy(context);
     ddwaf_destroy(handle);
 }

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -927,36 +927,35 @@ TEST(TestObject, MapObjectBuilderIncompatibleAllocators)
         std::runtime_error);
 }
 
-// TODO Reevaluate once allocators are exposed through the interface
-/*TEST(TestObject, ObjectWithNullAllocator)*/
-/*{*/
-/*auto root = object_builder::map({*/
-/*{"array"sv, object_builder::array({"array", "value"})},*/
-/*{"map"sv, object_builder::map({{"map", "value"}})},*/
-/*{"small string"sv, "small"sv},*/
-/*{"string view"sv, "this is a normal string view"sv},*/
-/*{"string"sv, "this is a normal string"s},*/
-/*{"const char *"sv, "this is a normal const char *"},*/
-/*{"bool"sv, false},*/
-/*{"int16"sv, static_cast<int16_t>(-16)},*/
-/*{"uint16"sv, static_cast<uint16_t>(16)},*/
-/*{"int32"sv, static_cast<int32_t>(-32)},*/
-/*{"uint32"sv, static_cast<uint32_t>(32)},*/
-/*{"int64"sv, static_cast<int64_t>(-64)},*/
-/*{"uint64"sv, static_cast<uint64_t>(64)},*/
-/*{"float"sv, 64.64},*/
-/*});*/
+TEST(TestObject, ObjectWithNullAllocator)
+{
+    auto root = object_builder::map({
+        {"array"sv, object_builder::array({"array", "value"})},
+        {"map"sv, object_builder::map({{"map", "value"}})},
+        {"small string"sv, "small"sv},
+        {"string view"sv, "this is a normal string view"sv},
+        {"string"sv, "this is a normal string"s},
+        {"const char *"sv, "this is a normal const char *"},
+        {"bool"sv, false},
+        {"int16"sv, static_cast<int16_t>(-16)},
+        {"uint16"sv, static_cast<uint16_t>(16)},
+        {"int32"sv, static_cast<int32_t>(-32)},
+        {"uint32"sv, static_cast<uint32_t>(32)},
+        {"int64"sv, static_cast<int64_t>(-64)},
+        {"uint64"sv, static_cast<uint64_t>(64)},
+        {"float"sv, 64.64},
+    });
 
-/*// Create a new owned_object using the internal reference to ensure it's not*/
-/*// double freed*/
-/*{*/
-/*null_counting_resource alloc;*/
-/*{*/
-/*owned_object other{root.ref(), &alloc};*/
-/*}*/
-/*EXPECT_EQ(alloc.deallocations(), 0);*/
-/*}*/
-/*}*/
+    // Create a new owned_object using the internal reference to ensure it's not
+    // double freed
+    {
+        null_counting_resource alloc;
+        {
+            owned_object other{root.ref(), &alloc};
+        }
+        EXPECT_EQ(alloc.deallocations(), 0);
+    }
+}
 
 TEST(TestObject, CloneInvalid)
 {

--- a/tools/infer_schema.cpp
+++ b/tools/infer_schema.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
 
     ddwaf_config config{{nullptr, nullptr}, nullptr};
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
     if (handle == nullptr) {
         std::cout << "Failed to load " << argv[1] << '\n';
         return EXIT_FAILURE;
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 
     ddwaf_object_map(&input);
     ddwaf_object_map(&settings);
-    ddwaf_object_map_add(&settings, "extract-schema", ddwaf_object_bool(&tmp, true));
+    ddwaf_object_map_add(&settings, "extract-schema", ddwaf_object_set_bool(&tmp, true));
     ddwaf_object_map_add(&input, "waf.context.processor", &settings);
     ddwaf_object_map_add(&input, "server.request.body", &body);
 
@@ -54,14 +54,14 @@ int main(int argc, char *argv[])
 
     ddwaf_result ret;
     ddwaf_context_eval(context, &input, nullptr, &ret, std::numeric_limits<uint32_t>::max());
-    if (ddwaf_object_size(&ret.derivatives) > 0) {
+    if (ddwaf_object_get_size(&ret.derivatives) > 0) {
         std::cout << object_to_json(ret.derivatives) << '\n';
     }
 
     ddwaf_result_free(&ret);
     ddwaf_context_destroy(context);
 
-    ddwaf_object_free(&input);
+    ddwaf_object_destroy(&input, alloc);
     ddwaf_destroy(handle);
 
     return EXIT_SUCCESS;

--- a/tools/infer_schema_bench.cpp
+++ b/tools/infer_schema_bench.cpp
@@ -32,8 +32,8 @@ int main(int argc, char *argv[])
 
     std::cout << (std::chrono::system_clock::now() - start).count() << std::endl;
 
-    ddwaf_object_free(&payload);
-    ddwaf_object_free(&schema);
+    ddwaf_object_destroy(&payload, alloc);
+    ddwaf_object_destroy(&schema, alloc);
 
 
     return EXIT_SUCCESS;

--- a/tools/ip_match_benchmark.cpp
+++ b/tools/ip_match_benchmark.cpp
@@ -65,7 +65,7 @@ ddwaf_object generate_rule_data(const std::vector<std::string>& ip_set)
     for (const auto& ip : ip_set) {
         ddwaf_object data_point;
         ddwaf_object_map(&data_point);
-        ddwaf_object_map_add(&data_point, "expiration", ddwaf_object_unsigned_force(&tmp, 0));
+        ddwaf_object_map_add(&data_point, "expiration", ddwaf_object_set_unsigned_force(&tmp, 0));
 
         ddwaf_object_map_add(&data_point, "value", ddwaf_object_stringl(&tmp, ip.c_str(), ip.size()));
 
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
 
     ddwaf_config config{{nullptr, nullptr}, nullptr};
     ddwaf_handle handle = ddwaf_init(&rule, &config, nullptr);
-    ddwaf_object_free(&rule);
+    ddwaf_object_destroy(&rule, alloc);
     if (handle == nullptr) {
         std::cout << "Failed to load " << argv[1] << '\n';
         return EXIT_FAILURE;
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
 
             auto update = generate_rule_data(ip_set);
             ddwaf_handle updated_handle = ddwaf_update(handle, &update, nullptr);
-            ddwaf_object_free(&update);
+            ddwaf_object_destroy(&update, alloc);
 
             if (updated_handle == nullptr) {
                 std::cout << "Failed to load rule data\n";
@@ -156,7 +156,7 @@ int main(int argc, char *argv[])
                 ddwaf_context_eval(context, &input, nullptr, nullptr, std::numeric_limits<uint32_t>::max());
                 auto count = (std::chrono::system_clock::now() - start).count();
 
-                ddwaf_object_free(&input);
+                ddwaf_object_destroy(&input, alloc);
                 results[size] += count;
 
                 ddwaf_context_destroy(context);

--- a/tools/verify_rule.cpp
+++ b/tools/verify_rule.cpp
@@ -13,17 +13,19 @@
 
 ddwaf_object convertRuleToRuleset(const YAML::Node &rulePayload)
 {
-    auto rule = rulePayload.as<ddwaf_object>();
+    auto *alloc = ddwaf_get_default_allocator();
+
     ddwaf_object root;
-    ddwaf_object version;
-    ddwaf_object array;
+    ddwaf_object_set_map(&root, 2, alloc);
+    auto *version = ddwaf_object_insert_key(&root, STRL("version"), alloc);
+    ddwaf_object_set_string_literal(version, STRL("2.1"));
 
-    ddwaf_object_map(&root);
-    ddwaf_object_array(&array);
-    ddwaf_object_array_add(&array, &rule);
+    auto *array = ddwaf_object_insert_key(&root, STRL("rules"), alloc);
+    ddwaf_object_set_array(array, 1, alloc);
 
-    ddwaf_object_map_add(&root, "version", ddwaf_object_string(&version, "2.1"));
-    ddwaf_object_map_add(&root, "rules", &array);
+    auto *rule = ddwaf_object_insert(array, alloc);
+    *rule = rulePayload.as<ddwaf_object>();
+
     return root;
 }
 
@@ -38,7 +40,7 @@ bool runVectors(YAML::Node rule, ddwaf_handle handle, bool runPositiveMatches)
              ++vector, ++counter) {
             auto root = vector->as<ddwaf_object>();
             if (root.type != DDWAF_OBJ_INVALID) {
-                ddwaf_context ctx = ddwaf_context_init(handle);
+                ddwaf_context ctx = ddwaf_context_init(handle, ddwaf_get_default_allocator());
                 DDWAF_RET_CODE ret = ddwaf_context_eval(ctx, &root, nullptr, true, nullptr, LONG_TIME);
 
                 bool hadError = ret < DDWAF_OK;
@@ -88,7 +90,7 @@ int main(int argc, char *argv[])
 
         ddwaf_object convertedRule = convertRuleToRuleset(rule);
         ddwaf_handle handle = ddwaf_init(&convertedRule, nullptr, nullptr);
-        ddwaf_object_free(&convertedRule);
+        ddwaf_object_destroy(&convertedRule, ddwaf_get_default_allocator());
 
         if (handle == nullptr) {
             // Verify if the rule should've loaded successfully or not

--- a/tools/verify_ruleset.cpp
+++ b/tools/verify_ruleset.cpp
@@ -15,6 +15,8 @@
 
 int main(int argc, char *argv[])
 {
+    auto *alloc = ddwaf_get_default_allocator();
+
     int retval = EXIT_SUCCESS;
 
     try {
@@ -29,10 +31,10 @@ int main(int argc, char *argv[])
 
         ddwaf_object diagnostics;
         ddwaf_handle handle = ddwaf_init(&rule, nullptr, &diagnostics);
-        ddwaf_object_free(&rule);
+        ddwaf_object_destroy(&rule, alloc);
 
         auto root = object_to_yaml(diagnostics);
-        ddwaf_object_free(&diagnostics);
+        ddwaf_object_destroy(&diagnostics, alloc);
 
         ddwaf_destroy(handle);
 


### PR DESCRIPTION
This PR introduces the new object interface with the following changes:
- Setters are now called `ddwaf_object_set_*` to make their purpose clear.
- Container setters now require an initial capacity.
- All memory-allocating functions now require passing the allocator, currently the only allocator available is provided through `ddwaf_get_default_allocator()`. User and internal allocators will be provided in the next PR.
- `ddwaf_object_is_*` functions have been introduced to better assert for types.
- The context now also requires an output allocator which will be used for allocation of output objects.
- Container insertion is now done in reverse, i.e. the insertion function returns the next available slot. This applies to both maps and arrays.

Remaining work (Next PRs):
- <del>Update objects to use allocators more effectively.</del>
- <del>Check for allocator compatibility where relevant.</del>
- <del>Propagate allocator from the context.</del>
- <del>Have a clear distinction between input , output and internal allocators.</del>
- <del>Remove `from_mutable_buffer` use case on `cow_string`</del>
- <del>Update interface:
  - <del>Pass input / ouput allocators to `context_init` / `context_eval`.</del>
  - <del>Pass allocators to memory-allocating `ddwaf_object` functions.</del>
- Provide input allocator to the context
- Provide functionality for a user allocator.
- Expose internal memory resources (monotonic and unsynchronized).