### PR TITLE
Support other scalar types on action parameters

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -9,13 +9,13 @@
       "type": "object",
       "properties": {
         "status_code": {
-          "type": "string"
+          "type": "number"
         },
         "type": {
           "type": "string"
         },
         "grpc_status_code": {
-          "type": "string"
+          "type": "number"
         }
       },
       "required": [
@@ -29,7 +29,7 @@
       "type": "object",
       "properties": {
         "status_code": {
-          "type": "string"
+          "type": "number"
         },
         "location": {
           "type": "string"

--- a/src/action_mapper.hpp
+++ b/src/action_mapper.hpp
@@ -7,10 +7,11 @@
 #pragma once
 
 #include <map>
-#include <memory>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+
+#include "utils.hpp"
 
 namespace ddwaf {
 
@@ -35,7 +36,7 @@ inline bool is_blocking_action(action_type type)
 struct action_parameters {
     action_type type;
     std::string type_str;
-    std::unordered_map<std::string, std::string> parameters;
+    std::unordered_map<std::string, scalar_type> parameters;
 };
 
 using action_mapper = std::map<std::string, action_parameters, std::less<>>;

--- a/src/builder/action_mapper_builder.cpp
+++ b/src/builder/action_mapper_builder.cpp
@@ -15,11 +15,12 @@
 
 #include "action_mapper.hpp"
 #include "builder/action_mapper_builder.hpp"
+#include "utils.hpp"
 
 namespace ddwaf {
 
 void action_mapper_builder::set_action(const std::string &id, std::string type,
-    std::unordered_map<std::string, std::string> parameters)
+    std::unordered_map<std::string, scalar_type> parameters)
 {
     auto [it, res] =
         action_by_id_.try_emplace(id, action_parameters{.type = action_type_from_string(type),

--- a/src/builder/action_mapper_builder.cpp
+++ b/src/builder/action_mapper_builder.cpp
@@ -59,8 +59,8 @@ const std::map<std::string, action_parameters, std::less<>>
     action_mapper_builder::default_actions_ = {
         {"block", {.type = action_type::block_request,
                       .type_str = "block_request",
-                      .parameters = {{"status_code", "403"}, {"type", "auto"},
-                          {"grpc_status_code", "10"}}}},
+                      .parameters = {{"status_code", 403ULL}, {"type", "auto"},
+                          {"grpc_status_code", 10ULL}}}},
         {"stack_trace",
             {.type = action_type::generate_stack, .type_str = "generate_stack", .parameters = {}}},
         {"extract_schema", {.type = action_type::generate_schema,

--- a/src/builder/action_mapper_builder.hpp
+++ b/src/builder/action_mapper_builder.hpp
@@ -26,7 +26,7 @@ public:
     action_mapper_builder &operator=(action_mapper_builder &&) = delete;
 
     void set_action(const std::string &id, std::string type,
-        std::unordered_map<std::string, std::string> parameters);
+        std::unordered_map<std::string, scalar_type> parameters);
 
     [[nodiscard]] static const action_parameters &get_default_action(std::string_view id);
 

--- a/src/configuration/actions_parser.cpp
+++ b/src/configuration/actions_parser.cpp
@@ -37,7 +37,7 @@ bool validate_status_code_presence_and_type(
     }
 
     if (holds_alternative<int64_t>(it->second)) {
-        if (int64_t value = std::get<int64_t>(it->second); value >= 0) {
+        if (const int64_t value = std::get<int64_t>(it->second); value >= 0) {
             it->second = static_cast<uint64_t>(value);
         }
     } else if (holds_alternative<std::string>(it->second)) {
@@ -60,10 +60,11 @@ void validate_and_add_block(auto &cfg, auto id, auto &type, auto &parameters)
 {
     // Accept any status code
     auto validator = [](uint64_t /*code*/) { return true; };
+    auto status_code = validate_status_code_presence_and_type(parameters, "status_code", validator);
+    auto grpc_status_code =
+        validate_status_code_presence_and_type(parameters, "grpc_status_code", validator);
 
-    if (!validate_status_code_presence_and_type(parameters, "status_code", validator) ||
-        !validate_status_code_presence_and_type(parameters, "grpc_status_code", validator) ||
-        !parameters.contains("type")) {
+    if (!status_code || !grpc_status_code || !parameters.contains("type")) {
         // If any of the parameters are missing, add the relevant default value
         // We could also avoid the above check ...
         auto default_params = action_mapper_builder::get_default_action("block");

--- a/src/configuration/common/configuration.hpp
+++ b/src/configuration/common/configuration.hpp
@@ -95,7 +95,7 @@ struct data_spec {
 struct action_spec {
     action_type type;
     std::string type_str;
-    std::unordered_map<std::string, std::string> parameters;
+    std::unordered_map<std::string, scalar_type> parameters;
 };
 
 enum class change_set : uint16_t {

--- a/src/configuration/common/raw_configuration.cpp
+++ b/src/configuration/common/raw_configuration.cpp
@@ -307,6 +307,44 @@ raw_configuration::operator std::unordered_map<std::string, std::string>() const
     return data;
 }
 
+raw_configuration::operator std::unordered_map<std::string, scalar_type>() const
+{
+    if (type != DDWAF_OBJ_MAP) {
+        throw bad_cast("map", strtype(type));
+    }
+
+    if (array == nullptr || nbEntries == 0) {
+        return {};
+    }
+
+    std::unordered_map<std::string, scalar_type> data;
+    data.reserve(nbEntries);
+    for (unsigned i = 0; i < nbEntries; i++) {
+        std::string key{
+            array[i].parameterName, static_cast<std::size_t>(array[i].parameterNameLength)};
+        switch (array[i].type) {
+        case DDWAF_OBJ_BOOL:
+            data.emplace(std::move(key), static_cast<bool>(raw_configuration(array[i])));
+            break;
+        case DDWAF_OBJ_SIGNED:
+            data.emplace(std::move(key), static_cast<int64_t>(raw_configuration(array[i])));
+            break;
+        case DDWAF_OBJ_UNSIGNED:
+            data.emplace(std::move(key), static_cast<uint64_t>(raw_configuration(array[i])));
+            break;
+        case DDWAF_OBJ_FLOAT:
+            data.emplace(std::move(key), static_cast<double>(raw_configuration(array[i])));
+            break;
+        case DDWAF_OBJ_STRING:
+            data.emplace(std::move(key), static_cast<std::string>(raw_configuration(array[i])));
+            break;
+        default:
+            throw malformed_object("item in scalar map not a valid scalar");
+        }
+    }
+    return data;
+}
+
 raw_configuration::operator semantic_version() const
 {
     if (type != DDWAF_OBJ_STRING || stringValue == nullptr) {

--- a/src/configuration/common/raw_configuration.hpp
+++ b/src/configuration/common/raw_configuration.hpp
@@ -49,6 +49,8 @@ public:
     explicit operator std::vector<std::string>() const;
     explicit operator std::vector<std::string_view>() const;
     explicit operator std::unordered_map<std::string, std::string>() const;
+    explicit operator std::unordered_map<std::string,
+        std::variant<bool, int64_t, uint64_t, double, std::string>>() const;
     explicit operator semantic_version() const;
 
     ~raw_configuration() = default;
@@ -88,6 +90,14 @@ template <> struct raw_configuration_traits<std::vector<std::string_view>> {
 
 template <> struct raw_configuration_traits<std::unordered_map<std::string, std::string>> {
     static const char *name() { return "std::unordered_map<std::string, std::string>"; }
+};
+
+template <> struct raw_configuration_traits<std::unordered_map<std::string, scalar_type>> {
+    static const char *name()
+    {
+        return "std::unordered_map<std::string, std::variant<bool, int64_t, uint64_t, double, "
+               "std::string>>";
+    }
 };
 
 template <> struct raw_configuration_traits<semantic_version> {

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -303,8 +303,6 @@ void serialize_action(std::string_view id, ddwaf_object &action_map, const actio
                 ddwaf_object_unsigned(&value, std::get<uint64_t>(v));
             } else if (std::holds_alternative<double>(v)) {
                 ddwaf_object_float(&value, std::get<double>(v));
-            } else {
-                ddwaf_object_null(&value);
             }
 
             ddwaf_object_map_addl(&param_map, k.data(), k.size(), &value);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -15,13 +15,13 @@
 #include <limits>
 #include <optional>
 #include <ostream>
-#include <span>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "ddwaf.h"
@@ -33,6 +33,7 @@
 #define STRL(value) value, sizeof(value) - 1
 
 template <typename T> using optional_ref = std::optional<std::reference_wrapper<T>>;
+using scalar_type = std::variant<bool, int64_t, uint64_t, double, std::string>;
 
 namespace ddwaf {
 

--- a/tests/common/gtest_utils.cpp
+++ b/tests/common/gtest_utils.cpp
@@ -198,7 +198,17 @@ std::ostream &operator<<(std::ostream &os, const ddwaf::test::action_map &action
                 param_start = false;
             }
 
-            os << indent(8) << k << ": " << v;
+            if (std::holds_alternative<std::string>(v)) {
+                os << indent(8) << k << ": " << std::get<std::string>(v);
+            } else if (std::holds_alternative<int64_t>(v)) {
+                os << indent(8) << k << ": " << std::get<int64_t>(v);
+            } else if (std::holds_alternative<uint64_t>(v)) {
+                os << indent(8) << k << ": " << std::get<uint64_t>(v);
+            } else if (std::holds_alternative<double>(v)) {
+                os << indent(8) << k << ": " << std::get<double>(v);
+            } else if (std::holds_alternative<bool>(v)) {
+                os << indent(8) << k << ": " << std::boolalpha << std::get<bool>(v);
+            }
         }
 
         os << "\n" << indent(4) << "}";
@@ -257,7 +267,7 @@ void PrintTo(const ddwaf::test::action_map &actions, ::std::ostream *os) { *os <
 }
 
 WafResultActionMatcher::WafResultActionMatcher(
-    std::map<std::string, std::map<std::string, std::string>> &&v)
+    std::map<std::string, std::map<std::string, ddwaf::test::scalar_type>> &&v)
     : expected_(std::move(v))
 {}
 
@@ -435,6 +445,46 @@ event as_if<event, void>::operator()() const
 
     return e;
 }
+std::map<std::string, ddwaf::test::scalar_type>
+as_if<std::map<std::string, ddwaf::test::scalar_type>, void>::operator()() const
+{
+    std::map<std::string, ddwaf::test::scalar_type> parameters;
+
+    for (auto it = node.begin(); it != node.end(); ++it) {
+        auto key = it->first.as<std::string>();
+
+        const std::string &value = it->second.Scalar();
+        if (it->second.Tag() == "?") {
+            try {
+                parameters.emplace(std::move(key), it->second.as<uint64_t>());
+                continue;
+            } catch (...) {}
+
+            try {
+                parameters.emplace(std::move(key), it->second.as<int64_t>());
+                continue;
+            } catch (...) {}
+
+            try {
+                parameters.emplace(std::move(key), it->second.as<double>());
+                continue;
+            } catch (...) {}
+
+            try {
+                if (!value.empty() && value[0] != 'Y' && value[0] != 'y' && value[0] != 'n' &&
+                    value[0] != 'N') {
+                    // Skip the yes / no variants of boolean
+                    parameters.emplace(std::move(key), it->second.as<bool>());
+                }
+                continue;
+            } catch (...) {}
+        }
+
+        parameters.emplace(std::move(key), value);
+    }
+
+    return parameters;
+}
 
 action_map as_if<action_map, void>::operator()() const
 {
@@ -445,8 +495,7 @@ action_map as_if<action_map, void>::operator()() const
     action_map actions;
     for (YAML::const_iterator it = node.begin(); it != node.end(); ++it) {
         auto key = it->first.as<std::string>();
-        auto parameters = it->second.as<std::map<std::string, std::string>>();
-
+        auto parameters = it->second.as<std::map<std::string, ddwaf::test::scalar_type>>();
         actions.emplace(key, parameters);
     }
 

--- a/tests/common/gtest_utils.hpp
+++ b/tests/common/gtest_utils.hpp
@@ -49,7 +49,8 @@ struct event {
     std::vector<match> matches;
 };
 
-using action_map = ::std::map<::std::string, ::std::map<::std::string, ::std::string>>;
+using scalar_type = std::variant<bool, int64_t, uint64_t, double, std::string>;
+using action_map = ::std::map<::std::string, ::std::map<::std::string, scalar_type>>;
 
 bool operator==(const event::match::argument &lhs, const event::match::argument &rhs);
 bool operator==(const event::match &lhs, const event::match &rhs);
@@ -79,6 +80,12 @@ template <> struct as_if<ddwaf::test::event::match, void> {
 template <> struct as_if<ddwaf::test::event, void> {
     explicit as_if(const Node &node_) : node(node_) {}
     ddwaf::test::event operator()() const;
+    const Node &node;
+};
+
+template <> struct as_if<std::map<std::string, ddwaf::test::scalar_type>, void> {
+    explicit as_if(const Node &node_) : node(node_) {}
+    std::map<std::string, ddwaf::test::scalar_type> operator()() const;
     const Node &node;
 };
 
@@ -172,6 +179,48 @@ inline ::testing::PolymorphicMatcher<MatchMatcher> WithMatches(
 
 std::list<ddwaf::test::event::match> from_matches(
     const std::vector<ddwaf::condition_match> &matches);
+
+/*inline bool operator==(const ddwaf::test::scalar_type& left, const ddwaf::test::scalar_type&
+ * right)*/
+/*{*/
+/*if (std::holds_alternative<std::string>(left)) {*/
+/*return std::holds_alternative<std::string>(right) && std::get<std::string>(left) ==
+ * std::get<std::string>(right);*/
+/*}*/
+
+/*if (std::holds_alternative<uint64_t>(left)) {*/
+/*return std::holds_alternative<uint64_t>(right) && std::get<uint64_t>(left) ==
+ * std::get<uint64_t>(right);*/
+/*}*/
+
+/*if (std::holds_alternative<int64_t>(left)) {*/
+/*return std::holds_alternative<int64_t>(right) && std::get<int64_t>(left) ==
+ * std::get<int64_t>(right);*/
+/*}*/
+
+/*if (std::holds_alternative<double>(left)) {*/
+/*return std::holds_alternative<double>(right) && std::get<double>(left) ==
+ * std::get<double>(right);*/
+/*}*/
+
+/*if (std::holds_alternative<bool>(left)) {*/
+/*return std::holds_alternative<bool>(right) && std::get<bool>(left) == std::get<bool>(right);*/
+/*}*/
+
+/*return false;*/
+/*}*/
+
+/*template <typename T>*/
+/*inline bool operator==(const ddwaf::test::scalar_type& left, const T& right)*/
+/*{*/
+/*return std::holds_alternative<T>(left) && std::get<T>(left) == right;*/
+/*}*/
+
+/*template <typename T>*/
+/*inline bool operator==(const T& left, const ddwaf::test::scalar_type& right)*/
+/*{*/
+/*return std::holds_alternative<T>(right) && left == std::get<T>(right);*/
+/*}*/
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define EXPECT_EVENTS(result, ...)                                                                 \

--- a/tests/integration/actions/yaml/action_types.yaml
+++ b/tests/integration/actions/yaml/action_types.yaml
@@ -1,0 +1,26 @@
+version: "2.1"
+rules:
+  - id: sanitize-rule
+    name: sanitize-rule
+    tags:
+      type: flow1
+      category: category1
+    conditions:
+      - operator: match_regex
+        parameters:
+          inputs:
+            - address: value
+          regex: ^sanitize
+          options:
+            case_sensitive: true
+    on_match:
+      - sanitize
+actions:
+  - id: sanitize
+    parameters:
+      string: thisisastring
+      int64: -200
+      uint64: 18446744073709551615
+      double: 22.22
+      bool: true
+    type: sanitize_something

--- a/tests/integration/exclusion/rule_filter/test.cpp
+++ b/tests/integration/exclusion/rule_filter/test.cpp
@@ -726,8 +726,8 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
                                    .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
-    EXPECT_ACTIONS(out,
-        {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}})
+    EXPECT_ACTIONS(out, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                               {"type", "auto"}}}})
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -764,8 +764,8 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
                                        .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
-        EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}})
+        EXPECT_ACTIONS(out, {{"block_request", {{"status_code", 403ULL},
+                                                   {"grpc_status_code", 10ULL}, {"type", "auto"}}}})
 
         ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
@@ -870,8 +870,8 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
                                        .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
-        EXPECT_ACTIONS(out, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}})
+        EXPECT_ACTIONS(out, {{"block_request", {{"status_code", 403ULL},
+                                                   {"grpc_status_code", 10ULL}, {"type", "auto"}}}})
 
         ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
@@ -914,8 +914,8 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
                                    .value = "192.168.0.1"sv,
                                    .address = "http.client_ip",
                                }}}}});
-    EXPECT_ACTIONS(out,
-        {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}})
+    EXPECT_ACTIONS(out, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                               {"type", "auto"}}}})
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -580,9 +580,9 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result1, {});
-        EXPECT_ACTIONS(
-            result2, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result2,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -656,11 +656,11 @@ TEST(TestWafIntegration, UpdateActionsByID)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(
-            result2, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result2,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result3,
-            {{"redirect_request", {{"status_code", "303"}, {"location", "http://google.com"}}}});
+            {{"redirect_request", {{"status_code", 303ULL}, {"location", "http://google.com"}}}});
 
         ddwaf_object_free(&result2);
         ddwaf_object_free(&result3);
