### PR TITLE
URI parsing preprocessor

### DIFF
--- a/cmake/objects.cmake
+++ b/cmake/objects.cmake
@@ -55,6 +55,7 @@ set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/processor/extract_schema.cpp
     ${libddwaf_SOURCE_DIR}/src/processor/fingerprint.cpp
     ${libddwaf_SOURCE_DIR}/src/processor/jwt_decode.cpp
+    ${libddwaf_SOURCE_DIR}/src/processor/uri_parse.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/exists.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/lfi_detector.cpp
     ${libddwaf_SOURCE_DIR}/src/condition/sqli_detector.cpp

--- a/src/builder/processor_builder.cpp
+++ b/src/builder/processor_builder.cpp
@@ -17,6 +17,7 @@
 #include "processor/extract_schema.hpp"
 #include "processor/fingerprint.hpp"
 #include "processor/jwt_decode.hpp"
+#include "processor/uri_parse.hpp"
 #include "scanner.hpp"
 
 namespace ddwaf {
@@ -93,6 +94,14 @@ template <> struct typed_processor_builder<jwt_decode> {
     }
 };
 
+template <> struct typed_processor_builder<uri_parse_processor> {
+    static std::unique_ptr<base_processor> build(const std::string &id, const processor_spec &spec)
+    {
+        return std::make_unique<uri_parse_processor>(
+            id, spec.expr, spec.mappings, spec.evaluate, spec.output);
+    }
+};
+
 template <typename T, typename Id, typename Spec, typename Scanners>
 concept has_build_with_scanners =
     requires(typed_processor_builder<T> b, Id id, Spec spec, Scanners scanners) {
@@ -130,6 +139,8 @@ std::unique_ptr<base_processor> processor_builder::build(const indexer<const sca
         return build_with_type<session_fingerprint>(id_, spec_, scanners);
     case processor_type::jwt_decode:
         return build_with_type<jwt_decode>(id_, spec_, scanners);
+    case processor_type::uri_parse:
+        return build_with_type<uri_parse_processor>(id_, spec_, scanners);
     default:
         break;
     }

--- a/src/configuration/common/configuration.hpp
+++ b/src/configuration/common/configuration.hpp
@@ -68,6 +68,7 @@ enum class processor_type : uint8_t {
     http_header_fingerprint,
     session_fingerprint,
     jwt_decode,
+    uri_parse,
 };
 
 struct processor_spec {

--- a/src/configuration/processor_parser.cpp
+++ b/src/configuration/processor_parser.cpp
@@ -22,6 +22,7 @@
 #include "processor/extract_schema.hpp"
 #include "processor/fingerprint.hpp"
 #include "processor/jwt_decode.hpp"
+#include "processor/uri_parse.hpp"
 #include "ruleset_info.hpp"
 #include "semver.hpp"
 #include "target_address.hpp"
@@ -120,6 +121,8 @@ void parse_processors(const raw_configuration::vector &processor_array,
                 type = processor_type::session_fingerprint;
             } else if (generator_id == "jwt_decode") {
                 type = processor_type::jwt_decode;
+            } else if (generator_id == "uri_parse") {
+                type = processor_type::uri_parse;
             } else {
                 throw unknown_generator(generator_id);
             }
@@ -143,8 +146,10 @@ void parse_processors(const raw_configuration::vector &processor_array,
                     parse_processor_mappings(mappings_vec, http_network_fingerprint::param_names);
             } else if (type == processor_type::session_fingerprint) {
                 mappings = parse_processor_mappings(mappings_vec, session_fingerprint::param_names);
-            } else {
+            } else if (type == processor_type::jwt_decode) {
                 mappings = parse_processor_mappings(mappings_vec, jwt_decode::param_names);
+            } else {
+                mappings = parse_processor_mappings(mappings_vec, uri_parse_processor::param_names);
             }
 
             std::vector<reference_spec> scanners;

--- a/src/processor/uri_parse.cpp
+++ b/src/processor/uri_parse.cpp
@@ -14,7 +14,6 @@
 #include "uri_utils.hpp"
 #include "utils.hpp"
 
-#include <cstdint>
 #include <string_view>
 #include <unordered_map>
 #include <utility>
@@ -136,11 +135,7 @@ std::pair<ddwaf_object, object_store::attribute> uri_parse_processor::eval_impl(
     ddwaf_object host = string_view_to_object(decomposed->authority.host);
 
     ddwaf_object port;
-    if (auto [res, value] = from_string<uint16_t>(decomposed->authority.port); res) {
-        ddwaf_object_unsigned(&port, value);
-    } else {
-        ddwaf_object_unsigned(&port, 0);
-    }
+    ddwaf_object_unsigned(&port, decomposed->authority.port);
 
     ddwaf_object path = string_view_to_object(decomposed->path);
     ddwaf_object query = split_query_parameters(*decomposed);

--- a/src/processor/uri_parse.cpp
+++ b/src/processor/uri_parse.cpp
@@ -1,0 +1,162 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+#include "processor/uri_parse.hpp"
+
+#include "argument_retriever.hpp"
+#include "clock.hpp"
+#include "ddwaf.h"
+#include "object_store.hpp"
+#include "processor/base.hpp"
+#include "uri_utils.hpp"
+#include "utils.hpp"
+
+#include <cstdint>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+using namespace std::literals;
+
+namespace ddwaf {
+
+namespace {
+
+ddwaf_object string_view_to_object(std::string_view str)
+{
+    ddwaf_object obj;
+    if (!str.empty()) {
+        ddwaf_object_stringl(&obj, str.data(), str.size());
+    } else {
+        ddwaf_object_string(&obj, "");
+    }
+    return obj;
+}
+
+ddwaf_object split_query_parameters(const uri_decomposed &decomposed)
+{
+    // This map is used to track if there are multiple instances of the same key, the
+    // value will either be a:
+    //   - A boolean if it's a flag
+    //   - A string if there's only one value
+    //   - An array if there are multiple values
+    std::unordered_map<std::string_view, ddwaf_object> query_keys;
+    auto query_remaining = decomposed.query;
+    while (!query_remaining.empty()) {
+        // Get the next query parameter
+        std::string_view parameter;
+        auto separator_pos = query_remaining.find_first_of('&');
+        if (separator_pos != std::string_view::npos) {
+            parameter = query_remaining.substr(0, separator_pos);
+            query_remaining = query_remaining.substr(separator_pos + 1);
+        } else {
+            parameter = query_remaining;
+            query_remaining = {};
+        }
+
+        std::string_view key;
+        ddwaf_object value;
+
+        // Check if it's in the key=value format
+        //  - key= is considered an empty string value
+        //  - key is considered a flag
+        auto assignment_pos = parameter.find_first_of('=');
+        if (assignment_pos == std::string_view::npos) {
+            key = parameter;
+
+            // Ignore empty keys
+            if (key.empty()) {
+                continue;
+            }
+
+            // We can consider this a modifier rather than a kv pair
+            ddwaf_object_bool(&value, true);
+        } else {
+            key = parameter.substr(0, assignment_pos);
+            // Ignore empty keys
+            if (key.empty()) {
+                continue;
+            }
+
+            auto value_str = parameter.substr(assignment_pos + 1);
+            ddwaf_object_stringl(&value, value_str.data(), value_str.size());
+        }
+
+        // Check if the key has the array suffix ([]) and strip it, if the suffix
+        // contains an index ([index]), we just consider it a separate key
+        if (key.ends_with("[]")) {
+            key.remove_suffix(sizeof("[]") - 1);
+        }
+
+        auto it = query_keys.find(key);
+        if (it == query_keys.end()) {
+            query_keys.emplace(key, value);
+        } else {
+            // Duplicate! We need to create an array or add to it
+            if (it->second.type != DDWAF_OBJ_ARRAY) {
+                ddwaf_object array;
+                ddwaf_object_array(&array);
+                ddwaf_object_array_add(&array, &it->second);
+                it->second = array;
+            }
+
+            ddwaf_object_array_add(&it->second, &value);
+        }
+    }
+
+    ddwaf_object query;
+    ddwaf_object_map(&query);
+    for (auto &[key, value] : query_keys) {
+        ddwaf_object_map_addl(&query, key.data(), key.size(), &value);
+    }
+
+    return query;
+}
+
+} // namespace
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::pair<ddwaf_object, object_store::attribute> uri_parse_processor::eval_impl(
+    const unary_argument<std::string_view> &input, processor_cache & /*cache*/,
+    ddwaf::timer & /*deadline*/) const
+{
+    const object_store::attribute attr =
+        input.ephemeral ? object_store::attribute::ephemeral : object_store::attribute::none;
+
+    auto decomposed = uri_parse(input.value);
+    if (!decomposed.has_value()) {
+        return {};
+    }
+
+    ddwaf_object scheme = string_view_to_object(decomposed->scheme);
+    ddwaf_object userinfo = string_view_to_object(decomposed->authority.userinfo);
+    ddwaf_object host = string_view_to_object(decomposed->authority.host);
+
+    ddwaf_object port;
+    if (auto [res, value] = from_string<uint16_t>(decomposed->authority.port); res) {
+        ddwaf_object_unsigned(&port, value);
+    } else {
+        ddwaf_object_unsigned(&port, 0);
+    }
+
+    ddwaf_object path = string_view_to_object(decomposed->path);
+    ddwaf_object query = split_query_parameters(*decomposed);
+    ddwaf_object fragment = string_view_to_object(decomposed->fragment);
+
+    ddwaf_object output;
+    ddwaf_object_map(&output);
+    ddwaf_object_map_addl(&output, STRL("scheme"), &scheme);
+    ddwaf_object_map_addl(&output, STRL("userinfo"), &userinfo);
+    ddwaf_object_map_addl(&output, STRL("host"), &host);
+    ddwaf_object_map_addl(&output, STRL("port"), &port);
+    ddwaf_object_map_addl(&output, STRL("path"), &path);
+    ddwaf_object_map_addl(&output, STRL("query"), &query);
+    ddwaf_object_map_addl(&output, STRL("fragment"), &fragment);
+
+    return {output, attr};
+}
+
+} // namespace ddwaf

--- a/src/processor/uri_parse.hpp
+++ b/src/processor/uri_parse.hpp
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+#pragma once
+
+#include "processor/base.hpp"
+
+namespace ddwaf {
+
+class uri_parse_processor : public structured_processor<uri_parse_processor> {
+public:
+    static constexpr std::array<std::string_view, 1> param_names{"inputs"};
+
+    uri_parse_processor(std::string id, std::shared_ptr<expression> expr,
+        std::vector<processor_mapping> mappings, bool evaluate, bool output)
+        : structured_processor(
+              std::move(id), std::move(expr), std::move(mappings), evaluate, output)
+    {}
+
+    std::pair<ddwaf_object, object_store::attribute> eval_impl(
+        const unary_argument<std::string_view> &input, processor_cache &cache,
+        ddwaf::timer &deadline) const;
+};
+
+} // namespace ddwaf

--- a/src/uri_utils.cpp
+++ b/src/uri_utils.cpp
@@ -14,6 +14,8 @@
 #include "utils.hpp"
 
 /*
+   RFC 3986
+   --
    URI           = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
    hier-part     = "//" authority path-abempty
                  / path-absolute
@@ -55,12 +57,22 @@
    segment       = *pchar
    segment-nz    = 1*pchar
    pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-   query         = *( pchar / "/" / "?" )
+   query         = *( ext-query-set / pchar / "/" / "?" )
    fragment      = *( pchar / "/" / "?" )
    pct-encoded   = "%" HEXDIG HEXDIG
    unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
    sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
                  / "*" / "+" / "," / ";" / "="
+   ext-query-set = "[" / "]"
+
+--
+  To account for the extended use of [] characters in the query string, which
+  is somewhat allowed by section 2.2 of RFC 3986, the ext-query-set has been
+  introduced, but only to the query string.
+
+  Note that these are also tolerated by the WHATWG standard.
+
+  Discussion in https://stackoverflow.com/questions/11490326
 */
 
 namespace ddwaf {
@@ -83,6 +95,8 @@ enum class token_type : uint8_t {
 };
 constexpr const auto &npos = std::string_view::npos;
 
+inline bool is_extended_query_set(char c) { return c == '[' || c == ']'; }
+
 inline bool is_unreserved(char c)
 {
     return ddwaf::isalnum(c) || c == '-' || c == '.' || c == '_' || c == '~';
@@ -100,7 +114,10 @@ inline bool is_path_char(char c)
 {
     return is_unreserved(c) || is_subdelim(c) || c == '%' || c == ':' || c == '@';
 }
-inline bool is_query_char(char c) { return is_path_char(c) || c == '/' || c == '?'; }
+inline bool is_query_char(char c)
+{
+    return is_extended_query_set(c) || is_path_char(c) || c == '/' || c == '?';
+}
 inline bool is_frag_char(char c) { return is_path_char(c) || c == '/' || c == '?'; }
 
 inline bool is_userinfo_char(char c)

--- a/src/uri_utils.cpp
+++ b/src/uri_utils.cpp
@@ -370,10 +370,11 @@ std::optional<uri_decomposed> uri_parse(std::string_view uri)
 
             auto port_substr = uri.substr(token_begin, i - token_begin);
             if (!port_substr.empty()) {
-                if (auto [res, value] = from_string<uint16_t>(port_substr); !res) {
+                if (auto [res, value] = from_string<uint16_t>(port_substr); res) {
+                    decomposed.authority.port = value;
+                } else {
                     return std::nullopt;
                 }
-                decomposed.authority.port = port_substr;
             }
 
             if (authority_end == uri.size()) {

--- a/src/uri_utils.hpp
+++ b/src/uri_utils.hpp
@@ -22,7 +22,7 @@ struct uri_decomposed {
         std::string_view userinfo{};
         std::string_view host{};
         std::optional<ipaddr> host_ip{};
-        std::string_view port{};
+        uint16_t port{};
         std::string_view raw;
     } authority;
     std::string_view scheme_and_authority;

--- a/tests/integration/processors/uri_parse/ruleset/postprocessor.json
+++ b/tests/integration/processors/uri_parse/ruleset/postprocessor.json
@@ -1,0 +1,28 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.8.0"
+  },
+  "rules": [],
+  "processors": [
+    {
+      "id": "processor-001",
+      "generator": "uri_parse",
+      "conditions": [],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.io.net.url"
+              }
+            ],
+            "output": "server.io.net.request.url"
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    }
+  ]
+}

--- a/tests/integration/processors/uri_parse/ruleset/preprocessor.json
+++ b/tests/integration/processors/uri_parse/ruleset/preprocessor.json
@@ -1,0 +1,51 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.8.0"
+  },
+  "rules": [
+    {
+      "id": "rule1",
+      "name": "rule1",
+      "tags": {
+        "type": "flow1",
+        "category": "category1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.request.url",
+                "key_path": [ "host" ]
+              }
+            ],
+            "regex": "^datadoghq.com$"
+          },
+          "operator": "match_regex"
+        }
+      ]
+    }
+  ],
+  "processors": [
+    {
+      "id": "processor-001",
+      "generator": "uri_parse",
+      "conditions": [],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.io.net.url"
+              }
+            ],
+            "output": "server.io.net.request.url"
+          }
+        ]
+      },
+      "evaluate": true,
+      "output": false
+    }
+  ]
+}

