### PR TITLE
[v2] Add memory resource to owned and borrowed objects

### DIFF
--- a/fuzzer/jwt_decode/src/main.cpp
+++ b/fuzzer/jwt_decode/src/main.cpp
@@ -17,7 +17,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     std::string_view value{reinterpret_cast<const char *>(bytes), size};
 
-    auto headers = owned_object::make_map({{"authorization", value}});
+    auto headers = object_builder::map({{"authorization", value}});
 
     jwt_decode gen{"id", {}, {}, false, true};
 

--- a/src/context_allocator.cpp
+++ b/src/context_allocator.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "context_allocator.hpp"
+#include "memory_resource.hpp"
 
 namespace ddwaf::memory {
 

--- a/src/context_allocator.hpp
+++ b/src/context_allocator.hpp
@@ -21,17 +21,6 @@ inline memory_resource *get_local_memory_resource() { return local_memory_resour
 
 inline void set_local_memory_resource(memory_resource *mr) { local_memory_resource = mr; }
 
-// The null memory resource is used as the default onef or the static thread
-// local memory resource. Only exposed for testing purposes.
-class null_memory_resource final : public memory_resource {
-    void *do_allocate(size_t /*bytes*/, size_t /*alignment*/) override { throw std::bad_alloc(); }
-    void do_deallocate(void * /*p*/, size_t /*bytes*/, size_t /*alignment*/) noexcept override {}
-    [[nodiscard]] bool do_is_equal(const memory_resource &other) const noexcept override
-    {
-        return this == &other;
-    }
-};
-
 // The memory resource guard replaces the current static thread local memory
 // resource with the user provided one on construction and reverts it back on
 // destruction.

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -55,8 +55,7 @@ public:
     ~dynamic_string()
     {
         if (buffer_ != nullptr) {
-            memory::memory_resource *alloc{memory::get_default_resource()};
-            alloc->deallocate(buffer_, capacity_, alignof(char));
+            alloc_->deallocate(buffer_, capacity_, alignof(char));
             buffer_ = nullptr;
             size_ = capacity_ = 0;
         }

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -24,6 +24,7 @@
 #include "context.hpp"
 #include "ddwaf.h"
 #include "log.hpp"
+#include "memory_resource.hpp"
 #include "obfuscator.hpp"
 #include "object.hpp"
 #include "object_store.hpp"
@@ -480,7 +481,7 @@ ddwaf_object *ddwaf_object_null(ddwaf_object *object)
         return nullptr;
     }
 
-    to_ref(object) = owned_object{nullptr}.move();
+    to_ref(object) = owned_object::make_null().move();
 
     return object;
 }
@@ -665,7 +666,7 @@ void ddwaf_object_free(ddwaf_object *object)
         return;
     }
 
-    detail::object_destroy(to_ref(object));
+    detail::object_destroy(to_ref(object), memory::get_default_resource());
 
     ddwaf_object_invalid(object);
 }

--- a/src/memory_resource.hpp
+++ b/src/memory_resource.hpp
@@ -30,4 +30,21 @@ using monotonic_buffer_resource = std::pmr::monotonic_buffer_resource;
 
 const auto get_default_resource = std::pmr::get_default_resource;
 
+// The null memory resource is used as the default onef or the static thread
+// local memory resource. Only exposed for testing purposes.
+class null_memory_resource final : public memory_resource {
+    void *do_allocate(size_t /*bytes*/, size_t /*alignment*/) override { throw std::bad_alloc(); }
+    void do_deallocate(void * /*p*/, size_t /*bytes*/, size_t /*alignment*/) noexcept override {}
+    [[nodiscard]] bool do_is_equal(const memory_resource &other) const noexcept override
+    {
+        return this == &other;
+    }
+};
+
+inline memory_resource *get_default_null_resource()
+{
+    static null_memory_resource resource;
+    return &resource;
+}
+
 } // namespace ddwaf::memory

--- a/src/processor/jwt_decode.cpp
+++ b/src/processor/jwt_decode.cpp
@@ -136,9 +136,9 @@ std::pair<owned_object, object_store::attribute> jwt_decode::eval_impl(
     }
 
     // Decode header and payload and generate output