@@ -734,9 +734,9 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result1, {});
-        EXPECT_ACTIONS(
-            result2, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result2,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -1200,9 +1200,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                         {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_ACTIONS(result1, {});
-        EXPECT_ACTIONS(
-            result2, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result2,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -1263,9 +1263,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                     .args = {
                         {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
-        EXPECT_ACTIONS(
-            result2, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result2,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result3, {});
 
         ddwaf_object_free(&result2);
@@ -1821,9 +1821,9 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result2, {});
-        EXPECT_ACTIONS(
-            result3, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result3,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result2);
         ddwaf_object_free(&result3);
@@ -1889,9 +1889,9 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result3, {});
-        EXPECT_ACTIONS(
-            result4, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result4,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result3);
         ddwaf_object_free(&result4);
@@ -1951,12 +1951,12 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(
-            result4, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
-        EXPECT_ACTIONS(
-            result5, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result4,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result5,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result4);
         ddwaf_object_free(&result5);
@@ -2005,9 +2005,9 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(
-            result4, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result4,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result5, {});
 
         ddwaf_object_free(&result4);
@@ -2053,9 +2053,9 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result5, {});
-        EXPECT_ACTIONS(
-            result6, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result6,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result5);
         ddwaf_object_free(&result6);
@@ -2084,12 +2084,12 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(
-            result5, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
-        EXPECT_ACTIONS(
-            result6, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result5,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result6,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result5);
         ddwaf_object_free(&result6);
@@ -2142,9 +2142,9 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result6, {});
-        EXPECT_ACTIONS(
-            result7, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result7,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&result6);
         ddwaf_object_free(&result7);
@@ -2181,9 +2181,9 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(
-            result7, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result7,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result8, {});
 
         ddwaf_object_free(&result7);
@@ -2213,9 +2213,9 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(
-            result7, {{"block_request",
-                         {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(result7,
+            {{"block_request",
+                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
         EXPECT_ACTIONS(result8, {});
 
         ddwaf_object_free(&result7);

--- a/tests/integration/rules/custom_rules/test.cpp
+++ b/tests/integration/rules/custom_rules/test.cpp
@@ -168,8 +168,9 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
 
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -212,8 +213,9 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -274,8 +276,9 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
                                    .op_value = "rule",
                                    .highlight = "rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -296,8 +299,9 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -362,8 +366,9 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -470,8 +475,9 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -492,8 +498,9 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
                                    .op_value = "rule",
                                    .highlight = "rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -558,8 +565,9 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -580,8 +588,9 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -660,8 +669,9 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
                                    .op_value = "rule",
                                    .highlight = "rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -691,8 +701,9 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -758,8 +769,9 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
                                    .op_value = "custom_rule",
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -780,8 +792,9 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
                                    .op_value = "rule",
                                    .highlight = "rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -863,8 +876,9 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                        .value = "custom_rule"sv,
                                        .address = "value34",
                                    }}}}});
-        EXPECT_ACTIONS(res, {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"},
-                                                   {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            res, {{"block_request",
+                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);

--- a/tests/unit/builder/action_mapper_builder_test.cpp
+++ b/tests/unit/builder/action_mapper_builder_test.cpp
@@ -40,9 +40,9 @@ TEST(TestActionMapperBuilder, DefaultActions)
         EXPECT_STR(action.type_str, "block_request");
 
         EXPECT_EQ(action.parameters.size(), 3);
-        EXPECT_STRV(action.parameters.at("status_code"), "403");
-        EXPECT_STRV(action.parameters.at("type"), "auto");
-        EXPECT_STRV(action.parameters.at("grpc_status_code"), "10");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("status_code")), "403");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("type")), "auto");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("grpc_status_code")), "10");
     }
 
     {
@@ -103,8 +103,8 @@ TEST(TestActionMapperBuilder, SetAction)
         EXPECT_STR(action.type_str, "redirect_request");
 
         EXPECT_EQ(action.parameters.size(), 2);
-        EXPECT_STRV(action.parameters.at("status_code"), "33");
-        EXPECT_STRV(action.parameters.at("location"), "datadoghq");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("status_code")), "33");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("location")), "datadoghq");
     }
 }
 