--- a/tests/integration/processors/uri_parse/ruleset/processor.json
+++ b/tests/integration/processors/uri_parse/ruleset/processor.json
@@ -1,0 +1,51 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.8.0"
+  },
+  "rules": [
+    {
+      "id": "rule1",
+      "name": "rule1",
+      "tags": {
+        "type": "flow1",
+        "category": "category1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.net.request.url",
+                "key_path": [ "host" ]
+              }
+            ],
+            "regex": "^datadoghq.com$"
+          },
+          "operator": "match_regex"
+        }
+      ]
+    }
+  ],
+  "processors": [
+    {
+      "id": "processor-001",
+      "generator": "uri_parse",
+      "conditions": [],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.io.net.url"
+              }
+            ],
+            "output": "server.io.net.request.url"
+          }
+        ]
+      },
+      "evaluate": true,
+      "output": true
+    }
+  ]
+}

--- a/tests/integration/processors/uri_parse/test.cpp
+++ b/tests/integration/processors/uri_parse/test.cpp
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "common/gtest_utils.hpp"
+
+using namespace ddwaf;
+using namespace std::literals;
+
+namespace {
+constexpr std::string_view base_dir = "integration/processors/uri_parse";
+
+TEST(TestUriParseIntegration, Preprocessor)
+{
+    auto rule = read_json_file("preprocessor.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    uint32_t size;
+    const char *const *addresses = ddwaf_known_addresses(handle, &size);
+    EXPECT_EQ(size, 2);
+    std::unordered_set<std::string_view> address_set(addresses, addresses + size);
+    EXPECT_TRUE(address_set.contains("server.io.net.url"));
+    EXPECT_TRUE(address_set.contains("server.io.net.request.url"));
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object url;
+    ddwaf_object_string(&url, "http://datadoghq.com:8080/path?query=value#something");
+
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&map, "server.io.net.url", &url);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    EXPECT_EVENTS(out, {.id = "rule1",
+                           .name = "rule1",
+                           .tags = {{"type", "flow1"}, {"category", "category1"}},
+                           .matches = {{.op = "match_regex",
+                               .op_value = "^datadoghq.com$",
+                               .highlight = "datadoghq.com"sv,
+                               .args = {{
+                                   .value = "datadoghq.com"sv,
+                                   .address = "server.io.net.request.url",
+                                   .path = {"host"},
+                               }}}}});
+
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 0);
+
+    ddwaf_object_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestUriParseIntegration, Postprocessor)
+{
+    auto rule = read_json_file("postprocessor.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    uint32_t size;
+    const char *const *addresses = ddwaf_known_addresses(handle, &size);
+    EXPECT_EQ(size, 1);
+    std::unordered_set<std::string_view> address_set(addresses, addresses + size);
+    EXPECT_TRUE(address_set.contains("server.io.net.url"));
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object url;
+    ddwaf_object_string(&url, "http://datadoghq.com:8080/path?query=value#something");
+
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&map, "server.io.net.url", &url);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+    EXPECT_JSON(*attributes,
+        R"({"server.io.net.request.url":{"scheme":"http","userinfo":"","host":"datadoghq.com","port":8080,"path":"/path","query":{"query":"value"},"fragment":"something"}})");
+
+    ddwaf_object_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestUriParseIntegration, Processor)
+{
+    auto rule = read_json_file("processor.json", base_dir);
+    ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    ASSERT_NE(handle, nullptr);
+    ddwaf_object_free(&rule);
+
+    uint32_t size;
+    const char *const *addresses = ddwaf_known_addresses(handle, &size);
+    EXPECT_EQ(size, 2);
+    std::unordered_set<std::string_view> address_set(addresses, addresses + size);
+    EXPECT_TRUE(address_set.contains("server.io.net.url"));
+    EXPECT_TRUE(address_set.contains("server.io.net.request.url"));
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object url;
+    ddwaf_object_string(&url, "http://datadoghq.com:8080/path?query=value#something");
+
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+    ddwaf_object_map_add(&map, "server.io.net.url", &url);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_MATCH);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    EXPECT_EVENTS(out, {.id = "rule1",
+                           .name = "rule1",
+                           .tags = {{"type", "flow1"}, {"category", "category1"}},
+                           .matches = {{.op = "match_regex",
+                               .op_value = "^datadoghq.com$",
+                               .highlight = "datadoghq.com"sv,
+                               .args = {{
+                                   .value = "datadoghq.com"sv,
+                                   .address = "server.io.net.request.url",
+                                   .path = {"host"},
+                               }}}}});
+
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+    EXPECT_JSON(*attributes,
+        R"({"server.io.net.request.url":{"scheme":"http","userinfo":"","host":"datadoghq.com","port":8080,"path":"/path","query":{"query":"value"},"fragment":"something"}})");
+
+    ddwaf_object_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+} // namespace

