### PR TITLE
Accept empty and inconsequential configurations

### DIFF
--- a/src/builder/waf_builder.hpp
+++ b/src/builder/waf_builder.hpp
@@ -28,7 +28,7 @@ public:
     waf_builder &operator=(waf_builder &&) = delete;
     waf_builder &operator=(const waf_builder &) = delete;
 
-    bool add_or_update(const std::string &path, raw_configuration &root, base_ruleset_info &info)
+    bool add_or_update(const std::string &path, raw_configuration &root, ruleset_info &info)
     {
         return cfg_mgr_.add_or_update(path, root, info);
     }

--- a/src/configuration/actions_parser.cpp
+++ b/src/configuration/actions_parser.cpp
@@ -18,6 +18,7 @@
 #include "configuration/common/parser_exception.hpp"
 #include "configuration/common/raw_configuration.hpp"
 #include "log.hpp"
+#include "ruleset_info.hpp"
 #include "uri_utils.hpp"
 
 namespace ddwaf {
@@ -87,7 +88,7 @@ void validate_and_add_redirect(auto &cfg, auto id, auto &type, auto &parameters)
 } // namespace
 
 void parse_actions(const raw_configuration::vector &actions_array, configuration_collector &cfg,
-    base_section_info &info)
+    ruleset_info::section_info &info)
 {
     for (unsigned i = 0; i < actions_array.size(); i++) {
         const auto &node_param = actions_array[i];

--- a/src/configuration/actions_parser.hpp
+++ b/src/configuration/actions_parser.hpp
@@ -13,10 +13,11 @@
 #include "configuration/common/configuration.hpp"
 #include "configuration/common/configuration_collector.hpp"
 #include "configuration/common/raw_configuration.hpp"
+#include "ruleset_info.hpp"
 
 namespace ddwaf {
 
 void parse_actions(const raw_configuration::vector &actions_array, configuration_collector &cfg,
-    base_section_info &info);
+    ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/common/common.hpp
+++ b/src/configuration/common/common.hpp
@@ -10,9 +10,6 @@
 
 #include "configuration/common/parser_exception.hpp"
 #include "configuration/common/raw_configuration.hpp"
-#include "ruleset_info.hpp"
-
-using base_section_info = ddwaf::base_ruleset_info::base_section_info;
 
 namespace ddwaf {
 

--- a/src/configuration/configuration_manager.cpp
+++ b/src/configuration/configuration_manager.cpp
@@ -33,7 +33,7 @@
 namespace ddwaf {
 
 bool configuration_manager::load(
-    raw_configuration::map &root, configuration_collector &collector, base_ruleset_info &info)
+    raw_configuration::map &root, configuration_collector &collector, ruleset_info &info)
 {
     auto metadata = at<raw_configuration::map>(root, "metadata", {});
     auto rules_version = at<std::string_view>(metadata, "rules_version", {});
@@ -268,7 +268,7 @@ void configuration_manager::remove_config(const configuration_change_spec &cfg)
 }
 
 bool configuration_manager::add_or_update(
-    const std::string &path, raw_configuration &root, base_ruleset_info &info)
+    const std::string &path, raw_configuration &root, ruleset_info &info)
 {
     try {
         raw_configuration::map root_map = static_cast<raw_configuration::map>(root);

--- a/src/configuration/configuration_manager.cpp
+++ b/src/configuration/configuration_manager.cpp
@@ -32,7 +32,7 @@
 
 namespace ddwaf {
 
-void configuration_manager::load(
+bool configuration_manager::load(
     raw_configuration::map &root, configuration_collector &collector, base_ruleset_info &info)
 {
     auto metadata = at<raw_configuration::map>(root, "metadata", {});
@@ -64,7 +64,7 @@ void configuration_manager::load(
             }
         }
 
-        return;
+        return info.state() != ruleset_info_state::invalid;
     }
 
     auto it = root.find("actions");
@@ -231,6 +231,8 @@ void configuration_manager::load(
             section.set_error(e.what());
         }
     }
+
+    return info.state() != ruleset_info_state::invalid;
 }
 
 void configuration_manager::remove_config(const configuration_change_spec &cfg)
@@ -288,8 +290,7 @@ bool configuration_manager::add_or_update(
         configuration_change_spec new_config;
         configuration_collector collector{new_config, global_config_};
 
-        load(root_map, collector, info);
-        if (new_config.empty()) {
+        if (!load(root_map, collector, info)) {
             configs_.erase(it);
             return false;
         }

--- a/src/configuration/configuration_manager.hpp
+++ b/src/configuration/configuration_manager.hpp
@@ -57,6 +57,12 @@ public:
 protected:
     void remove_config(const configuration_change_spec &cfg);
 
+    // This function returns:
+    //  - true: when the configuration was fully or partially loaded, this
+    //          will also be the return value when the configuration is empty or
+    //          inconsequential, i.e. no element can be loaded due to compat
+    //  - false: when no elements within the configuration could be loaded due
+    //           to errors. This implies that the configuration must be rejected
     static bool load(
         raw_configuration::map &root, configuration_collector &collector, ruleset_info &info);
 

--- a/src/configuration/configuration_manager.hpp
+++ b/src/configuration/configuration_manager.hpp
@@ -27,7 +27,7 @@ public:
     configuration_manager &operator=(configuration_manager &&) = delete;
     configuration_manager &operator=(const configuration_manager &) = delete;
 
-    bool add_or_update(const std::string &path, raw_configuration &root, base_ruleset_info &info);
+    bool add_or_update(const std::string &path, raw_configuration &root, ruleset_info &info);
     bool remove(const std::string &path);
 
     std::pair<const configuration_spec &, change_set> consolidate();
@@ -58,7 +58,7 @@ protected:
     void remove_config(const configuration_change_spec &cfg);
 
     static bool load(
-        raw_configuration::map &root, configuration_collector &collector, base_ruleset_info &info);
+        raw_configuration::map &root, configuration_collector &collector, ruleset_info &info);
 
     std::unordered_map<std::string, configuration_change_spec> configs_;
     configuration_spec global_config_;

--- a/src/configuration/configuration_manager.hpp
+++ b/src/configuration/configuration_manager.hpp
@@ -57,7 +57,7 @@ public:
 protected:
     void remove_config(const configuration_change_spec &cfg);
 
-    static void load(
+    static bool load(
         raw_configuration::map &root, configuration_collector &collector, base_ruleset_info &info);
 
     std::unordered_map<std::string, configuration_change_spec> configs_;

--- a/src/configuration/data_parser.cpp
+++ b/src/configuration/data_parser.cpp
@@ -18,6 +18,7 @@
 #include "configuration/common/raw_configuration.hpp"
 #include "configuration/data_parser.hpp"
 #include "log.hpp"
+#include "ruleset_info.hpp"
 #include "uuid.hpp"
 
 namespace ddwaf {
@@ -53,8 +54,8 @@ data_type data_type_from_string(std::string_view str_type)
     return data_type::unknown;
 }
 
-void parse_data(
-    const raw_configuration::vector &data_array, base_section_info &info, auto &&emplace_fn)
+void parse_data(const raw_configuration::vector &data_array, ruleset_info::section_info &info,
+    auto &&emplace_fn)
 {
     for (unsigned i = 0; i < data_array.size(); ++i) {
         const ddwaf::raw_configuration object = data_array[i];
@@ -92,7 +93,7 @@ void parse_data(
 } // namespace
 
 void parse_rule_data(const raw_configuration::vector &data_array, configuration_collector &cfg,
-    base_section_info &info)
+    ruleset_info::section_info &info)
 {
     parse_data(data_array, info,
         [&cfg](std::string &&data_id, std::string &&id, data_type type,
@@ -102,7 +103,7 @@ void parse_rule_data(const raw_configuration::vector &data_array, configuration_
 }
 
 void parse_exclusion_data(const raw_configuration::vector &data_array, configuration_collector &cfg,
-    base_section_info &info)
+    ruleset_info::section_info &info)
 {
     parse_data(data_array, info,
         [&cfg](std::string &&data_id, std::string &&id, data_type type,

--- a/src/configuration/data_parser.hpp
+++ b/src/configuration/data_parser.hpp
@@ -9,12 +9,13 @@
 #include "configuration/common/common.hpp"
 #include "configuration/common/configuration_collector.hpp"
 #include "configuration/common/raw_configuration.hpp"
+#include "ruleset_info.hpp"
 
 namespace ddwaf {
 
 void parse_rule_data(const raw_configuration::vector &data_array, configuration_collector &cfg,
-    base_section_info &info);
+    ruleset_info::section_info &info);
 void parse_exclusion_data(const raw_configuration::vector &data_array, configuration_collector &cfg,
-    base_section_info &info);
+    ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/exclusion_parser.cpp
+++ b/src/configuration/exclusion_parser.cpp
@@ -23,6 +23,7 @@
 #include "exclusion/common.hpp"
 #include "exclusion/object_filter.hpp"
 #include "log.hpp"
+#include "ruleset_info.hpp"
 #include "semver.hpp"
 #include "target_address.hpp"
 #include "version.hpp"
@@ -112,7 +113,7 @@ rule_filter_spec parse_rule_filter(const raw_configuration::map &filter)
 } // namespace
 
 void parse_filters(const raw_configuration::vector &filter_array, configuration_collector &cfg,
-    base_section_info &info)
+    ruleset_info::section_info &info)
 {
     for (unsigned i = 0; i < filter_array.size(); i++) {
         const auto &node_param = filter_array[i];

--- a/src/configuration/exclusion_parser.hpp
+++ b/src/configuration/exclusion_parser.hpp
@@ -13,6 +13,6 @@
 namespace ddwaf {
 
 void parse_filters(const raw_configuration::vector &filter_array, configuration_collector &cfg,
-    ruleset_info::base_section_info &info);
+    ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/legacy_rule_parser.cpp
+++ b/src/configuration/legacy_rule_parser.cpp
@@ -32,6 +32,7 @@
 #include "matcher/phrase_match.hpp"
 #include "matcher/regex_match.hpp"
 #include "rule.hpp"
+#include "ruleset_info.hpp"
 #include "target_address.hpp"
 #include "transformer/base.hpp"
 #include "utils.hpp"
@@ -129,7 +130,7 @@ std::shared_ptr<expression> parse_expression(
 } // namespace
 
 void parse_legacy_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info)
+    ruleset_info::section_info &info)
 {
     for (unsigned i = 0; i < rule_array.size(); ++i) {
         std::string id;

--- a/src/configuration/legacy_rule_parser.hpp
+++ b/src/configuration/legacy_rule_parser.hpp
@@ -9,10 +9,11 @@
 #include "configuration/common/common.hpp"
 #include "configuration/common/configuration_collector.hpp"
 #include "configuration/common/raw_configuration.hpp"
+#include "ruleset_info.hpp"
 
 namespace ddwaf {
 
 void parse_legacy_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info);
+    ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/processor_override_parser.cpp
+++ b/src/configuration/processor_override_parser.cpp
@@ -55,7 +55,7 @@ processor_override_spec parse_override(const raw_configuration::map &node)
 } // namespace
 
 void parse_processor_overrides(const raw_configuration::vector &override_array,
-    configuration_collector &cfg, ruleset_info::base_section_info &info)
+    configuration_collector &cfg, ruleset_info::section_info &info)
 {
     for (unsigned i = 0; i < override_array.size(); ++i) {
         const auto &node_param = override_array[i];

--- a/src/configuration/processor_override_parser.hpp
+++ b/src/configuration/processor_override_parser.hpp
@@ -13,6 +13,6 @@
 namespace ddwaf {
 
 void parse_processor_overrides(const raw_configuration::vector &override_array,
-    configuration_collector &cfg, ruleset_info::base_section_info &info);
+    configuration_collector &cfg, ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/processor_parser.cpp
+++ b/src/configuration/processor_parser.cpp
@@ -81,7 +81,7 @@ std::vector<processor_mapping> parse_processor_mappings(
 } // namespace
 
 void parse_processors(const raw_configuration::vector &processor_array,
-    configuration_collector &cfg, ruleset_info::base_section_info &info)
+    configuration_collector &cfg, ruleset_info::section_info &info)
 {
     for (unsigned i = 0; i < processor_array.size(); i++) {
         const auto &node_param = processor_array[i];

--- a/src/configuration/processor_parser.hpp
+++ b/src/configuration/processor_parser.hpp
@@ -14,6 +14,6 @@
 namespace ddwaf {
 
 void parse_processors(const raw_configuration::vector &processor_array,
-    configuration_collector &cfg, ruleset_info::base_section_info &info);
+    configuration_collector &cfg, ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/rule_override_parser.cpp
+++ b/src/configuration/rule_override_parser.cpp
@@ -79,7 +79,7 @@ rule_override_spec parse_override(const raw_configuration::map &node)
 } // namespace
 
 void parse_rule_overrides(const raw_configuration::vector &override_array,
-    configuration_collector &cfg, ruleset_info::base_section_info &info)
+    configuration_collector &cfg, ruleset_info::section_info &info)
 {
     for (unsigned i = 0; i < override_array.size(); ++i) {
         const auto &node_param = override_array[i];

--- a/src/configuration/rule_override_parser.hpp
+++ b/src/configuration/rule_override_parser.hpp
@@ -13,6 +13,6 @@
 namespace ddwaf {
 
 void parse_rule_overrides(const raw_configuration::vector &override_array,
-    configuration_collector &cfg, ruleset_info::base_section_info &info);
+    configuration_collector &cfg, ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/rule_parser.cpp
+++ b/src/configuration/rule_parser.cpp
@@ -23,6 +23,7 @@
 #include "ddwaf.h"
 #include "log.hpp"
 #include "rule.hpp"
+#include "ruleset_info.hpp"
 #include "semver.hpp"
 #include "target_address.hpp"
 #include "transformer/base.hpp"
@@ -122,7 +123,7 @@ rule_spec parse_rule(raw_configuration::map &rule, core_rule::source_type source
 }
 
 void parse_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info, core_rule::source_type source)
+    ruleset_info::section_info &info, core_rule::source_type source)
 {
     for (unsigned i = 0; i < rule_array.size(); ++i) {
         std::string id;
@@ -174,13 +175,13 @@ void parse_rules(const raw_configuration::vector &rule_array, configuration_coll
 } // namespace
 
 void parse_base_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info)
+    ruleset_info::section_info &info)
 {
     parse_rules(rule_array, cfg, info, core_rule::source_type::base);
 }
 
 void parse_user_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info)
+    ruleset_info::section_info &info)
 {
     parse_rules(rule_array, cfg, info, core_rule::source_type::user);
 }

--- a/src/configuration/rule_parser.hpp
+++ b/src/configuration/rule_parser.hpp
@@ -9,13 +9,14 @@
 #include "configuration/common/common.hpp"
 #include "configuration/common/configuration_collector.hpp"
 #include "configuration/common/raw_configuration.hpp"
+#include "ruleset_info.hpp"
 
 namespace ddwaf {
 
 void parse_base_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info);
+    ruleset_info::section_info &info);
 
 void parse_user_rules(const raw_configuration::vector &rule_array, configuration_collector &cfg,
-    base_section_info &info);
+    ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/configuration/scanner_parser.cpp
+++ b/src/configuration/scanner_parser.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<matcher::base> parse_scanner_matcher(const raw_configuration::ma
 } // namespace
 
 void parse_scanners(const raw_configuration::vector &scanner_array, configuration_collector &cfg,
-    ruleset_info::base_section_info &info)
+    ruleset_info::section_info &info)
 {
     for (unsigned i = 0; i < scanner_array.size(); i++) {
         const auto &node_param = scanner_array[i];

--- a/src/configuration/scanner_parser.hpp
+++ b/src/configuration/scanner_parser.hpp
@@ -14,6 +14,6 @@
 namespace ddwaf {
 
 void parse_scanners(const raw_configuration::vector &scanner_array, configuration_collector &cfg,
-    ruleset_info::base_section_info &info);
+    ruleset_info::section_info &info);
 
 } // namespace ddwaf

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -103,15 +103,12 @@ ddwaf::waf *ddwaf_init(
                 limits_from_config(config), free_fn, obfuscator_from_config(config));
 
             ddwaf::raw_configuration input = *ruleset;
-            if (diagnostics == nullptr) {
-                ddwaf::null_ruleset_info ri;
-
-                builder.add_or_update("default", input, ri);
-                return new ddwaf::waf{builder.build()};
-            }
-
             ddwaf::ruleset_info ri;
-            const ddwaf::scope_exit on_exit([&]() { ri.to_object(*diagnostics); });
+            const ddwaf::scope_exit on_exit([&]() {
+                if (diagnostics != nullptr) {
+                    ri.to_object(*diagnostics);
+                }
+            });
             builder.add_or_update("default", input, ri);
             return new ddwaf::waf{builder.build()};
         }
@@ -280,13 +277,12 @@ bool ddwaf_builder_add_or_update_config(ddwaf::waf_builder *builder, const char 
     try {
         auto input = static_cast<ddwaf::raw_configuration>(*config);
 
-        if (diagnostics == nullptr) {
-            ddwaf::null_ruleset_info ri;
-            return builder->add_or_update({path, path_len}, input, ri);
-        }
-
         ddwaf::ruleset_info ri;
-        const ddwaf::scope_exit on_exit([&]() { ri.to_object(*diagnostics); });
+        const ddwaf::scope_exit on_exit([&]() {
+            if (diagnostics != nullptr) {
+                ri.to_object(*diagnostics);
+            }
+        });
         return builder->add_or_update({path, path_len}, input, ri);
     } catch (const std::exception &e) {
         DDWAF_ERROR("{}", e.what());

--- a/src/ruleset_info.hpp
+++ b/src/ruleset_info.hpp
@@ -18,7 +18,7 @@ namespace ddwaf {
 
 inline std::string index_to_id(unsigned idx) { return "index:" + to_string<std::string>(idx); }
 
-enum class ruleset_info_state : uint8_t { indeterminate, invalid, valid };
+enum class ruleset_info_state : uint8_t { empty, invalid, valid };
 
 class ruleset_info {
 public:
@@ -117,7 +117,7 @@ public:
                 return ruleset_info_state::invalid;
             }
 
-            return ruleset_info_state::indeterminate;
+            return ruleset_info_state::empty;
         }
 
     protected:
@@ -190,7 +190,7 @@ public:
             return ruleset_info_state::invalid;
         }
 
-        auto final_state = ruleset_info_state::indeterminate;
+        auto final_state = ruleset_info_state::empty;
         for (const auto &[_, section] : sections_) {
             switch (section.state()) {
             case ruleset_info_state::valid:

--- a/tests/integration/interface/builder/test.cpp
+++ b/tests/integration/interface/builder/test.cpp
@@ -22,7 +22,7 @@ TEST(TestEngineBuilderFunctional, EmptyConfig)
     ddwaf_builder builder = ddwaf_builder_init(nullptr);
     ASSERT_NE(builder, nullptr);
 
-    ddwaf_builder_add_or_update_config(builder, LSTRARG("default"), &config, nullptr);
+    ASSERT_TRUE(ddwaf_builder_add_or_update_config(builder, LSTRARG("default"), &config, nullptr));
     ddwaf_object_free(&config);
 
     ddwaf_handle handle = ddwaf_builder_build_instance(builder);
@@ -40,7 +40,8 @@ TEST(TestEngineBuilderFunctional, BaseRules)
     {
         auto config = read_file("base_rules_1.yaml", base_dir);
         ASSERT_NE(config.type, DDWAF_OBJ_INVALID);
-        ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &config, nullptr);
+        ASSERT_TRUE(
+            ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &config, nullptr));
         ddwaf_object_free(&config);
     }
 
@@ -66,7 +67,8 @@ TEST(TestEngineBuilderFunctional, BaseRules)
         ddwaf_destroy(handle);
         auto config = read_file("base_rules_2.yaml", base_dir);
         ASSERT_NE(config.type, DDWAF_OBJ_INVALID);
-        ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &config, nullptr);
+        ASSERT_TRUE(
+            ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &config, nullptr));
         ddwaf_object_free(&config);
     }
 
@@ -109,7 +111,8 @@ TEST(TestEngineBuilderFunctional, RemoveDuplicateBaseRules)
     {
         auto config = read_file("base_rules_1.yaml", base_dir);
         ASSERT_NE(config.type, DDWAF_OBJ_INVALID);
-        ddwaf_builder_add_or_update_config(builder, LSTRARG("rules1"), &config, nullptr);
+        ASSERT_TRUE(
+            ddwaf_builder_add_or_update_config(builder, LSTRARG("rules1"), &config, nullptr));
         ddwaf_object_free(&config);
     }
 
@@ -117,7 +120,8 @@ TEST(TestEngineBuilderFunctional, RemoveDuplicateBaseRules)
     {
         auto config = read_file("base_rules_1_2_duplicate.yaml", base_dir);
         ASSERT_NE(config.type, DDWAF_OBJ_INVALID);
-        ddwaf_builder_add_or_update_config(builder, LSTRARG("rules2"), &config, nullptr);
+        ASSERT_TRUE(
+            ddwaf_builder_add_or_update_config(builder, LSTRARG("rules2"), &config, nullptr));
         ddwaf_object_free(&config);
     }
 
@@ -182,7 +186,8 @@ TEST(TestEngineBuilderFunctional, CustomRules)
     {
         auto config = read_file("custom_rules_1.yaml", base_dir);
         ASSERT_NE(config.type, DDWAF_OBJ_INVALID);
-        ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &config, nullptr);
+        ASSERT_TRUE(
+            ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &config, nullptr));
         ddwaf_object_free(&config);
     }
 
@@ -208,7 +213,8 @@ TEST(TestEngineBuilderFunctional, CustomRules)
         ddwaf_destroy(handle);
         auto config = read_file("custom_rules_2.yaml", base_dir);
         ASSERT_NE(config.type, DDWAF_OBJ_INVALID);
-        ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &config, nullptr);
+        ASSERT_TRUE(
+            ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &config, nullptr));
         ddwaf_object_free(&config);
     }
 

--- a/tests/integration/interface/builder/yaml/all_skipped_items.yaml
+++ b/tests/integration/interface/builder/yaml/all_skipped_items.yaml
@@ -1,0 +1,39 @@
+version: '2.1'
+exclusions:
+  - id: 1
+    max_version: 0.1.1
+    rules_target:
+      - rule_id: 1
+    on_match: monitor
+  - id: 2
+    max_version: 0.1.1
+    rules_target:
+      - rule_id: 1
+    on_match: bypass
+rules:
+  - id: 1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+    max_version: 0.1.1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule1
+  - id: 2
+    name: rule2
+    tags:
+      type: flow2
+      category: category2
+      confidence: 1
+    max_version: 0.1.1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value2
+          regex: rule2
+

--- a/tests/integration/interface/builder/yaml/invalid_section_and_loadable_items.yaml
+++ b/tests/integration/interface/builder/yaml/invalid_section_and_loadable_items.yaml
@@ -1,0 +1,15 @@
+version: '2.1'
+rules: 
+  - id: 1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule1
+custom_rules: {}
+

--- a/tests/integration/interface/builder/yaml/multiple_empty_sections_invalid_and_valid_items.yaml
+++ b/tests/integration/interface/builder/yaml/multiple_empty_sections_invalid_and_valid_items.yaml
@@ -1,0 +1,36 @@
+version: '2.1'
+exclusions:
+  - max_version: 0.1.1
+    rules_target:
+      - rule_id: 1
+    on_match: monitor
+rules: 
+  - id: 1
+    name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule1
+custom_rules:
+  - name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule1
+processors: []
+rules_override: []
+processor_override: []
+rules_data: []
+exclusion_data: []
+actions: []
+scanners: []

--- a/tests/integration/interface/builder/yaml/multiple_empty_sections_invalid_items.yaml
+++ b/tests/integration/interface/builder/yaml/multiple_empty_sections_invalid_items.yaml
@@ -1,0 +1,36 @@
+version: '2.1'
+exclusions:
+  - max_version: 0.1.1
+    rules_target:
+      - rule_id: 1
+    on_match: monitor
+
+rules: 
+  - name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule1
+custom_rules:
+  - name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule1
+processors: []
+rules_override: []
+processor_override: []
+rules_data: []
+exclusion_data: []
+actions: []
+scanners: []

--- a/tests/integration/interface/builder/yaml/multiple_sections_empty_config.yaml
+++ b/tests/integration/interface/builder/yaml/multiple_sections_empty_config.yaml
@@ -1,0 +1,11 @@
+version: '2.1'
+exclusions: []
+rules: []
+custom_rules: []
+processors: []
+rules_override: []
+processor_override: []
+rules_data: []
+exclusion_data: []
+actions: []
+scanners: []

--- a/tests/integration/interface/builder/yaml/multiple_sections_one_with_invalid_items.yaml
+++ b/tests/integration/interface/builder/yaml/multiple_sections_one_with_invalid_items.yaml
@@ -1,0 +1,21 @@
+version: '2.1'
+exclusions: []
+rules: 
+  - name: rule1
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value1
+          regex: rule1
+custom_rules: []
+processors: []
+rules_override: []
+processor_override: []
+rules_data: []
+exclusion_data: []
+actions: []
+scanners: []

--- a/tests/unit/ruleset_info_test.cpp
+++ b/tests/unit/ruleset_info_test.cpp
@@ -231,24 +231,4 @@ TEST(TestRulesetInfo, SectionErrorRulesetInfo)
     ddwaf_object_free(&root);
 }
 
-TEST(TestRulesetInfo, NullRulesetInfo)
-{
-    // This test just verifies there are no side-effects to the null ruleset info
-    null_ruleset_info info;
-    info.set_ruleset_version("1.2.3");
-
-    {
-        auto &section = info.add_section("rules");
-        section.add_loaded("loaded");
-        section.add_failed("failed", parser_error_severity::error, "error");
-    }
-
-    {
-        auto &section = info.add_section("exclusions");
-        section.add_loaded("loaded");
-        section.add_failed("failed", parser_error_severity::error, "error");
-    }
-
-    EXPECT_TRUE(true);
-}
 } // namespace

--- a/tests/unit/waf_test.cpp
+++ b/tests/unit/waf_test.cpp
@@ -23,7 +23,7 @@ ddwaf::waf build_instance(std::string_view rule_file)
 
     raw_configuration ruleset = object;
     waf_builder builder{object_limits{}, ddwaf_object_free, std::make_shared<match_obfuscator>()};
-    ddwaf::null_ruleset_info info;
+    ddwaf::ruleset_info info;
     auto res = builder.add_or_update("default", ruleset, info);
     ddwaf_object_free(&object);
 


### PR DESCRIPTION
This PR modifies the behaviour of the builder to allow configurations which have no side-effects, i.e. inconsequential configurations. These are configurations which have no errors but also no loadable items, for example, a configuration may contain rules with a `max_version` below the current one, therefore it's perfectly valid but nothing will be loaded. Similarly, a configuration may be entirely empty or contain only empty sections.

While these configs don't provide any value, they also cause no harm, therefore they are now accepted instead of rejected.

In addition, this PR also removes the `null_ruleset_info` and `base_ruleset_info` classes as production deployments will always require diagnostics.