@@ -127,8 +127,8 @@ TEST(TestActionMapperBuilder, OverrideDefaultAction)
         EXPECT_STR(action.type_str, "redirect_request");
 
         EXPECT_EQ(action.parameters.size(), 2);
-        EXPECT_STRV(action.parameters.at("status_code"), "33");
-        EXPECT_STRV(action.parameters.at("location"), "datadoghq");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("status_code")), "33");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("location")), "datadoghq");
     }
 }
 
@@ -159,8 +159,8 @@ TEST(TestActionMapperBuilder, DuplicateDefaultAction)
         EXPECT_STR(action.type_str, "redirect_request");
 
         EXPECT_EQ(action.parameters.size(), 2);
-        EXPECT_STRV(action.parameters.at("status_code"), "33");
-        EXPECT_STRV(action.parameters.at("location"), "datadoghq");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("status_code")), "33");
+        EXPECT_STRV(std::get<std::string>(action.parameters.at("location")), "datadoghq");
     }
 }
 

--- a/tests/unit/builder/action_mapper_builder_test.cpp
+++ b/tests/unit/builder/action_mapper_builder_test.cpp
@@ -40,9 +40,9 @@ TEST(TestActionMapperBuilder, DefaultActions)
         EXPECT_STR(action.type_str, "block_request");
 
         EXPECT_EQ(action.parameters.size(), 3);