--- a/tests/unit/processor/uri_parse_test.cpp
+++ b/tests/unit/processor/uri_parse_test.cpp
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
+
+#include "common/gtest_utils.hpp"
+#include "ddwaf.h"
+#include "processor/uri_parse.hpp"
+
+using namespace ddwaf;
+using namespace std::literals;
+
+namespace {
+
+TEST(TestUriParseProcessor, Basic)
+{
+    std::string_view url =
+        "https://user@test.com:222/"
+        "path?query=value1&query=value2&flag&emptyvalue=&array[]=1&array[]=2&normal=value#frag";
+
+    uri_parse_processor gen{"id", {}, {}, false, true};
+
+    ddwaf::timer deadline{2s};
+    processor_cache cache;
+    auto [output, attr] = gen.eval_impl(
+        {.address = {}, .key_path = {}, .ephemeral = false, .value = url}, cache, deadline);
+    EXPECT_EQ(output.type, DDWAF_OBJ_MAP);
+    EXPECT_EQ(attr, object_store::attribute::none);
+
+    EXPECT_JSON(output,
+        R"({"scheme":"https","userinfo":"user","host":"test.com","port":222,"path":"/path","query":{"normal":"value","array":["1","2"],"emptyvalue":"","flag":true,"query":["value1","value2"]},"fragment":"frag"})");
+
+    ddwaf_object_free(&output);
+}
+
+} // namespace