-    auto output = owned_object::make_map(
+    auto output = object_builder::map(
         {{"header", decode_and_parse(jwt.header)}, {"payload", decode_and_parse(jwt.payload)},
-            {"signature", owned_object::make_map({{"available", !jwt.signature.empty()}})}});
+            {"signature", object_builder::map({{"available", !jwt.signature.empty()}})}});
 
     return {std::move(output), attr};
 }

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -310,9 +310,9 @@ void result_serializer::serialize(const object_store &store, std::vector<rule_re
 
 std::pair<owned_object, result_components> result_serializer::initialise_result_object()
 {
-    auto object = owned_object::make_map({{"events", owned_object::make_array()},
-        {"actions", owned_object::make_map()}, {"duration", owned_object::make_unsigned(0)},
-        {"timeout", false}, {"attributes", owned_object::make_map()}, {"keep", false}});
+    auto object = object_builder::map({{"events", object_builder::array()},
+        {"actions", object_builder::map()}, {"duration", owned_object::make_unsigned(0)},
+        {"timeout", false}, {"attributes", object_builder::map()}, {"keep", false}});
 
     const result_components res{.events = object.at(0),
         .actions = object.at(1),

--- a/tests/common/yaml_utils.cpp
+++ b/tests/common/yaml_utils.cpp
@@ -159,7 +159,7 @@ owned_object node_to_owned_object(const Node &node)
         return owned_object{value};
     }
     case NodeType::Null:
-        return owned_object{nullptr};
+        return owned_object::make_null();
     case NodeType::Undefined:
         return {};
     }

--- a/tests/unit/attribute_collector_test.cpp
+++ b/tests/unit/attribute_collector_test.cpp
@@ -58,7 +58,7 @@ TEST(TestAttributeCollector, InsertDuplicate)
 TEST(TestAttributeCollector, CollectAvailableScalar)
 {
     std::string_view expected = "value";
-    auto input = owned_object::make_map({{"input_address", expected}});
+    auto input = object_builder::map({{"input_address", expected}});
 
     object_store store;
     store.insert(std::move(input));
@@ -79,8 +79,8 @@ TEST(TestAttributeCollector, CollectAvailableScalar)
 TEST(TestAttributeCollector, CollectAvailableKeyPathScalar)
 {
     std::string_view expected = "value";
-    auto input = owned_object::make_map({{"input_address",
-        owned_object::make_map({{"first", owned_object::make_map({{"second", expected}})}})}});
+    auto input = object_builder::map({{"input_address",
+        object_builder::map({{"first", object_builder::map({{"second", expected}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -103,9 +103,9 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathScalar)
 TEST(TestAttributeCollector, CollectAvailableKeyPathSingleValueArray)
 {
     std::string_view expected = "value";
-    auto input = owned_object::make_map({{"input_address",
-        owned_object::make_map({{"first",
-            owned_object::make_map({{"second", owned_object::make_array({expected})}})}})}});
+    auto input = object_builder::map({{"input_address",
+        object_builder::map(
+            {{"first", object_builder::map({{"second", object_builder::array({expected})}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -128,10 +128,10 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathSingleValueArray)
 TEST(TestAttributeCollector, CollectAvailableKeyPathMultiValueArray)
 {
     std::string_view expected = "value0";
-    auto input = owned_object::make_map({{"input_address",
-        owned_object::make_map(
-            {{"first", owned_object::make_map({{"second",
-                           owned_object::make_array({expected, "value1", "value2"})}})}})}});
+    auto input = object_builder::map(
+        {{"input_address", object_builder::map({{"first",
+                               object_builder::map({{"second",
+                                   object_builder::array({expected, "value1", "value2"})}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -153,9 +153,9 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathMultiValueArray)
 
 TEST(TestAttributeCollector, CollectUnavailableKeyPath)
 {
-    auto input = owned_object::make_map({{"input_address",
-        owned_object::make_map({{"first", owned_object::make_map({{"second",
-                                              owned_object::make_map({{"third", "value"}})}})}})}});
+    auto input = object_builder::map({{"input_address",
+        object_builder::map({{"first",
+            object_builder::map({{"second", object_builder::map({{"third", "value"}})}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -174,8 +174,8 @@ TEST(TestAttributeCollector, CollectUnavailableKeyPath)
 TEST(TestAttributeCollector, CollectPendingKeyPathScalar)
 {
     std::string_view expected = "value";
-    auto input = owned_object::make_map({{"input_address",
-        owned_object::make_map({{"first", owned_object::make_map({{"second", expected}})}})}});
+    auto input = object_builder::map({{"input_address",
+        object_builder::map({{"first", object_builder::map({{"second", expected}})}})}});
     object_store store;
 
     attribute_collector collector;
@@ -200,9 +200,9 @@ TEST(TestAttributeCollector, CollectPendingKeyPathScalar)
 
 TEST(TestAttributeCollector, CollectAvailableKeyPathInvalidValue)
 {
-    auto input = owned_object::make_map(
-        {{"input_address", owned_object::make_map({{"first",
-                               owned_object::make_map({{"second", owned_object::make_map()}})}})}});
+    auto input = object_builder::map(
+        {{"input_address", object_builder::map({{"first",
+                               object_builder::map({{"second", object_builder::map()}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -221,7 +221,7 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathInvalidValue)
 TEST(TestAttributeCollector, CollectDuplicateScalar)
 {
     std::string_view expected = "value";
-    auto input = owned_object::make_map({{"input_address", expected}});
+    auto input = object_builder::map({{"input_address", expected}});
 
     object_store store;
     store.insert(std::move(input));
@@ -243,7 +243,7 @@ TEST(TestAttributeCollector, CollectDuplicateScalar)
 TEST(TestAttributeCollector, CollectAvailableScalarFromSingleValueArray)
 {
     std::string_view expected = "value";
-    auto input = owned_object::make_map({{"input_address", owned_object::make_array({expected})}});
+    auto input = object_builder::map({{"input_address", object_builder::array({expected})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -264,8 +264,8 @@ TEST(TestAttributeCollector, CollectAvailableScalarFromSingleValueArray)
 TEST(TestAttributeCollector, CollectAvailableScalarFromMultiValueArray)
 {
     std::string_view expected = "value0";
-    auto input = owned_object::make_map(
-        {{"input_address", owned_object::make_array({expected, "value1", "value2"})}});
+    auto input = object_builder::map(
+        {{"input_address", object_builder::array({expected, "value1", "value2"})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -285,8 +285,8 @@ TEST(TestAttributeCollector, CollectAvailableScalarFromMultiValueArray)
 
 TEST(TestAttributeCollector, CollectInvalidObjectFromArray)
 {
-    auto input = owned_object::make_map(
-        {{"input_address", owned_object::make_array({owned_object::make_map()})}});
+    auto input =
+        object_builder::map({{"input_address", object_builder::array({object_builder::map()})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -318,7 +318,7 @@ TEST(TestAttributeCollector, CollectUnavailableScalar)
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
     std::string_view expected = "value";
-    auto input = owned_object::make_map({{"input_address", expected}});
+    auto input = object_builder::map({{"input_address", expected}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -353,7 +353,7 @@ TEST(TestAttributeCollector, CollectUnavailableScalarFromSingleValueArray)
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
     std::string_view expected = "value";
-    auto input = owned_object::make_map({{"input_address", owned_object::make_array({expected})}});
+    auto input = object_builder::map({{"input_address", object_builder::array({expected})}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -388,8 +388,8 @@ TEST(TestAttributeCollector, CollectUnavailableScalarFromMultiValueArray)
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
     std::string_view expected = "value0";
-    auto input = owned_object::make_map(
-        {{"input_address", owned_object::make_array({expected, "value1", "value2"})}});
+    auto input = object_builder::map(
+        {{"input_address", object_builder::array({expected, "value1", "value2"})}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -423,7 +423,7 @@ TEST(TestAttributeCollector, CollectUnavailableInvalidObject)
 
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
-    auto input = owned_object::make_map({{"input_address", owned_object::make_array()}});
+    auto input = object_builder::map({{"input_address", object_builder::array()}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -470,7 +470,7 @@ TEST(TestAttributeCollector, CollectMultipleUnavailableScalars)
         // After adding the attribute, collect_pending should extract, copy and return
         // the expected attribute
         std::string_view expected = "value";
-        auto input = owned_object::make_map({{"input_address_0", expected}});
+        auto input = object_builder::map({{"input_address_0", expected}});
 
         store.insert(std::move(input));
 
@@ -493,7 +493,7 @@ TEST(TestAttributeCollector, CollectMultipleUnavailableScalars)
         // the expected attribute
 
         std::string_view expected = "value";
-        auto input = owned_object::make_map({{"input_address_2", expected}});
+        auto input = object_builder::map({{"input_address_2", expected}});
         store.insert(std::move(input));
 
         collector.collect_pending(store);
@@ -512,7 +512,7 @@ TEST(TestAttributeCollector, CollectMultipleUnavailableScalars)
         // the expected attribute
 
         std::string_view expected = "value";
-        auto input = owned_object::make_map({{"input_address_1", expected}});
+        auto input = object_builder::map({{"input_address_1", expected}});
 
         store.insert(std::move(input));
 

--- a/tests/unit/condition/cmdi_detector_test.cpp
+++ b/tests/unit/condition/cmdi_detector_test.cpp
@@ -37,8 +37,8 @@ TEST(TestCmdiDetector, InvalidType)
 {
     cmdi_detector cond{{gen_param_def("server.sys.exec.cmd", "server.request.query")}};
 
-    auto root = owned_object::make_map(
-        {{"server.sys.exec.cmd", owned_object::make_map()}, {"server.request.query", "whatever"}});
+    auto root = object_builder::map(
+        {{"server.sys.exec.cmd", object_builder::map()}, {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -53,8 +53,8 @@ TEST(TestCmdiDetector, EmptyResource)
 {
     cmdi_detector cond{{gen_param_def("server.sys.exec.cmd", "server.request.query")}};
 
-    auto root = owned_object::make_map({{"server.sys.exec.cmd", owned_object::make_array()},
-        {"server.request.query", "whatever"}});
+    auto root = object_builder::map(
+        {{"server.sys.exec.cmd", object_builder::array()}, {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -98,9 +98,9 @@ TEST(TestCmdiDetector, NoInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({{"server.request.query", param}});
+        auto root = object_builder::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -138,9 +138,9 @@ TEST(TestCmdiDetector, NoExecutableInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({{"server.request.query", param}});
+        auto root = object_builder::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -195,9 +195,9 @@ TEST(TestCmdiDetector, NoShellInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({{"server.request.query", param}});
+        auto root = object_builder::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -231,9 +231,9 @@ TEST(TestCmdiDetector, ExecutableInjectionLinux)
     };
 
     for (const auto &[resource, param, expected] : samples) {
-        auto root = owned_object::make_map({{"server.request.query", param}});
+        auto root = object_builder::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -253,10 +253,10 @@ TEST(TestCmdiDetector, ExecutableInjectionLinux)
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, expected.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, expected);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], expected.c_str());
+        EXPECT_STR(cache.match->highlights[0], expected);
     }
 }
 
@@ -281,9 +281,9 @@ TEST(TestCmdiDetector, ExecutableInjectionWindows)
     };
 
     for (const auto &[resource, param, expected] : samples) {
-        auto root = owned_object::make_map({{"server.request.query", param}});
+        auto root = object_builder::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -299,14 +299,14 @@ TEST(TestCmdiDetector, ExecutableInjectionWindows)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, expected.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, expected);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], expected.c_str());
+        EXPECT_STR(cache.match->highlights[0], expected);
     }
 }
 
@@ -326,9 +326,9 @@ TEST(TestCmdiDetector, ExecutableWithSpacesInjection)
     };
 
     for (const auto &[resource, param, expected] : samples) {
-        auto root = owned_object::make_map({{"server.request.query", param}});
+        auto root = object_builder::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -344,14 +344,14 @@ TEST(TestCmdiDetector, ExecutableWithSpacesInjection)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, expected.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, expected);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], expected.c_str());
+        EXPECT_STR(cache.match->highlights[0], expected);
     }
 }
 
@@ -554,9 +554,9 @@ TEST(TestCmdiDetector, LinuxShellInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({{"server.request.query", param}});
+        auto root = object_builder::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -572,14 +572,14 @@ TEST(TestCmdiDetector, LinuxShellInjection)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -643,9 +643,9 @@ TEST(TestCmdiDetector, WindowsShellInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({{"server.request.query", param}});
+        auto root = object_builder::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -661,14 +661,14 @@ TEST(TestCmdiDetector, WindowsShellInjection)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -681,12 +681,12 @@ TEST(TestCmdiDetector, ExecutableInjectionMultipleArguments)
         {"halt", "bin"}, {"-h", "usr"}, {"executable", "/usr/bin/halt"}};
     std::string resource_str = generate_resource_string(resource);
 
-    auto root = owned_object::make_map();
-    auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+    auto root = object_builder::map();
+    auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
     for (const auto &arg : resource) { array.emplace_back(arg); }
 
-    auto map = root.emplace("server.request.query", owned_object::make_map());
+    auto map = root.emplace("server.request.query", object_builder::map());
     for (const auto &[key, value] : params) { map.emplace(key, value); }
 
     object_store store;
@@ -700,7 +700,7 @@ TEST(TestCmdiDetector, ExecutableInjectionMultipleArguments)
 
     EXPECT_TRUE(cache.match);
     EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
-    EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+    EXPECT_STR(cache.match->args[0].resolved, resource_str);
     EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
     EXPECT_STRV(cache.match->args[1].address, "server.request.query");
@@ -720,12 +720,12 @@ TEST(TestCmdiDetector, EmptyExecutable)
 
     std::string resource_str = generate_resource_string(resource);
 
-    auto root = owned_object::make_map();
-    auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+    auto root = object_builder::map();
+    auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
     for (const auto &arg : resource) { array.emplace_back(arg); }
 
-    auto map = root.emplace("server.request.query", owned_object::make_map());
+    auto map = root.emplace("server.request.query", object_builder::map());
     for (const auto &[key, value] : params) { map.emplace(key, value); }
 
     object_store store;
@@ -748,12 +748,12 @@ TEST(TestCmdiDetector, ShellInjectionMultipleArguments)
 
     std::string resource_str = generate_resource_string(resource);
 
-    auto root = owned_object::make_map();
-    auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
+    auto root = object_builder::map();
+    auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
 
     for (const auto &arg : resource) { array.emplace_back(arg); }
 
-    auto map = root.emplace("server.request.query", owned_object::make_map());
+    auto map = root.emplace("server.request.query", object_builder::map());
     for (const auto &[key, value] : params) { map.emplace(key, value); }
 
     object_store store;
@@ -767,7 +767,7 @@ TEST(TestCmdiDetector, ShellInjectionMultipleArguments)
 
     EXPECT_TRUE(cache.match);
     EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
-    EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+    EXPECT_STR(cache.match->args[0].resolved, resource_str);
     EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
     EXPECT_STRV(cache.match->args[1].address, "server.request.query");

--- a/tests/unit/condition/exists_condition_test.cpp
+++ b/tests/unit/condition/exists_condition_test.cpp
@@ -23,7 +23,7 @@ TEST(TestExistsCondition, AddressAvailable)
 {
     exists_condition cond{{gen_variadic_param("server.request.uri_raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri_raw", owned_object{}}});
+    auto root = object_builder::map({{"server.request.uri_raw", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));
@@ -39,10 +39,9 @@ TEST(TestExistsCondition, KeyPathAvailable)
     exists_condition cond{{{{{{"server.request.uri_raw", get_target_index("server.request.uri_raw"),
         {"path", "to", "object"}}}}}}};
 
-    auto root = owned_object::make_map({{"server.request.uri_raw",
-        owned_object::make_map(
-            {{"path", owned_object::make_map(
-                          {{"to", owned_object::make_map({{"object", owned_object{}}})}})}})}});
+    auto root = object_builder::map({{"server.request.uri_raw",
+        object_builder::map({{"path",
+            object_builder::map({{"to", object_builder::map({{"object", owned_object{}}})}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -57,7 +56,7 @@ TEST(TestExistsCondition, AddressNotAvaialble)
 {
     exists_condition cond{{gen_variadic_param("server.request.uri_raw")}};
 
-    auto root = owned_object::make_map({{"server.request.query", owned_object{}}});
+    auto root = object_builder::map({{"server.request.query", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));
@@ -73,8 +72,8 @@ TEST(TestExistsCondition, KeyPathNotAvailable)
     exists_condition cond{{{{{{"server.request.uri_raw", get_target_index("server.request.uri_raw"),
         {"path", "to", "object"}}}}}}};
 
-    auto root = owned_object::make_map({{"server.request.uri_raw",
-        owned_object::make_map({{"path", owned_object::make_map({{"to", owned_object{}}})}})}});
+    auto root = object_builder::map({{"server.request.uri_raw",
+        object_builder::map({{"path", object_builder::map({{"to", owned_object{}}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -90,10 +89,9 @@ TEST(TestExistsCondition, KeyPathAvailableButExcluded)
     exists_condition cond{{{{{{"server.request.uri_raw", get_target_index("server.request.uri_raw"),
         {"path", "to", "object"}}}}}}};
 
-    auto root = owned_object::make_map({{"server.request.uri_raw",
-        owned_object::make_map(
-            {{"path", owned_object::make_map(
-                          {{"to", owned_object::make_map({{"object", owned_object{}}})}})}})}});
+    auto root = object_builder::map({{"server.request.uri_raw",
+        object_builder::map({{"path",
+            object_builder::map({{"to", object_builder::map({{"object", owned_object{}}})}})}})}});
 
     std::unordered_set<object_view> excluded = {root.at(0)};
     object_store store;
@@ -118,7 +116,7 @@ TEST(TestExistsCondition, MultipleAddresses)
         {gen_variadic_param("server.request.uri_raw", "server.request.body", "usr.id")}};
 
     auto validate_address = [&](const std::string &address, bool expected = true) {
-        auto root = owned_object::make_map({{address, owned_object{}}});
+        auto root = object_builder::map({{address, owned_object{}}});
 
         object_store store;
         store.insert(std::move(root));
@@ -145,11 +143,11 @@ TEST(TestExistsCondition, MultipleAddressesAndKeyPaths)
 
     auto validate_address = [&](const std::string &address, const std::vector<std::string> &kp,
                                 bool expected = true) {
-        auto root = owned_object::make_map();
-        auto map = root.emplace(address, owned_object::make_map());
+        auto root = object_builder::map();
+        auto map = root.emplace(address, object_builder::map());
         // NOLINTNEXTLINE(modernize-loop-convert)
         for (auto it = kp.begin(); it != kp.end(); ++it) {
-            map = map.emplace(*it, owned_object::make_map());
+            map = map.emplace(*it, object_builder::map());
         }
 
         object_store store;
@@ -178,10 +176,9 @@ TEST(TestExistsNegatedCondition, KeyPathAvailable)
     exists_negated_condition cond{{{{{{"server.request.uri_raw",
         get_target_index("server.request.uri_raw"), {"path", "to", "object"}}}}}}};
 
-    auto root = owned_object::make_map({{"server.request.uri_raw",
-        owned_object::make_map(
-            {{"path", owned_object::make_map(
-                          {{"to", owned_object::make_map({{"object", owned_object{}}})}})}})}});
+    auto root = object_builder::map({{"server.request.uri_raw",
+        object_builder::map({{"path",
+            object_builder::map({{"to", object_builder::map({{"object", owned_object{}}})}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -197,8 +194,8 @@ TEST(TestExistsNegatedCondition, KeyPathNotAvailable)
     exists_negated_condition cond{{{{{{"server.request.uri_raw",
         get_target_index("server.request.uri_raw"), {"path", "to", "object"}}}}}}};
 
-    auto root = owned_object::make_map({{"server.request.uri_raw",
-        owned_object::make_map({{"path", owned_object::make_map({{"to", owned_object{}}})}})}});
+    auto root = object_builder::map({{"server.request.uri_raw",
+        object_builder::map({{"path", object_builder::map({{"to", owned_object{}}})}})}});
     object_store store;
     store.insert(std::move(root));
 
@@ -213,10 +210,9 @@ TEST(TestExistsNegatedCondition, KeyPathAvailableButExcluded)
     exists_negated_condition cond{{{{{{"server.request.uri_raw",
         get_target_index("server.request.uri_raw"), {"path", "to", "object"}}}}}}};
 
-    auto root = owned_object::make_map({{"server.request.uri_raw",
-        owned_object::make_map(
-            {{"path", owned_object::make_map(
-                          {{"to", owned_object::make_map({{"object", owned_object{}}})}})}})}});
+    auto root = object_builder::map({{"server.request.uri_raw",
+        object_builder::map({{"path",
+            object_builder::map({{"to", object_builder::map({{"object", owned_object{}}})}})}})}});
 
     std::unordered_set<object_view> excluded = {root.at(0)};
 

--- a/tests/unit/condition/scalar_condition_test.cpp
+++ b/tests/unit/condition/scalar_condition_test.cpp
@@ -40,7 +40,7 @@ TEST(TestScalarCondition, NoMatch)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", owned_object{}}});
+    auto root = object_builder::map({{"server.request.uri.raw", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));
@@ -57,7 +57,7 @@ TEST(TestScalarCondition, Timeout)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", owned_object{}}});
+    auto root = object_builder::map({{"server.request.uri.raw", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));
@@ -72,7 +72,7 @@ TEST(TestScalarCondition, SimpleMatch)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -92,7 +92,7 @@ TEST(TestScalarCondition, CachedMatch)
     ddwaf::timer deadline{2s};
     condition_cache cache;
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
 
     {
         object_store store;
@@ -121,8 +121,8 @@ TEST(TestScalarCondition, SimpleMatchOnKeys)
     scalar_condition cond{
         std::make_unique<matcher::regex_match>(".*", 0, true), {}, {std::move(param)}};
 
-    auto root = owned_object::make_map(
-        {{"server.request.uri.raw", owned_object::make_map({{"hello", "hello"}})}});
+    auto root = object_builder::map(
+        {{"server.request.uri.raw", object_builder::map({{"hello", "hello"}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -139,7 +139,7 @@ TEST(TestScalarCondition, SimpleEphemeralMatch)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
 
     object_store store;
     {

--- a/tests/unit/condition/scalar_negated_condition_test.cpp
+++ b/tests/unit/condition/scalar_negated_condition_test.cpp
@@ -49,7 +49,7 @@ TEST(TestScalarNegatedCondition, NoMatch)
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -66,7 +66,7 @@ TEST(TestScalarNegatedCondition, Timeout)
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -81,7 +81,7 @@ TEST(TestScalarNegatedCondition, SimpleMatch)
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", owned_object{}}});
+    auto root = object_builder::map({{"server.request.uri.raw", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));
@@ -101,7 +101,7 @@ TEST(TestScalarNegatedCondition, CachedMatch)
     ddwaf::timer deadline{2s};
     condition_cache cache;
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", owned_object{}}});
+    auto root = object_builder::map({{"server.request.uri.raw", owned_object{}}});
 
     {
         object_store store;
@@ -130,8 +130,8 @@ TEST(TestScalarNegatedCondition, SimpleMatchOnKeys)
     scalar_negated_condition cond{
         std::make_unique<matcher::regex_match>("hello", 0, true), {}, {std::move(target)}};
 
-    auto root = owned_object::make_map(
-        {{"server.request.uri.raw", owned_object::make_map({{"bye", "hello"}})}});
+    auto root =
+        object_builder::map({{"server.request.uri.raw", object_builder::map({{"bye", "hello"}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -148,7 +148,7 @@ TEST(TestScalarNegatedCondition, SimpleEphemeralMatch)
     scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = owned_object::make_map({{"server.request.uri.raw", owned_object{}}});
+    auto root = object_builder::map({{"server.request.uri.raw", owned_object{}}});
 
     object_store store;
     {

--- a/tests/unit/condition/shi_detector_array_test.cpp
+++ b/tests/unit/condition/shi_detector_array_test.cpp
@@ -21,8 +21,8 @@ TEST(TestShiDetectorArray, InvalidType)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
-    auto root = owned_object::make_map(
-        {{"server.sys.shell.cmd", owned_object::make_map()}, {"server.request.query", "whatever"}});
+    auto root = object_builder::map(
+        {{"server.sys.shell.cmd", object_builder::map()}, {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -37,8 +37,8 @@ TEST(TestShiDetectorArray, EmptyResource)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
-    auto root = owned_object::make_map({{"server.sys.shell.cmd", owned_object::make_array()},
-        {"server.request.query", "whatever"}});
+    auto root = object_builder::map(
+        {{"server.sys.shell.cmd", object_builder::array()}, {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -52,9 +52,9 @@ TEST(TestShiDetectorArray, EmptyResource)
 TEST(TestShiDetectorArray, InvalidTypeWithinArray)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
-    auto root = owned_object::make_map({{"server.request.query", "cat /etc/passwd"},
-        {"server.sys.shell.cmd", owned_object::make_array({"ls", "-l", ";", 22,
-                                     owned_object::make_map(), "cat /etc/passwd"})}});
+    auto root = object_builder::map({{"server.request.query", "cat /etc/passwd"},
+        {"server.sys.shell.cmd", object_builder::array({"ls", "-l", ";", 22, object_builder::map(),
+                                     "cat /etc/passwd"})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -109,9 +109,9 @@ TEST(TestShiDetectorArray, NoMatchAndFalsePositives)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
         for (const auto &arg : resource) { array.emplace_back(arg); }
 
         object_store store;
@@ -146,9 +146,9 @@ TEST(TestShiDetectorArray, ExecutablesAndRedirections)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
         std::string resource_str;
         for (const auto &arg : resource) {
             array.emplace_back(arg);
@@ -169,14 +169,14 @@ TEST(TestShiDetectorArray, ExecutablesAndRedirections)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -200,9 +200,9 @@ TEST(TestShiDetectorArray, OverlappingInjections)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
 
         std::string resource_str;
         for (const auto &arg : resource) {
@@ -240,9 +240,9 @@ TEST(TestShiDetectorArray, InjectionsWithinCommandSubstitution)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
 
         std::string resource_str;
         for (const auto &arg : resource) {
@@ -264,14 +264,14 @@ TEST(TestShiDetectorArray, InjectionsWithinCommandSubstitution)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -285,9 +285,9 @@ TEST(TestShiDetectorArray, InjectionsWithinProcessSubstitution)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
 
         std::string resource_str;
         for (const auto &arg : resource) {
@@ -309,14 +309,14 @@ TEST(TestShiDetectorArray, InjectionsWithinProcessSubstitution)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -336,9 +336,9 @@ TEST(TestShiDetectorArray, OffByOnePayloadsMatch)
         {{"l", "-l", "-a", ";", "l -l"}, "l -l"}};
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", owned_object::make_array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
 
         std::string resource_str;
         for (const auto &arg : resource) {
@@ -360,14 +360,14 @@ TEST(TestShiDetectorArray, OffByOnePayloadsMatch)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource_str.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource_str);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 

--- a/tests/unit/condition/shi_detector_string_test.cpp
+++ b/tests/unit/condition/shi_detector_string_test.cpp
@@ -21,7 +21,7 @@ TEST(TestShiDetectorString, InvalidType)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
-    auto root = owned_object::make_map(
+    auto root = object_builder::map(
         {{"server.sys.shell.cmd", owned_object{}}, {"server.request.query", "whatever"}});
 
     object_store store;
@@ -37,8 +37,8 @@ TEST(TestShiDetectorString, EmptyResource)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
-    auto root = owned_object::make_map(
-        {{"server.sys.shell.cmd", ""}, {"server.request.query", "whatever"}});
+    auto root =
+        object_builder::map({{"server.sys.shell.cmd", ""}, {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -76,7 +76,7 @@ TEST(TestShiDetectorString, NoMatchAndFalsePositives)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({
+        auto root = object_builder::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -107,7 +107,7 @@ TEST(TestShiDetectorString, ExecutablesAndRedirections)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({
+        auto root = object_builder::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -123,14 +123,14 @@ TEST(TestShiDetectorString, ExecutablesAndRedirections)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -151,7 +151,7 @@ TEST(TestShiDetectorString, InjectionsWithinCommandSubstitution)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({
+        auto root = object_builder::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -167,14 +167,14 @@ TEST(TestShiDetectorString, InjectionsWithinCommandSubstitution)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -188,7 +188,7 @@ TEST(TestShiDetectorString, InjectionsWithinProcessSubstitution)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({
+        auto root = object_builder::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -204,14 +204,14 @@ TEST(TestShiDetectorString, InjectionsWithinProcessSubstitution)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -227,7 +227,7 @@ TEST(TestShiDetectorString, OffByOnePayloadsMatch)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = owned_object::make_map({
+        auto root = object_builder::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -243,14 +243,14 @@ TEST(TestShiDetectorString, OffByOnePayloadsMatch)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, param.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, param);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], param.c_str());
+        EXPECT_STR(cache.match->highlights[0], param);
     }
 }
 
@@ -289,7 +289,7 @@ TEST(TestShiDetectorString, MultipleArgumentsMatch)
     };
 
     for (const auto &resource : samples) {
-        auto root = owned_object::make_map({{"server.sys.shell.cmd", resource},
+        auto root = object_builder::map({{"server.sys.shell.cmd", resource},
             {"server.request.query", yaml_to_object<owned_object>(params)}});
 
         object_store store;
@@ -303,7 +303,7 @@ TEST(TestShiDetectorString, MultipleArgumentsMatch)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
-        EXPECT_STR(cache.match->args[0].resolved, resource.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, resource);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
     }
 }

--- a/tests/unit/condition/sqli_detector_internals_test.cpp
+++ b/tests/unit/condition/sqli_detector_internals_test.cpp
@@ -295,7 +295,7 @@ TEST(TestSqliDetectorInternals, StripLiterals)
     for (const auto &[statement, expected_stripped] : samples) {
         auto tokens = tokenize(statement);
         auto obtained_stripped = internal::strip_literals(statement, tokens);
-        EXPECT_STREQ(obtained_stripped.c_str(), expected_stripped.c_str());
+        EXPECT_STR(obtained_stripped, expected_stripped);
     }
 }
 

--- a/tests/unit/condition/sqli_detector_test.cpp
+++ b/tests/unit/condition/sqli_detector_test.cpp
@@ -34,7 +34,7 @@ TEST_P(DialectTestFixture, InvalidSql)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -59,7 +59,7 @@ TEST_P(DialectTestFixture, InjectionWithoutTokens)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -96,7 +96,7 @@ TEST_P(DialectTestFixture, BenignInjections)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -146,7 +146,7 @@ TEST_P(DialectTestFixture, MaliciousInjections)
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -160,14 +160,14 @@ TEST_P(DialectTestFixture, MaliciousInjections)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.db.statement");
-        EXPECT_STR(cache.match->args[0].resolved, obfuscated.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, obfuscated);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, input.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, input);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], input.c_str());
+        EXPECT_STR(cache.match->highlights[0], input);
     }
 }
 
@@ -217,7 +217,7 @@ TEST_P(DialectTestFixture, Tautologies)
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -231,14 +231,14 @@ TEST_P(DialectTestFixture, Tautologies)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.db.statement");
-        EXPECT_STR(cache.match->args[0].resolved, obfuscated.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, obfuscated);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, input.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, input);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], input.c_str());
+        EXPECT_STR(cache.match->highlights[0], input);
     }
 }
 
@@ -262,7 +262,7 @@ TEST_P(DialectTestFixture, Comments)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -276,14 +276,14 @@ TEST_P(DialectTestFixture, Comments)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.db.statement");
-        EXPECT_STR(cache.match->args[0].resolved, obfuscated.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, obfuscated);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, input.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, input);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], input.c_str());
+        EXPECT_STR(cache.match->highlights[0], input);
     }
 }
 
@@ -304,7 +304,7 @@ TEST(TestSqliDetectorMySql, Comments)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", "mysql"}, {"server.request.query", input}});
 
         object_store store;
@@ -318,14 +318,14 @@ TEST(TestSqliDetectorMySql, Comments)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.db.statement");
-        EXPECT_STR(cache.match->args[0].resolved, obfuscated.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, obfuscated);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, input.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, input);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], input.c_str());
+        EXPECT_STR(cache.match->highlights[0], input);
     }
 }
 
@@ -349,7 +349,7 @@ TEST(TestSqliDetectorMySql, Tautologies)
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", "mysql"}, {"server.request.query", input}});
 
         object_store store;
@@ -363,14 +363,14 @@ TEST(TestSqliDetectorMySql, Tautologies)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.db.statement");
-        EXPECT_STR(cache.match->args[0].resolved, obfuscated.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, obfuscated);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, input.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, input);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], input.c_str());
+        EXPECT_STR(cache.match->highlights[0], input);
     }
 }
 
@@ -397,7 +397,7 @@ TEST(TestSqliDetectorPgSql, Tautologies)
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = owned_object::make_map({{"server.db.statement", statement},
+        auto root = object_builder::map({{"server.db.statement", statement},
             {"server.db.system", "pgsql"}, {"server.request.query", input}});
 
         object_store store;
@@ -411,14 +411,14 @@ TEST(TestSqliDetectorPgSql, Tautologies)
 
         EXPECT_TRUE(cache.match);
         EXPECT_STRV(cache.match->args[0].address, "server.db.statement");
-        EXPECT_STR(cache.match->args[0].resolved, obfuscated.c_str());
+        EXPECT_STR(cache.match->args[0].resolved, obfuscated);
         EXPECT_TRUE(cache.match->args[0].key_path.empty());
 
         EXPECT_STRV(cache.match->args[1].address, "server.request.query");
-        EXPECT_STR(cache.match->args[1].resolved, input.c_str());
+        EXPECT_STR(cache.match->args[1].resolved, input);
         EXPECT_TRUE(cache.match->args[1].key_path.empty());
 
-        EXPECT_STR(cache.match->highlights[0], input.c_str());
+        EXPECT_STR(cache.match->highlights[0], input);
     }
 }
 } // namespace

--- a/tests/unit/condition/ssrf_detector_test.cpp
+++ b/tests/unit/condition/ssrf_detector_test.cpp
@@ -29,7 +29,7 @@ void match_path_and_input(
     ssrf_detector cond{{gen_param_def("server.io.net.url", "server.request.query")}};
 
     for (const auto &[path, sample] : samples) {
-        auto root = owned_object::make_map({{"server.io.net.url", path},
+        auto root = object_builder::map({{"server.io.net.url", path},
             {"server.request.query", yaml_to_object<owned_object>(sample.yaml)}});
 
         object_store store;

--- a/tests/unit/context_test.cpp
+++ b/tests/unit/context_test.cpp
@@ -39,7 +39,7 @@ TEST(TestContext, MatchTimeout)
     ddwaf::timer deadline{0s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
 
     std::vector<rule_result> results;
@@ -62,7 +62,7 @@ TEST(TestContext, NoMatch)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.2"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.2"}});
     ctx.insert(std::move(root));
 
     std::vector<rule_result> results;
@@ -86,7 +86,7 @@ TEST(TestContext, Match)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
 
     std::vector<rule_result> results;
@@ -126,7 +126,7 @@ TEST(TestContext, MatchMultipleRulesInCollectionSingleRun)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
     ctx.insert(std::move(root));
 
     std::vector<rule_result> results;
@@ -189,8 +189,7 @@ TEST(TestContext, MatchMultipleRulesWithPrioritySingleRun)
     {
         context ctx(ruleset);
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         ddwaf::timer deadline{2s};
@@ -209,8 +208,7 @@ TEST(TestContext, MatchMultipleRulesWithPrioritySingleRun)
     {
         context ctx(ruleset);
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         ddwaf::timer deadline{2s};
@@ -262,7 +260,7 @@ TEST(TestContext, MatchMultipleRulesInCollectionDoubleRun)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -290,7 +288,7 @@ TEST(TestContext, MatchMultipleRulesInCollectionDoubleRun)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -334,7 +332,7 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -364,7 +362,7 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
     {
         // An existing match in a collection will not inhibit a match in a
         // priority collection.
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -429,7 +427,7 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -459,7 +457,7 @@ TEST(TestContext, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
     {
         // An existing match in a collection will not inhibit a match in a
         // priority collection.
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -501,7 +499,7 @@ TEST(TestContext, MatchMultipleCollectionsSingleRun)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
     ctx.insert(std::move(root));
 
     std::vector<rule_result> results;
@@ -545,7 +543,7 @@ TEST(TestContext, MatchPriorityCollectionsSingleRun)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
     ctx.insert(std::move(root));
 
     std::vector<rule_result> results;
@@ -587,7 +585,7 @@ TEST(TestContext, MatchMultipleCollectionsDoubleRun)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -596,7 +594,7 @@ TEST(TestContext, MatchMultipleCollectionsDoubleRun)
     }
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -642,7 +640,7 @@ TEST(TestContext, MatchMultiplePriorityCollectionsDoubleRun)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -651,7 +649,7 @@ TEST(TestContext, MatchMultiplePriorityCollectionsDoubleRun)
     }
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -694,7 +692,7 @@ TEST(TestContext, RuleFilterWithCondition)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
     ctx.insert(std::move(root));
 
     auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -740,8 +738,8 @@ TEST(TestContext, RuleFilterWithEphemeralConditionMatch)
     context ctx(rbuilder.build());
 
     {
-        auto persistent = owned_object::make_map({{"usr.id", "admin"}});
-        auto ephemeral = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto persistent = object_builder::map({{"usr.id", "admin"}});
+        auto ephemeral = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
         EXPECT_TRUE(ctx.insert(std::move(ephemeral), context::attribute::ephemeral));
@@ -751,7 +749,7 @@ TEST(TestContext, RuleFilterWithEphemeralConditionMatch)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
         auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
@@ -805,8 +803,8 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralBypassPersistentMonitor)
     context ctx(rbuilder.build());
 
     {
-        auto persistent = owned_object::make_map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
-        auto ephemeral = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto persistent = object_builder::map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
+        auto ephemeral = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
         EXPECT_TRUE(ctx.insert(std::move(ephemeral), context::attribute::ephemeral));
@@ -816,7 +814,7 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralBypassPersistentMonitor)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
 
         auto [code, res] = ctx.eval(LONG_TIME);
@@ -873,8 +871,8 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralMonitorPersistentBypass)
     context ctx(rbuilder.build());
 
     {
-        auto persistent = owned_object::make_map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
-        auto ephemeral = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto persistent = object_builder::map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
+        auto ephemeral = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
         EXPECT_TRUE(ctx.insert(std::move(ephemeral), context::attribute::ephemeral));
@@ -884,7 +882,7 @@ TEST(TestContext, OverlappingRuleFiltersEphemeralMonitorPersistentBypass)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
 
         auto [code, res] = ctx.eval(LONG_TIME);
@@ -926,7 +924,7 @@ TEST(TestContext, RuleFilterTimeout)
     ddwaf::timer deadline{0s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
 
     EXPECT_THROW(ctx.eval_filters(deadline), ddwaf::timeout_exception);
@@ -966,7 +964,7 @@ TEST(TestContext, NoRuleFilterWithCondition)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.2"}});
+    auto root = object_builder::map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.2"}});
     ctx.insert(std::move(root));
 
     auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1198,7 +1196,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRulesWithConditions)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1211,7 +1209,7 @@ TEST(TestContext, MultipleRuleFiltersNonOverlappingRulesWithConditions)
     }
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1275,7 +1273,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRulesWithConditions)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1290,7 +1288,7 @@ TEST(TestContext, MultipleRuleFiltersOverlappingRulesWithConditions)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1331,7 +1329,7 @@ TEST(TestContext, InputFilterExclude)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
 
     auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1366,21 +1364,21 @@ TEST(TestContext, InputFilterExcludeEphemeral)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
         auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
         auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_OK);
     }
 
     {
-        auto root = owned_object::make_map({{"http.peer_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.peer_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
         auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
@@ -1411,7 +1409,7 @@ TEST(TestContext, InputFilterExcludeEphemeral)
 
 /*context ctx(rbuilder.build());*/
 
-/*auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});*/
+/*auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});*/
 /*    {*/
 /*auto [code, res] = ctx.eval({}, std::move(root), LONG_TIME);*/
 /*EXPECT_EQ(code, DDWAF_OK);*/
@@ -1452,7 +1450,7 @@ TEST(TestContext, InputFilterExcludeRule)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root));
 
     // The rule is added to the filter stage so that it's excluded from the
@@ -1494,7 +1492,7 @@ TEST(TestContext, InputFilterExcludeRuleEphemeral)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root), attribute::ephemeral);
 
     auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1530,7 +1528,7 @@ TEST(TestContext, InputFilterMonitorRuleEphemeral)
     ddwaf::timer deadline{2s};
     context ctx(rbuilder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     ctx.insert(std::move(root), attribute::ephemeral);
 
     auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1573,12 +1571,12 @@ TEST(TestContext, InputFilterExcluderRuleEphemeralAndPersistent)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root), attribute::ephemeral);
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
     }
 
@@ -1617,12 +1615,12 @@ TEST(TestContext, InputFilterMonitorRuleEphemeralAndPersistent)
     context ctx(rbuilder.build());
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root), attribute::ephemeral);
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
     }
 
@@ -1678,7 +1676,7 @@ TEST(TestContext, InputFilterWithCondition)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1693,8 +1691,7 @@ TEST(TestContext, InputFilterWithCondition)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1709,8 +1706,7 @@ TEST(TestContext, InputFilterWithCondition)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1756,8 +1752,8 @@ TEST(TestContext, InputFilterWithEphemeralCondition)
 
     context ctx(rbuilder.build());
     {
-        auto persistent = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
-        auto ephemeral = owned_object::make_map({{"usr.id", "admin"}});
+        auto persistent = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto ephemeral = object_builder::map({{"usr.id", "admin"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
         EXPECT_TRUE(ctx.insert(std::move(ephemeral), context::attribute::ephemeral));
@@ -1766,7 +1762,7 @@ TEST(TestContext, InputFilterWithEphemeralCondition)
     }
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
         auto [code, res] = ctx.eval(LONG_TIME);
         EXPECT_EQ(code, DDWAF_MATCH);
@@ -1819,7 +1815,7 @@ TEST(TestContext, InputFilterMultipleRules)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1838,8 +1834,7 @@ TEST(TestContext, InputFilterMultipleRules)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1858,8 +1853,7 @@ TEST(TestContext, InputFilterMultipleRules)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1927,7 +1921,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1947,8 +1941,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1968,8 +1961,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFilters)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2068,7 +2060,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(object_view{root});
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2088,7 +2080,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
         ctx.insert(object_view{root});
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2108,8 +2100,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root = owned_object::make_map(
-            {{"server.request.headers", owned_object::make_map({{"cookie", "mycookie"}})}});
+        auto root = object_builder::map(
+            {{"server.request.headers", object_builder::map({{"cookie", "mycookie"}})}});
         ctx.insert(object_view{root});
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2129,8 +2121,7 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(object_view{root});
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2150,8 +2141,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root = owned_object::make_map(
-            {{"server.request.headers", owned_object::make_map({{"cookie", "mycookie"}})},
+        auto root = object_builder::map(
+            {{"server.request.headers", object_builder::map({{"cookie", "mycookie"}})},
                 {"usr.id", "admin"}});
         ctx.insert(object_view{root});
 
@@ -2172,8 +2163,8 @@ TEST(TestContext, InputFilterMultipleRulesMultipleFiltersMultipleObjects)
         ddwaf::timer deadline{2s};
         context ctx(rbuilder.build());
 
-        auto root = owned_object::make_map(
-            {{"server.request.headers", owned_object::make_map({{"cookie", "mycookie"}})},
+        auto root = object_builder::map(
+            {{"server.request.headers", object_builder::map({{"cookie", "mycookie"}})},
                 {"usr.id", "admin"}, {"http.client_ip", "192.168.0.1"}});
         ctx.insert(object_view{root});
 

--- a/tests/unit/exclusion/common_test.cpp
+++ b/tests/unit/exclusion/common_test.cpp
@@ -21,7 +21,7 @@ TEST(ExclusionObjectSet, Empty)
 
 TEST(ExclusionObjectSet, PersistentOnly)
 {
-    auto root = owned_object::make_map({{"value", "node"}});
+    auto root = object_builder::map({{"value", "node"}});
 
     exclusion::object_set excluded{{root.at(0)}, {}};
     EXPECT_FALSE(excluded.empty());
@@ -31,7 +31,7 @@ TEST(ExclusionObjectSet, PersistentOnly)
 
 TEST(ExclusionObjectSet, EphemeralOnly)
 {
-    auto root = owned_object::make_map({{"value", "node"}});
+    auto root = object_builder::map({{"value", "node"}});
 
     exclusion::object_set excluded{{}, {root.at(0)}};
     EXPECT_FALSE(excluded.empty());
@@ -41,7 +41,7 @@ TEST(ExclusionObjectSet, EphemeralOnly)
 
 TEST(ExclusionObjectSet, EphemeralAndPersistent)
 {
-    auto root = owned_object::make_map({{"first", "node"}, {"second", "node"}});
+    auto root = object_builder::map({{"first", "node"}, {"second", "node"}});
 
     exclusion::object_set excluded{{root.at(1)}, {root.at(0)}};
     EXPECT_FALSE(excluded.empty());
@@ -79,7 +79,7 @@ TEST(ExclusionObjectSetRef, Empty)
 
 TEST(ExclusionObjectSetRef, PersistentOnly)
 {
-    auto root = owned_object::make_map({{"value", "node"}});
+    auto root = object_builder::map({{"value", "node"}});
 
     std::unordered_set<object_view> persistent{root.at(0)};
     exclusion::object_set_ref excluded{persistent, {}};
@@ -90,7 +90,7 @@ TEST(ExclusionObjectSetRef, PersistentOnly)
 
 TEST(ExclusionObjectSetRef, EphemeralOnly)
 {
-    auto root = owned_object::make_map({{"value", "node"}});
+    auto root = object_builder::map({{"value", "node"}});
 
     std::unordered_set<object_view> ephemeral{root.at(0)};
     exclusion::object_set_ref excluded{{}, ephemeral};
@@ -101,7 +101,7 @@ TEST(ExclusionObjectSetRef, EphemeralOnly)
 
 TEST(ExclusionObjectSetRef, EphemeralAndPersistent)
 {
-    auto root = owned_object::make_map({{"first", "node"}, {"second", "node"}});
+    auto root = object_builder::map({{"first", "node"}, {"second", "node"}});
 
     std::unordered_set<object_view> persistent{root.at(1)};
     std::unordered_set<object_view> ephemeral{root.at(0)};

--- a/tests/unit/exclusion/input_filter_test.cpp
+++ b/tests/unit/exclusion/input_filter_test.cpp
@@ -18,7 +18,7 @@ TEST(TestInputFilter, InputExclusionNoConditions)
 {
     object_store store;
 
-    auto root = owned_object::make_map({{"query", "value"}});
+    auto root = object_builder::map({{"query", "value"}});
     store.insert(root);
 
     auto obj_filter = std::make_shared<object_filter>();
@@ -43,7 +43,7 @@ TEST(TestInputFilter, EphemeralInputExclusionNoConditions)
 {
     object_store store;
 
-    auto root = owned_object::make_map({{"query", "value"}});
+    auto root = object_builder::map({{"query", "value"}});
     store.insert(root, object_store::attribute::ephemeral);
 
     auto obj_filter = std::make_shared<object_filter>();
@@ -68,8 +68,8 @@ TEST(TestInputFilter, ObjectExclusionNoConditions)
 {
     object_store store;
 
-    auto root = owned_object::make_map();
-    auto child = root.emplace("query", owned_object::make_map());
+    auto root = object_builder::map();
+    auto child = root.emplace("query", object_builder::map());
     child.emplace("params", "param");
 
     store.insert(root);
@@ -96,8 +96,8 @@ TEST(TestInputFilter, EphemeralObjectExclusionNoConditions)
 {
     object_store store;
 
-    auto root = owned_object::make_map();
-    auto child = root.emplace("query", owned_object::make_map());
+    auto root = object_builder::map();
+    auto child = root.emplace("query", object_builder::map());
     child.emplace("params", "param");
 
     store.insert(root, object_store::attribute::ephemeral);
@@ -128,7 +128,7 @@ TEST(TestInputFilter, PersistentInputExclusionWithPersistentCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     ddwaf::object_store store;
     store.insert(root);
 
@@ -157,7 +157,7 @@ TEST(TestInputFilter, EphemeralInputExclusionWithEphemeralCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
     ddwaf::object_store store;
     store.insert(root, object_store::attribute::ephemeral);
@@ -189,10 +189,10 @@ TEST(TestInputFilter, PersistentInputExclusionWithEphemeralCondition)
 
     ddwaf::object_store store;
 
-    auto root = owned_object::make_map({{"usr.id", "admin"}});
+    auto root = object_builder::map({{"usr.id", "admin"}});
     store.insert(std::move(root), object_store::attribute::ephemeral);
 
-    root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     store.insert(root);
 
     auto obj_filter = std::make_shared<object_filter>();
@@ -222,10 +222,10 @@ TEST(TestInputFilter, EphemeralInputExclusionWithPersistentCondition)
 
     ddwaf::object_store store;
 
-    auto root = owned_object::make_map({{"usr.id", "admin"}});
+    auto root = object_builder::map({{"usr.id", "admin"}});
     store.insert(std::move(root));
 
-    root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     store.insert(root, object_store::attribute::ephemeral);
 
     auto obj_filter = std::make_shared<object_filter>();
@@ -253,7 +253,7 @@ TEST(TestInputFilter, InputExclusionWithConditionAndTransformers)
     builder.add_target("usr.id", {}, {transformer_id::lowercase});
     builder.end_condition<matcher::exact_match>(std::vector<std::string>{"admin"});
 
-    auto root = owned_object::make_map({{"usr.id", "ADMIN"}});
+    auto root = object_builder::map({{"usr.id", "ADMIN"}});
 
     ddwaf::object_store store;
     store.insert(root);
@@ -282,7 +282,7 @@ TEST(TestInputFilter, InputExclusionFailedCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.2"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.2"}});
 
     ddwaf::object_store store;
     store.insert(root);
@@ -307,11 +307,11 @@ TEST(TestInputFilter, ObjectExclusionWithCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = owned_object::make_map({
+    auto root = object_builder::map({
         {"http.client_ip", "192.168.0.1"},
     });
 
-    auto child = root.emplace("query", owned_object::make_map({{"params", "value"}}));
+    auto child = root.emplace("query", object_builder::map({{"params", "value"}}));
 
     ddwaf::object_store store;
     store.insert(root);
@@ -341,8 +341,8 @@ TEST(TestInputFilter, ObjectExclusionFailedCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.2"},
-        {"query", owned_object::make_map({{"params", "value"}})}});
+    auto root = object_builder::map(
+        {{"http.client_ip", "192.168.0.2"}, {"query", object_builder::map({{"params", "value"}})}});
 
     ddwaf::object_store store;
     store.insert(root);
@@ -383,7 +383,7 @@ TEST(TestInputFilter, InputValidateCachedMatch)
     // matched on the second run.
     input_filter::cache_type cache;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         ddwaf::object_store store;
         store.insert(root);
@@ -393,7 +393,7 @@ TEST(TestInputFilter, InputValidateCachedMatch)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         ddwaf::object_store store;
         store.insert(root);
@@ -425,11 +425,11 @@ TEST(TestInputFilter, InputValidateCachedEphemeralMatch)
     // only the latest address. This ensures that the IP condition can't be
     // matched on the second run.
     std::vector<owned_object> objects;
-    objects.emplace_back(owned_object::make_map({{"http.client_ip", "192.168.0.1"}}));
-    objects.emplace_back(owned_object::make_map({{"usr.id", "admin"}}));
-    objects.emplace_back(owned_object::make_map({{"usr.id", "admin"}}));
-    objects.emplace_back(owned_object::make_map({{"http.client_ip", "192.168.0.1"}}));
-    objects.emplace_back(owned_object::make_map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"}}));
+    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"}}));
+    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
 
     input_filter::cache_type cache;
     ddwaf::object_store store;
@@ -493,7 +493,7 @@ TEST(TestInputFilter, InputMatchWithoutCache)
     // In this test we validate that when the cache is empty and only one
     // address is passed, the filter doesn't match (as it should be).
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         ddwaf::object_store store;
         store.insert(root);
@@ -504,7 +504,7 @@ TEST(TestInputFilter, InputMatchWithoutCache)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         ddwaf::object_store store;
         store.insert(root);
@@ -539,8 +539,8 @@ TEST(TestInputFilter, InputNoMatchWithoutCache)
     ddwaf::object_store store;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(owned_object::make_map({{"http.client_ip", "192.168.0.1"}}));
-    objects.emplace_back(owned_object::make_map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"}}));
+    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
 
     {
         store.insert(objects[0]);
@@ -592,8 +592,8 @@ TEST(TestInputFilter, InputCachedMatchSecondRun)
 
     std::vector<owned_object> objects;
     objects.emplace_back(
-        owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}}));
-    objects.emplace_back(owned_object::make_map({{"random", "random"}}));
+        object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}}));
+    objects.emplace_back(object_builder::map({{"random", "random"}}));
 
     {
         auto scope = store.get_eval_scope();
@@ -643,10 +643,10 @@ TEST(TestInputFilter, ObjectValidateCachedMatch)
     input_filter::cache_type cache;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(owned_object::make_map({{"http.client_ip", "192.168.0.1"},
-        {"query", owned_object::make_map({{"params", "value"}})}}));
-    objects.emplace_back(owned_object::make_map(
-        {{"usr.id", "admin"}, {"query", owned_object::make_map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
+        {"query", object_builder::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder::map(
+        {{"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}}));
 
     {
         ddwaf::object_store store;
@@ -690,8 +690,8 @@ TEST(TestInputFilter, ObjectMatchWithoutCache)
     // In this test we validate that when the cache is empty and only one
     // address is passed, the filter doesn't match (as it should be).
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"},
-            {"query", owned_object::make_map({{"params", "value"}})}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"},
+            {"query", object_builder::map({{"params", "value"}})}});
         ddwaf::object_store store;
         store.insert(root);
 
@@ -702,8 +702,8 @@ TEST(TestInputFilter, ObjectMatchWithoutCache)
 
     {
 
-        auto root = owned_object::make_map(
-            {{"usr.id", "admin"}, {"query", owned_object::make_map({{"params", "value"}})}});
+        auto root = object_builder::map(
+            {{"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}});
         ddwaf::object_store store;
         store.insert(root);
 
@@ -737,9 +737,9 @@ TEST(TestInputFilter, ObjectNoMatchWithoutCache)
     ddwaf::object_store store;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(owned_object::make_map({{"http.client_ip", "192.168.0.1"},
-        {"query", owned_object::make_map({{"params", "value"}})}}));
-    objects.emplace_back(owned_object::make_map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
+        {"query", object_builder::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
 
     {
         store.insert(objects[0]);
@@ -787,9 +787,9 @@ TEST(TestInputFilter, ObjectCachedMatchSecondRun)
     input_filter::cache_type cache;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(owned_object::make_map({{"http.client_ip", "192.168.0.1"},
-        {"usr.id", "admin"}, {"query", owned_object::make_map({{"params", "value"}})}}));
-    objects.emplace_back(owned_object::make_map({{"random", "random"}}));
+    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
+        {"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder::map({{"random", "random"}}));
 
     {
         auto scope = store.get_eval_scope();
@@ -833,10 +833,10 @@ TEST(TestInputFilter, MatchWithDynamicMatcher)
     input_filter filter("filter", builder.build(), {rule.get()}, std::move(obj_filter));
 
     std::vector<owned_object> objects;
-    objects.emplace_back(owned_object::make_map({{"http.client_ip", "192.168.0.1"},
-        {"usr.id", "admin"}, {"query", owned_object::make_map({{"params", "value"}})}}));
-    objects.emplace_back(owned_object::make_map({{"http.client_ip", "192.168.0.1"},
-        {"usr.id", "admin"}, {"query", owned_object::make_map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
+        {"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
+        {"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}}));
 
     {
         ddwaf::object_store store;

--- a/tests/unit/exclusion/object_filter_test.cpp
+++ b/tests/unit/exclusion/object_filter_test.cpp
@@ -19,8 +19,8 @@ TEST(TestObjectFilter, RootTarget)
 
     object_store store;
 
-    auto root = owned_object::make_map({
-        {"query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+    auto root = object_builder::map({
+        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
     });
     store.insert(root);
 
@@ -48,11 +48,11 @@ TEST(TestObjectFilter, DuplicateTarget)
     object_filter::cache_type cache;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(owned_object::make_map({
-        {"query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+    objects.emplace_back(object_builder::map({
+        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
     }));
-    objects.emplace_back(owned_object::make_map({
-        {"query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+    objects.emplace_back(object_builder::map({
+        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
     }));
     {
         store.insert(objects[0]);
@@ -85,8 +85,8 @@ TEST(TestObjectFilter, DuplicateCachedTarget)
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
 
-    auto root = owned_object::make_map({
-        {"query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+    auto root = object_builder::map({
+        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
     });
     store.insert(root);
 
@@ -108,9 +108,9 @@ TEST(TestObjectFilter, SingleTarget)
 
     object_store store;
 
-    auto root = owned_object::make_map();
+    auto root = object_builder::map();
     auto child = root.emplace(
-        "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+        "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
     store.insert(root);
 
@@ -138,9 +138,9 @@ TEST(TestObjectFilter, DuplicateSingleTarget)
     object_filter::cache_type cache;
 
     {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         auto child = root.emplace(
-            "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(std::move(root));
 
@@ -150,9 +150,9 @@ TEST(TestObjectFilter, DuplicateSingleTarget)
     }
 
     {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         auto child = root.emplace(
-            "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(std::move(root));
 
@@ -169,17 +169,17 @@ TEST(TestObjectFilter, MultipleTargets)
 
     object_store store;
 
-    auto root = owned_object::make_map();
+    auto root = object_builder::map();
 
     // Query
     auto child = root.emplace(
-        "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+        "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
     // Path Params
-    auto sibling = root.emplace("path_params", owned_object::make_map({{"username", "Paco"}}));
+    auto sibling = root.emplace("path_params", object_builder::map({{"username", "Paco"}}));
 
     auto object = sibling.emplace(
-        "token", owned_object::make_map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
+        "token", object_builder::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
 
     store.insert(root);
 
@@ -211,16 +211,16 @@ TEST(TestObjectFilter, DuplicateMultipleTargets)
     object_filter::cache_type cache;
 
     {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         // Query
         auto child = root.emplace(
-            "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         // Path Params
-        auto sibling = root.emplace("path_params", owned_object::make_map({{"username", "Paco"}}));
+        auto sibling = root.emplace("path_params", object_builder::map({{"username", "Paco"}}));
 
-        auto object = sibling.emplace("token",
-            owned_object::make_map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
+        auto object = sibling.emplace(
+            "token", object_builder::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
 
         store.insert(std::move(root));
 
@@ -232,16 +232,16 @@ TEST(TestObjectFilter, DuplicateMultipleTargets)
     }
 
     {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         // Query
         auto child = root.emplace(
-            "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         // Path Params
-        auto sibling = root.emplace("path_params", owned_object::make_map({{"username", "Paco"}}));
+        auto sibling = root.emplace("path_params", object_builder::map({{"username", "Paco"}}));
 
-        auto object = sibling.emplace("token",
-            owned_object::make_map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
+        auto object = sibling.emplace(
+            "token", object_builder::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
 
         store.insert(std::move(root));
 
@@ -261,10 +261,10 @@ TEST(TestObjectFilter, MissingTarget)
 
     object_store store;
 
-    auto root = owned_object::make_map({
-        {"query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
-        {"path_params", owned_object::make_map({{"username", "Paco"},
-                            {"token", owned_object::make_map({{"value", "naskjdnakjsd"},
+    auto root = object_builder::map({
+        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+        {"path_params", object_builder::map({{"username", "Paco"},
+                            {"token", object_builder::map({{"value", "naskjdnakjsd"},
                                           {"expiration", "yesterday"}})}})},
     });
     store.insert(root);
@@ -284,9 +284,9 @@ TEST(TestObjectFilter, SingleTargetCache)
 
     object_store store;
 
-    auto root = owned_object::make_map();
+    auto root = object_builder::map();
     auto child = root.emplace(
-        "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+        "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
     store.insert(root);
 
@@ -321,9 +321,9 @@ TEST(TestObjectFilter, MultipleTargetsCache)
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
     {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         auto child = root.emplace(
-            "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(std::move(root));
 
@@ -333,12 +333,12 @@ TEST(TestObjectFilter, MultipleTargetsCache)
     }
 
     {
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         // Path Params
-        auto sibling = root.emplace("path_params", owned_object::make_map({{"username", "Paco"}}));
+        auto sibling = root.emplace("path_params", object_builder::map({{"username", "Paco"}}));
 
-        auto object = sibling.emplace("token",
-            owned_object::make_map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
+        auto object = sibling.emplace(
+            "token", object_builder::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
 
         store.insert(std::move(root));
 
@@ -364,9 +364,9 @@ TEST(TestObjectFilter, SingleGlobTarget)
     {
         object_store store;
         object_filter::cache_type cache;
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         auto child = root.emplace(
-            "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(root);
 
@@ -380,9 +380,9 @@ TEST(TestObjectFilter, SingleGlobTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         auto child = root.emplace("query",
-            owned_object::make_map({{"params", owned_object::make_map({{"value", "paramsvalue"}})},
+            object_builder::map({{"params", object_builder::map({{"value", "paramsvalue"}})},
                 {"uri", "uri_value"}}));
 
         store.insert(root);
@@ -397,7 +397,7 @@ TEST(TestObjectFilter, SingleGlobTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = owned_object::make_map({{"query", owned_object{}}});
+        auto root = object_builder::map({{"query", owned_object{}}});
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, false, deadline);
@@ -418,9 +418,9 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         auto child = root.emplace(
-            "query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(root);
 
@@ -434,9 +434,9 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = owned_object::make_map();
+        auto root = object_builder::map();
         auto child = root.emplace("query",
-            owned_object::make_map({{"params", owned_object::make_map({{"value", "paramsvalue"}})},
+            object_builder::map({{"params", object_builder::map({{"value", "paramsvalue"}})},
                 {"uri", "uri_value"}}));
 
         store.insert(root);
@@ -451,7 +451,7 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = owned_object::make_map({{"query", owned_object{}}});
+        auto root = object_builder::map({{"query", owned_object{}}});
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, false, deadline);
@@ -473,11 +473,10 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        owned_object root = owned_object::make_map();
-        auto child = root.emplace(
-            "query", owned_object::make_map(
-                         {{"params", owned_object::make_map({{"other", "paramsvalue"}})}}));
-        auto grandnephew = child.emplace("uri", owned_object::make_map({{"other", "paramsvalue"}}));
+        owned_object root = object_builder::map();
+        auto child = root.emplace("query",
+            object_builder::map({{"params", object_builder::map({{"other", "paramsvalue"}})}}));
+        auto grandnephew = child.emplace("uri", object_builder::map({{"other", "paramsvalue"}}));
 
         store.insert(root);
 
@@ -490,11 +489,10 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        owned_object root = owned_object::make_map();
-        auto child = root.emplace("query", owned_object::make_map());
-        auto grandchild =
-            child.emplace("params", owned_object::make_map({{"value", "paramsvalue"}}));
-        auto grandnephew = child.emplace("uri", owned_object::make_map({{"value", "paramsvalue"}}));
+        owned_object root = object_builder::map();
+        auto child = root.emplace("query", object_builder::map());
+        auto grandchild = child.emplace("params", object_builder::map({{"value", "paramsvalue"}}));
+        auto grandnephew = child.emplace("uri", object_builder::map({{"value", "paramsvalue"}}));
 
         store.insert(root);
 
@@ -507,10 +505,9 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
     {
         object_store store;
         object_filter::cache_type cache;
-        owned_object root = owned_object::make_map(
-            {{"query", owned_object::make_map(
-                           {{"value", owned_object::make_map({{"whatever", "paramsvalue"}})},
-                               {"other", owned_object::make_map({{"random", "paramsvalue"}})}})}});
+        owned_object root = object_builder::map({{"query",
+            object_builder::map({{"value", object_builder::map({{"whatever", "paramsvalue"}})},
+                {"other", object_builder::map({{"random", "paramsvalue"}})}})}});
 
         store.insert(root);
 
@@ -523,7 +520,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         object_filter::cache_type cache;
 
         owned_object root =
-            owned_object::make_map({{"query", owned_object::make_map({{"value", "value"}})}});
+            object_builder::map({{"query", object_builder::map({{"value", "value"}})}});
 
         store.insert(root);
 
@@ -545,14 +542,14 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        owned_object root = owned_object::make_map();
-        auto child = root.emplace("query", owned_object::make_map());
-        auto grandchild = child.emplace("params", owned_object::make_map());
+        owned_object root = object_builder::map();
+        auto child = root.emplace("query", object_builder::map());
+        auto grandchild = child.emplace("params", object_builder::map());
         auto greatgrandchild = grandchild.emplace("something",
-            owned_object::make_map({{"other", "paramsvalue"}, {"somethingelse", "paramsvalue"}}));
-        auto grandnephew = child.emplace("uri", owned_object::make_map());
+            object_builder::map({{"other", "paramsvalue"}, {"somethingelse", "paramsvalue"}}));
+        auto grandnephew = child.emplace("uri", object_builder::map());
         auto greatgrandnephew = grandnephew.emplace("random",
-            owned_object::make_map({{"other", "paramsvalue"}, {"somethingelse", "paramsvalue"}}));
+            object_builder::map({{"other", "paramsvalue"}, {"somethingelse", "paramsvalue"}}));
 
         store.insert(root);
 
@@ -568,9 +565,9 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = owned_object::make_map({{"query",
-            owned_object::make_map({{"params", owned_object::make_map({{"something", "value"}})},
-                {"uri", owned_object::make_map({{"random", "value"}})}})}});
+        auto root = object_builder::map({{"query",
+            object_builder::map({{"params", object_builder::map({{"something", "value"}})},
+                {"uri", object_builder::map({{"random", "value"}})}})}});
 
         store.insert(root);
 
@@ -582,8 +579,8 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = owned_object::make_map(
-            {{"query", owned_object::make_map({{"params", "value"}, {"uri", "value"}})}});
+        auto root = object_builder::map(
+            {{"query", object_builder::map({{"params", "value"}, {"uri", "value"}})}});
 
         store.insert(root);
 
@@ -667,9 +664,9 @@ TEST(TestObjectFilter, ArrayWithGlobTargets)
     {
         object_store store;
         object_filter::cache_type cache;
-        auto root = owned_object::make_map({{"query",
-            owned_object::make_map({{"a", owned_object::make_array({owned_object::make_map({{"c",
-                                              owned_object::make_map({{"d", "value"}})}})})}})}});
+        auto root = object_builder::map({{"query",
+            object_builder::map({{"a", object_builder::array({object_builder::map(
+                                           {{"c", object_builder::map({{"d", "value"}})}})})}})}});
 
         store.insert(root);
 
@@ -685,8 +682,8 @@ TEST(TestObjectFilter, Timeout)
 
     object_store store;
 
-    auto root = owned_object::make_map(
-        {{"query", owned_object::make_map({{"params", "paramsvalue"}, {"uri", "uri_value"}})}});
+    auto root = object_builder::map(
+        {{"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})}});
     store.insert(root);
 
     object_filter filter;

--- a/tests/unit/exclusion/rule_filter_test.cpp
+++ b/tests/unit/exclusion/rule_filter_test.cpp
@@ -31,7 +31,7 @@ TEST(TestRuleFilter, Match)
     EXPECT_EQ(addresses.size(), 1);
     EXPECT_STREQ(addresses.begin()->second.c_str(), "http.client_ip");
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -64,7 +64,7 @@ TEST(TestRuleFilter, MatchWithDynamicMatcher)
     EXPECT_STREQ(addresses.begin()->second.c_str(), "http.client_ip");
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -77,7 +77,7 @@ TEST(TestRuleFilter, MatchWithDynamicMatcher)
     }
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -115,7 +115,7 @@ TEST(TestRuleFilter, EphemeralMatch)
     EXPECT_EQ(addresses.size(), 1);
     EXPECT_STREQ(addresses.begin()->second.c_str(), "http.client_ip");
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root), object_store::attribute::ephemeral);
@@ -141,7 +141,7 @@ TEST(TestRuleFilter, NoMatch)
 
     ddwaf::exclusion::rule_filter filter{"filter", builder.build(), {}};
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -175,7 +175,7 @@ TEST(TestRuleFilter, ValidateCachedMatch)
     // only the latest address. This ensures that the IP condition can't be
     // matched on the second run.
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -185,7 +185,7 @@ TEST(TestRuleFilter, ValidateCachedMatch)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -227,7 +227,7 @@ TEST(TestRuleFilter, CachedMatchAndEphemeralMatch)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -238,7 +238,7 @@ TEST(TestRuleFilter, CachedMatchAndEphemeralMatch)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -278,7 +278,7 @@ TEST(TestRuleFilter, ValidateEphemeralMatchCache)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -289,7 +289,7 @@ TEST(TestRuleFilter, ValidateEphemeralMatchCache)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -321,7 +321,7 @@ TEST(TestRuleFilter, MatchWithoutCache)
     ddwaf::object_store store;
     {
         ddwaf::exclusion::rule_filter::cache_type cache;
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -331,7 +331,7 @@ TEST(TestRuleFilter, MatchWithoutCache)
 
     {
         ddwaf::exclusion::rule_filter::cache_type cache;
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         store.insert(std::move(root));
 
@@ -361,7 +361,7 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
     // address is passed, the filter doesn't match (as it should be).
     {
         ddwaf::exclusion::rule_filter::cache_type cache;
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -372,7 +372,7 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
 
     {
         ddwaf::exclusion::rule_filter::cache_type cache;
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -405,8 +405,7 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
     // In this test we validate that when a match has already occurred, the
     // second run for the same filter returns nothing.
     {
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         store.insert(std::move(root));
 
@@ -416,7 +415,7 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
     }
 
     {
-        auto root = owned_object::make_map({{"random", "random"}});
+        auto root = object_builder::map({{"random", "random"}});
 
         store.insert(std::move(root));
 

--- a/tests/unit/expression_test.cpp
+++ b/tests/unit/expression_test.cpp
@@ -22,7 +22,7 @@ TEST(TestExpression, SimpleMatch)
 
     auto expr = builder.build();
 
-    auto root = owned_object::make_map({{"server.request.query", "value"}});
+    auto root = object_builder::map({{"server.request.query", "value"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -56,7 +56,7 @@ TEST(TestExpression, SimpleNegatedMatch)
 
     auto expr = builder.build();
 
-    auto root = owned_object::make_map({{"server.request.query", "val"}});
+    auto root = object_builder::map({{"server.request.query", "val"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -90,7 +90,7 @@ TEST(TestExpression, EphemeralMatch)
 
     auto expr = builder.build();
 
-    auto root = owned_object::make_map({{"server.request.query", "value"}});
+    auto root = object_builder::map({{"server.request.query", "value"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root), object_store::attribute::ephemeral);
@@ -131,7 +131,7 @@ TEST(TestExpression, MultiInputMatchOnSecondEval)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "bad"}});
+        auto root = object_builder::map({{"server.request.query", "bad"}});
 
         store.insert(std::move(root));
 
@@ -145,7 +145,7 @@ TEST(TestExpression, MultiInputMatchOnSecondEval)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.body", "value"}});
+        auto root = object_builder::map({{"server.request.body", "value"}});
 
         store.insert(std::move(root));
 
@@ -182,7 +182,7 @@ TEST(TestExpression, EphemeralMatchOnSecondEval)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.body", "bad"}});
+        auto root = object_builder::map({{"server.request.body", "bad"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -196,7 +196,7 @@ TEST(TestExpression, EphemeralMatchOnSecondEval)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.body", "value"}});
+        auto root = object_builder::map({{"server.request.body", "value"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -236,12 +236,12 @@ TEST(TestExpression, EphemeralMatchTwoConditions)
     expression::cache_type cache;
 
     {
-        auto root = owned_object::make_map({{"server.request.query", "value"}});
+        auto root = object_builder::map({{"server.request.query", "value"}});
         store.insert(std::move(root), object_store::attribute::ephemeral);
     }
 
     {
-        auto root = owned_object::make_map({{"server.request.body", "value"}});
+        auto root = object_builder::map({{"server.request.body", "value"}});
         store.insert(std::move(root));
     }
 
@@ -290,7 +290,7 @@ TEST(TestExpression, EphemeralMatchOnFirstConditionFirstEval)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "value"}});
+        auto root = object_builder::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -304,7 +304,7 @@ TEST(TestExpression, EphemeralMatchOnFirstConditionFirstEval)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.body", "value"}});
+        auto root = object_builder::map({{"server.request.body", "value"}});
 
         store.insert(std::move(root));
 
@@ -337,7 +337,7 @@ TEST(TestExpression, EphemeralMatchOnFirstConditionSecondEval)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.body", "value"}});
+        auto root = object_builder::map({{"server.request.body", "value"}});
 
         store.insert(std::move(root));
 
@@ -351,7 +351,7 @@ TEST(TestExpression, EphemeralMatchOnFirstConditionSecondEval)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "value"}});
+        auto root = object_builder::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -379,7 +379,7 @@ TEST(TestExpression, DuplicateInput)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "bad"}});
+        auto root = object_builder::map({{"server.request.query", "bad"}});
 
         store.insert(std::move(root));
 
@@ -393,7 +393,7 @@ TEST(TestExpression, DuplicateInput)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "value"}});
+        auto root = object_builder::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root));
 
@@ -421,7 +421,7 @@ TEST(TestExpression, DuplicateEphemeralInput)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "value"}});
+        auto root = object_builder::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -435,7 +435,7 @@ TEST(TestExpression, DuplicateEphemeralInput)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "value"}});
+        auto root = object_builder::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root), object_store::attribute::ephemeral);
 
@@ -461,7 +461,7 @@ TEST(TestExpression, MatchDuplicateInputNoCache)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "bad"}});
+        auto root = object_builder::map({{"server.request.query", "bad"}});
 
         store.insert(std::move(root));
 
@@ -474,7 +474,7 @@ TEST(TestExpression, MatchDuplicateInputNoCache)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "value"}});
+        auto root = object_builder::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root));
 
@@ -517,7 +517,7 @@ TEST(TestExpression, TwoConditionsSingleInputNoMatch)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "bad_value"}});
+        auto root = object_builder::map({{"server.request.query", "bad_value"}});
 
         store.insert(std::move(root));
 
@@ -529,7 +529,7 @@ TEST(TestExpression, TwoConditionsSingleInputNoMatch)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "value"}});
+        auto root = object_builder::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root));
 
@@ -554,7 +554,7 @@ TEST(TestExpression, TwoConditionsSingleInputMatch)
 
     auto expr = builder.build();
 
-    auto root = owned_object::make_map({{"server.request.query", "value"}});
+    auto root = object_builder::map({{"server.request.query", "value"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -583,8 +583,8 @@ TEST(TestExpression, TwoConditionsMultiInputSingleEvalMatch)
     ddwaf::object_store store;
     expression::cache_type cache;
 
-    auto root = owned_object::make_map(
-        {{"server.request.query", "query"}, {"server.request.body", "body"}});
+    auto root =
+        object_builder::map({{"server.request.query", "query"}, {"server.request.body", "body"}});
 
     store.insert(std::move(root));
 
@@ -614,7 +614,7 @@ TEST(TestExpression, TwoConditionsMultiInputMultiEvalMatch)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map({{"server.request.query", "query"}});
+        auto root = object_builder::map({{"server.request.query", "query"}});
 
         store.insert(std::move(root));
 
@@ -626,7 +626,7 @@ TEST(TestExpression, TwoConditionsMultiInputMultiEvalMatch)
     {
         auto scope = store.get_eval_scope();
 
-        auto root = owned_object::make_map(
+        auto root = object_builder::map(
             {{"server.request.query", "red-herring"}, {"server.request.body", "body"}});
 
         store.insert(std::move(root));
@@ -646,8 +646,8 @@ TEST(TestExpression, MatchWithKeyPath)
     builder.end_condition<matcher::regex_match>(".*", 0, true);
     auto expr = builder.build();
 
-    auto root = owned_object::make_map(
-        {{"server.request.query", owned_object::make_map({{"key", "value"}})}});
+    auto root =
+        object_builder::map({{"server.request.query", object_builder::map({{"key", "value"}})}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -676,7 +676,7 @@ TEST(TestExpression, MatchWithTransformer)
     builder.end_condition<matcher::regex_match>("value", 0, true);
     auto expr = builder.build();
 
-    auto root = owned_object::make_map({{"server.request.query", "VALUE"}});
+    auto root = object_builder::map({{"server.request.query", "VALUE"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -705,7 +705,7 @@ TEST(TestExpression, MatchWithMultipleTransformers)
     builder.end_condition<matcher::regex_match>("^ value $", 0, true);
     auto expr = builder.build();
 
-    auto root = owned_object::make_map({{"server.request.query", "    VALUE    "}});
+    auto root = object_builder::map({{"server.request.query", "    VALUE    "}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -733,8 +733,8 @@ TEST(TestExpression, MatchOnKeys)
     builder.end_condition<matcher::regex_match>("value", 0, true);
     auto expr = builder.build();
 
-    auto root = owned_object::make_map(
-        {{"server.request.query", owned_object::make_map({{"value", "1729"}})}});
+    auto root =
+        object_builder::map({{"server.request.query", object_builder::map({{"value", "1729"}})}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -763,8 +763,8 @@ TEST(TestExpression, MatchOnKeysWithTransformer)
     builder.end_condition<matcher::regex_match>("value", 0, true);
     auto expr = builder.build();
 
-    auto root = owned_object::make_map(
-        {{"server.request.query", owned_object::make_map({{"VALUE", "1729"}})}});
+    auto root =
+        object_builder::map({{"server.request.query", object_builder::map({{"VALUE", "1729"}})}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -793,7 +793,7 @@ TEST(TestExpression, ExcludeInput)
     builder.end_condition<matcher::regex_match>(".*", 0, true);
     auto expr = builder.build();
 
-    auto root = owned_object::make_map({{"server.request.query", "value"}});
+    auto root = object_builder::map({{"server.request.query", "value"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -815,8 +815,8 @@ TEST(TestExpression, ExcludeKeyPath)
     builder.end_condition<matcher::regex_match>(".*", 0, true);
     auto expr = builder.build();
 
-    auto root = owned_object::make_map(
-        {{"server.request.query", owned_object::make_map({{"key", "value"}})}});
+    auto root =
+        object_builder::map({{"server.request.query", object_builder::map({{"key", "value"}})}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));

--- a/tests/unit/key_iterator_test.cpp
+++ b/tests/unit/key_iterator_test.cpp
@@ -73,7 +73,7 @@ TEST(TestKeyIterator, TestSignedScalar)
 
 TEST(TestKeyIterator, TestArraySingleItem)
 {
-    auto object = owned_object::make_array({"string"});
+    auto object = object_builder::array({"string"});
 
     exclusion::object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -86,7 +86,7 @@ TEST(TestKeyIterator, TestArraySingleItem)
 
 TEST(TestKeyIterator, TestArrayMultipleItems)
 {
-    auto object = owned_object::make_array();
+    auto object = object_builder::array();
     for (unsigned i = 0; i < 50; i++) { object.emplace_back(std::to_string(i)); }
 
     exclusion::object_set_ref exclude;
@@ -100,11 +100,11 @@ TEST(TestKeyIterator, TestArrayMultipleItems)
 
 TEST(TestKeyIterator, TestDeepArray)
 {
-    auto object = owned_object::make_array();
+    auto object = object_builder::array();
     borrowed_object array{object};
     for (unsigned i = 0; i < 10; i++) {
         array.emplace_back("val" + std::to_string(i));
-        array = array.emplace_back(owned_object::make_array());
+        array = array.emplace_back(object_builder::array());
     }
 
     exclusion::object_set_ref exclude;
@@ -118,8 +118,8 @@ TEST(TestKeyIterator, TestDeepArray)
 
 TEST(TestKeyIterator, TestArrayNoScalars)
 {
-    auto object = owned_object::make_array();
-    for (unsigned i = 0; i < 50; i++) { object.emplace_back(owned_object::make_array()); }
+    auto object = object_builder::array();
+    for (unsigned i = 0; i < 50; i++) { object.emplace_back(object_builder::array()); }
 
     exclusion::object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -130,7 +130,7 @@ TEST(TestKeyIterator, TestArrayNoScalars)
 
 TEST(TestKeyIterator, TestMapSingleItem)
 {
-    auto object = owned_object::make_map({{"key", "value"}});
+    auto object = object_builder::map({{"key", "value"}});
 
     exclusion::object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -146,7 +146,7 @@ TEST(TestKeyIterator, TestMapSingleItem)
 
 TEST(TestKeyIterator, TestMapMultipleItems)
 {
-    auto object = owned_object::make_map();
+    auto object = object_builder::map();
 
     for (unsigned i = 0; i < 50; i++) {
         auto index = std::to_string(i);
@@ -174,7 +174,7 @@ TEST(TestKeyIterator, TestMapMultipleItems)
 
 TEST(TestKeyIterator, TestMapMultipleNullAndInvalid)
 {
-    auto object = owned_object::make_map();
+    auto object = object_builder::map();
 
     for (unsigned i = 0; i < 25; i++) {
         {
@@ -184,7 +184,7 @@ TEST(TestKeyIterator, TestMapMultipleNullAndInvalid)
 
         {
             auto index = std::to_string(i * 3 + 1);
-            object.emplace("key" + index, nullptr);
+            object.emplace("key" + index, owned_object::make_null());
         }
 
         {
@@ -242,13 +242,13 @@ TEST(TestKeyIterator, TestMapMultipleNullAndInvalid)
 
 TEST(TestKeyIterator, TestDeepMap)
 {
-    auto object = owned_object::make_map();
+    auto object = object_builder::map();
     borrowed_object map{object};
 
     for (unsigned i = 0; i < 10; i++) {
         auto index = std::to_string(i);
         map.emplace("str" + index, "val" + index);
-        map = map.emplace("map" + index, owned_object::make_map());
+        map = map.emplace("map" + index, object_builder::map());
     }
 
     exclusion::object_set_ref exclude;
@@ -292,8 +292,8 @@ TEST(TestKeyIterator, TestDeepMap)
 // addesses (e.g. server.request.query).
 TEST(TestKeyIterator, TestNoRootKey)
 {
-    auto object = owned_object::make_map();
-    object.emplace("root", owned_object::make_map({{"key", "value"}}));
+    auto object = object_builder::map();
+    object.emplace("root", object_builder::map({{"key", "value"}}));
 
     exclusion::object_set_ref exclude;
     ddwaf::key_iterator it(object.at(0), {}, exclude);
@@ -354,8 +354,8 @@ TEST(TestKeyIterator, TestContainerMix)
 
 TEST(TestKeyIterator, TestMapNoScalars)
 {
-    auto object = owned_object::make_map();
-    for (unsigned i = 0; i < 50; i++) { object.emplace("key", owned_object::make_map()); }
+    auto object = object_builder::map();
+    for (unsigned i = 0; i < 50; i++) { object.emplace("key", object_builder::map()); }
 
     exclusion::object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -390,7 +390,7 @@ TEST(TestKeyIterator, TestInvalidObjectPath)
 
 TEST(TestKeyIterator, TestSimplePath)
 {
-    auto object = owned_object::make_map({{"key", "value"}, {"key1", "value"}, {"key2", "value"}});
+    auto object = object_builder::map({{"key", "value"}, {"key1", "value"}, {"key2", "value"}});
 
     {
         std::vector<std::string> key_path{"key"};
@@ -424,9 +424,9 @@ TEST(TestKeyIterator, TestSimplePath)
 
 TEST(TestKeyIterator, TestMultiPath)
 {
-    auto object = owned_object::make_map(
-        {{"first", owned_object::make_map({{"second", owned_object::make_map({{"third", "final"},
-                                                          {"value", "value_third"}})},
+    auto object = object_builder::map(
+        {{"first", object_builder::map({{"second", object_builder::map({{"third", "final"},
+                                                       {"value", "value_third"}})},
                        {"value", "value_second"}})},
             {"value", "value_first"}});
 
@@ -582,7 +582,7 @@ TEST(TestKeyIterator, TestContainerMixInvalidPath)
 
 TEST(TestKeyIterator, TestExcludeSingleObject)
 {
-    auto object = owned_object::make_map({{"key", "value"}});
+    auto object = object_builder::map({{"key", "value"}});
 
     std::unordered_set<object_view> persistent{object.at(0)};
 
@@ -594,10 +594,10 @@ TEST(TestKeyIterator, TestExcludeSingleObject)
 
 TEST(TestKeyIterator, TestExcludeMultipleObjects)
 {
-    auto root = owned_object::make_map({{"key", "value"}});
+    auto root = object_builder::map({{"key", "value"}});
 
     auto map =
-        root.emplace("other", owned_object::make_map({{"hello_key", "hello"}, {"bye_key", "bye"}}));
+        root.emplace("other", object_builder::map({{"hello_key", "hello"}, {"bye_key", "bye"}}));
 
     std::unordered_set<object_view> persistent{root.at(0), map.at(1)};
     exclusion::object_set_ref exclude{persistent, {}};
@@ -625,8 +625,8 @@ TEST(TestKeyIterator, TestExcludeMultipleObjects)
 
 TEST(TestKeyIterator, TestExcludeObjectInKeyPath)
 {
-    auto root = owned_object::make_map();
-    auto child = root.emplace("parent", owned_object::make_map());
+    auto root = object_builder::map();
+    auto child = root.emplace("parent", object_builder::map());
     child.emplace("child", "value");
 
     std::unordered_set<object_view> persistent{child.at(0)};
@@ -639,7 +639,7 @@ TEST(TestKeyIterator, TestExcludeObjectInKeyPath)
 
 TEST(TestKeyIterator, TestExcludeRootOfKeyPath)
 {
-    auto root = owned_object::make_map({{"parent", owned_object::make_map({{"child", "value"}})}});
+    auto root = object_builder::map({{"parent", object_builder::map({{"child", "value"}})}});
 
     std::unordered_set<object_view> persistent{root.at(0)};
     exclusion::object_set_ref exclude{persistent, {}};

--- a/tests/unit/module_test.cpp
+++ b/tests/unit/module_test.cpp
@@ -50,7 +50,7 @@ TEST(TestModuleUngrouped, SingleRuleMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -62,7 +62,7 @@ TEST(TestModuleUngrouped, SingleRuleMatch)
     }
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(root);
         std::vector<rule_result> results;
@@ -115,7 +115,7 @@ TEST(TestModuleUngrouped, MultipleMonitoringRuleMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -129,7 +129,7 @@ TEST(TestModuleUngrouped, MultipleMonitoringRuleMatch)
     }
 
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(root);
         std::vector<rule_result> results;
@@ -183,7 +183,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -240,7 +240,7 @@ TEST(TestModuleUngrouped, MonitoringRuleMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -254,7 +254,7 @@ TEST(TestModuleUngrouped, MonitoringRuleMatch)
 
     // Check that we can still match the blocking rule
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.2"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.2"}});
         store.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -310,7 +310,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatchBasePrecedence)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -370,7 +370,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatchUserPrecedence)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -409,7 +409,7 @@ TEST(TestModuleUngrouped, NonExpiringModule)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -446,7 +446,7 @@ TEST(TestModuleUngrouped, ExpiringModule)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -484,7 +484,7 @@ TEST(TestModuleUngrouped, DisabledRules)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -536,7 +536,7 @@ TEST(TestModuleGrouped, MultipleGroupsMonitoringRuleMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -592,7 +592,7 @@ TEST(TestModuleGrouped, MultipleGroupsBlockingRuleMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -647,7 +647,7 @@ TEST(TestModuleGrouped, SingleGroupBlockingRuleMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -701,7 +701,7 @@ TEST(TestModuleGrouped, SingleGroupMonitoringRuleMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -756,7 +756,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupMonitoringUserMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -811,7 +811,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupMonitoringBaseMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -867,7 +867,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupBlockingBaseMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -923,7 +923,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupBlockingUserMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -979,7 +979,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupBlockingBaseMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1035,7 +1035,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupBlockingUserMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1090,7 +1090,7 @@ TEST(TestModuleGrouped, UserPrecedenceMultipleGroupsMonitoringMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1146,7 +1146,7 @@ TEST(TestModuleGrouped, UserPrecedenceMultipleGroupsBlockingMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1201,7 +1201,7 @@ TEST(TestModuleGrouped, BasePrecedenceMultipleGroupsMonitoringMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1257,7 +1257,7 @@ TEST(TestModuleGrouped, BasePrecedenceMultipleGroupsBlockingMatch)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1402,7 +1402,7 @@ TEST(TestModuleGrouped, MultipleGroupsRulesAndMatches)
 
         ddwaf::object_store store;
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.2"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.2"}});
         store.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -1504,7 +1504,7 @@ TEST(TestModuleGrouped, MultipleGroupsSingleMatchPerGroup)
 
         ddwaf::object_store store;
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1607,7 +1607,7 @@ TEST(TestModuleGrouped, MultipleGroupsOnlyBlockingMatch)
 
         ddwaf::object_store store;
 
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1648,7 +1648,7 @@ TEST(TestModuleGrouped, DisabledRules)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1683,7 +1683,7 @@ TEST(TestModuleGrouped, NonExpiringModule)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1720,7 +1720,7 @@ TEST(TestModuleGrouped, ExpiringModule)
 
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -5,13 +5,66 @@
 // Copyright 2021 Datadog, Inc.
 
 #include "common/gtest_utils.hpp"
+#include "memory_resource.hpp"
 #include "object.hpp"
+
 #include <stdexcept>
 
 using namespace ddwaf;
 using namespace std::literals;
 
 namespace {
+
+class counting_resource : public memory::memory_resource {
+public:
+    [[nodiscard]] std::size_t allocations() const { return allocations_; }
+    [[nodiscard]] std::size_t deallocations() const { return deallocations_; }
+
+private:
+    void *do_allocate(std::size_t bytes, std::size_t alignment) override
+    {
+        ++allocations_;
+        return resource_->allocate(bytes, alignment);
+    }
+
+    void do_deallocate(void *ptr, std::size_t bytes, std::size_t alignment) override
+    {
+        ++deallocations_;
+        resource_->deallocate(ptr, bytes, alignment);
+    }
+
+    [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override
+    {
+        return &other == resource_;
+    }
+
+    std::size_t allocations_{0};
+    std::size_t deallocations_{0};
+    memory::memory_resource *resource_{memory::get_default_resource()};
+};
+
+class null_counting_resource : public memory::memory_resource {
+public:
+    [[nodiscard]] std::size_t deallocations() const { return deallocations_; }
+
+private:
+    void *do_allocate(std::size_t /*bytes*/, std::size_t /*alignment*/) override
+    {
+        throw std::bad_alloc();
+    }
+
+    void do_deallocate(void * /*ptr*/, std::size_t /*bytes*/, std::size_t /*alignment*/) override
+    {
+        ++deallocations_;
+    }
+
+    [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override
+    {
+        return &other == memory::get_default_null_resource();
+    }
+
+    std::size_t deallocations_{0};
+};
 
 TEST(TestObject, NullBorrowedObject)
 {
@@ -31,11 +84,6 @@ TEST(TestObject, NullObject)
 {
     {
         auto ow = owned_object::make_null();
-        EXPECT_EQ(ow.type(), object_type::null);
-    }
-
-    {
-        owned_object ow{nullptr};
         EXPECT_EQ(ow.type(), object_type::null);
     }
 }
@@ -126,6 +174,32 @@ TEST(TestObject, StringObject)
     }
 }
 
+TEST(TestObject, StringObjectWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto ow = owned_object::make_string("this is a string", &alloc);
+        EXPECT_EQ(ow.type(), object_type::string);
+        EXPECT_TRUE(ow.is_string());
+        EXPECT_TRUE(ow.is_valid());
+        EXPECT_EQ(ow.as<std::string_view>(), "this is a string");
+    }
+
+    EXPECT_EQ(alloc.allocations(), 1);
+    EXPECT_EQ(alloc.deallocations(), 1);
+
+    {
+        owned_object ow{"this is a string", &alloc};
+        EXPECT_TRUE(ow.is_string());
+        EXPECT_TRUE(ow.is_valid());
+        EXPECT_EQ(ow.as<std::string_view>(), "this is a string");
+    }
+
+    EXPECT_EQ(alloc.allocations(), 2);
+    EXPECT_EQ(alloc.deallocations(), 2);
+}
+
 TEST(TestObject, SmallStringObject)
 {
     {
@@ -154,24 +228,72 @@ TEST(TestObject, StringLiteralObject)
     EXPECT_EQ(ow.as<std::string_view>(), "this is a string");
 }
 
-TEST(TestObject, ArrayObjectInitializer)
+TEST(TestObject, EmptyArrayObject)
 {
-    auto root = owned_object::make_array({"hello", "this", "is", "an", "array"});
+    {
+        auto root = owned_object::make_array();
+        EXPECT_EQ(root.type(), object_type::array);
+        EXPECT_TRUE(root.is_valid());
+        EXPECT_TRUE(root.is_array());
+        EXPECT_TRUE(root.empty());
+        EXPECT_EQ(root.size(), 0);
+    }
+
+    {
+        auto root = owned_object::make_array(0);
+        EXPECT_EQ(root.type(), object_type::array);
+        EXPECT_TRUE(root.is_valid());
+        EXPECT_TRUE(root.is_array());
+        EXPECT_TRUE(root.empty());
+        EXPECT_EQ(root.size(), 0);
+    }
+}
+
+TEST(TestObject, EmptyArrayObjectWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = owned_object::make_array(0, &alloc);
+        EXPECT_EQ(root.type(), object_type::array);
+        EXPECT_TRUE(root.is_valid());
+        EXPECT_TRUE(root.is_array());
+        EXPECT_TRUE(root.empty());
+        EXPECT_EQ(root.size(), 0);
+    }
+
+    EXPECT_EQ(alloc.allocations(), 0);
+    EXPECT_EQ(alloc.deallocations(), 0);
+}
+
+TEST(TestObject, EmptyPreallocatedArrayObject)
+{
+    auto root = owned_object::make_array(20);
     EXPECT_EQ(root.type(), object_type::array);
     EXPECT_TRUE(root.is_valid());
-    EXPECT_EQ(root.size(), 5);
+    EXPECT_TRUE(root.is_array());
+    EXPECT_TRUE(root.empty());
+    EXPECT_EQ(root.size(), 0);
 }
 
-TEST(TestObject, MapObjectInitializer)
+TEST(TestObject, EmptyPreallocatedArrayObjectWithAllocator)
 {
-    auto root = owned_object::make_map({{"hello"sv, owned_object::make_array({"array", "value"})},
-        {"this"sv, "is"sv}, {"an"sv, "array"sv}});
-    EXPECT_EQ(root.type(), object_type::map);
-    EXPECT_TRUE(root.is_valid());
-    EXPECT_EQ(root.size(), 3);
+    counting_resource alloc;
+
+    {
+        auto root = owned_object::make_array(20, &alloc);
+        EXPECT_EQ(root.type(), object_type::array);
+        EXPECT_TRUE(root.is_valid());
+        EXPECT_TRUE(root.is_array());
+        EXPECT_TRUE(root.empty());
+        EXPECT_EQ(root.size(), 0);
+    }
+
+    EXPECT_EQ(alloc.allocations(), 1);
+    EXPECT_EQ(alloc.deallocations(), 1);
 }
 
-TEST(TestObject, ArrayObject)
+TEST(TestObject, ArrayObjectEmplaceBack)
 {
     auto root = owned_object::make_array();
     EXPECT_EQ(root.type(), object_type::array);
@@ -210,7 +332,201 @@ TEST(TestObject, ArrayObject)
     }
 }
 
-TEST(TestObject, MapObject)
+TEST(TestObject, ArrayObjectEmplaceBackWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = owned_object::make_array(0, &alloc);
+        EXPECT_EQ(root.type(), object_type::array);
+        EXPECT_TRUE(root.is_valid());
+
+        for (unsigned i = 0; i < 20; i++) {
+            root.emplace_back(
+                owned_object::make_string(std::to_string(i) + "_012345678901234"s, &alloc));
+        }
+
+        object_view view(root);
+        ASSERT_TRUE(view.has_value());
+        EXPECT_EQ(view.size(), 20);
+        EXPECT_EQ(view.type(), object_type::array);
+        EXPECT_TRUE(view.is_container());
+        EXPECT_FALSE(view.is_scalar());
+        EXPECT_FALSE(view.is_map());
+        EXPECT_TRUE(view.is_array());
+
+        EXPECT_EQ(view.ptr(), root.ptr());
+
+        for (unsigned i = 0; i < 20; i++) {
+            auto expected_value = std::to_string(i) + "_012345678901234";
+
+            {
+                auto [key, value] = view.at(i);
+                EXPECT_FALSE(key.has_value());
+                EXPECT_EQ(value.as<std::string>(), expected_value);
+            }
+
+            {
+                auto value = view.at_value(i);
+                EXPECT_EQ(value.as<std::string>(), expected_value);
+            }
+
+            {
+                auto key = view.at_key(i);
+                EXPECT_FALSE(key.has_value());
+            }
+        }
+    }
+
+    EXPECT_EQ(alloc.allocations(), 23);
+    EXPECT_EQ(alloc.deallocations(), 23);
+}
+
+TEST(TestObject, PreallocatedArrayObjectEmplaceBack)
+{
+    auto root = owned_object::make_array(20);
+    EXPECT_EQ(root.type(), object_type::array);
+    EXPECT_TRUE(root.is_valid());
+
+    for (unsigned i = 0; i < 20; i++) { root.emplace_back(std::to_string(i + 100)); }
+
+    object_view view(root);
+    ASSERT_TRUE(view.has_value());
+    EXPECT_EQ(view.size(), 20);
+    EXPECT_EQ(view.type(), object_type::array);
+    EXPECT_TRUE(view.is_container());
+    EXPECT_FALSE(view.is_scalar());
+    EXPECT_FALSE(view.is_map());
+    EXPECT_TRUE(view.is_array());
+
+    EXPECT_EQ(view.ptr(), root.ptr());
+
+    for (unsigned i = 0; i < 20; i++) {
+        auto expected_value = std::to_string(100 + i);
+        {
+            auto [key, value] = view.at(i);
+            EXPECT_FALSE(key.has_value());
+            EXPECT_EQ(value.as<std::string>(), expected_value);
+        }
+
+        {
+            auto value = view.at_value(i);
+            EXPECT_EQ(value.as<std::string>(), expected_value);
+        }
+
+        {
+            auto key = view.at_key(i);
+            EXPECT_FALSE(key.has_value());
+        }
+    }
+}
+
+TEST(TestObject, PreallocatedArrayObjectEmplaceBackWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = owned_object::make_array(20, &alloc);
+        EXPECT_EQ(root.type(), object_type::array);
+        EXPECT_TRUE(root.is_valid());
+
+        for (unsigned i = 0; i < 20; i++) {
+            root.emplace_back(
+                owned_object::make_string(std::to_string(i) + "_012345678901234"s, &alloc));
+        }
+
+        object_view view(root);
+        ASSERT_TRUE(view.has_value());
+        EXPECT_EQ(view.size(), 20);
+        EXPECT_EQ(view.type(), object_type::array);
+        EXPECT_TRUE(view.is_container());
+        EXPECT_FALSE(view.is_scalar());
+        EXPECT_FALSE(view.is_map());
+        EXPECT_TRUE(view.is_array());
+
+        EXPECT_EQ(view.ptr(), root.ptr());
+
+        for (unsigned i = 0; i < 20; i++) {
+            auto expected_value = std::to_string(i) + "_012345678901234";
+
+            {
+                auto [key, value] = view.at(i);
+                EXPECT_FALSE(key.has_value());
+                EXPECT_EQ(value.as<std::string>(), expected_value);
+            }
+
+            {
+                auto value = view.at_value(i);
+                EXPECT_EQ(value.as<std::string>(), expected_value);
+            }
+
+            {
+                auto key = view.at_key(i);
+                EXPECT_FALSE(key.has_value());
+            }
+        }
+    }
+
+    EXPECT_EQ(alloc.allocations(), 21);
+    EXPECT_EQ(alloc.deallocations(), 21);
+}
+
+TEST(TestObject, ArrayObjectIncompatibleAllocators)
+{
+    memory::monotonic_buffer_resource alloc;
+
+    auto root = owned_object::make_array(20);
+    EXPECT_THROW(root.emplace_back(owned_object::make_string("012345678901234"sv, &alloc)),
+        std::runtime_error);
+}
+
+TEST(TestObject, EmptyMapObject)
+{
+    auto root = owned_object::make_map(0);
+    EXPECT_EQ(root.type(), object_type::map);
+    EXPECT_TRUE(root.is_valid());
+    EXPECT_TRUE(root.empty());
+}
+
+TEST(TestObject, EmptyMapObjectWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = owned_object::make_map(0, &alloc);
+        EXPECT_EQ(root.type(), object_type::map);
+        EXPECT_TRUE(root.is_valid());
+        EXPECT_TRUE(root.empty());
+    }
+
+    EXPECT_EQ(alloc.allocations(), 0);
+    EXPECT_EQ(alloc.deallocations(), 0);
+}
+
+TEST(TestObject, EmptyPreallocatedMapObject)
+{
+    auto root = owned_object::make_map(20);
+    EXPECT_EQ(root.type(), object_type::map);
+    EXPECT_TRUE(root.is_valid());
+    EXPECT_TRUE(root.empty());
+}
+
+TEST(TestObject, EmptyPreallocatedMapObjectWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = owned_object::make_map(20, &alloc);
+        EXPECT_EQ(root.type(), object_type::map);
+        EXPECT_TRUE(root.is_valid());
+        EXPECT_TRUE(root.empty());
+    }
+
+    EXPECT_EQ(alloc.allocations(), 1);
+    EXPECT_EQ(alloc.deallocations(), 1);
+}
+
+TEST(TestObject, MapObjectEmplace)
 {
     auto root = owned_object::make_map();
     EXPECT_EQ(root.type(), object_type::map);
@@ -247,6 +563,397 @@ TEST(TestObject, MapObject)
             auto key = view.at_key(i);
             EXPECT_EQ(key.as<std::string_view>(), expected_key);
         }
+    }
+}
+
+TEST(TestObject, MapObjectEmplaceWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = owned_object::make_map(0, &alloc);
+        EXPECT_EQ(root.type(), object_type::map);
+        EXPECT_TRUE(root.is_valid());
+
+        for (unsigned i = 0; i < 20; i++) {
+            root.emplace(std::to_string(i),
+                owned_object::make_string(std::to_string(i) + "_012345678901234"s, &alloc));
+        }
+
+        object_view view(root);
+        ASSERT_TRUE(view.has_value());
+        EXPECT_EQ(view.size(), 20);
+        EXPECT_EQ(view.type(), object_type::map);
+        EXPECT_TRUE(view.is_container());
+        EXPECT_FALSE(view.is_scalar());
+        EXPECT_TRUE(view.is_map());
+        EXPECT_FALSE(view.is_array());
+
+        EXPECT_EQ(view.ptr(), root.ptr());
+
+        for (unsigned i = 0; i < 20; i++) {
+            auto expected_key = std::to_string(i);
+            auto expected_value = std::to_string(i) + "_012345678901234"s;
+
+            {
+                auto [key, value] = view.at(i);
+                EXPECT_EQ(key.as<std::string_view>(), expected_key);
+                EXPECT_EQ(value.as<std::string_view>(), expected_value);
+            }
+
+            {
+                auto value = view.at_value(i);
+                EXPECT_EQ(value.as<std::string>(), expected_value);
+            }
+
+            {
+                auto key = view.at_key(i);
+                EXPECT_EQ(key.as<std::string_view>(), expected_key);
+            }
+        }
+    }
+
+    EXPECT_EQ(alloc.allocations(), 23);
+    EXPECT_EQ(alloc.deallocations(), 23);
+}
+
+TEST(TestObject, PreallocatedMapObjectEmplace)
+{
+    auto root = owned_object::make_map(20);
+    EXPECT_EQ(root.type(), object_type::map);
+    EXPECT_TRUE(root.is_valid());
+
+    for (unsigned i = 0; i < 20; i++) { root.emplace(std::to_string(i), std::to_string(i + 100)); }
+
+    object_view view(root);
+    ASSERT_TRUE(view.has_value());
+    EXPECT_EQ(view.size(), 20);
+    EXPECT_EQ(view.type(), object_type::map);
+    EXPECT_TRUE(view.is_container());
+    EXPECT_FALSE(view.is_scalar());
+    EXPECT_TRUE(view.is_map());
+    EXPECT_FALSE(view.is_array());
+
+    EXPECT_EQ(view.ptr(), root.ptr());
+
+    for (unsigned i = 0; i < 20; i++) {
+        auto expected_key = std::to_string(i);
+        auto expected_value = std::to_string(100 + i);
+        {
+            auto [key, value] = view.at(i);
+            EXPECT_EQ(key.as<std::string_view>(), expected_key);
+            EXPECT_EQ(value.as<std::string_view>(), expected_value);
+        }
+
+        {
+            auto value = view.at_value(i);
+            EXPECT_EQ(value.as<std::string>(), expected_value);
+        }
+
+        {
+            auto key = view.at_key(i);
+            EXPECT_EQ(key.as<std::string_view>(), expected_key);
+        }
+    }
+}
+
+TEST(TestObject, PreallocatedMapObjectEmplaceWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = owned_object::make_map(20, &alloc);
+        EXPECT_EQ(root.type(), object_type::map);
+        EXPECT_TRUE(root.is_valid());
+
+        for (unsigned i = 0; i < 20; i++) {
+            root.emplace(std::to_string(i),
+                owned_object::make_string(std::to_string(i) + "_012345678901234"s, &alloc));
+        }
+
+        object_view view(root);
+        ASSERT_TRUE(view.has_value());
+        EXPECT_EQ(view.size(), 20);
+        EXPECT_EQ(view.type(), object_type::map);
+        EXPECT_TRUE(view.is_container());
+        EXPECT_FALSE(view.is_scalar());
+        EXPECT_TRUE(view.is_map());
+        EXPECT_FALSE(view.is_array());
+
+        EXPECT_EQ(view.ptr(), root.ptr());
+
+        for (unsigned i = 0; i < 20; i++) {
+            auto expected_key = std::to_string(i);
+            auto expected_value = std::to_string(i) + "_012345678901234"s;
+
+            {
+                auto [key, value] = view.at(i);
+                EXPECT_EQ(key.as<std::string_view>(), expected_key);
+                EXPECT_EQ(value.as<std::string_view>(), expected_value);
+            }
+
+            {
+                auto value = view.at_value(i);
+                EXPECT_EQ(value.as<std::string>(), expected_value);
+            }
+
+            {
+                auto key = view.at_key(i);
+                EXPECT_EQ(key.as<std::string_view>(), expected_key);
+            }
+        }
+    }
+
+    EXPECT_EQ(alloc.allocations(), 21);
+    EXPECT_EQ(alloc.deallocations(), 21);
+}
+
+TEST(TestObject, MapObjectIncompatibleAllocators)
+{
+    memory::monotonic_buffer_resource alloc;
+
+    auto root = owned_object::make_map(20);
+    EXPECT_THROW(root.emplace("key"sv, owned_object::make_string("012345678901234"sv, &alloc)),
+        std::runtime_error);
+}
+
+TEST(TestObject, ArrayObjectBuilder)
+{
+    auto root = object_builder::array({"hello", "this", "is", "an", "array"});
+    EXPECT_EQ(root.type(), object_type::array);
+    EXPECT_TRUE(root.is_valid());
+    EXPECT_EQ(root.size(), 5);
+}
+
+TEST(TestObject, MapObjectBuilder)
+{
+    auto root = object_builder::map({{"hello"sv, object_builder::array({"array", "value"})},
+        {"this"sv, "is"sv}, {"an"sv, "array"sv}});
+    EXPECT_EQ(root.type(), object_type::map);
+    EXPECT_TRUE(root.is_valid());
+    EXPECT_EQ(root.size(), 3);
+}
+
+TEST(TestObject, HeterogenousArrayObjectBuilder)
+{
+    auto root = object_builder::array({object_builder::array({"array", "value"}),
+        object_builder::map({{"map", "value"}}), "small"sv, "this is a normal string view"sv,
+        "this is a normal string"s, "this is a normal const char *", false,
+        static_cast<int16_t>(-16), static_cast<uint16_t>(16), static_cast<int32_t>(-32),
+        static_cast<uint32_t>(32), static_cast<int64_t>(-64), static_cast<uint64_t>(64), 64.64});
+    EXPECT_EQ(root.type(), object_type::array);
+    EXPECT_TRUE(root.is_valid());
+    EXPECT_EQ(root.size(), 14);
+
+    EXPECT_EQ(root.at(0).type(), object_type::array);
+    EXPECT_EQ(root.at(1).type(), object_type::map);
+    EXPECT_EQ(root.at(2).type(), object_type::small_string);
+    EXPECT_EQ(root.at(3).type(), object_type::string);
+    EXPECT_EQ(root.at(4).type(), object_type::string);
+    EXPECT_EQ(root.at(5).type(), object_type::string);
+    EXPECT_EQ(root.at(6).type(), object_type::boolean);
+    EXPECT_EQ(root.at(7).type(), object_type::int64);
+    EXPECT_EQ(root.at(8).type(), object_type::uint64);
+    EXPECT_EQ(root.at(9).type(), object_type::int64);
+    EXPECT_EQ(root.at(10).type(), object_type::uint64);
+    EXPECT_EQ(root.at(11).type(), object_type::int64);
+    EXPECT_EQ(root.at(12).type(), object_type::uint64);
+    EXPECT_EQ(root.at(13).type(), object_type::float64);
+}
+
+TEST(TestObject, HeterogenousMapObjectBuilder)
+{
+    auto root = object_builder::map({
+        {"array"sv, object_builder::array({"array", "value"})},
+        {"map"sv, object_builder::map({{"map", "value"}})},
+        {"small string"sv, "small"sv},
+        {"string view"sv, "this is a normal string view"sv},
+        {"string"sv, "this is a normal string"s},
+        {"const char *"sv, "this is a normal const char *"},
+        {"bool"sv, false},
+        {"int16"sv, static_cast<int16_t>(-16)},
+        {"uint16"sv, static_cast<uint16_t>(16)},
+        {"int32"sv, static_cast<int32_t>(-32)},
+        {"uint32"sv, static_cast<uint32_t>(32)},
+        {"int64"sv, static_cast<int64_t>(-64)},
+        {"uint64"sv, static_cast<uint64_t>(64)},
+        {"float"sv, 64.64},
+    });
+    EXPECT_EQ(root.type(), object_type::map);
+    EXPECT_TRUE(root.is_valid());
+    EXPECT_EQ(root.size(), 14);
+
+    EXPECT_EQ(root.at(0).type(), object_type::array);
+    EXPECT_EQ(root.at(1).type(), object_type::map);
+    EXPECT_EQ(root.at(2).type(), object_type::small_string);
+    EXPECT_EQ(root.at(3).type(), object_type::string);
+    EXPECT_EQ(root.at(4).type(), object_type::string);
+    EXPECT_EQ(root.at(5).type(), object_type::string);
+    EXPECT_EQ(root.at(6).type(), object_type::boolean);
+    EXPECT_EQ(root.at(7).type(), object_type::int64);
+    EXPECT_EQ(root.at(8).type(), object_type::uint64);
+    EXPECT_EQ(root.at(9).type(), object_type::int64);
+    EXPECT_EQ(root.at(10).type(), object_type::uint64);
+    EXPECT_EQ(root.at(11).type(), object_type::int64);
+    EXPECT_EQ(root.at(12).type(), object_type::uint64);
+    EXPECT_EQ(root.at(13).type(), object_type::float64);
+}
+
+TEST(TestObject, HeterogenousArrayObjectBuilderWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = object_builder::array(
+            {object_builder::array({"array", "value"}, &alloc),
+                object_builder::map({{"map", "value"}}, &alloc), "small"sv,
+                "this is a normal string view"sv, "this is a normal string"s,
+                "this is a normal const char *", false, static_cast<int16_t>(-16),
+                static_cast<uint16_t>(16), static_cast<int32_t>(-32), static_cast<uint32_t>(32),
+                static_cast<int64_t>(-64), static_cast<uint64_t>(64), 64.64},
+            &alloc);
+        EXPECT_EQ(root.type(), object_type::array);
+        EXPECT_TRUE(root.is_valid());
+        EXPECT_EQ(root.size(), 14);
+
+        EXPECT_EQ(root.at(0).type(), object_type::array);
+        EXPECT_EQ(root.at(1).type(), object_type::map);
+        EXPECT_EQ(root.at(2).type(), object_type::small_string);
+        EXPECT_EQ(root.at(3).type(), object_type::string);
+        EXPECT_EQ(root.at(4).type(), object_type::string);
+        EXPECT_EQ(root.at(5).type(), object_type::string);
+        EXPECT_EQ(root.at(6).type(), object_type::boolean);
+        EXPECT_EQ(root.at(7).type(), object_type::int64);
+        EXPECT_EQ(root.at(8).type(), object_type::uint64);
+        EXPECT_EQ(root.at(9).type(), object_type::int64);
+        EXPECT_EQ(root.at(10).type(), object_type::uint64);
+        EXPECT_EQ(root.at(11).type(), object_type::int64);
+        EXPECT_EQ(root.at(12).type(), object_type::uint64);
+        EXPECT_EQ(root.at(13).type(), object_type::float64);
+    }
+
+    EXPECT_EQ(alloc.allocations(), 6);
+    EXPECT_EQ(alloc.deallocations(), 6);
+}
+
+TEST(TestObject, HeterogenousMapObjectBuilderWithAllocator)
+{
+    counting_resource alloc;
+
+    {
+        auto root = object_builder::map(
+            {
+                {"array"sv, object_builder::array({"array", "value"}, &alloc)},
+                {"map"sv, object_builder::map({{"map", "value"}}, &alloc)},
+                {"small string"sv, "is"sv},
+                {"string view key"sv, "this is a normal string view"sv},
+                {"standard string key"sv, "this is a normal string"s},
+                {"const char *"sv, "this is a normal const char *"},
+                {"bool"sv, false},
+                {"int16"sv, static_cast<int16_t>(-16)},
+                {"uint16"sv, static_cast<uint16_t>(16)},
+                {"int32"sv, static_cast<int32_t>(-32)},
+                {"uint32"sv, static_cast<uint32_t>(32)},
+                {"int64"sv, static_cast<int64_t>(-64)},
+                {"uint64"sv, static_cast<uint64_t>(64)},
+                {"float"sv, 64.64},
+            },
+            &alloc);
+
+        EXPECT_EQ(root.type(), object_type::map);
+        EXPECT_TRUE(root.is_valid());
+        EXPECT_EQ(root.size(), 14);
+
+        EXPECT_EQ(root.at(0).type(), object_type::array);
+        EXPECT_EQ(root.at(1).type(), object_type::map);
+        EXPECT_EQ(root.at(2).type(), object_type::small_string);
+        EXPECT_EQ(root.at(3).type(), object_type::string);
+        EXPECT_EQ(root.at(4).type(), object_type::string);
+        EXPECT_EQ(root.at(5).type(), object_type::string);
+        EXPECT_EQ(root.at(6).type(), object_type::boolean);
+        EXPECT_EQ(root.at(7).type(), object_type::int64);
+        EXPECT_EQ(root.at(8).type(), object_type::uint64);
+        EXPECT_EQ(root.at(9).type(), object_type::int64);
+        EXPECT_EQ(root.at(10).type(), object_type::uint64);
+        EXPECT_EQ(root.at(11).type(), object_type::int64);
+        EXPECT_EQ(root.at(12).type(), object_type::uint64);
+        EXPECT_EQ(root.at(13).type(), object_type::float64);
+    }
+
+    EXPECT_EQ(alloc.allocations(), 8);
+    EXPECT_EQ(alloc.deallocations(), 8);
+}
+
+TEST(TestObject, ArrayObjectBuilderIncompatibleAllocator)
+{
+    memory::monotonic_buffer_resource alloc;
+
+    EXPECT_THROW(
+        object_builder::array(
+            {"hello", "this", "is", "an", "array", object_builder::array({"hello"})}, &alloc),
+        std::runtime_error);
+    EXPECT_THROW(object_builder::array({"hello", "this", "is", "an", "array",
+                                           object_builder::map({{"hello", "bye"}})},
+                     &alloc),
+        std::runtime_error);
+
+    EXPECT_THROW(object_builder::array({"hello", "this", "is", "an", "array",
+                     object_builder::array({"hello"}, &alloc)}),
+        std::runtime_error);
+    EXPECT_THROW(object_builder::array({"hello", "this", "is", "an", "array",
+                     object_builder::map({{"hello", "bye"}}, &alloc)}),
+        std::runtime_error);
+}
+
+TEST(TestObject, MapObjectBuilderIncompatibleAllocators)
+{
+    memory::monotonic_buffer_resource alloc;
+    EXPECT_THROW(object_builder::map({{"hello"sv, object_builder::array({"array", "value"})},
+                                         {"this"sv, "is"sv}, {"an"sv, "array"sv}},
+                     &alloc),
+        std::runtime_error);
+    EXPECT_THROW(object_builder::map({{"hello"sv, object_builder::map({{"array", "value"}})},
+                                         {"this"sv, "is"sv}, {"an"sv, "array"sv}},
+                     &alloc),
+        std::runtime_error);
+
+    EXPECT_THROW(
+        object_builder::map({{"hello"sv, object_builder::array({"array", "value"}, &alloc)},
+            {"this"sv, "is"sv}, {"an"sv, "array"sv}}),
+        std::runtime_error);
+    EXPECT_THROW(
+        object_builder::map({{"hello"sv, object_builder::map({{"array", "value"}}, &alloc)},
+            {"this"sv, "is"sv}, {"an"sv, "array"sv}}),
+        std::runtime_error);
+}
+
+TEST(TestObject, ObjectWithNullAllocator)
+{
+    auto root = object_builder::map({
+        {"array"sv, object_builder::array({"array", "value"})},
+        {"map"sv, object_builder::map({{"map", "value"}})},
+        {"small string"sv, "small"sv},
+        {"string view"sv, "this is a normal string view"sv},
+        {"string"sv, "this is a normal string"s},
+        {"const char *"sv, "this is a normal const char *"},
+        {"bool"sv, false},
+        {"int16"sv, static_cast<int16_t>(-16)},
+        {"uint16"sv, static_cast<uint16_t>(16)},
+        {"int32"sv, static_cast<int32_t>(-32)},
+        {"uint32"sv, static_cast<uint32_t>(32)},
+        {"int64"sv, static_cast<int64_t>(-64)},
+        {"uint64"sv, static_cast<uint64_t>(64)},
+        {"float"sv, 64.64},
+    });
+
+    // Create a new owned_object using the internal reference to ensure it's not
+    // double freed
+    {
+        null_counting_resource alloc;
+        {
+            owned_object other{root.ref(), &alloc};
+        }
+        EXPECT_EQ(alloc.deallocations(), 0);
     }
 }
 
@@ -301,6 +1008,24 @@ TEST(TestObject, CloneFloat)
 TEST(TestObject, CloneString)
 {
     auto input = owned_object::make_string("this is a string");
+    auto output = input.clone();
+    EXPECT_TRUE(output.is_string());
+    EXPECT_EQ(input.as<std::string_view>(), output.as<std::string_view>());
+    EXPECT_EQ(input.size(), output.size());
+}
+
+TEST(TestObject, CloneSmallString)
+{
+    auto input = owned_object::make_string("this");
+    auto output = input.clone();
+    EXPECT_TRUE(output.is_string());
+    EXPECT_EQ(input.as<std::string_view>(), output.as<std::string_view>());
+    EXPECT_EQ(input.size(), output.size());
+}
+
+TEST(TestObject, CloneStringLiteral)
+{
+    auto input = owned_object::make_string_literal(STRL("this"));
     auto output = input.clone();
     EXPECT_TRUE(output.is_string());
     EXPECT_EQ(input.as<std::string_view>(), output.as<std::string_view>());
@@ -365,7 +1090,7 @@ TEST(TestObject, CloneArray)
 
 TEST(TestObject, CloneMap)
 {
-    auto input = owned_object::make_map({{"bool", true}, {"string", "string"}, {"signed", 5}});
+    auto input = object_builder::map({{"bool", true}, {"string", "string"}, {"signed", 5}});
 
     auto output = input.clone();
     EXPECT_EQ(output.type(), object_type::map);
@@ -397,6 +1122,257 @@ TEST(TestObject, CloneMap)
 
         EXPECT_EQ(output_child.type(), input_child.type());
         EXPECT_EQ(output_child.as<int64_t>(), input_child.as<int64_t>());
+    }
+}
+
+TEST(TestObject, CloneHeterogenous)
+{
+    auto input = object_builder::map({{"bool", true}, {"string", "string"}, {"signed", 5},
+        {"array", object_builder::array({"1", 2, "3", 4})}});
+
+    auto output = input.clone();
+    EXPECT_EQ(output.type(), object_type::map);
+    EXPECT_EQ(input.size(), output.size());
+
+    {
+        auto input_child = input.at(0);
+        auto output_child = output.at(0);
+
+        EXPECT_EQ(output_child.type(), input_child.type());
+        EXPECT_EQ(output_child.as<bool>(), input_child.as<bool>());
+    }
+
+    {
+        auto input_child = input.at(1);
+        auto output_child = output.at(1);
+
+        EXPECT_EQ(output_child.type(), input_child.type());
+
+        auto output_str = output_child.as<std::string_view>();
+        auto input_str = input_child.as<std::string_view>();
+        EXPECT_EQ(output_str, input_str);
+        EXPECT_NE(output_str.data(), input_str.data());
+    }
+
+    {
+        auto input_child = input.at(2);
+        auto output_child = output.at(2);
+
+        EXPECT_EQ(output_child.type(), input_child.type());
+        EXPECT_EQ(output_child.as<int64_t>(), input_child.as<int64_t>());
+    }
+
+    {
+        auto input_child = input.at(3);
+        auto output_child = output.at(3);
+
+        EXPECT_EQ(output_child.type(), input_child.type());
+        EXPECT_EQ(output_child.size(), input_child.size());
+
+        {
+            auto input_grandchild = input_child.at(0);
+            auto output_grandchild = output_child.at(0);
+
+            EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+            EXPECT_STR(
+                output_grandchild.as<std::string_view>(), input_grandchild.as<std::string_view>());
+        }
+
+        {
+            auto input_grandchild = input_child.at(1);
+            auto output_grandchild = output_child.at(1);
+
+            EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+            EXPECT_EQ(output_grandchild.as<int64_t>(), input_grandchild.as<int64_t>());
+        }
+
+        {
+            auto input_grandchild = input_child.at(2);
+            auto output_grandchild = output_child.at(2);
+
+            EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+            EXPECT_STR(
+                output_grandchild.as<std::string_view>(), input_grandchild.as<std::string_view>());
+        }
+
+        {
+            auto input_grandchild = input_child.at(3);
+            auto output_grandchild = output_child.at(3);
+
+            EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+            EXPECT_EQ(output_grandchild.as<int64_t>(), input_grandchild.as<int64_t>());
+        }
+    }
+}
+
+TEST(TestObject, CloneHeterogenousWithAllocator)
+{
+    auto input = object_builder::map(
+        {{"bool value key ...", true}, {"string value key", "string value value"},
+            {"signed value key", 5}, {"array value key", object_builder::array({"1", 2, "3", 4})}});
+
+    counting_resource alloc;
+
+    {
+        auto output = input.clone(&alloc);
+        EXPECT_EQ(output.type(), object_type::map);
+        EXPECT_EQ(input.size(), output.size());
+
+        {
+            auto input_child = input.at(0);
+            auto output_child = output.at(0);
+
+            EXPECT_EQ(output_child.type(), input_child.type());
+            EXPECT_EQ(output_child.as<bool>(), input_child.as<bool>());
+        }
+
+        {
+            auto input_child = input.at(1);
+            auto output_child = output.at(1);
+
+            EXPECT_EQ(output_child.type(), input_child.type());
+
+            auto output_str = output_child.as<std::string_view>();
+            auto input_str = input_child.as<std::string_view>();
+            EXPECT_EQ(output_str, input_str);
+            EXPECT_NE(output_str.data(), input_str.data());
+        }
+
+        {
+            auto input_child = input.at(2);
+            auto output_child = output.at(2);
+
+            EXPECT_EQ(output_child.type(), input_child.type());
+            EXPECT_EQ(output_child.as<int64_t>(), input_child.as<int64_t>());
+        }
+
+        {
+            auto input_child = input.at(3);
+            auto output_child = output.at(3);
+
+            EXPECT_EQ(output_child.type(), input_child.type());
+            EXPECT_EQ(output_child.size(), input_child.size());
+
+            {
+                auto input_grandchild = input_child.at(0);
+                auto output_grandchild = output_child.at(0);
+
+                EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+                EXPECT_STR(output_grandchild.as<std::string_view>(),
+                    input_grandchild.as<std::string_view>());
+            }
+
+            {
+                auto input_grandchild = input_child.at(1);
+                auto output_grandchild = output_child.at(1);
+
+                EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+                EXPECT_EQ(output_grandchild.as<int64_t>(), input_grandchild.as<int64_t>());
+            }
+
+            {
+                auto input_grandchild = input_child.at(2);
+                auto output_grandchild = output_child.at(2);
+
+                EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+                EXPECT_STR(output_grandchild.as<std::string_view>(),
+                    input_grandchild.as<std::string_view>());
+            }
+
+            {
+                auto input_grandchild = input_child.at(3);
+                auto output_grandchild = output_child.at(3);
+
+                EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+                EXPECT_EQ(output_grandchild.as<int64_t>(), input_grandchild.as<int64_t>());
+            }
+        }
+    }
+
+    EXPECT_EQ(alloc.allocations(), 7);
+    EXPECT_EQ(alloc.deallocations(), 7);
+}
+
+TEST(TestObject, CloneHeterogenousWithIncompatibleAllocator)
+{
+    auto input = object_builder::map(
+        {{"bool value key ...", true}, {"string value key", "string value value"},
+            {"signed value key", 5}, {"array value key", object_builder::array({"1", 2, "3", 4})}});
+
+    memory::monotonic_buffer_resource alloc;
+
+    auto output = input.clone(&alloc);
+    EXPECT_EQ(output.type(), object_type::map);
+    EXPECT_EQ(input.size(), output.size());
+
+    {
+        auto input_child = input.at(0);
+        auto output_child = output.at(0);
+
+        EXPECT_EQ(output_child.type(), input_child.type());
+        EXPECT_EQ(output_child.as<bool>(), input_child.as<bool>());
+    }
+
+    {
+        auto input_child = input.at(1);
+        auto output_child = output.at(1);
+
+        EXPECT_EQ(output_child.type(), input_child.type());
+
+        auto output_str = output_child.as<std::string_view>();
+        auto input_str = input_child.as<std::string_view>();
+        EXPECT_EQ(output_str, input_str);
+        EXPECT_NE(output_str.data(), input_str.data());
+    }
+
+    {
+        auto input_child = input.at(2);
+        auto output_child = output.at(2);
+
+        EXPECT_EQ(output_child.type(), input_child.type());
+        EXPECT_EQ(output_child.as<int64_t>(), input_child.as<int64_t>());
+    }
+
+    {
+        auto input_child = input.at(3);
+        auto output_child = output.at(3);
+
+        EXPECT_EQ(output_child.type(), input_child.type());
+        EXPECT_EQ(output_child.size(), input_child.size());
+
+        {
+            auto input_grandchild = input_child.at(0);
+            auto output_grandchild = output_child.at(0);
+
+            EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+            EXPECT_STR(
+                output_grandchild.as<std::string_view>(), input_grandchild.as<std::string_view>());
+        }
+
+        {
+            auto input_grandchild = input_child.at(1);
+            auto output_grandchild = output_child.at(1);
+
+            EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+            EXPECT_EQ(output_grandchild.as<int64_t>(), input_grandchild.as<int64_t>());
+        }
+
+        {
+            auto input_grandchild = input_child.at(2);
+            auto output_grandchild = output_child.at(2);
+
+            EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+            EXPECT_STR(
+                output_grandchild.as<std::string_view>(), input_grandchild.as<std::string_view>());
+        }
+
+        {
+            auto input_grandchild = input_child.at(3);
+            auto output_grandchild = output_child.at(3);
+
+            EXPECT_EQ(output_grandchild.type(), input_grandchild.type());
+            EXPECT_EQ(output_grandchild.as<int64_t>(), input_grandchild.as<int64_t>());
+        }
     }
 }
 

--- a/tests/unit/object_view_test.cpp
+++ b/tests/unit/object_view_test.cpp
@@ -45,7 +45,7 @@ TEST(TestObjectView, InvalidObject)
 
 TEST(TestObjectView, NullObject)
 {
-    owned_object original{nullptr};
+    auto original = owned_object::make_null();
 
     object_view view(original);
 
@@ -514,10 +514,10 @@ TEST(TestObjectView, AsOrDefault)
 
 TEST(TestObjectView, KeyPathAccess)
 {
-    auto root = owned_object::make_map({
-        {"1", owned_object::make_map({{"1.2", 111}, {"1.3", 123}})},
-        {"2", owned_object::make_map({{"2.1", owned_object::make_map({{"2.1.1", 9}})}})},
-        {"3", owned_object::make_array({"3.1"})},
+    auto root = object_builder::map({
+        {"1", object_builder::map({{"1.2", 111}, {"1.3", 123}})},
+        {"2", object_builder::map({{"2.1", object_builder::map({{"2.1.1", 9}})}})},
+        {"3", object_builder::array({"3.1"})},
     });
 
     object_view view(root);
@@ -893,10 +893,10 @@ TEST(TestMapView, IteratorAccess)
 
 TEST(TestMapView, KeyPathAccess)
 {
-    auto root = owned_object::make_map({
-        {"1", owned_object::make_map({{"1.2", 111}, {"1.3", 123}})},
-        {"2", owned_object::make_map({{"2.1", owned_object::make_map({{"2.1.1", 9}})}})},
-        {"3", owned_object::make_array({"3.1"})},
+    auto root = object_builder::map({
+        {"1", object_builder::map({{"1.2", 111}, {"1.3", 123}})},
+        {"2", object_builder::map({{"2.1", object_builder::map({{"2.1.1", 9}})}})},
+        {"3", object_builder::array({"3.1"})},
     });
 
     map_view view(root);

--- a/tests/unit/processor/extract_schema_test.cpp
+++ b/tests/unit/processor/extract_schema_test.cpp
@@ -27,7 +27,7 @@ TEST(TestExtractSchema, UnknownScalarSchema)
 
 TEST(TestExtractSchema, NullScalarSchema)
 {
-    owned_object input{nullptr};
+    auto input = owned_object::make_null();
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -99,7 +99,7 @@ TEST(TestExtractSchema, FloatScalarSchema)
 
 TEST(TestExtractSchema, EmptyArraySchema)
 {
-    auto input = owned_object::make_array();
+    auto input = object_builder::array();
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -111,7 +111,7 @@ TEST(TestExtractSchema, EmptyArraySchema)
 
 TEST(TestExtractSchema, ArraySchema)
 {
-    auto input = owned_object::make_array({22, "string", owned_object{}, nullptr});
+    auto input = object_builder::array({22, "string", owned_object{}, owned_object::make_null()});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -123,7 +123,7 @@ TEST(TestExtractSchema, ArraySchema)
 
 TEST(TestExtractSchema, ArrayWithDuplicateScalarSchema)
 {
-    auto input = owned_object::make_array({"string", "string", "string", "string"});
+    auto input = object_builder::array({"string", "string", "string", "string"});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -135,10 +135,9 @@ TEST(TestExtractSchema, ArrayWithDuplicateScalarSchema)
 
 TEST(TestExtractSchema, ArrayWithDuplicateMapsSchema)
 {
-    auto input =
-        owned_object::make_array({owned_object::make_map({{"unsigned", 5}, {"string", "str"}}),
-            owned_object::make_map({{"signed", -5}}), owned_object::make_map({{"unsigned", 5}}),
-            owned_object::make_map({{"unsigned", 109}, {"string", "wahtever"}})});
+    auto input = object_builder::array({object_builder::map({{"unsigned", 5}, {"string", "str"}}),
+        object_builder::map({{"signed", -5}}), object_builder::map({{"unsigned", 5}}),
+        object_builder::map({{"unsigned", 109}, {"string", "wahtever"}})});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -151,9 +150,9 @@ TEST(TestExtractSchema, ArrayWithDuplicateMapsSchema)
 
 TEST(TestExtractSchema, ArrayWithDuplicateArraysSchema)
 {
-    auto input = owned_object::make_array(
-        {owned_object::make_array({5, "str"}), owned_object::make_array({-5}),
-            owned_object::make_array({5}), owned_object::make_array({109, "wahtever"})});
+    auto input =
+        object_builder::array({object_builder::array({5, "str"}), object_builder::array({-5}),
+            object_builder::array({5}), object_builder::array({109, "wahtever"})});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -165,10 +164,9 @@ TEST(TestExtractSchema, ArrayWithDuplicateArraysSchema)
 
 TEST(TestExtractSchema, ArrayWithDuplicateContainersSchema)
 {
-    auto input =
-        owned_object::make_array({owned_object::make_map({{"unsigned", 5}, {"string", "str"}}),
-            owned_object::make_array({-5}), owned_object::make_array({5}),
-            owned_object::make_map({{"string", "wahtever"}, {"unsigned", 109}})});
+    auto input = object_builder::array({object_builder::map({{"unsigned", 5}, {"string", "str"}}),
+        object_builder::array({-5}), object_builder::array({5}),
+        object_builder::map({{"string", "wahtever"}, {"unsigned", 109}})});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -181,7 +179,7 @@ TEST(TestExtractSchema, ArrayWithDuplicateContainersSchema)
 
 TEST(TestExtractSchema, EmptyMapSchema)
 {
-    auto input = owned_object::make_map();
+    auto input = object_builder::map();
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -193,10 +191,10 @@ TEST(TestExtractSchema, EmptyMapSchema)
 
 TEST(TestExtractSchema, MapSchema)
 {
-    auto input = owned_object::make_map(
-        {{"unsigned", 22}, {"string", "string"}, {"invalid", owned_object{}}, {"null", nullptr},
-            {"map", owned_object::make_map({{"unsigned", 5}, {"string", "str"}})},
-            {"array", owned_object::make_array({-5})}});
+    auto input = object_builder::map({{"unsigned", 22}, {"string", "string"},
+        {"invalid", owned_object{}}, {"null", owned_object::make_null()},
+        {"map", object_builder::map({{"unsigned", 5}, {"string", "str"}})},
+        {"array", object_builder::array({-5})}});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -209,10 +207,10 @@ TEST(TestExtractSchema, MapSchema)
 
 TEST(TestExtractSchema, DepthLimit)
 {
-    auto input = owned_object::make_array();
+    auto input = object_builder::array();
     borrowed_object parent{input};
     for (unsigned i = 0; i < extract_schema::max_container_depth + 10; ++i) {
-        parent = parent.emplace_back(owned_object::make_array());
+        parent = parent.emplace_back(object_builder::array());
     }
 
     extract_schema gen{"id", {}, {}, {}, false, true};
@@ -226,9 +224,9 @@ TEST(TestExtractSchema, DepthLimit)
 
 TEST(TestExtractSchema, ArrayNodesLimit)
 {
-    auto input = owned_object::make_array();
+    auto input = object_builder::array();
     for (unsigned i = 0; i < extract_schema::max_array_nodes + 10; ++i) {
-        input.emplace_back(owned_object::make_array());
+        input.emplace_back(object_builder::array());
     }
 
     extract_schema gen{"id", {}, {}, {}, false, true};
@@ -240,9 +238,9 @@ TEST(TestExtractSchema, ArrayNodesLimit)
 
 TEST(TestExtractSchema, RecordNodesLimit)
 {
-    auto input = owned_object::make_map();
+    auto input = object_builder::map();
     for (unsigned i = 0; i < extract_schema::max_record_nodes + 10; ++i) {
-        input.emplace("child", owned_object::make_array());
+        input.emplace("child", object_builder::array());
     }
 
     extract_schema gen{"id", {}, {}, {}, false, true};
@@ -323,7 +321,7 @@ TEST(TestExtractSchema, SchemaWithScannerSingleValueNoKey)
 
 TEST(TestExtractSchema, SchemaWithScannerArrayNoKey)
 {
-    auto input = owned_object::make_array({"string"});
+    auto input = object_builder::array({"string"});
 
     scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}},
         std::make_unique<matcher::regex_match>("string", 6, true),
@@ -339,7 +337,7 @@ TEST(TestExtractSchema, SchemaWithScannerArrayNoKey)
 
 TEST(TestExtractSchema, SchemaWithScannerArrayWithKey)
 {
-    auto input = owned_object::make_map({{"string", owned_object::make_array({"string"})}});
+    auto input = object_builder::map({{"string", object_builder::array({"string"})}});
 
     scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}},
         std::make_unique<matcher::regex_match>("string", 6, true),
@@ -356,8 +354,8 @@ TEST(TestExtractSchema, SchemaWithScannerArrayWithKey)
 
 TEST(TestExtractSchema, SchemaWithScannerNestedArrayWithKey)
 {
-    auto input = owned_object::make_map(
-        {{"string", owned_object::make_array({owned_object::make_array({"string"})})}});
+    auto input = object_builder::map(
+        {{"string", object_builder::array({object_builder::array({"string"})})}});
 
     scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}},
         std::make_unique<matcher::regex_match>("string", 6, true),

--- a/tests/unit/processor/fingerprint_test.cpp
+++ b/tests/unit/processor/fingerprint_test.cpp
@@ -14,10 +14,10 @@ namespace {
 
 TEST(TestHttpEndpointFingerprint, Basic)
 {
-    auto query = owned_object::make_map(
+    auto query = object_builder::map(
         {{"Key1", owned_object{}}, {"KEY2", owned_object{}}, {"key,3", owned_object{}}});
 
-    auto body = owned_object::make_map({
+    auto body = object_builder::map({
         {"KEY1", owned_object{}},
         {"KEY2", owned_object{}},
         {"KEY", owned_object{}},
@@ -45,9 +45,9 @@ TEST(TestHttpEndpointFingerprint, Basic)
 
 TEST(TestHttpEndpointFingerprint, EmptyQuery)
 {
-    auto query = owned_object::make_map();
+    auto query = object_builder::map();
 
-    auto body = owned_object::make_map({
+    auto body = object_builder::map({
         {"KEY1", owned_object{}},
         {"KEY2", owned_object{}},
         {"KEY", owned_object{}},
@@ -71,13 +71,13 @@ TEST(TestHttpEndpointFingerprint, EmptyQuery)
 TEST(TestHttpEndpointFingerprint, EmptyBody)
 {
 
-    auto query = owned_object::make_map({
+    auto query = object_builder::map({
         {"Key1", owned_object{}},
         {"KEY2", owned_object{}},
         {"key,3", owned_object{}},
     });
 
-    auto body = owned_object::make_map();
+    auto body = object_builder::map();
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -94,8 +94,8 @@ TEST(TestHttpEndpointFingerprint, EmptyBody)
 
 TEST(TestHttpEndpointFingerprint, EmptyEverything)
 {
-    auto query = owned_object::make_map();
-    auto body = owned_object::make_map();
+    auto query = object_builder::map();
+    auto body = object_builder::map();
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -111,13 +111,13 @@ TEST(TestHttpEndpointFingerprint, EmptyEverything)
 
 TEST(TestHttpEndpointFingerprint, KeyConsistency)
 {
-    auto query = owned_object::make_map({
+    auto query = object_builder::map({
         {"Key1", owned_object{}},
         {"KEY2", owned_object{}},
         {"key3,Key4", owned_object{}},
     });
 
-    auto body = owned_object::make_map({
+    auto body = object_builder::map({
         {"KeY1", owned_object{}},
         {"kEY2", owned_object{}},
         {"KEY3", owned_object{}},
@@ -140,13 +140,13 @@ TEST(TestHttpEndpointFingerprint, KeyConsistency)
 
 TEST(TestHttpEndpointFingerprint, UriRawConsistency)
 {
-    auto query = owned_object::make_map({
+    auto query = object_builder::map({
         {"Key1", owned_object{}},
         {"KEY2", owned_object{}},
         {"key,3", owned_object{}},
     });
 
-    auto body = owned_object::make_map({
+    auto body = object_builder::map({
         {"KEY1", owned_object{}},
         {"KEY2", owned_object{}},
         {"KEY", owned_object{}},
@@ -222,7 +222,7 @@ TEST(TestHttpEndpointFingerprint, UriRawConsistency)
 
 TEST(TestHttpEndpointFingerprint, Regeneration)
 {
-    auto query = owned_object::make_map({
+    auto query = object_builder::map({
         {"Key1", owned_object{}},
         {"KEY2", owned_object{}},
         {"key,3", owned_object{}},
@@ -244,7 +244,7 @@ TEST(TestHttpEndpointFingerprint, Regeneration)
     }
 
     {
-        auto body = owned_object::make_map({
+        auto body = object_builder::map({
             {"KEY1", owned_object{}},
             {"KEY2", owned_object{}},
             {"KEY", owned_object{}},
@@ -265,7 +265,7 @@ TEST(TestHttpEndpointFingerprint, Regeneration)
 
 TEST(TestHttpHeaderFingerprint, AllKnownHeaders)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"referer", owned_object{}},
         {"CONNECTION", owned_object{}},
         {"Accept_Encoding", owned_object{}},
@@ -292,7 +292,7 @@ TEST(TestHttpHeaderFingerprint, AllKnownHeaders)
 
 TEST(TestHttpHeaderFingerprint, NoHeaders)
 {
-    auto headers = owned_object::make_map();
+    auto headers = object_builder::map();
     http_header_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -307,7 +307,7 @@ TEST(TestHttpHeaderFingerprint, NoHeaders)
 
 TEST(TestHttpHeaderFingerprint, SomeKnownHeaders)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"referer", owned_object{}},
         {"accept-encoding", owned_object{}},
         {"cache-control", owned_object{}},
@@ -330,7 +330,7 @@ TEST(TestHttpHeaderFingerprint, SomeKnownHeaders)
 
 TEST(TestHttpHeaderFingerprint, UserAgent)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"referer", owned_object{}},
         {"connection", owned_object{}},
         {"accept-encoding", owned_object{}},
@@ -358,7 +358,7 @@ TEST(TestHttpHeaderFingerprint, UserAgent)
 
 TEST(TestHttpHeaderFingerprint, UserAgentAsArray)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"referer", owned_object{}},
         {"connection", owned_object{}},
         {"accept-encoding", owned_object{}},
@@ -369,7 +369,7 @@ TEST(TestHttpHeaderFingerprint, UserAgentAsArray)
         {"content-type", owned_object{}},
         {"accept", owned_object{}},
         {"accept-language", owned_object{}},
-        {"user-agent", owned_object::make_array({"Random"})},
+        {"user-agent", object_builder::array({"Random"})},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -386,7 +386,7 @@ TEST(TestHttpHeaderFingerprint, UserAgentAsArray)
 
 TEST(TestHttpHeaderFingerprint, UserAgentAsArrayInvalidType)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"referer", owned_object{}},
         {"connection", owned_object{}},
         {"accept-encoding", owned_object{}},
@@ -397,7 +397,7 @@ TEST(TestHttpHeaderFingerprint, UserAgentAsArrayInvalidType)
         {"content-type", owned_object{}},
         {"accept", owned_object{}},
         {"accept-language", owned_object{}},
-        {"user-agent", owned_object::make_array({42})},
+        {"user-agent", object_builder::array({42})},
     });
     http_header_fingerprint gen{"id", {}, {}, false, true};
 
@@ -413,7 +413,7 @@ TEST(TestHttpHeaderFingerprint, UserAgentAsArrayInvalidType)
 
 TEST(TestHttpHeaderFingerprint, MultipleUserAgents)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"referer", owned_object{}},
         {"connection", owned_object{}},
         {"accept-encoding", owned_object{}},
@@ -424,7 +424,7 @@ TEST(TestHttpHeaderFingerprint, MultipleUserAgents)
         {"content-type", owned_object{}},
         {"accept", owned_object{}},
         {"accept-language", owned_object{}},
-        {"user-agent", owned_object::make_array({"Random", "Bot"})},
+        {"user-agent", object_builder::array({"Random", "Bot"})},
     });
     http_header_fingerprint gen{"id", {}, {}, false, true};
 
@@ -440,7 +440,7 @@ TEST(TestHttpHeaderFingerprint, MultipleUserAgents)
 
 TEST(TestHttpHeaderFingerprint, ExcludedUnknownHeaders)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"referer", owned_object{}},
         {"connection", owned_object{}},
         {"accept-encoding", owned_object{}},
@@ -481,7 +481,7 @@ TEST(TestHttpHeaderFingerprint, ExcludedUnknownHeaders)
 
 TEST(TestHttpHeaderFingerprint, UnknownHeaders)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"referer", owned_object{}},
         {"connection", owned_object{}},
         {"accept-encoding", owned_object{}},
@@ -526,7 +526,7 @@ TEST(TestHttpHeaderFingerprint, UnknownHeaders)
 
 TEST(TestHttpNetworkFingerprint, AllXFFHeaders)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"x-forwarded-for", "192.168.1.1"},
         {"x-real-ip", owned_object{}},
         {"true-client-ip", owned_object{}},
@@ -552,7 +552,7 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeaders)
 }
 TEST(TestHttpNetworkFingerprint, NoHeaders)
 {
-    auto headers = owned_object::make_map();
+    auto headers = object_builder::map();
     http_network_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -567,7 +567,7 @@ TEST(TestHttpNetworkFingerprint, NoHeaders)
 
 TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPs)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"x-forwarded-for", "192.168.1.1,::1,8.7.6.5"},
         {"x-real-ip", owned_object{}},
         {"true-client-ip", owned_object{}},
@@ -594,8 +594,8 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPs)
 
 TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsAsArray)
 {
-    auto headers = owned_object::make_map({
-        {"x-forwarded-for", owned_object::make_array({"192.168.1.1,::1,8.7.6.5"})},
+    auto headers = object_builder::map({
+        {"x-forwarded-for", object_builder::array({"192.168.1.1,::1,8.7.6.5"})},
         {"x-real-ip", owned_object{}},
         {"true-client-ip", owned_object{}},
         {"x-client-ip", owned_object{}},
@@ -620,8 +620,8 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsAsArray)
 
 TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsAsArrayInvalidType)
 {
-    auto headers = owned_object::make_map({
-        {"x-forwarded-for", owned_object::make_array({42})},
+    auto headers = object_builder::map({
+        {"x-forwarded-for", object_builder::array({42})},
         {"x-real-ip", owned_object{}},
         {"true-client-ip", owned_object{}},
         {"x-client-ip", owned_object{}},
@@ -647,8 +647,8 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsAsArrayInvalidTyp
 
 TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsDuplicateXFF)
 {
-    auto headers = owned_object::make_map({
-        {"x-forwarded-for", owned_object::make_array({"192.168.1.1,::1,8.7.6.5", "192.168.1.44"})},
+    auto headers = object_builder::map({
+        {"x-forwarded-for", object_builder::array({"192.168.1.1,::1,8.7.6.5", "192.168.1.44"})},
         {"x-real-ip", owned_object{}},
         {"true-client-ip", owned_object{}},
         {"x-client-ip", owned_object{}},
@@ -674,7 +674,7 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsDuplicateXFF)
 
 TEST(TestHttpNetworkFingerprint, AllXFFHeadersRandomChosenHeader)
 {
-    auto headers = owned_object::make_map({
+    auto headers = object_builder::map({
         {"x-forwarded-for", owned_object{}},
         {"x-real-ip", owned_object{}},
         {"true-client-ip", owned_object{}},
@@ -704,7 +704,7 @@ TEST(TestHttpNetworkFingerprint, HeaderPrecedence)
     http_network_fingerprint gen{"id", {}, {}, false, true};
 
     auto get_headers = [](std::size_t begin) {
-        auto headers = owned_object::make_map();
+        auto headers = object_builder::map();
         std::array<std::string, 10> names{"x-forwarded-for", "x-real-ip", "true-client-ip",
             "x-client-ip", "x-forwarded", "forwarded-for", "x-cluster-client-ip",
             "fastly-client-ip", "cf-connecting-ip", "cf-connecting-ipv6"};
@@ -745,7 +745,7 @@ TEST(TestHttpNetworkFingerprint, HeaderPrecedence)
 
 TEST(TestSessionFingerprint, UserOnly)
 {
-    auto cookies = owned_object::make_map();
+    auto cookies = object_builder::map();
     session_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -762,7 +762,7 @@ TEST(TestSessionFingerprint, UserOnly)
 
 TEST(TestSessionFingerprint, SessionOnly)
 {
-    auto cookies = owned_object::make_map();
+    auto cookies = object_builder::map();
     session_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -779,7 +779,7 @@ TEST(TestSessionFingerprint, SessionOnly)
 
 TEST(TestSessionFingerprint, CookiesOnly)
 {
-    auto cookies = owned_object::make_map({
+    auto cookies = object_builder::map({
         {"name", "albert"},
         {"theme", "dark"},
         {"language", "en-GB"},
@@ -805,7 +805,7 @@ TEST(TestSessionFingerprint, CookiesOnly)
 
 TEST(TestSessionFingerprint, UserCookieAndSession)
 {
-    auto cookies = owned_object::make_map({
+    auto cookies = object_builder::map({
         {"name", "albert"},
         {"theme", "dark"},
         {"language", "en-GB"},
@@ -831,7 +831,7 @@ TEST(TestSessionFingerprint, UserCookieAndSession)
 
 TEST(TestSessionFingerprint, CookieKeysNormalization)
 {
-    auto cookies = owned_object::make_map({
+    auto cookies = object_builder::map({
         {"nAmE", "albert"},
         {"THEME", "dark"},
         {"language,ID", "en-GB"},
@@ -857,7 +857,7 @@ TEST(TestSessionFingerprint, CookieKeysNormalization)
 
 TEST(TestSessionFingerprint, CookieValuesNormalization)
 {
-    auto cookies = owned_object::make_map({
+    auto cookies = object_builder::map({
         {"name", "albert,martinez"},
         {"theme", "dark"},
         {"language", "en-GB,en-US"},
@@ -883,14 +883,14 @@ TEST(TestSessionFingerprint, CookieValuesNormalization)
 
 TEST(TestSessionFingerprint, CookieValuesAsArray)
 {
-    auto cookies = owned_object::make_map({
-        {"name", owned_object::make_array({"albert,martinez"})},
-        {"theme", owned_object::make_array({"dark"})},
-        {"language", owned_object::make_array({"en-GB,en-US"})},
-        {"tracking_id", owned_object::make_array({"xyzabc"})},
-        {"gdpr_consent", owned_object::make_array({",yes"})},
-        {"session_id", owned_object::make_array({"ansd0182u2n,"})},
-        {"last_visit", owned_object::make_array({"2024-07-16T12:00:00Z"})},
+    auto cookies = object_builder::map({
+        {"name", object_builder::array({"albert,martinez"})},
+        {"theme", object_builder::array({"dark"})},
+        {"language", object_builder::array({"en-GB,en-US"})},
+        {"tracking_id", object_builder::array({"xyzabc"})},
+        {"gdpr_consent", object_builder::array({",yes"})},
+        {"session_id", object_builder::array({"ansd0182u2n,"})},
+        {"last_visit", object_builder::array({"2024-07-16T12:00:00Z"})},
     });
 
     session_fingerprint gen{"id", {}, {}, false, true};
@@ -909,14 +909,14 @@ TEST(TestSessionFingerprint, CookieValuesAsArray)
 
 TEST(TestSessionFingerprint, CookieValuesAsArrayInvalidType)
 {
-    auto cookies = owned_object::make_map({
-        {"name", owned_object::make_array({42})},
-        {"theme", owned_object::make_array({42})},
-        {"language", owned_object::make_array({42})},
-        {"tracking_id", owned_object::make_array({42})},
-        {"gdpr_consent", owned_object::make_array({42})},
-        {"session_id", owned_object::make_array({42})},
-        {"last_visit", owned_object::make_array({42})},
+    auto cookies = object_builder::map({
+        {"name", object_builder::array({42})},
+        {"theme", object_builder::array({42})},
+        {"language", object_builder::array({42})},
+        {"tracking_id", object_builder::array({42})},
+        {"gdpr_consent", object_builder::array({42})},
+        {"session_id", object_builder::array({42})},
+        {"last_visit", object_builder::array({42})},
     });
 
     session_fingerprint gen{"id", {}, {}, false, true};
@@ -935,14 +935,14 @@ TEST(TestSessionFingerprint, CookieValuesAsArrayInvalidType)
 
 TEST(TestSessionFingerprint, CookieValuesArrayMultiples)
 {
-    auto cookies = owned_object::make_map({
-        {"name", owned_object::make_array({"albert,martinez", "albert,martinez"})},
-        {"theme", owned_object::make_array({"dark", "dark"})},
-        {"language", owned_object::make_array({"en-GB,en-US", "en-GB,en-US"})},
-        {"tracking_id", owned_object::make_array({"xyzabc", "xyzabc"})},
-        {"gdpr_consent", owned_object::make_array({",yes", ",yes"})},
-        {"session_id", owned_object::make_array({"ansd0182u2n,", "ansd0182u2n,"})},
-        {"last_visit", owned_object::make_array({"2024-07-16T12:00:00Z", "2024-07-16T12:00:00Z"})},
+    auto cookies = object_builder::map({
+        {"name", object_builder::array({"albert,martinez", "albert,martinez"})},
+        {"theme", object_builder::array({"dark", "dark"})},
+        {"language", object_builder::array({"en-GB,en-US", "en-GB,en-US"})},
+        {"tracking_id", object_builder::array({"xyzabc", "xyzabc"})},
+        {"gdpr_consent", object_builder::array({",yes", ",yes"})},
+        {"session_id", object_builder::array({"ansd0182u2n,", "ansd0182u2n,"})},
+        {"last_visit", object_builder::array({"2024-07-16T12:00:00Z", "2024-07-16T12:00:00Z"})},
     });
 
     session_fingerprint gen{"id", {}, {}, false, true};
@@ -961,7 +961,7 @@ TEST(TestSessionFingerprint, CookieValuesArrayMultiples)
 
 TEST(TestSessionFingerprint, CookieEmptyValues)
 {
-    auto cookies = owned_object::make_map({
+    auto cookies = object_builder::map({
         {"name", owned_object{}},
         {"theme", owned_object{}},
         {"language", owned_object{}},
@@ -987,7 +987,7 @@ TEST(TestSessionFingerprint, CookieEmptyValues)
 
 TEST(TestSessionFingerprint, CookieEmptyKeys)
 {
-    auto cookies = owned_object::make_map({
+    auto cookies = object_builder::map({
         {"", "albert,martinez"},
         {"", "dark"},
         {"", "en-GB,en-US"},
@@ -1013,7 +1013,7 @@ TEST(TestSessionFingerprint, CookieEmptyKeys)
 
 TEST(TestSessionFingerprint, EmptyEverything)
 {
-    auto cookies = owned_object::make_map();
+    auto cookies = object_builder::map();
     session_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -1045,7 +1045,7 @@ TEST(TestSessionFingerprint, Regeneration)
     }
 
     {
-        auto cookies = owned_object::make_map({
+        auto cookies = object_builder::map({
             {"name", "albert,martinez"},
             {"theme", "dark"},
             {"language", "en-GB,en-US"},

--- a/tests/unit/processor/jwt_decode_test.cpp
+++ b/tests/unit/processor/jwt_decode_test.cpp
@@ -15,7 +15,7 @@ namespace {
 
 TEST(TestJwtDecoder, Basic)
 {
-    auto headers = owned_object::make_map({{"authorization",
+    auto headers = object_builder::map({{"authorization",
         "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
         "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -43,8 +43,8 @@ TEST(TestJwtDecoder, Basic)
 
 TEST(TestJwtDecoder, KeyPathLeadsToSingleValueArray)
 {
-    auto headers = owned_object::make_map({{"authorization",
-        owned_object::make_array(
+    auto headers = object_builder::map({{"authorization",
+        object_builder::array(
             {"Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
              "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
              "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -72,8 +72,8 @@ TEST(TestJwtDecoder, KeyPathLeadsToSingleValueArray)
 
 TEST(TestJwtDecoder, KeyPathLeadsToValidMultiValueArray)
 {
-    auto headers = owned_object::make_map({{"authorization",
-        owned_object::make_array(
+    auto headers = object_builder::map({{"authorization",
+        object_builder::array(
             {"Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
              "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
              "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -104,8 +104,8 @@ TEST(TestJwtDecoder, KeyPathLeadsToInvalidMultiValueArray)
 {
     // Even though the token is there, we only take the first element of arrays as we're trying
     // to account for the serialisation not perform a JWT search.
-    auto headers = owned_object::make_map({{"authorization",
-        owned_object::make_array({"Arachni",
+    auto headers = object_builder::map({{"authorization",
+        object_builder::array({"Arachni",
             "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
             "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
             "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -153,7 +153,7 @@ TEST(TestJwtDecoder, MissingKeypath)
 
 TEST(TestJwtDecoder, EmptyHeader)
 {
-    auto headers = owned_object::make_map({{"authorization",
+    auto headers = object_builder::map({{"authorization",
         "Bearer ."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
         "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -181,7 +181,7 @@ TEST(TestJwtDecoder, EmptyHeader)
 
 TEST(TestJwtDecoder, EmptyPayload)
 {
-    auto headers = owned_object::make_map({{"authorization",
+    auto headers = object_builder::map({{"authorization",
         "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
         ".o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
         "8B48NpATozzMHn0j3rE0xVUldxShzy0xeJ7vYAccVXu2Gs9rnTVqouc-UZu_wJHkZiKBL67j8_"
@@ -208,7 +208,7 @@ TEST(TestJwtDecoder, EmptyPayload)
 
 TEST(TestJwtDecoder, LargePayloadBeyondLimit)
 {
-    auto headers = owned_object::make_map({{"authorization",
+    auto headers = object_builder::map({{"authorization",
         "Bearer "
         "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
         "eyJrZXlfMCI6eyJrZXlfMSI6eyJrZXlfMiI6eyJrZXlfMyI6eyJrZXlfNCI6eyJrZXlfNSI6eyJrZXlfNiI6ey"
@@ -234,7 +234,7 @@ TEST(TestJwtDecoder, LargePayloadBeyondLimit)
 
 TEST(TestJwtDecoder, NoSignature)
 {
-    auto headers = owned_object::make_map({{"authorization",
+    auto headers = object_builder::map({{"authorization",
         "Bearer "
         "eyJhbGciOiJub25lIn0."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
@@ -259,7 +259,7 @@ TEST(TestJwtDecoder, NoSignature)
 TEST(TestJwtDecoder, NoPayloadNoSignatureMissingDelim)
 {
     auto headers =
-        owned_object::make_map({{"authorization", "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."}});
+        object_builder::map({{"authorization", "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."}});
 
     jwt_decode gen{"id", {}, {}, false, true};
 
@@ -277,7 +277,7 @@ TEST(TestJwtDecoder, NoPayloadNoSignatureMissingDelim)
 TEST(TestJwtDecoder, NoPayloadNoSignatureMissingAllDelim)
 {
     auto headers =
-        owned_object::make_map({{"authorization", "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9"}});
+        object_builder::map({{"authorization", "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9"}});
     jwt_decode gen{"id", {}, {}, false, true};
 
     std::vector<std::string> key_path{"authorization"};
@@ -293,7 +293,7 @@ TEST(TestJwtDecoder, NoPayloadNoSignatureMissingAllDelim)
 
 TEST(TestJwtDecoder, NoSignatureNoDelim)
 {
-    auto headers = owned_object::make_map({{"authorization",
+    auto headers = object_builder::map({{"authorization",
         "Bearer "
         "eyJhbGciOiJub25lIn0."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"

--- a/tests/unit/processor/processor_test.cpp
+++ b/tests/unit/processor/processor_test.cpp
@@ -42,7 +42,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalUnconditional)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map = owned_object::make_map({{"input_address", "input_string"}});
+    auto input_map = object_builder::map({{"input_address", "input_string"}});
     object_store store;
     store.insert(input_map);
 
@@ -80,7 +80,7 @@ TEST(TestProcessor, MultiMappingOutputNoEvalUnconditional)
     owned_object first_output = owned_object::make_string("first_output_string");
     owned_object second_output = owned_object::make_string("second_output_string");
 
-    auto input_map = owned_object::make_map({{"input_address.first", "first_input_string"},
+    auto input_map = object_builder::map({{"input_address.first", "first_input_string"},
         {"input_address.second", "second_input_string"}});
 
     object_store store;
@@ -134,8 +134,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalTrue)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map =
-        owned_object::make_map({{"input_address", "input_string"}, {"enabled?", true}});
+    auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", true}});
 
     object_store store;
     store.insert(input_map);
@@ -178,7 +177,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map = owned_object::make_map({{"enabled?", true}});
+    auto input_map = object_builder::map({{"enabled?", true}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -213,7 +212,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
     auto attributes = collector.get_available_attributes_and_reset();
     EXPECT_EQ(attributes.size(), 0);
 
-    input_map = owned_object::make_map({
+    input_map = object_builder::map({
         {"input_address", "input_string"},
     });
 
@@ -232,8 +231,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalFalse)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map =
-        owned_object::make_map({{"input_address", "input_string"}, {"enabled?", false}});
+    auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", false}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -269,7 +267,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map = owned_object::make_map({
+    auto input_map = object_builder::map({
         {"input_address", "input_string"},
     });
 
@@ -315,8 +313,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map =
-        owned_object::make_map({{"input_address", "input_string"}, {"enabled?", true}});
+    auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", true}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -363,8 +360,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalFalse)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map =
-        owned_object::make_map({{"input_address", "input_string"}, {"enabled?", false}});
+    auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", false}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -403,7 +399,7 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
     owned_object first_output = owned_object::make_string("first_output_string");
     owned_object second_output = owned_object::make_string("second_output_string");
 
-    auto input_map = owned_object::make_map({{"input_address.first", "first_input_string"},
+    auto input_map = object_builder::map({{"input_address.first", "first_input_string"},
         {"input_address.second", "second_input_string"}});
 
     object_store store;
@@ -459,7 +455,7 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map = owned_object::make_map({
+    auto input_map = object_builder::map({
         {"input_address", "input_string"},
     });
 
@@ -509,8 +505,8 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
 
 TEST(TestProcessor, OutputAlreadyAvailableInStore)
 {
-    auto input_map =
-        owned_object::make_map({{"input_address", "input_string"}, {"output_address", nullptr}});
+    auto input_map = object_builder::map(
+        {{"input_address", "input_string"}, {"output_address", owned_object::make_null()}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -537,7 +533,7 @@ TEST(TestProcessor, OutputAlreadyAvailableInStore)
 
 TEST(TestProcessor, OutputAlreadyGenerated)
 {
-    auto input_map = owned_object::make_map({
+    auto input_map = object_builder::map({
         {"input_address", "input_string"},
     });
 
@@ -567,8 +563,8 @@ TEST(TestProcessor, OutputAlreadyGenerated)
 
 TEST(TestProcessor, EvalAlreadyAvailableInStore)
 {
-    auto input_map =
-        owned_object::make_map({{"input_address", "input_string"}, {"output_address", nullptr}});
+    auto input_map = object_builder::map(
+        {{"input_address", "input_string"}, {"output_address", owned_object::make_null()}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -598,7 +594,7 @@ TEST(TestProcessor, OutputEvalWithoutattributesMap)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map = owned_object::make_map({
+    auto input_map = object_builder::map({
         {"input_address", "input_string"},
     });
 

--- a/tests/unit/processor/structured_processor_test.cpp
+++ b/tests/unit/processor/structured_processor_test.cpp
@@ -44,9 +44,9 @@ TEST(TestStructuredProcessor, AllParametersAvailable)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map = owned_object::make_map(
+    auto input_map = object_builder::map(
         {{"unary_address", "unary_string"}, {"optional_address", "optional_string"},
-            {"variadic_address_1", 1UL}, {"variadic_address_2", 1UL}});
+            {"variadic_address_1", 1U}, {"variadic_address_2", 1U}});
     object_store store;
     store.insert(input_map);
 
@@ -92,8 +92,8 @@ TEST(TestStructuredProcessor, OptionalParametersNotAvailable)
 {
     owned_object output = owned_object::make_string("output_string");
 
-    auto input_map = owned_object::make_map({{"unary_address", "unary_string"},
-        {"variadic_address_1", 1UL}, {"variadic_address_2", 1UL}});
+    auto input_map = object_builder::map({{"unary_address", "unary_string"},
+        {"variadic_address_1", 1U}, {"variadic_address_2", 1U}});
 
     object_store store;
     store.insert(input_map);
@@ -138,8 +138,8 @@ TEST(TestStructuredProcessor, OptionalParametersNotAvailable)
 
 TEST(TestStructuredProcessor, RequiredParameterNotAvailable)
 {
-    auto input_map = owned_object::make_map({{"optional_address", "optional_string"},
-        {"variadic_address_1", 1UL}, {"variadic_address_2", 1UL}});
+    auto input_map = object_builder::map({{"optional_address", "optional_string"},
+        {"variadic_address_1", 1U}, {"variadic_address_2", 1U}});
 
     object_store store;
     store.insert(input_map);
@@ -178,7 +178,7 @@ TEST(TestStructuredProcessor, RequiredParameterNotAvailable)
 
 TEST(TestStructuredProcessor, NoVariadocParametersAvailable)
 {
-    auto input_map = owned_object::make_map({
+    auto input_map = object_builder::map({
         {"unary_address", "unary_string"},
         {"optional_address", "optional_string"},
     });

--- a/tests/unit/rule_test.cpp
+++ b/tests/unit/rule_test.cpp
@@ -27,7 +27,7 @@ TEST(TestRule, Match)
     std::unordered_map<std::string, std::string> tags{{"type", "type"}, {"category", "category"}};
     core_rule rule("id", "name", std::move(tags), builder.build(), {"update", "block", "passlist"});
 
-    auto root = owned_object::make_map();
+    auto root = object_builder::map();
     root.emplace("http.client_ip", "192.168.0.1");
 
     ddwaf::object_store store;
@@ -86,7 +86,7 @@ TEST(TestRule, EphemeralMatch)
 
     ddwaf::object_store store;
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
     ddwaf::timer deadline{2s};
 
@@ -123,7 +123,7 @@ TEST(TestRule, NoMatch)
     std::unordered_map<std::string, std::string> tags{{"type", "type"}, {"category", "category"}};
     core_rule rule("id", "name", std::move(tags), builder.build());
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
     ddwaf::object_store store;
     store.insert(std::move(root));
@@ -157,7 +157,7 @@ TEST(TestRule, ValidateCachedMatch)
     // only the latest address. This ensures that the IP condition can't be
     // matched on the second run.
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -168,7 +168,7 @@ TEST(TestRule, ValidateCachedMatch)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -229,7 +229,7 @@ TEST(TestRule, MatchWithoutCache)
     // the second run when there isn't a cached match.
     ddwaf::object_store store;
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
         store.insert(std::move(root));
 
         ddwaf::timer deadline{2s};
@@ -239,7 +239,7 @@ TEST(TestRule, MatchWithoutCache)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         store.insert(std::move(root));
 
@@ -291,7 +291,7 @@ TEST(TestRule, NoMatchWithoutCache)
     // In this test we validate that when the cache is empty and only one
     // address is passed, the filter doesn't match (as it should be).
     {
-        auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -303,7 +303,7 @@ TEST(TestRule, NoMatchWithoutCache)
     }
 
     {
-        auto root = owned_object::make_map({{"usr.id", "admin"}});
+        auto root = object_builder::map({{"usr.id", "admin"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -337,8 +337,7 @@ TEST(TestRule, FullCachedMatchSecondRun)
 
     core_rule::cache_type cache;
     {
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -350,8 +349,7 @@ TEST(TestRule, FullCachedMatchSecondRun)
     }
 
     {
-        auto root =
-            owned_object::make_map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         ddwaf::object_store store;
         store.insert(std::move(root));
@@ -374,7 +372,7 @@ TEST(TestRule, ExcludeObject)
 
     core_rule rule("id", "name", std::move(tags), builder.build(), {"update", "block", "passlist"});
 
-    auto root = owned_object::make_map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
     ddwaf::object_store store;
     store.insert(std::move(root));
 

--- a/tests/unit/waf_test.cpp
+++ b/tests/unit/waf_test.cpp
@@ -48,7 +48,7 @@ TEST(TestWaf, BasicContextRun)
 {
     auto instance = build_instance("interface.yaml");
 
-    auto root = owned_object::make_map({{"value1", "rule1"}});
+    auto root = object_builder::map({{"value1", "rule1"}});
     auto *ctx = instance.create_context();
 
     EXPECT_TRUE(ctx->insert(std::move(root)));


### PR DESCRIPTION
This PR expands https://github.com/DataDog/libddwaf/pull/418 to use allocators on owned and borrowed objects, ensuring that objects are allocator-compatible and that all possible allocations are performed with the correct allocator.

All relevant changes are in `object.hpp`.

Note that the size of the PR is due to ancillary changes required due to the following changes to the owned object:
- The `nullptr_t` constructor for `owned_object` has been removed as it was causing conflicts with other constructors.
- The `make_(array|map)` functions accepting initializer lists have been extracted out into `object_builder::(map|array)` as they were also causing conflicts due to the introduction of the capacity parameter to the other overloads.

These changes can be safely ignored.

Remaining work (Next PRs):
- <del>Update objects to use allocators more effectively.</del>
- <del>Check for allocator compatibility where relevant.</del>
- Propagate allocator from the context.
- Have a clear distinction between input , output and internal allocators.
- Update interface:
  - Pass input / ouput allocators to `context_init`.
  - Pass allocators to memory-allocating `ddwaf_object` functions.