-        EXPECT_STRV(std::get<std::string>(action.parameters.at("status_code")), "403");
+        EXPECT_EQ(std::get<uint64_t>(action.parameters.at("status_code")), 403);
         EXPECT_STRV(std::get<std::string>(action.parameters.at("type")), "auto");
-        EXPECT_STRV(std::get<std::string>(action.parameters.at("grpc_status_code")), "10");
+        EXPECT_EQ(std::get<uint64_t>(action.parameters.at("grpc_status_code")), 10);
     }
 
     {
@@ -86,7 +86,7 @@ TEST(TestActionMapperBuilder, SetAction)
 {
     action_mapper_builder builder;
     builder.set_action(
-        "redirect", "redirect_request", {{"status_code", "33"}, {"location", "datadoghq"}});
+        "redirect", "redirect_request", {{"status_code", 33ULL}, {"location", "datadoghq"}});
 
     auto actions = builder.build();
 
@@ -103,7 +103,7 @@ TEST(TestActionMapperBuilder, SetAction)
         EXPECT_STR(action.type_str, "redirect_request");
 
         EXPECT_EQ(action.parameters.size(), 2);
-        EXPECT_STRV(std::get<std::string>(action.parameters.at("status_code")), "33");
+        EXPECT_EQ(std::get<uint64_t>(action.parameters.at("status_code")), 33);
         EXPECT_STRV(std::get<std::string>(action.parameters.at("location")), "datadoghq");
     }
 }