--- a/tests/unit/processor/uri_parse_test.cpp
+++ b/tests/unit/processor/uri_parse_test.cpp
@@ -13,7 +13,81 @@ using namespace std::literals;
 
 namespace {
 
-TEST(TestUriParseProcessor, Basic)
+TEST(TestUriParseProcessor, QueryParameters)
+{
+    std::vector<std::pair<std::string, std::string>> samples = {
+        {"https://datadoghq.com/?query", R"({"query": true})"},
+        {"https://datadoghq.com/?query&flag&other",
+            R"({"query": true, "flag": true, "other": true})"},
+        {"https://datadoghq.com/?query&other=value", R"({"query": true,"other":"value"})"},
+        {"https://datadoghq.com/?other=value&query", R"({"query": true,"other":"value"})"},
+        {"https://datadoghq.com/?query=", R"({"query": ""})"},
+        {"https://datadoghq.com/?query=&other=", R"({"query": "", "other": ""})"},
+        {"https://datadoghq.com/?query=&other=value", R"({"query": "","other":"value"})"},
+        {"https://datadoghq.com/?other=value&query=", R"({"query": "","other":"value"})"},
+        {"https://datadoghq.com/?query=value", R"({"query": "value"})"},
+        {"https://datadoghq.com/?query=value&other=something",
+            R"({"query":"value","other":"something"})"},
+        {"https://datadoghq.com/?query=value&query=something",
+            R"({"query":["value","something"]})"},
+        {"https://datadoghq.com/?query=value&other=whatever&query=something",
+            R"({"query":["value","something"],"other":"whatever"})"},
+        {"https://datadoghq.com/?query[]=value&query[]=something",
+            R"({"query":["value","something"]})"},
+        {"https://datadoghq.com/?query[]=value&other=whatever&query[]=something",
+            R"({"query":["value","something"],"other":"whatever"})"},
+        {"https://datadoghq.com/?query[]=value&other=whatever&query[]=something&other=whatever",
+            R"({"query":["value","something"],"other":["whatever", "whatever"]})"},
+        {"https://datadoghq.com/?query[0]=value&query[1]=something",
+            R"({"query[0]":"value","query[1]":"something"})"},
+    };
+
+    uri_parse_processor gen{"id", {}, {}, false, true};
+
+    for (auto &[url, result] : samples) {
+        ddwaf::timer deadline{2s};
+        processor_cache cache;
+        auto [output, attr] = gen.eval_impl(
+            {.address = {}, .key_path = {}, .ephemeral = false, .value = url}, cache, deadline);
+        EXPECT_EQ(output.type, DDWAF_OBJ_MAP);
+        EXPECT_EQ(attr, object_store::attribute::none);
+
+        const auto *query = ddwaf_object_find(&output, STRL("query"));
+        EXPECT_JSON(*query, result);
+
+        ddwaf_object_free(&output);
+    }
+}
+
+TEST(TestUriParseProcessor, MixedUrls)
+{
+    std::vector<std::pair<std::string, std::string>> samples = {
+        {"https://",
+            R"({"scheme":"https","userinfo":"","host":"","port":0,"path":"","query":{},"fragment":""})"},
+        {"ftp://",
+            R"({"scheme":"ftp","userinfo":"","host":"","port":0,"path":"","query":{},"fragment":""})"},
+        {"https://user@test.com:222/"
+         "path?query=value1&query=value2&flag&emptyvalue=&array[]=1&array[]=2&normal=value#frag",
+            R"({"scheme":"https","userinfo":"user","host":"test.com","port":222,"path":"/path","query":{"normal":"value","array":["1","2"],"emptyvalue":"","flag":true,"query":["value1","value2"]},"fragment":"frag"})"},
+    };
+
+    uri_parse_processor gen{"id", {}, {}, false, true};
+
+    for (auto &[url, result] : samples) {
+        ddwaf::timer deadline{2s};
+        processor_cache cache;
+        auto [output, attr] = gen.eval_impl(
+            {.address = {}, .key_path = {}, .ephemeral = false, .value = url}, cache, deadline);
+        EXPECT_EQ(output.type, DDWAF_OBJ_MAP);
+        EXPECT_EQ(attr, object_store::attribute::none);
+
+        EXPECT_JSON(output, result);
+
+        ddwaf_object_free(&output);
+    }
+}
+
+TEST(TestUriParseProcessor, Ephemeral)
 {
     std::string_view url =
         "https://user@test.com:222/"
@@ -24,14 +98,29 @@ TEST(TestUriParseProcessor, Basic)
     ddwaf::timer deadline{2s};
     processor_cache cache;
     auto [output, attr] = gen.eval_impl(
-        {.address = {}, .key_path = {}, .ephemeral = false, .value = url}, cache, deadline);
+        {.address = {}, .key_path = {}, .ephemeral = true, .value = url}, cache, deadline);
     EXPECT_EQ(output.type, DDWAF_OBJ_MAP);
-    EXPECT_EQ(attr, object_store::attribute::none);
+    EXPECT_EQ(attr, object_store::attribute::ephemeral);
 
     EXPECT_JSON(output,
         R"({"scheme":"https","userinfo":"user","host":"test.com","port":222,"path":"/path","query":{"normal":"value","array":["1","2"],"emptyvalue":"","flag":true,"query":["value1","value2"]},"fragment":"frag"})");
 
     ddwaf_object_free(&output);
+}
+
+TEST(TestUriParseProcessor, Malformed)
+{
+    std::vector<std::string> samples = {"http://authority?que<>ry"};
+
+    uri_parse_processor gen{"id", {}, {}, false, true};
+
+    for (auto &url : samples) {
+        ddwaf::timer deadline{2s};
+        processor_cache cache;
+        auto [output, attr] = gen.eval_impl(
+            {.address = {}, .key_path = {}, .ephemeral = false, .value = url}, cache, deadline);
+        EXPECT_EQ(output.type, DDWAF_OBJ_INVALID);
+    }
 }
 
 } // namespace

