### PR TITLE
Negated operator fixes & improvements

### DIFF
--- a/cmake/objects.cmake
+++ b/cmake/objects.cmake
@@ -60,7 +60,7 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/condition/sqli_detector.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/ssrf_detector.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/scalar_condition.cpp
-    ${libddwaf_SOURCE_DIR}/src/condition/scalar_negated_condition.cpp
+    ${libddwaf_SOURCE_DIR}/src/condition/negated_scalar_condition.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/shi_common.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/shi_detector.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/cmdi_detector.cpp

--- a/cmake/objects.cmake
+++ b/cmake/objects.cmake
@@ -5,6 +5,7 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/context_allocator.cpp
     ${libddwaf_SOURCE_DIR}/src/serializer.cpp
     ${libddwaf_SOURCE_DIR}/src/object.cpp
+    ${libddwaf_SOURCE_DIR}/src/object_helpers.cpp
     ${libddwaf_SOURCE_DIR}/src/object_store.cpp
     ${libddwaf_SOURCE_DIR}/src/module.cpp
     ${libddwaf_SOURCE_DIR}/src/expression.cpp
@@ -15,7 +16,6 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/obfuscator.cpp
     ${libddwaf_SOURCE_DIR}/src/uri_utils.cpp
     ${libddwaf_SOURCE_DIR}/src/json_utils.cpp
-    ${libddwaf_SOURCE_DIR}/src/utils.cpp
     ${libddwaf_SOURCE_DIR}/src/platform.cpp
     ${libddwaf_SOURCE_DIR}/src/sha256.cpp
     ${libddwaf_SOURCE_DIR}/src/uuid.cpp

--- a/cmake/objects.cmake
+++ b/cmake/objects.cmake
@@ -60,6 +60,7 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/condition/sqli_detector.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/ssrf_detector.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/scalar_condition.cpp
+    ${libddwaf_SOURCE_DIR}/src/condition/scalar_negated_condition.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/shi_common.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/shi_detector.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/cmdi_detector.cpp

--- a/src/attribute_collector.cpp
+++ b/src/attribute_collector.cpp
@@ -12,9 +12,9 @@
 #include "attribute_collector.hpp"
 #include "ddwaf.h"
 #include "log.hpp"
+#include "object_helpers.hpp"
 #include "object_store.hpp"
 #include "target_address.hpp"