@@ -112,7 +112,7 @@ TEST(TestActionMapperBuilder, OverrideDefaultAction)
 {
     action_mapper_builder builder;
     builder.set_action(
-        "block", "redirect_request", {{"status_code", "33"}, {"location", "datadoghq"}});
+        "block", "redirect_request", {{"status_code", 33ULL}, {"location", "datadoghq"}});
 
     auto actions = builder.build();
 
@@ -127,7 +127,7 @@ TEST(TestActionMapperBuilder, OverrideDefaultAction)
         EXPECT_STR(action.type_str, "redirect_request");
 
         EXPECT_EQ(action.parameters.size(), 2);
-        EXPECT_STRV(std::get<std::string>(action.parameters.at("status_code")), "33");
+        EXPECT_EQ(std::get<uint64_t>(action.parameters.at("status_code")), 33);
         EXPECT_STRV(std::get<std::string>(action.parameters.at("location")), "datadoghq");
     }
 }
@@ -144,7 +144,7 @@ TEST(TestActionMapperBuilder, DuplicateDefaultAction)
 {
     action_mapper_builder builder;
     builder.set_action(
-        "block", "redirect_request", {{"status_code", "33"}, {"location", "datadoghq"}});
+        "block", "redirect_request", {{"status_code", 33ULL}, {"location", "datadoghq"}});
     EXPECT_THROW(builder.set_action("block", "redirect_request", {}), std::runtime_error);
     auto actions = builder.build();
 