--- a/tests/unit/uri_utils_test.cpp
+++ b/tests/unit/uri_utils_test.cpp
@@ -176,13 +176,13 @@ TEST(TestURI, SchemeHost)
 
 TEST(TestURI, SchemeQuery)
 {
-    auto uri = ddwaf::uri_parse("http:?hello");
+    auto uri = ddwaf::uri_parse("http:?hello&other=whatever&array[]=something&bye=");
     ASSERT_TRUE(uri);
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
     EXPECT_TRUE(uri->authority.port.empty());
-    EXPECT_STRV(uri->query, "hello");
+    EXPECT_STRV(uri->query, "hello&other=whatever&array[]=something&bye=");
 }
 
 TEST(TestURI, SchemeFragment)
@@ -373,7 +373,7 @@ TEST(TestURI, SchemeHostQuery)
 
 TEST(TestURI, SchemeHostMalformedQuery)
 {
-    ASSERT_FALSE(ddwaf::uri_parse("http://authority?que[]ry"));
+    ASSERT_FALSE(ddwaf::uri_parse("http://authority?que<>ry"));
 }
 
 TEST(TestURI, SchemeHostPath)

--- a/tests/unit/uri_utils_test.cpp
+++ b/tests/unit/uri_utils_test.cpp
@@ -20,7 +20,7 @@ TEST(TestURI, Scheme)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_TRUE(uri->authority.raw.empty());
         EXPECT_TRUE(uri->scheme_and_authority.empty());
         EXPECT_TRUE(uri->path.empty());