-#include "utils.hpp"
 
 namespace ddwaf {
 
@@ -71,7 +71,7 @@ attribute_collector::collection_state attribute_collector::collect_helper(const 
         return collection_state::unavailable;
     }
 
-    const auto *resolved = object::find_key_path(*object, input_key_path);
+    const auto *resolved = object::find_key_path(object, input_key_path, {}, {});
     if (resolved == nullptr) {
         // The key path is not expected to be provided later on, therefore
         // we mark it as failed.

--- a/src/condition/exists.cpp
+++ b/src/condition/exists.cpp
@@ -3,12 +3,9 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
-#include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <span>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -19,6 +16,7 @@
 #include "ddwaf.h"
 #include "exception.hpp"
 #include "exclusion/common.hpp"
+#include "object_helpers.hpp"
 #include "utils.hpp"
 
 namespace ddwaf {
@@ -26,28 +24,6 @@ namespace ddwaf {
 namespace {
 
 enum class search_outcome : uint8_t { found, not_found, unknown };
-
-const ddwaf_object *find_key(
-    const ddwaf_object &parent, std::string_view key, const object_limits &limits)
-{
-    const std::size_t size =
-        std::min(static_cast<uint32_t>(parent.nbEntries), limits.max_container_size);
-    for (std::size_t i = 0; i < size; ++i) {
-        const auto &child = parent.array[i];
-
-        if (child.parameterName == nullptr) [[unlikely]] {
-            continue;
-        }
-        const std::string_view child_key{
-            child.parameterName, static_cast<std::size_t>(child.parameterNameLength)};
-
-        if (key == child_key) {
-            return &child;
-        }
-    }
-
-    return nullptr;
-}
 
 search_outcome exists(const ddwaf_object *root, std::span<const std::string> key_path,
     const exclusion::object_set_ref &objects_excluded, const object_limits &limits)
@@ -65,7 +41,7 @@ search_outcome exists(const ddwaf_object *root, std::span<const std::string> key
 
     // The parser ensures that the key path is within the limits specified by
     // the user, hence we don't need to check for depth
-    while ((root = find_key(*root, *it, limits)) != nullptr) {
+    while ((root = object::find_key(*root, *it, limits)) != nullptr) {
         if (objects_excluded.contains(root)) {
             // We found the next root but it has been excluded, so we
             // can't know for sure if the required key path exists

--- a/src/condition/exists.cpp
+++ b/src/condition/exists.cpp
@@ -115,7 +115,7 @@ search_outcome exists(const ddwaf_object *root, std::span<const std::string> key
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-[[nodiscard]] eval_result exists_negated_condition::eval_impl(
+[[nodiscard]] eval_result negated_exists_condition::eval_impl(
     const unary_argument<const ddwaf_object *> &input, condition_cache &cache,
     const exclusion::object_set_ref &objects_excluded, const object_limits &limits,
     ddwaf::timer & /*deadline*/) const

--- a/src/condition/exists.hpp
+++ b/src/condition/exists.hpp
@@ -28,12 +28,12 @@ protected:
     friend class base_impl<exists_condition>;
 };
 
-class exists_negated_condition : public base_impl<exists_negated_condition> {
+class negated_exists_condition : public base_impl<negated_exists_condition> {
 public:
     static constexpr std::array<std::string_view, 1> param_names{"inputs"};
 
-    explicit exists_negated_condition(std::vector<condition_parameter> args)
-        : base_impl<exists_negated_condition>(std::move(args))
+    explicit negated_exists_condition(std::vector<condition_parameter> args)
+        : base_impl<negated_exists_condition>(std::move(args))
     {}
 
 protected:
@@ -41,7 +41,7 @@ protected:
         condition_cache &cache, const exclusion::object_set_ref &objects_excluded,
         const object_limits &limits, ddwaf::timer & /*deadline*/) const;
 
-    friend class base_impl<exists_negated_condition>;
+    friend class base_impl<negated_exists_condition>;
 };
 
 } // namespace ddwaf

--- a/src/condition/negated_scalar_condition.cpp
+++ b/src/condition/negated_scalar_condition.cpp
@@ -20,8 +20,8 @@
 #include "iterator.hpp"
 #include "log.hpp"
 #include "matcher/base.hpp"
+#include "negated_scalar_condition.hpp"
 #include "object_store.hpp"
-#include "scalar_negated_condition.hpp"
 #include "transformer/base.hpp"
 #include "transformer/manager.hpp"
 #include "utils.hpp"
@@ -176,7 +176,7 @@ const ddwaf_object *find_key_path(const ddwaf_object *root, std::span<const std:
 
 } // namespace
 
-eval_result scalar_negated_condition::eval(condition_cache &cache, const object_store &store,
+eval_result negated_scalar_condition::eval(condition_cache &cache, const object_store &store,
     const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
     const object_limits &limits, ddwaf::timer &deadline) const
 {

--- a/src/condition/negated_scalar_condition.hpp
+++ b/src/condition/negated_scalar_condition.hpp
@@ -10,9 +10,9 @@
 
 namespace ddwaf {
 
-class scalar_negated_condition : public base_condition {
+class negated_scalar_condition : public base_condition {
 public:
-    scalar_negated_condition(std::unique_ptr<matcher::base> &&matcher, std::string data_id,
+    negated_scalar_condition(std::unique_ptr<matcher::base> &&matcher, std::string data_id,
         std::vector<condition_parameter> args)
         : matcher_(std::move(matcher)), data_id_(std::move(data_id))
     {

--- a/src/condition/scalar_condition.cpp
+++ b/src/condition/scalar_condition.cpp
@@ -30,12 +30,10 @@ namespace ddwaf {
 
 namespace {
 
-template <typename ResultType, typename Iterator>
-ResultType eval_object(Iterator &it, std::string_view address, bool ephemeral,
+template <typename Iterator>
+std::optional<condition_match> eval_object(Iterator &it, std::string_view address, bool ephemeral,
     const matcher::base &matcher, const std::span<const transformer_id> &transformers,
     const object_limits &limits)
-    requires(std::is_same_v<ResultType, bool> ||
-             std::is_same_v<ResultType, std::optional<condition_match>>)
 {
     // The iterator is guaranteed to be valid at this point, which means the
     // object pointer should not be nullptr
@@ -61,12 +59,8 @@ ResultType eval_object(Iterator &it, std::string_view address, bool ephemeral,
 
                 DDWAF_TRACE("Target {} matched parameter value {}", address, highlight);
 
-                if constexpr (std::is_same_v<ResultType, bool>) {
-                    return true;
-                } else {
-                    return {{{{"input"sv, object_to_string(dst), address, it.get_current_path()}},
-                        {std::move(highlight)}, matcher.name(), matcher.to_string(), ephemeral}};
-                }
+                return {{{{"input"sv, object_to_string(dst), address, it.get_current_path()}},
+                    {std::move(highlight)}, matcher.name(), matcher.to_string(), ephemeral}};
             }
         }
     }
@@ -78,20 +72,14 @@ ResultType eval_object(Iterator &it, std::string_view address, bool ephemeral,
 
     DDWAF_TRACE("Target {} matched parameter value {}", address, highlight);
 
-    if constexpr (std::is_same_v<ResultType, bool>) {
-        return true;
-    } else {
-        return {{{{"input"sv, object_to_string(src), address, it.get_current_path()}},
-            {std::move(highlight)}, matcher.name(), matcher.to_string(), ephemeral}};
-    }
+    return {{{{"input"sv, object_to_string(src), address, it.get_current_path()}},
+        {std::move(highlight)}, matcher.name(), matcher.to_string(), ephemeral}};
 }
 
-template <typename ResultType, typename Iterator>
-ResultType eval_target(Iterator &it, std::string_view address, bool ephemeral,
+template <typename Iterator>
+std::optional<condition_match> eval_target(Iterator &it, std::string_view address, bool ephemeral,
     const matcher::base &matcher, const std::span<const transformer_id> &transformers,
     const object_limits &limits, ddwaf::timer &deadline)
-    requires(std::is_same_v<ResultType, bool> ||
-             std::is_same_v<ResultType, std::optional<condition_match>>)
 {
     for (; it; ++it) {
         if (deadline.expired()) {
@@ -102,7 +90,7 @@ ResultType eval_target(Iterator &it, std::string_view address, bool ephemeral,
             continue;
         }
 
-        auto match = eval_object<ResultType>(it, address, ephemeral, matcher, transformers, limits);
+        auto match = eval_object(it, address, ephemeral, matcher, transformers, limits);
         if (match) {
             // If this target matched, we can stop processing
             return match;
@@ -162,11 +150,11 @@ eval_result scalar_condition::eval(condition_cache &cache, const object_store &s
         // TODO: iterators could be cached to avoid reinitialisation
         if (target.source == data_source::keys) {
             object::key_iterator it(object, target.key_path, objects_excluded, limits);
-            match = eval_target<std::optional<condition_match>>(
+            match = eval_target(
                 it, target.name, ephemeral, *matcher, target.transformers, limits, deadline);
         } else {
             object::value_iterator it(object, target.key_path, objects_excluded, limits);
-            match = eval_target<std::optional<condition_match>>(
+            match = eval_target(
                 it, target.name, ephemeral, *matcher, target.transformers, limits, deadline);
         }
 
@@ -174,59 +162,6 @@ eval_result scalar_condition::eval(condition_cache &cache, const object_store &s
             cache.match = std::move(match);
             return {.outcome = true, .ephemeral = ephemeral};
         }
-    }
-
-    return {.outcome = false, .ephemeral = false};
-}
-
-eval_result scalar_negated_condition::eval(condition_cache &cache, const object_store &store,
-    const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
-    const object_limits &limits, ddwaf::timer &deadline) const
-{
-    if (deadline.expired()) {
-        throw ddwaf::timeout_exception();
-    }
-
-    const auto *matcher = get_matcher(matcher_, data_id_, dynamic_matchers);
-    if (matcher == nullptr) {
-        return {};
-    }
-
-    if (cache.targets.size() != 1) {
-        cache.targets.assign(1, nullptr);
-    }
-
-    auto [object, attr] = store.get_target(target_.index);
-    if (object == nullptr || object == cache.targets[0]) {
-        return {};
-    }
-
-    const bool ephemeral = (attr == object_store::attribute::ephemeral);
-    if (!ephemeral) {
-        cache.targets[0] = object;
-    }
-
-    bool match = false;
-    if (target_.source == data_source::keys) {
-        object::key_iterator it(object, target_.key_path, objects_excluded, limits);
-        match = eval_target<bool>(
-            it, target_.name, ephemeral, *matcher, target_.transformers, limits, deadline);
-    } else {
-        object::value_iterator it(object, target_.key_path, objects_excluded, limits);
-        match = eval_target<bool>(
-            it, target_.name, ephemeral, *matcher, target_.transformers, limits, deadline);
-    }
-
-    if (!match) {
-        cache.match = {{.args = {{.name = "input"sv,
-                            .resolved = object_to_string(*object),
-                            .address = target_.name,
-                            .key_path = {target_.key_path.begin(), target_.key_path.end()}}},
-            .highlights = {},
-            .operator_name = matcher->negated_name(),
-            .operator_value = matcher->to_string(),
-            .ephemeral = ephemeral}};
-        return {.outcome = true, .ephemeral = ephemeral};
     }
 
     return {.outcome = false, .ephemeral = false};

--- a/src/condition/scalar_negated_condition.cpp
+++ b/src/condition/scalar_negated_condition.cpp
@@ -1,0 +1,234 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+#include "clock.hpp"
+#include "condition/base.hpp"
+#include "ddwaf.h"
+#include "exception.hpp"
+#include "exclusion/common.hpp"
+#include "iterator.hpp"
+#include "log.hpp"
+#include "matcher/base.hpp"
+#include "object_store.hpp"
+#include "scalar_negated_condition.hpp"
+#include "transformer/base.hpp"
+#include "transformer/manager.hpp"
+#include "utils.hpp"
+
+using namespace std::literals;
+
+namespace ddwaf {
+
+// Support for key path, only raise an event when there key path is actually present
+// When using key paths containing a scalar or a single-value array, report the value that didn't match
+// Ignore "unevaluated" non-matches (e,g. string shorter than min_length on match_regex)
+namespace {
+
+// Types to represent:
+// - No evaluation was performed - unknown_type
+// - Evaluation was performed but there was no match - no_match_type
+struct unknown_type {};
+struct no_match_type {};
+
+using result_type = std::variant<unknown_type, no_match_type, condition_match>;
+
+template <typename Iterator>
+bool eval_object(Iterator &it, std::string_view address, const matcher::base &matcher,
+    const std::span<const transformer_id> &transformers, const object_limits &limits)
+{
+    // The iterator is guaranteed to be valid at this point, which means the
+    // object pointer should not be nullptr
+    ddwaf_object src = *(*it);
+
+    if (src.type == DDWAF_OBJ_STRING) {
+        if (src.stringValue == nullptr) {
+            return {};
+        }
+
+        src.nbEntries = find_string_cutoff(src.stringValue, src.nbEntries, limits);
+        if (!transformers.empty()) {
+            ddwaf_object dst;
+            ddwaf_object_invalid(&dst);
+
+            auto transformed = transformer::manager::transform(src, dst, transformers);
+            const scope_exit on_exit([&dst] { ddwaf_object_free(&dst); });
+            if (transformed) {
+                auto [res, highlight] = matcher.match(dst);
+                if (!res) {
+                    return {};
+                }
+
+                DDWAF_TRACE("Target {} matched parameter value {}", address, highlight);
+
+                return true;
+            }
+        }
+    }
+
+    auto [res, highlight] = matcher.match(src);
+    if (!res) {
+        return {};
+    }
+
+    DDWAF_TRACE("Target {} matched parameter value {}", address, highlight);
+
+    return true;
+}
+
+template <typename Iterator>
+bool eval_target(Iterator &it, std::string_view address, const matcher::base &matcher, const std::span<const transformer_id> &transformers, const object_limits &limits, ddwaf::timer &deadline)
+{
+    for (; it; ++it) {
+        if (deadline.expired()) {
+            throw ddwaf::timeout_exception();
+        }
+
+        if (!matcher.is_supported_type(it.type())) {
+            continue;
+        }
+
+        auto match = eval_object(it, address, matcher, transformers, limits);
+        if (match) {
+            // If this target matched, we can stop processing
+            return match;
+        }
+    }
+
+    return {};
+}
+
+const matcher::base *get_matcher(const std::unique_ptr<matcher::base> &matcher,
+    const std::string &data_id, const matcher_mapper &dynamic_matchers)
+{
+    if (matcher || data_id.empty()) {
+        return matcher.get();
+    }
+
+    auto it = dynamic_matchers.find(data_id);
+    if (it != dynamic_matchers.end()) {
+        return it->second.get();
+    }
+
+    return nullptr;
+}
+
+// TODO Refactor from exists
+const ddwaf_object *find_key(
+    const ddwaf_object &parent, std::string_view key, const object_limits &limits)
+{
+    const std::size_t size =
+        std::min(static_cast<uint32_t>(parent.nbEntries), limits.max_container_size);
+    for (std::size_t i = 0; i < size; ++i) {
+        const auto &child = parent.array[i];
+
+        if (child.parameterName == nullptr) [[unlikely]] {
+            continue;
+        }
+        const std::string_view child_key{
+            child.parameterName, static_cast<std::size_t>(child.parameterNameLength)};
+
+        if (key == child_key) {
+            return &child;
+        }
+    }
+
+    return nullptr;
+}
+
+const ddwaf_object* find_key_path(const ddwaf_object *root, std::span<const std::string> key_path,
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits)
+{
+    if (key_path.empty()) {
+        return root;
+    }
+
+    if (root->type == DDWAF_OBJ_MAP) {
+        auto it = key_path.begin();
+        while ((root = find_key(*root, *it, limits)) != nullptr) {
+            if (objects_excluded.contains(root)) {
+                break;
+            }
+
+            if (++it == key_path.end()) {
+                return root;
+            }
+
+            if (root->type != DDWAF_OBJ_MAP) {
+                break;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+
+} // namespace
+
+eval_result scalar_negated_condition::eval(condition_cache &cache, const object_store &store,
+    const exclusion::object_set_ref &objects_excluded, const matcher_mapper &dynamic_matchers,
+    const object_limits &limits, ddwaf::timer &deadline) const
+{
+    if (deadline.expired()) {
+        throw ddwaf::timeout_exception();
+    }
+
+    const auto *matcher = get_matcher(matcher_, data_id_, dynamic_matchers);
+    if (matcher == nullptr) {
+        return {};
+    }
+
+    if (cache.targets.size() != 1) {
+        cache.targets.assign(1, nullptr);
+    }
+
+    auto [object, attr] = store.get_target(target_.index);
+    if (object == nullptr || object == cache.targets[0]) {
+        return {};
+    }
+
+    const bool ephemeral = (attr == object_store::attribute::ephemeral);
+    if (!ephemeral) {
+        cache.targets[0] = object;
+    }
+
+    bool match = false;
+    if (target_.source == data_source::keys) {
+        object::key_iterator it(object, target_.key_path, objects_excluded, limits);
+        match = eval_target(it, target_.name, *matcher, target_.transformers, limits, deadline);
+
+        if (!match) {
+            cache.match = {{.args = {{.name = "input"sv,
+                                .resolved = {},
+                                .address = target_.name,
+                                .key_path = {target_.key_path.begin(), target_.key_path.end()}}},
+                .highlights = {},
+                .operator_name = matcher->negated_name(),
+                .operator_value = matcher->to_string(),
+                .ephemeral = ephemeral}};
+            return {.outcome = true, .ephemeral = ephemeral};
+        }
+    } else {
+        const auto *target_object = find_key_path(object, target_.key_path, objects_excluded, limits);
+        if (target_object == nullptr) {
+            return {.outcome = false, .ephemeral = false};
+        }
+
+        object::value_iterator it(object, target_.key_path, objects_excluded, limits);
+        match = eval_target(it, target_.name, *matcher, target_.transformers, limits, deadline);
+    }
+
+    return {.outcome = false, .ephemeral = false};
+}
+
+} // namespace ddwaf

--- a/src/condition/scalar_negated_condition.hpp
+++ b/src/condition/scalar_negated_condition.hpp
@@ -10,9 +10,9 @@
 
 namespace ddwaf {
 
-class scalar_condition : public base_condition {
+class scalar_negated_condition : public base_condition {
 public:
-    scalar_condition(std::unique_ptr<matcher::base> &&matcher, std::string data_id,
+    scalar_negated_condition(std::unique_ptr<matcher::base> &&matcher, std::string data_id,
         std::vector<condition_parameter> args)
         : matcher_(std::move(matcher)), data_id_(std::move(data_id))
     {
@@ -24,7 +24,11 @@ public:
             throw std::invalid_argument("matcher initialised without arguments");
         }
 
-        targets_ = std::move(args[0].targets);
+        if (args[0].targets.size() > 1) {
+            throw std::invalid_argument("negated matchers don't support variadic arguments");
+        }
+
+        target_ = std::move(args[0].targets[0]);
     }
 
     eval_result eval(condition_cache &cache, const object_store &store,
@@ -33,19 +37,19 @@ public:
 
     void get_addresses(std::unordered_map<target_index, std::string> &addresses) const override
     {
-        for (const auto &target : targets_) { addresses.emplace(target.index, target.name); }
+        addresses.emplace(target_.index, target_.name);
     }
 
     static constexpr auto arguments()
     {
         return std::array<parameter_specification, 1>{
-            {{.name = "inputs", .variadic = true, .optional = false}}};
+            {{.name = "inputs", .variadic = false, .optional = false}}};
     }
 
 protected:
     std::unique_ptr<matcher::base> matcher_;
     std::string data_id_;
-    std::vector<condition_target> targets_;
+    condition_target target_;
 };
 
 } // namespace ddwaf

--- a/src/configuration/common/expression_parser.cpp
+++ b/src/configuration/common/expression_parser.cpp
@@ -14,8 +14,8 @@
 #include "condition/cmdi_detector.hpp"
 #include "condition/exists.hpp"
 #include "condition/lfi_detector.hpp"
+#include "condition/negated_scalar_condition.hpp"
 #include "condition/scalar_condition.hpp"
-#include "condition/scalar_negated_condition.hpp"
 #include "condition/shi_detector.hpp"
 #include "condition/sqli_detector.hpp"
 #include "condition/ssrf_detector.hpp"
@@ -237,12 +237,12 @@ std::shared_ptr<expression> parse_expression(const raw_configuration::vector &co
             conditions.emplace_back(std::make_unique<exists_condition>(std::move(arguments)));
         } else if (operator_name == "!exists") {
             auto arguments =
-                parse_arguments<exists_negated_condition>(params, source, transformers);
+                parse_arguments<negated_exists_condition>(params, source, transformers);
             conditions.emplace_back(
-                std::make_unique<exists_negated_condition>(std::move(arguments)));
+                std::make_unique<negated_exists_condition>(std::move(arguments)));
         } else if (operator_name.starts_with('!')) {
             conditions.emplace_back(
-                build_condition<scalar_negated_condition, matcher::ip_match, matcher::exact_match,
+                build_condition<negated_scalar_condition, matcher::ip_match, matcher::exact_match,
                     matcher::regex_match, matcher::phrase_match, matcher::equals<>>(
                     operator_name.substr(1), params, source, transformers));
         } else {

--- a/src/configuration/common/expression_parser.cpp
+++ b/src/configuration/common/expression_parser.cpp
@@ -15,6 +15,7 @@
 #include "condition/exists.hpp"
 #include "condition/lfi_detector.hpp"
 #include "condition/scalar_condition.hpp"
+#include "condition/scalar_negated_condition.hpp"
 #include "condition/shi_detector.hpp"
 #include "condition/sqli_detector.hpp"
 #include "condition/ssrf_detector.hpp"

--- a/src/exclusion/object_filter.cpp
+++ b/src/exclusion/object_filter.cpp
@@ -15,6 +15,7 @@
 #include "exclusion/common.hpp"
 #include "exclusion/object_filter.hpp"
 #include "log.hpp"
+#include "object_helpers.hpp"
 #include "object_store.hpp"
 #include "utils.hpp"
 

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -13,6 +13,7 @@
 #include "ddwaf.h"
 #include "exclusion/common.hpp"
 #include "iterator.hpp"
+#include "object_helpers.hpp"
 #include "utils.hpp"
 
 namespace ddwaf::object {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -14,7 +14,7 @@
 #include "ddwaf.h"
 #include "json_utils.hpp"
 #include "log.hpp"
-#include "utils.hpp"
+#include "object_helpers.hpp"
 
 extern "C" {
 namespace {

--- a/src/object_helpers.cpp
+++ b/src/object_helpers.cpp
@@ -120,6 +120,10 @@ const ddwaf_object *find_key(
 const ddwaf_object *find_key_path(const ddwaf_object *root, std::span<const std::string> key_path,
     const exclusion::object_set_ref &objects_excluded, const object_limits &limits)
 {
+    if (objects_excluded.contains(root)) {
+        return nullptr;
+    }
+
     if (key_path.empty()) {
         return root;
     }

--- a/src/object_helpers.cpp
+++ b/src/object_helpers.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <list>
@@ -13,6 +14,8 @@
 #include <utility>
 
 #include "ddwaf.h"
+#include "exclusion/common.hpp"
+#include "object_helpers.hpp"
 #include "utils.hpp"
 
 namespace ddwaf::object {
@@ -92,35 +95,53 @@ ddwaf_object clone(const ddwaf_object *input)
     return copy;
 }
 
-// This could eventually be delegated to the argument retriever, albeit it would
-// need to be refactored to allow for key path retrieval or not
-const ddwaf_object *find_key_path(const ddwaf_object &root, std::span<const std::string> key_path)
+const ddwaf_object *find_key(
+    const ddwaf_object &parent, std::string_view key, const object_limits &limits)
 {
-    const auto *current = &root;
-    for (auto it = key_path.begin(); current != nullptr && it != key_path.end(); ++it) {
-        const auto &root = *current;
-        if (root.type != DDWAF_OBJ_MAP) {
-            return nullptr;
+    const std::size_t size =
+        std::min(static_cast<uint32_t>(parent.nbEntries), limits.max_container_size);
+    for (std::size_t i = 0; i < size; ++i) {
+        const auto &child = parent.array[i];
+
+        if (child.parameterName == nullptr) [[unlikely]] {
+            continue;
         }
+        const std::string_view child_key{
+            child.parameterName, static_cast<std::size_t>(child.parameterNameLength)};
 
-        // Reset to search for next object in the path
-        current = nullptr;
-        for (std::size_t i = 0; i < static_cast<uint32_t>(root.nbEntries); ++i) {
-            const auto &child = root.array[i];
+        if (key == child_key) {
+            return &child;
+        }
+    }
 
-            if (child.parameterName == nullptr) [[unlikely]] {
-                continue;
+    return nullptr;
+}
+
+const ddwaf_object *find_key_path(const ddwaf_object *root, std::span<const std::string> key_path,
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits)
+{
+    if (key_path.empty()) {
+        return root;
+    }
+
+    if (root->type == DDWAF_OBJ_MAP) {
+        auto it = key_path.begin();
+        while ((root = find_key(*root, *it, limits)) != nullptr) {
+            if (objects_excluded.contains(root)) {
+                break;
             }
-            const std::string_view child_key{
-                child.parameterName, static_cast<std::size_t>(child.parameterNameLength)};
 
-            if (*it == child_key) {
-                current = &child;
+            if (++it == key_path.end()) {
+                return root;
+            }
+
+            if (root->type != DDWAF_OBJ_MAP) {
                 break;
             }
         }
     }
-    return current;
+
+    return nullptr;
 }
 
 void assign(ddwaf_object &dest, const ddwaf_object &source)

--- a/src/object_helpers.hpp
+++ b/src/object_helpers.hpp
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+#pragma once
+
+#include <span>
+#include <string>
+
+#include "ddwaf.h"
+#include "exclusion/common.hpp"
+
+// Internals
+// clang-format off
+#define PWI_DATA_TYPES (DDWAF_OBJ_SIGNED | DDWAF_OBJ_UNSIGNED | DDWAF_OBJ_STRING | DDWAF_OBJ_BOOL | DDWAF_OBJ_FLOAT)
+#define PWI_CONTAINER_TYPES (DDWAF_OBJ_ARRAY | DDWAF_OBJ_MAP)
+#define DDWAF_RESULT_INITIALISER {false,  {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_ARRAY}, {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_MAP}, {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_MAP}, 0}
+// clang-format on
+
+namespace ddwaf::object {
+
+inline bool is_container(const ddwaf_object *obj)
+{
+    return obj != nullptr && (obj->type & PWI_CONTAINER_TYPES) != 0 && obj->array != nullptr;
+}
+
+inline bool is_map(const ddwaf_object *obj)
+{
+    return obj != nullptr && obj->type == DDWAF_OBJ_MAP && obj->array != nullptr;
+}
+
+inline bool is_scalar(const ddwaf_object *obj)
+{
+    return obj != nullptr && (obj->type & PWI_DATA_TYPES) != 0;
+}
+
+inline bool is_invalid_or_null(const ddwaf_object *obj)
+{
+    return obj != nullptr && (obj->type == DDWAF_OBJ_INVALID || obj->type == DDWAF_OBJ_NULL);
+}
+
+ddwaf_object clone(const ddwaf_object *input);
+
+const ddwaf_object *find_key(
+    const ddwaf_object &parent, std::string_view key, const object_limits &limits);
+
+const ddwaf_object *find_key_path(const ddwaf_object *root, std::span<const std::string> key_path,
+    const exclusion::object_set_ref &objects_excluded, const object_limits &limits);
+
+// Assign source to dest without leaking keys
+void assign(ddwaf_object &dest, const ddwaf_object &source);
+
+} // namespace ddwaf::object

--- a/src/processor/jwt_decode.cpp
+++ b/src/processor/jwt_decode.cpp
@@ -11,6 +11,7 @@
 #include "cow_string.hpp"
 #include "ddwaf.h"
 #include "json_utils.hpp"
+#include "object_helpers.hpp"
 #include "object_store.hpp"
 #include "processor/base.hpp"
 #include "transformer/base64_decode.hpp"
@@ -79,7 +80,7 @@ std::string_view find_token(const ddwaf_object &root, std::span<const std::strin
 {
     const ddwaf_object *object = &root;
     if (!key_path.empty()) {
-        object = object::find_key_path(root, key_path);
+        object = object::find_key_path(object, key_path, {}, {});
         if (object == nullptr) {
             return {};
         }

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -19,6 +19,7 @@
 #include "condition/base.hpp"
 #include "ddwaf.h"
 #include "obfuscator.hpp"
+#include "object_helpers.hpp"
 #include "object_store.hpp"
 #include "rule.hpp"
 #include "serializer.hpp"

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -34,13 +34,6 @@
 
 template <typename T> using optional_ref = std::optional<std::reference_wrapper<T>>;
 
-// Internals
-// clang-format off
-#define PWI_DATA_TYPES (DDWAF_OBJ_SIGNED | DDWAF_OBJ_UNSIGNED | DDWAF_OBJ_STRING | DDWAF_OBJ_BOOL | DDWAF_OBJ_FLOAT)
-#define PWI_CONTAINER_TYPES (DDWAF_OBJ_ARRAY | DDWAF_OBJ_MAP)
-#define DDWAF_RESULT_INITIALISER {false,  {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_ARRAY}, {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_MAP}, {nullptr, 0, {nullptr}, 0, DDWAF_OBJ_MAP}, 0}
-// clang-format on
-
 namespace ddwaf {
 
 struct eval_result {
@@ -89,36 +82,6 @@ inline size_t find_string_cutoff(const char *str, size_t length, object_limits l
 
     return pos;
 }
-
-namespace object {
-
-inline bool is_container(const ddwaf_object *obj)
-{
-    return obj != nullptr && (obj->type & PWI_CONTAINER_TYPES) != 0 && obj->array != nullptr;
-}
-
-inline bool is_map(const ddwaf_object *obj)
-{
-    return obj != nullptr && obj->type == DDWAF_OBJ_MAP && obj->array != nullptr;
-}
-
-inline bool is_scalar(const ddwaf_object *obj)
-{
-    return obj != nullptr && (obj->type & PWI_DATA_TYPES) != 0;
-}
-
-inline bool is_invalid_or_null(const ddwaf_object *obj)
-{
-    return obj != nullptr && (obj->type == DDWAF_OBJ_INVALID || obj->type == DDWAF_OBJ_NULL);
-}
-
-ddwaf_object clone(const ddwaf_object *input);
-
-const ddwaf_object *find_key_path(const ddwaf_object &root, std::span<const std::string> key_path);
-
-// Assign source to dest without leaking keys
-void assign(ddwaf_object &dest, const ddwaf_object &source);
-} // namespace object
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 inline bool isalpha(char c) { return (static_cast<unsigned>(c) | 32) - 'a' < 26; }

--- a/tests/common/base_utils.hpp
+++ b/tests/common/base_utils.hpp
@@ -5,8 +5,8 @@
 // Copyright 2021 Datadog, Inc.
 #pragma once
 
+#include "condition/negated_scalar_condition.hpp"
 #include "condition/scalar_condition.hpp"
-#include "condition/scalar_negated_condition.hpp"
 #include "expression.hpp"
 #include "matcher/base.hpp"
 #include "radixlib.h"
@@ -60,7 +60,7 @@ public:
                 std::make_unique<scalar_condition>(std::make_unique<T>(std::forward<Args>(args)...),
                     std::string{}, std::move(arguments_)));
         } else {
-            conditions_.emplace_back(std::make_unique<scalar_negated_condition>(
+            conditions_.emplace_back(std::make_unique<negated_scalar_condition>(
                 std::make_unique<T>(std::forward<Args>(args)...), std::string{},
                 std::move(arguments_)));
         }
@@ -74,7 +74,7 @@ public:
             conditions_.emplace_back(std::make_unique<scalar_condition>(
                 std::unique_ptr<matcher::base>{}, std::move(data_id), std::move(arguments_)));
         } else {
-            conditions_.emplace_back(std::make_unique<scalar_negated_condition>(
+            conditions_.emplace_back(std::make_unique<negated_scalar_condition>(
                 std::unique_ptr<matcher::base>{}, std::move(data_id), std::move(arguments_)));
         }
     }

--- a/tests/common/base_utils.hpp
+++ b/tests/common/base_utils.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "condition/scalar_condition.hpp"
+#include "condition/scalar_negated_condition.hpp"
 #include "expression.hpp"
 #include "matcher/base.hpp"
 #include "radixlib.h"

--- a/tests/unit/condition/exists_condition_test.cpp
+++ b/tests/unit/condition/exists_condition_test.cpp
@@ -229,9 +229,9 @@ TEST(TestExistsCondition, MultipleAddressesAndKeyPaths)
     validate_address("usr.session_id", {}, false);
 }
 
-TEST(TestExistsNegatedCondition, KeyPathAvailable)
+TEST(TestNegatedExistsCondition, KeyPathAvailable)
 {
-    exists_negated_condition cond{{{{{{"server.request.uri_raw",
+    negated_exists_condition cond{{{{{{"server.request.uri_raw",
         get_target_index("server.request.uri_raw"), {"path", "to", "object"}}}}}}};
 
     ddwaf_object tmp;
@@ -261,9 +261,9 @@ TEST(TestExistsNegatedCondition, KeyPathAvailable)
     ASSERT_FALSE(res.outcome);
 }
 
-TEST(TestExistsNegatedCondition, KeyPathNotAvailable)
+TEST(TestNegatedExistsCondition, KeyPathNotAvailable)
 {
-    exists_negated_condition cond{{{{{{"server.request.uri_raw",
+    negated_exists_condition cond{{{{{{"server.request.uri_raw",
         get_target_index("server.request.uri_raw"), {"path", "to", "object"}}}}}}};
 
     ddwaf_object tmp;
@@ -289,9 +289,9 @@ TEST(TestExistsNegatedCondition, KeyPathNotAvailable)
     ASSERT_TRUE(res.outcome);
 }
 
-TEST(TestExistsNegatedCondition, KeyPathAvailableButExcluded)
+TEST(TestNegatedExistsCondition, KeyPathAvailableButExcluded)
 {
-    exists_negated_condition cond{{{{{{"server.request.uri_raw",
+    negated_exists_condition cond{{{{{{"server.request.uri_raw",
         get_target_index("server.request.uri_raw"), {"path", "to", "object"}}}}}}};
 
     ddwaf_object tmp;

--- a/tests/unit/condition/negated_scalar_condition_test.cpp
+++ b/tests/unit/condition/negated_scalar_condition_test.cpp
@@ -4,7 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
-#include "condition/scalar_negated_condition.hpp"
+#include "condition/negated_scalar_condition.hpp"
 #include "exception.hpp"
 #include "matcher/regex_match.hpp"
 #include "utils.hpp"
@@ -21,32 +21,32 @@ template <typename... Args> condition_parameter gen_variadic_param(Args... addre
     return {{{std::string{addresses}, get_target_index(addresses)}...}};
 }
 
-TEST(TestScalarNegatedCondition, VariadicTargetInConstructor)
+TEST(TestNegatedScalarCondition, VariadicTargetInConstructor)
 {
-    EXPECT_THROW((scalar_negated_condition{std::make_unique<matcher::regex_match>(".*", 0, true),
+    EXPECT_THROW((negated_scalar_condition{std::make_unique<matcher::regex_match>(".*", 0, true),
                      {}, {gen_variadic_param("server.request.uri.raw", "server.request.query")}}),
         std::invalid_argument);
 }
 
-TEST(TestScalarNegatedCondition, TooManyAddressesInConstructor)
+TEST(TestNegatedScalarCondition, TooManyAddressesInConstructor)
 {
     EXPECT_THROW(
-        (scalar_negated_condition{std::make_unique<matcher::regex_match>(".*", 0, true), {},
+        (negated_scalar_condition{std::make_unique<matcher::regex_match>(".*", 0, true), {},
             {gen_variadic_param("server.request.uri.raw"),
                 gen_variadic_param("server.request.query")}}),
         std::invalid_argument);
 }
 
-TEST(TestScalarNegatedCondition, NoAddressesInConstructor)
+TEST(TestNegatedScalarCondition, NoAddressesInConstructor)
 {
     EXPECT_THROW(
-        (scalar_negated_condition{std::make_unique<matcher::regex_match>(".*", 0, true), {}, {}}),
+        (negated_scalar_condition{std::make_unique<matcher::regex_match>(".*", 0, true), {}, {}}),
         std::invalid_argument);
 }
 
-TEST(TestScalarNegatedCondition, NoMatch)
+TEST(TestNegatedScalarCondition, NoMatch)
 {
-    scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
+    negated_scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf_object tmp;
@@ -64,9 +64,9 @@ TEST(TestScalarNegatedCondition, NoMatch)
     ASSERT_FALSE(res.ephemeral);
 }
 
-TEST(TestScalarNegatedCondition, Timeout)
+TEST(TestNegatedScalarCondition, Timeout)
 {
-    scalar_negated_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
+    negated_scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf_object tmp;
@@ -82,9 +82,9 @@ TEST(TestScalarNegatedCondition, Timeout)
     EXPECT_THROW(cond.eval(cache, store, {}, {}, {}, deadline), ddwaf::timeout_exception);
 }
 
-TEST(TestScalarNegatedCondition, SimpleMatch)
+TEST(TestNegatedScalarCondition, SimpleMatch)
 {
-    scalar_negated_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
+    negated_scalar_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf_object tmp;
@@ -102,9 +102,9 @@ TEST(TestScalarNegatedCondition, SimpleMatch)
     ASSERT_FALSE(res.ephemeral);
 }
 
-TEST(TestScalarNegatedCondition, CachedMatch)
+TEST(TestNegatedScalarCondition, CachedMatch)
 {
-    scalar_negated_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
+    negated_scalar_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf::timer deadline{2s};
@@ -136,12 +136,12 @@ TEST(TestScalarNegatedCondition, CachedMatch)
     ddwaf_object_free(&root);
 }
 
-TEST(TestScalarNegatedCondition, SimpleMatchOnKeys)
+TEST(TestNegatedScalarCondition, SimpleMatchOnKeys)
 {
     auto target = gen_variadic_param("server.request.uri.raw");
     target.targets[0].source = data_source::keys;
 
-    scalar_negated_condition cond{
+    negated_scalar_condition cond{
         std::make_unique<matcher::regex_match>("hello", 0, true), {}, {std::move(target)}};
 
     ddwaf_object tmp;
@@ -162,9 +162,9 @@ TEST(TestScalarNegatedCondition, SimpleMatchOnKeys)
     ASSERT_FALSE(res.ephemeral);
 }
 
-TEST(TestScalarNegatedCondition, SimpleEphemeralMatch)
+TEST(TestNegatedScalarCondition, SimpleEphemeralMatch)
 {
-    scalar_negated_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
+    negated_scalar_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
     ddwaf_object tmp;

--- a/tests/unit/condition/scalar_negated_condition_test.cpp
+++ b/tests/unit/condition/scalar_negated_condition_test.cpp
@@ -4,7 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
-#include "condition/scalar_condition.hpp"
+#include "condition/scalar_negated_condition.hpp"
 #include "exception.hpp"
 #include "matcher/regex_match.hpp"
 #include "utils.hpp"

--- a/tests/unit/expression_test.cpp
+++ b/tests/unit/expression_test.cpp
@@ -79,7 +79,7 @@ TEST(TestExpression, SimpleNegatedMatch)
     EXPECT_FALSE(matches[0].ephemeral);
     EXPECT_MATCHES(matches, {.op = "!match_regex",
                                 .op_value = ".*",
-                                .highlight = ""sv,
+                                .highlight = "val"sv,
                                 .args = {{
                                     .value = "val"sv,
                                     .address = "server.request.query",

--- a/tests/unit/utils_test.cpp
+++ b/tests/unit/utils_test.cpp
@@ -6,6 +6,7 @@
 
 #include <unordered_map>
 
+#include "object_helpers.hpp"
 #include "utils.hpp"
 
 #include "common/gtest_utils.hpp"

--- a/validator/tests/rules/operators/match_regex/005_rule3_negated_match_regex_with_transformer.yaml
+++ b/validator/tests/rules/operators/match_regex/005_rule3_negated_match_regex_with_transformer.yaml
@@ -1,0 +1,21 @@
+{
+  name: "Basic run with negated match_regex operator and transformer",
+  runs: [
+    {
+      persistent-input: {
+        rule3-input: "something else or other"
+      },
+      rules: [
+        {
+          3: [
+            {
+              address: rule3-input,
+              value: "something else or other"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/match_regex/006_rule3_negated_match_regex_with_transformer_no_match.yaml
+++ b/validator/tests/rules/operators/match_regex/006_rule3_negated_match_regex_with_transformer_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with negated match_regex operator and transformer and no match",
+  runs: [
+    {
+      persistent-input: {
+        rule3-input: "ARACHNI"
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/match_regex/ruleset.yaml
+++ b/validator/tests/rules/operators/match_regex/ruleset.yaml
@@ -15,7 +15,7 @@ rules:
             min_length: 7
             case_sensitive: false
   - id: "2"
-    name: rule2-ip-match
+    name: rule2-not-match-regex
     tags:
       type: flow2
       category: category
@@ -25,6 +25,21 @@ rules:
           inputs:
             - address: rule2-input
           regex: "Arachni"
+          options:
+            min_length: 7
+            case_sensitive: false
+  - id: "3"
+    name: rule3-not-match-regex-with-transformer
+    tags:
+      type: flow3
+      category: category
+    conditions:
+      - operator: "!match_regex"
+        parameters:
+          inputs:
+            - address: rule3-input
+              transformers: [ lowercase ]
+          regex: "arachni"
           options:
             min_length: 7
             case_sensitive: false


### PR DESCRIPTION
This PR improves negated operators with the following changes:
- Support for key path, only raise an event when there key path is actually present
- When using key paths containing a scalar or a single-value array, report the value that didn't match
- Ignore non-evaluated non-matches (e,g. incompatible type)

Related Jiras: [APPSEC-58464]

[APPSEC-58464]: https://datadoghq.atlassian.net/browse/APPSEC-58464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