@@ -159,7 +159,7 @@ TEST(TestActionMapperBuilder, DuplicateDefaultAction)
         EXPECT_STR(action.type_str, "redirect_request");
 
         EXPECT_EQ(action.parameters.size(), 2);
-        EXPECT_STRV(std::get<std::string>(action.parameters.at("status_code")), "33");
+        EXPECT_EQ(std::get<uint64_t>(action.parameters.at("status_code")), 33);
         EXPECT_STRV(std::get<std::string>(action.parameters.at("location")), "datadoghq");
     }
 }

--- a/tests/unit/configuration/action_parser_test.cpp
+++ b/tests/unit/configuration/action_parser_test.cpp
@@ -263,10 +263,114 @@ TEST(TestActionParser, RedirectActionInvalidStatusCode)
     }
 }
 
+TEST(TestActionParser, RedirectActionNegativeStatusCode)
+{
+    auto object = yaml_to_object(
+        R"([{id: redirect, parameters: {location: "http://www.google.com", status_code: -303}, type: redirect_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("redirect"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("redirect"));
+    EXPECT_TRUE(cfg.actions.contains("redirect"));
+
+    {
+        const auto &spec = cfg.actions["redirect"];
+        EXPECT_EQ(spec.type, action_type::redirect_request);
+        EXPECT_EQ(spec.type_str, "redirect_request");
+        EXPECT_EQ(spec.parameters.size(), 2);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 303);
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
+    }
+}
+
 TEST(TestActionParser, RedirectActionInvalid300StatusCode)
 {
     auto object = yaml_to_object(
         R"([{id: redirect, parameters: {location: "http://www.google.com", status_code: 304}, type: redirect_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("redirect"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("redirect"));
+    EXPECT_TRUE(cfg.actions.contains("redirect"));
+
+    {
+        const auto &spec = cfg.actions["redirect"];
+        EXPECT_EQ(spec.type, action_type::redirect_request);
+        EXPECT_EQ(spec.type_str, "redirect_request");
+        EXPECT_EQ(spec.parameters.size(), 2);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 303);
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
+    }
+}
+
+TEST(TestActionParser, RedirectActionStringStatusCode)
+{
+    auto object = yaml_to_object(
+        R"([{id: redirect, parameters: {location: "http://www.google.com", status_code: "303"}, type: redirect_request}])");
 
     configuration_spec cfg;
     configuration_change_spec change;
@@ -627,8 +731,114 @@ TEST(TestActionParser, BlockActionMissingStatusCode)
 
         const auto &parameters = spec.parameters;
         EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
-        // EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 302);
-        // EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 302);
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
+    }
+}
+
+TEST(TestActionParser, BlockActionNegativeStatusCode)
+{
+    auto object = yaml_to_object(
+        R"([{id: block, parameters: {type: "auto", grpc_status_code: -302, status_code: -10}, type: block_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("block"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("block"));
+    EXPECT_TRUE(cfg.actions.contains("block"));
+
+    {
+        const auto &spec = cfg.actions["block"];
+        EXPECT_EQ(spec.type, action_type::block_request);
+        EXPECT_EQ(spec.type_str, "block_request");
+        EXPECT_EQ(spec.parameters.size(), 3);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 10);
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
+    }
+}
+
+TEST(TestActionParser, BlockActionStringStatusCode)
+{
+    auto object = yaml_to_object(
+        R"([{id: block, parameters: {type: "auto", grpc_status_code: "302", status_code: "10"}, type: block_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("block"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("block"));
+    EXPECT_TRUE(cfg.actions.contains("block"));
+
+    {
+        const auto &spec = cfg.actions["block"];
+        EXPECT_EQ(spec.type, action_type::block_request);
+        EXPECT_EQ(spec.type_str, "block_request");
+        EXPECT_EQ(spec.parameters.size(), 3);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 10);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 302);
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
 
@@ -1005,6 +1215,153 @@ TEST(TestActionParser, DuplicateAction)
 
     EXPECT_TRUE(change.actions.contains("block_1"));
     EXPECT_TRUE(cfg.actions.contains("block_1"));
+}
+
+TEST(TestActionParser, ParameterTypes)
+{
+    auto object = yaml_to_object(
+        R"([{id: sanitize, parameters: {string: thisisastring, int64: -200, uint64: 18446744073709551615, double: 22.22, bool: true}, type: new_action_type}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("sanitize"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("sanitize"));
+    EXPECT_TRUE(cfg.actions.contains("sanitize"));
+
+    auto &spec = cfg.actions.find("sanitize")->second;
+
+    auto it = spec.parameters.find("string");
+    EXPECT_NE(it, spec.parameters.end());
+    ASSERT_TRUE(std::holds_alternative<std::string>(it->second));
+    EXPECT_STR(std::get<std::string>(it->second), "thisisastring");
+
+    it = spec.parameters.find("int64");
+    EXPECT_NE(it, spec.parameters.end());
+    EXPECT_TRUE(std::holds_alternative<int64_t>(it->second));
+    EXPECT_EQ(std::get<int64_t>(it->second), -200);
+
+    it = spec.parameters.find("uint64");
+    EXPECT_NE(it, spec.parameters.end());
+    EXPECT_TRUE(std::holds_alternative<uint64_t>(it->second));
+    EXPECT_EQ(std::get<uint64_t>(it->second), std::numeric_limits<uint64_t>::max());
+
+    it = spec.parameters.find("double");
+    EXPECT_NE(it, spec.parameters.end());
+    EXPECT_TRUE(std::holds_alternative<double>(it->second));
+    EXPECT_EQ(std::get<double>(it->second), 22.22);
+
+    it = spec.parameters.find("bool");
+    EXPECT_NE(it, spec.parameters.end());
+    EXPECT_TRUE(std::holds_alternative<bool>(it->second));
+    EXPECT_EQ(std::get<bool>(it->second), true);
+}
+
+TEST(TestActionParser, InvalidParameterContainer)
+{
+    auto object = yaml_to_object(R"([{id: sanitize, parameters: [], type: new_action_type}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("sanitize"), failed.end());
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+
+        auto it = errors.find("invalid type 'array' for key 'parameters', expected 'map'");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<raw_configuration::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("sanitize"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
+}
+
+TEST(TestActionParser, InvalidParameterType)
+{
+    auto object =
+        yaml_to_object(R"([{id: sanitize, parameters: {value: {}}, type: new_action_type}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("sanitize"), failed.end());
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 1);
+
+        auto it = errors.find("malformed object, item in scalar map not a valid scalar");
+        EXPECT_NE(it, errors.end());
+
+        auto error_rules = static_cast<raw_configuration::string_set>(it->second);
+        EXPECT_EQ(error_rules.size(), 1);
+        EXPECT_NE(error_rules.find("sanitize"), error_rules.end());
+
+        ddwaf_object_free(&root);
+    }
 }
 
 } // namespace

--- a/tests/unit/configuration/action_parser_test.cpp
+++ b/tests/unit/configuration/action_parser_test.cpp
@@ -118,13 +118,13 @@ TEST(TestActionParser, SingleAction)
 
 TEST(TestActionParser, RedirectAction)
 {
-    std::vector<std::tuple<std::string, std::string, std::string>> redirections{
-        {"redirect_301", "301", "http://www.datadoghq.com"},
-        {"redirect_302", "302", "http://www.datadoghq.com"},
-        {"redirect_303", "303", "http://www.datadoghq.com"},
-        {"redirect_307", "307", "http://www.datadoghq.com"},
-        {"redirect_https", "303", "https://www.datadoghq.com"},
-        {"redirect_path", "303", "/security/appsec"},
+    std::vector<std::tuple<std::string, uint64_t, std::string>> redirections{
+        {"redirect_301", 301, "http://www.datadoghq.com"},
+        {"redirect_302", 302, "http://www.datadoghq.com"},
+        {"redirect_303", 303, "http://www.datadoghq.com"},
+        {"redirect_307", 307, "http://www.datadoghq.com"},
+        {"redirect_https", 303, "https://www.datadoghq.com"},
+        {"redirect_path", 303, "/security/appsec"},
     };
 
     std::string yaml;
@@ -184,7 +184,7 @@ TEST(TestActionParser, RedirectAction)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), status_code);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), status_code);
         EXPECT_STR(std::get<std::string>(parameters.at("location")), url);
     }
 