@@ -34,7 +34,7 @@ TEST(TestURI, Scheme)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_TRUE(uri->authority.raw.empty());
         EXPECT_TRUE(uri->scheme_and_authority.empty());
         EXPECT_TRUE(uri->path.empty());
@@ -60,7 +60,7 @@ TEST(TestURI, SchemeAndPath)
         EXPECT_STRV(uri->scheme, "file");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->path, "/usr/lib/libddwaf.so");
         EXPECT_EQ(uri->path_index, 7);
     }
@@ -71,7 +71,7 @@ TEST(TestURI, SchemeAndPath)
         EXPECT_STRV(uri->scheme, "file");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->path, "/usr/lib/libddwaf.so");
         EXPECT_EQ(uri->path_index, 5);
     }
@@ -82,7 +82,7 @@ TEST(TestURI, SchemeAndPath)
         EXPECT_STRV(uri->scheme, "file");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->path, "/../lib/libddwaf.so");
         EXPECT_EQ(uri->path_index, 5);
     }
@@ -92,7 +92,7 @@ TEST(TestURI, SchemeAndPath)
         EXPECT_STRV(uri->scheme, "file");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->path, "../lib/libddwaf.so");
         EXPECT_EQ(uri->path_index, 5);
     }
@@ -103,7 +103,7 @@ TEST(TestURI, SchemeAndPath)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->path, "/");
         EXPECT_TRUE(uri->fragment.empty());
     }
@@ -113,7 +113,7 @@ TEST(TestURI, SchemeAndPath)
         EXPECT_STRV(uri->scheme, "urn");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->path, "oasis:names:specification:docbook:dtd:xml:4.1.2");
         EXPECT_TRUE(uri->fragment.empty());
     }
@@ -124,7 +124,7 @@ TEST(TestURI, SchemeAndPath)
         EXPECT_STRV(uri->scheme, "tel");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->path, "+1-816-555-1212");
         EXPECT_TRUE(uri->fragment.empty());
     }
@@ -135,7 +135,7 @@ TEST(TestURI, SchemeAndPath)
         EXPECT_STRV(uri->scheme, "mailto");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->path, "John.Doe@example.com");
         EXPECT_TRUE(uri->fragment.empty());
     }
@@ -151,7 +151,7 @@ TEST(TestURI, SchemeHost)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_STRV(uri->authority.host, "authority");
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
     }
 
     {
@@ -160,7 +160,7 @@ TEST(TestURI, SchemeHost)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_STRV(uri->authority.host, "authority.with.dots");
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
     }
 
     {
@@ -170,7 +170,7 @@ TEST(TestURI, SchemeHost)
         EXPECT_EQ(uri->authority.host_index, 4);
         EXPECT_STRV(uri->authority.host, "a");
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
     }
 }
 
@@ -181,7 +181,7 @@ TEST(TestURI, SchemeQuery)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->query, "hello&other=whatever&array[]=something&bye=");
 }
 
@@ -192,7 +192,7 @@ TEST(TestURI, SchemeFragment)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->fragment, "hello");
 }
 
@@ -203,7 +203,7 @@ TEST(TestURI, SchemeQueryFragment)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->query, "hello");
     EXPECT_STRV(uri->fragment, "bye");
 }
@@ -216,7 +216,7 @@ TEST(TestURI, SchemeIPv4Host)
     EXPECT_STRV(uri->authority.host, "1.2.3.4");
     EXPECT_TRUE(uri->authority.host_ip);
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
 }
 
 TEST(TestURI, SchemeIPv6Host)
@@ -227,7 +227,7 @@ TEST(TestURI, SchemeIPv6Host)
     EXPECT_STRV(uri->authority.host, "200:22:11:33:44:ab:cc:bf");
     EXPECT_TRUE(uri->authority.host_ip);
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
 }
 
 TEST(TestURI, SchemeIPv6HostPort)
@@ -238,7 +238,7 @@ TEST(TestURI, SchemeIPv6HostPort)
     EXPECT_STRV(uri->authority.host, "200:22:11:33:44:ab:cc:bf");
     EXPECT_TRUE(uri->authority.host_ip);
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "1234");
+    EXPECT_EQ(uri->authority.port, 1234);
 }
 
 TEST(TestURI, SchemeMalformedIPv6Host)
@@ -254,7 +254,7 @@ TEST(TestURI, SchemeUser)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_STRV(uri->authority.userinfo, "paco");
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
     }
 
     {
@@ -263,7 +263,7 @@ TEST(TestURI, SchemeUser)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_STRV(uri->authority.userinfo, "paco");
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
     }
 }
 
@@ -275,7 +275,7 @@ TEST(TestURI, SchemeUserPort)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_STRV(uri->authority.userinfo, "paco");
-        EXPECT_EQ(uri->authority.port, "1919");
+        EXPECT_EQ(uri->authority.port, 1919);
     }
 }
 
@@ -287,7 +287,7 @@ TEST(TestURI, SchemeUserHost)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_STRV(uri->authority.host, "authority");
         EXPECT_STRV(uri->authority.userinfo, "paco");
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
     }
 }
 
@@ -299,7 +299,7 @@ TEST(TestURI, SchemeUserHostPort)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_STRV(uri->authority.host, "authority");
         EXPECT_STRV(uri->authority.userinfo, "paco");
-        EXPECT_EQ(uri->authority.port, "1919");
+        EXPECT_EQ(uri->authority.port, 1919);
     }
 }
 
@@ -311,7 +311,7 @@ TEST(TestURI, SchemeHostPort)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_STRV(uri->authority.host, "authority");
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_STRV(uri->authority.port, "1");
+        EXPECT_EQ(uri->authority.port, 1);
     }
 
     {
@@ -321,7 +321,7 @@ TEST(TestURI, SchemeHostPort)
         EXPECT_STRV(uri->scheme, "h");
         EXPECT_TRUE(uri->authority.host.empty());
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_STRV(uri->authority.port, "19283");
+        EXPECT_EQ(uri->authority.port, 19283);
     }
 
     {
@@ -346,7 +346,7 @@ TEST(TestURI, SchemeHostQuery)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_STRV(uri->authority.host, "authority");
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->query, "query");
     }
 
@@ -356,7 +356,7 @@ TEST(TestURI, SchemeHostQuery)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_STRV(uri->authority.host, "authority");
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->query, "query");
     }
 
@@ -366,7 +366,7 @@ TEST(TestURI, SchemeHostQuery)
         EXPECT_STRV(uri->scheme, "http");
         EXPECT_STRV(uri->authority.host, "authority");
         EXPECT_TRUE(uri->authority.userinfo.empty());
-        EXPECT_TRUE(uri->authority.port.empty());
+        EXPECT_EQ(uri->authority.port, 0);
         EXPECT_STRV(uri->query, "q@uery");
     }
 }
@@ -384,7 +384,7 @@ TEST(TestURI, SchemeHostPath)
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_STRV(uri->path, "/path");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
 }
 
 TEST(TestURI, SchemeHostMalformedPath)
@@ -399,7 +399,7 @@ TEST(TestURI, SchemeHostFragment)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->fragment, "f");
 }
 
@@ -415,7 +415,7 @@ TEST(TestURI, SchemeHostPortQuery)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "123");
+    EXPECT_EQ(uri->authority.port, 123);
     EXPECT_STRV(uri->query, "query");
 }
 
@@ -426,7 +426,7 @@ TEST(TestURI, SchemeHostPortPath)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "12");
+    EXPECT_EQ(uri->authority.port, 12);
     EXPECT_STRV(uri->path, "/path");
 }
 
@@ -437,7 +437,7 @@ TEST(TestURI, SchemeHostPortFragment)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "1");
+    EXPECT_EQ(uri->authority.port, 1);
     EXPECT_STRV(uri->fragment, "f");
 }
 
@@ -448,7 +448,7 @@ TEST(TestURI, SchemeUserHostQuery)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_STRV(uri->authority.userinfo, "user");
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->query, "query");
 }
 
@@ -459,7 +459,7 @@ TEST(TestURI, SchemeUserHostPath)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_STRV(uri->authority.userinfo, "us");
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/path");
 }
 
@@ -470,7 +470,7 @@ TEST(TestURI, SchemeUserHostFragment)
     EXPECT_STRV(uri->scheme, "http");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_STRV(uri->authority.userinfo, "u");
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->fragment, "f");
 }
 
@@ -496,7 +496,7 @@ TEST(TestURI, Complete)
         EXPECT_STRV(uri->scheme, "http+s.i-a");
         EXPECT_STRV(uri->authority.host, "hello.com");
         EXPECT_STRV(uri->authority.userinfo, "user");
-        EXPECT_STRV(uri->authority.port, "1929");
+        EXPECT_EQ(uri->authority.port, 1929);
         EXPECT_STRV(uri->authority.raw, "user@hello.com:1929");
         EXPECT_STRV(uri->scheme_and_authority, "http+s.i-a://user@hello.com:1929");
         EXPECT_STRV(uri->path, "/path/to/nowhere");