@@ -258,7 +258,7 @@ TEST(TestActionParser, RedirectActionInvalidStatusCode)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "303");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 303);
         EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
     }
 }
@@ -310,7 +310,7 @@ TEST(TestActionParser, RedirectActionInvalid300StatusCode)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "303");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 303);
         EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
     }
 }
@@ -362,7 +362,7 @@ TEST(TestActionParser, RedirectActionMissingStatusCode)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "303");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 303);
         EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
     }
 }
@@ -414,8 +414,8 @@ TEST(TestActionParser, RedirectActionMissingLocation)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
-        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 10);
         EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
@@ -467,8 +467,8 @@ TEST(TestActionParser, RedirectActionNonHttpURL)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
-        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 10);
         EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
@@ -520,8 +520,8 @@ TEST(TestActionParser, RedirectActionInvalidRelativePathURL)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
-        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 10);
         EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
@@ -574,7 +574,7 @@ TEST(TestActionParser, OverrideDefaultBlockAction)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "302");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 302);
         EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
     }
 }
@@ -626,8 +626,8 @@ TEST(TestActionParser, BlockActionMissingStatusCode)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
-        // EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "302");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
+        // EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 302);
         // EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
@@ -720,8 +720,8 @@ TEST(TestActionParser, BlockActionMissingGrpcStatusCode)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "302");
-        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 302);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 10);
         EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
@@ -773,8 +773,8 @@ TEST(TestActionParser, BlockActionMissingType)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "302");
-        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "11");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 302);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 11);
         EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
@@ -825,8 +825,8 @@ TEST(TestActionParser, BlockActionMissingParameters)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
-        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 10);
         EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }

--- a/tests/unit/configuration/action_parser_test.cpp
+++ b/tests/unit/configuration/action_parser_test.cpp
@@ -184,8 +184,8 @@ TEST(TestActionParser, RedirectAction)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), status_code.c_str());
-        EXPECT_STR(parameters.at("location"), url.c_str());
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), status_code);
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), url);
     }
 
     EXPECT_TRUE(change.base_rules.empty());