@@ -511,7 +511,7 @@ TEST(TestURI, Complete)
         EXPECT_STRV(uri->scheme, "s");
         EXPECT_STRV(uri->authority.host, "h");
         EXPECT_STRV(uri->authority.userinfo, "u");
-        EXPECT_STRV(uri->authority.port, "1");
+        EXPECT_EQ(uri->authority.port, 1);
         EXPECT_STRV(uri->scheme_and_authority, "s://u@h:1");
         EXPECT_STRV(uri->path, "/p");
         EXPECT_STRV(uri->authority.raw, "u@h:1");
@@ -525,7 +525,7 @@ TEST(TestURI, RelativeRefHostPortQuery)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "123");
+    EXPECT_EQ(uri->authority.port, 123);
     EXPECT_STRV(uri->query, "query");
 }
 
@@ -536,7 +536,7 @@ TEST(TestURI, RelativeRefHostPortPath)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "12");
+    EXPECT_EQ(uri->authority.port, 12);
     EXPECT_STRV(uri->path, "/path");
 }
 
@@ -547,7 +547,7 @@ TEST(TestURI, RelativeRefHostPortFragment)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "1");
+    EXPECT_EQ(uri->authority.port, 1);
     EXPECT_STRV(uri->fragment, "f");
 }
 
@@ -558,7 +558,7 @@ TEST(TestURI, RelativeRefUserHostQuery)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_STRV(uri->authority.userinfo, "user");
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->query, "query");
 }
 
@@ -569,7 +569,7 @@ TEST(TestURI, RelativeRefUserHostPath)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_STRV(uri->authority.userinfo, "us");
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/path");
 }
 
@@ -580,7 +580,7 @@ TEST(TestURI, RelativeRefUserHostFragment)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "authority");
     EXPECT_STRV(uri->authority.userinfo, "u");
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->fragment, "f");
 }
 
@@ -591,7 +591,7 @@ TEST(TestURI, RelativeRefAbsolutePath)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "");
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/path");
 }
 
@@ -602,7 +602,7 @@ TEST(TestURI, RelativeRefAbsolutePathFragment)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "");
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/path");
     EXPECT_STRV(uri->fragment, "f");
 }
@@ -614,7 +614,7 @@ TEST(TestURI, RelativeRefAbsolutePathQuery)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "");
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/path");
     EXPECT_STRV(uri->query, "query");
 }
@@ -626,7 +626,7 @@ TEST(TestURI, RelativeRefAbsolutePathQueryFragment)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_STRV(uri->authority.port, "");
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/path");
     EXPECT_STRV(uri->query, "query");
     EXPECT_STRV(uri->fragment, "f");
@@ -639,7 +639,7 @@ TEST(TestURI, RelativeRefQuery)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/");
     EXPECT_STRV(uri->query, "hello");
 }
@@ -651,7 +651,7 @@ TEST(TestURI, RelativeRefFragment)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/");
     EXPECT_STRV(uri->fragment, "hello");
 }
@@ -663,7 +663,7 @@ TEST(TestURI, RelativeRefQueryFragment)
     EXPECT_STRV(uri->scheme, "");
     EXPECT_STRV(uri->authority.host, "");
     EXPECT_TRUE(uri->authority.userinfo.empty());
-    EXPECT_TRUE(uri->authority.port.empty());
+    EXPECT_EQ(uri->authority.port, 0);
     EXPECT_STRV(uri->path, "/");
     EXPECT_STRV(uri->query, "hello");
     EXPECT_STRV(uri->fragment, "bye");

--- a/tools/waf_runner.cpp
+++ b/tools/waf_runner.cpp
@@ -136,17 +136,15 @@ int main(int argc, char *argv[])
         }
 
         ddwaf_object ret;
-        auto code =
             ddwaf_run(context, &persistent, &ephemeral, &ret, std::numeric_limits<uint64_t>::max());
 
-        if (code == DDWAF_MATCH) {
-            YAML::Emitter out(std::cout);
-            out.SetIndent(2);
-            out.SetMapFormat(YAML::Block);
-            out.SetSeqFormat(YAML::Block);
-            out << object_to_yaml(ret);
-            std::cout << '\n';
-        }
+        YAML::Emitter out(std::cout);
+        out.SetIndent(2);
+        out.SetMapFormat(YAML::Block);
+        out.SetSeqFormat(YAML::Block);
+        out << object_to_yaml(ret);
+        std::cout << '\n';
+
         ddwaf_object_free(&ret);
     }
 


### PR DESCRIPTION
This PR adds a new preprocessor which parses a URI and extracts its constituent components into a new address. This new address can then be used to evaluate specific parts of a URL without over-complicated and inaccurate regular expressions. An example definition of this preprocessor in configuration can be seen below:

```json
{
  "id": "processor-001",
  "generator": "uri_parse",
  "conditions": [],
  "parameters": {
    "mappings": [
      {
        "inputs": [
          {
            "address": "server.io.net.url"
          }
        ],
        "output": "server.io.net.request.url"
      }
    ]
  },
  "evaluate": true,
  "output": false
}
```

The output of this preprocessor is a map with the following contents:

```yaml
{
  "scheme": <string>,
  "userinfo": <string>,
  "host": <string>,
  "port": <unsigned>,
  "path": <string>,
  "query": {},
  "fragment": <string>
}
```

Related Jiras: [APPSEC-58778]

[APPSEC-58778]: https://datadoghq.atlassian.net/browse/APPSEC-58778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