@@ -258,8 +258,8 @@ TEST(TestActionParser, RedirectActionInvalidStatusCode)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "303");
-        EXPECT_STR(parameters.at("location"), "http://www.google.com");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "303");
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
     }
 }
 
@@ -310,8 +310,8 @@ TEST(TestActionParser, RedirectActionInvalid300StatusCode)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "303");
-        EXPECT_STR(parameters.at("location"), "http://www.google.com");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "303");
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
     }
 }
 
@@ -362,8 +362,8 @@ TEST(TestActionParser, RedirectActionMissingStatusCode)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "303");
-        EXPECT_STR(parameters.at("location"), "http://www.google.com");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "303");
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
     }
 }
 
@@ -414,9 +414,9 @@ TEST(TestActionParser, RedirectActionMissingLocation)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "403");
-        EXPECT_STR(parameters.at("grpc_status_code"), "10");
-        EXPECT_STR(parameters.at("type"), "auto");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
+        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
 
@@ -467,9 +467,9 @@ TEST(TestActionParser, RedirectActionNonHttpURL)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "403");
-        EXPECT_STR(parameters.at("grpc_status_code"), "10");
-        EXPECT_STR(parameters.at("type"), "auto");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
+        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
 
@@ -520,9 +520,9 @@ TEST(TestActionParser, RedirectActionInvalidRelativePathURL)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "403");
-        EXPECT_STR(parameters.at("grpc_status_code"), "10");
-        EXPECT_STR(parameters.at("type"), "auto");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
+        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
 
@@ -574,8 +574,8 @@ TEST(TestActionParser, OverrideDefaultBlockAction)
         EXPECT_EQ(spec.parameters.size(), 2);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "302");
-        EXPECT_STR(parameters.at("location"), "http://www.google.com");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "302");
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
     }
 }
 
@@ -626,9 +626,9 @@ TEST(TestActionParser, BlockActionMissingStatusCode)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "403");
-        EXPECT_STR(parameters.at("grpc_status_code"), "302");
-        EXPECT_STR(parameters.at("type"), "auto");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
+        // EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "302");
+        // EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
 
@@ -720,9 +720,9 @@ TEST(TestActionParser, BlockActionMissingGrpcStatusCode)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "302");
-        EXPECT_STR(parameters.at("grpc_status_code"), "10");
-        EXPECT_STR(parameters.at("type"), "auto");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "302");
+        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
 
@@ -773,9 +773,9 @@ TEST(TestActionParser, BlockActionMissingType)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "302");
-        EXPECT_STR(parameters.at("grpc_status_code"), "11");
-        EXPECT_STR(parameters.at("type"), "auto");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "302");
+        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "11");
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
 
@@ -825,9 +825,9 @@ TEST(TestActionParser, BlockActionMissingParameters)
         EXPECT_EQ(spec.parameters.size(), 3);
 
         const auto &parameters = spec.parameters;
-        EXPECT_STR(parameters.at("status_code"), "403");
-        EXPECT_STR(parameters.at("grpc_status_code"), "10");
-        EXPECT_STR(parameters.at("type"), "auto");
+        EXPECT_STR(std::get<std::string>(parameters.at("status_code")), "403");
+        EXPECT_STR(std::get<std::string>(parameters.at("grpc_status_code")), "10");
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }
 

--- a/tests/unit/serializer_test.cpp
+++ b/tests/unit/serializer_test.cpp
@@ -122,7 +122,8 @@ TEST(TestEventSerializer, SerializeSingleEventSingleMatch)
                                              .path = {"root", "key"}}}}}});
 
     EXPECT_ACTIONS(result_object,
-        {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}},
+        {{"block_request",
+             {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}},
             {"monitor_request", {}}});
 
     ddwaf_object_free(&result_object);
@@ -227,7 +228,8 @@ TEST(TestEventSerializer, SerializeSingleEventMultipleMatches)
                                              }}}}});
 
     EXPECT_ACTIONS(result_object,
-        {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}},
+        {{"block_request",
+             {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}},
             {"monitor_request", {}}});
 
     ddwaf_object_free(&result_object);
@@ -359,7 +361,8 @@ TEST(TestEventSerializer, SerializeMultipleEvents)
         {});
 
     EXPECT_ACTIONS(result_object,
-        {{"block_request", {{"status_code", "403"}, {"grpc_status_code", "10"}, {"type", "auto"}}},
+        {{"block_request",
+             {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}},
             {"monitor_request", {}}, {"unknown", {}}});
 
     ddwaf_object_free(&result_object);
@@ -681,7 +684,7 @@ TEST(TestEventSerializer, StackTraceAction)
 
         auto it = obtained.find("generate_stack");
         EXPECT_TRUE(it->second.contains("stack_id"));
-        EXPECT_EQ(it->second.at("stack_id"), stack_id);
+        EXPECT_EQ(std::get<std::string>(it->second.at("stack_id")), stack_id);
     }
 
     ddwaf_object_free(&result_object);


### PR DESCRIPTION
This PR extends the set of allowed types on action parameters to include all other scalars. This is a small improvement which can be taken advantage of to prevent intermediate type conversions. In v2, other complex types will also be supported.

Related Jiras: [APPSEC-58779]

[APPSEC-58779]: https://datadoghq.atlassian.net/browse/APPSEC-58779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