### PR TITLE
Subcontext: refactor evaluation stages from context

### DIFF
--- a/cmake/objects.cmake
+++ b/cmake/objects.cmake
@@ -1,7 +1,7 @@
 set(LIBDDWAF_SOURCE
     ${libddwaf_SOURCE_DIR}/src/clock.cpp
     ${libddwaf_SOURCE_DIR}/src/interface.cpp
-    ${libddwaf_SOURCE_DIR}/src/context.cpp
+    ${libddwaf_SOURCE_DIR}/src/evaluation_engine.cpp
     ${libddwaf_SOURCE_DIR}/src/context_allocator.cpp
     ${libddwaf_SOURCE_DIR}/src/serializer.cpp
     ${libddwaf_SOURCE_DIR}/src/object_store.cpp

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -9,13 +9,9 @@
 #include <memory>
 #include <utility>
 
-#include "attribute_collector.hpp"
 #include "context_allocator.hpp"
-#include "exclusion/common.hpp"
-#include "exclusion/input_filter.hpp"
-#include "exclusion/rule_filter.hpp"
+#include "evaluation_engine.hpp"
 #include "memory_resource.hpp"
-#include "obfuscator.hpp"
 #include "pointer.hpp"
 #include "ruleset.hpp"
 
@@ -29,22 +25,8 @@ public:
 
     explicit context(std::shared_ptr<ruleset> ruleset,
         nonnull_ptr<memory::memory_resource> output_alloc = memory::get_default_resource())
-        : output_alloc_(output_alloc), ruleset_(std::move(ruleset)), collector_(output_alloc),
-          preprocessors_(*ruleset_->preprocessors), postprocessors_(*ruleset_->postprocessors),
-          rule_filters_(*ruleset_->rule_filters), input_filters_(*ruleset_->input_filters),
-          rule_matchers_(*ruleset_->rule_matchers),
-          exclusion_matchers_(*ruleset_->exclusion_matchers), actions_(*ruleset_->actions),
-          obfuscator_(*ruleset_->obfuscator)
-    {
-        processor_cache_.reserve(
-            ruleset_->preprocessors->size() + ruleset_->postprocessors->size());
-        rule_filter_cache_.reserve(ruleset_->rule_filters->size());
-        input_filter_cache_.reserve(ruleset_->input_filters->size());
-
-        for (std::size_t i = 0; i < ruleset_->rule_modules.size(); ++i) {
-            ruleset_->rule_modules[i].init_cache(rule_module_cache_[i]);
-        }
-    }
+        : engine_(std::move(ruleset), output_alloc)
+    {}
 
     context(const context &) = delete;
     context &operator=(const context &) = delete;
@@ -70,74 +52,15 @@ public:
         return true;
     }
 
-    std::pair<bool, owned_object> eval(uint64_t);
-
-    void eval_preprocessors(ddwaf::timer &deadline);
-    void eval_postprocessors(ddwaf::timer &deadline);
-    // This function below returns a reference to an internal object,
-    // however using them this way helps with testing
-    exclusion::context_policy &eval_filters(ddwaf::timer &deadline);
-    void eval_rules(const exclusion::context_policy &policy, std::vector<rule_result> &results,
-        ddwaf::timer &deadline);
+    std::pair<bool, owned_object> eval(uint64_t timeout)
+    {
+        timer deadline{std::chrono::microseconds(timeout)};
+        return engine_.eval(store_, deadline);
+    }
 
 protected:
-    bool is_first_run() const { return store_.empty(); }
-    bool check_new_rule_targets() const
-    {
-        // NOLINTNEXTLINE(readability-use-anyofallof)
-        for (const auto &[target, str] : ruleset_->rule_addresses) {
-            if (store_.is_new_target(target)) {
-                return true;
-            }
-        }
-        return false;
-    }
-    bool check_new_filter_targets() const
-    {
-        // NOLINTNEXTLINE(readability-use-anyofallof)
-        for (const auto &[target, str] : ruleset_->filter_addresses) {
-            if (store_.is_new_target(target)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    // This memory resource is used primarily for the allocation of memory
-    // which will be returned to the user.
-    nonnull_ptr<memory::memory_resource> output_alloc_;
-
-    std::shared_ptr<ruleset> ruleset_;
-    ddwaf::object_store store_;
-    attribute_collector collector_;
-
-    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
-    const std::vector<std::unique_ptr<base_processor>> &preprocessors_;
-    const std::vector<std::unique_ptr<base_processor>> &postprocessors_;
-
-    const std::vector<exclusion::rule_filter> &rule_filters_;
-    const std::vector<exclusion::input_filter> &input_filters_;
-
-    const matcher_mapper &rule_matchers_;
-    const matcher_mapper &exclusion_matchers_;
-
-    const action_mapper &actions_;
-
-    const match_obfuscator &obfuscator_;
-    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
-
-    using input_filter = exclusion::input_filter;
-    using rule_filter = exclusion::rule_filter;
-
-    memory::unordered_map<base_processor *, processor_cache> processor_cache_;
-
-    // Caches of filters and conditions
-    memory::unordered_map<const rule_filter *, rule_filter::cache_type> rule_filter_cache_;
-    memory::unordered_map<const input_filter *, input_filter::cache_type> input_filter_cache_;
-    exclusion::context_policy exclusion_policy_;
-
-    // Cache of modules to avoid processing once a result has been obtained
-    std::array<rule_module_cache, rule_module_count> rule_module_cache_;
+    evaluation_engine engine_;
+    object_store store_;
 };
 
 class context_wrapper {

--- a/src/evaluation_engine.hpp
+++ b/src/evaluation_engine.hpp
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025 Datadog, Inc.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "attribute_collector.hpp"
+#include "context_allocator.hpp"
+#include "exclusion/common.hpp"
+#include "exclusion/input_filter.hpp"
+#include "exclusion/rule_filter.hpp"
+#include "memory_resource.hpp"
+#include "obfuscator.hpp"
+#include "pointer.hpp"
+#include "ruleset.hpp"
+
+namespace ddwaf {
+
+enum class evaluation_scope : uint8_t { context = 0, subcontext = 1 };
+
+class evaluation_engine {
+public:
+    explicit evaluation_engine(std::shared_ptr<ruleset> ruleset,
+        nonnull_ptr<memory::memory_resource> output_alloc = memory::get_default_resource())
+        : output_alloc_(output_alloc), ruleset_(std::move(ruleset)), collector_(output_alloc),
+          preprocessors_(*ruleset_->preprocessors), postprocessors_(*ruleset_->postprocessors),
+          rule_filters_(*ruleset_->rule_filters), input_filters_(*ruleset_->input_filters),
+          rule_matchers_(*ruleset_->rule_matchers),
+          exclusion_matchers_(*ruleset_->exclusion_matchers), actions_(*ruleset_->actions),
+          obfuscator_(*ruleset_->obfuscator)
+    {
+        processor_cache_.reserve(
+            ruleset_->preprocessors->size() + ruleset_->postprocessors->size());
+        rule_filter_cache_.reserve(ruleset_->rule_filters->size());
+        input_filter_cache_.reserve(ruleset_->input_filters->size());
+
+        for (std::size_t i = 0; i < ruleset_->rule_modules.size(); ++i) {
+            ruleset_->rule_modules[i].init_cache(rule_module_cache_[i]);
+        }
+    }
+
+    evaluation_engine(const evaluation_engine &) = delete;
+    evaluation_engine &operator=(const evaluation_engine &) = delete;
+    evaluation_engine(evaluation_engine &&) = delete;
+    evaluation_engine &operator=(evaluation_engine &&) = delete;
+    ~evaluation_engine() = default;
+
+    std::pair<bool, owned_object> eval(object_store &store, timer &deadline);
+
+    void eval_preprocessors(object_store &store, timer &deadline);
+    void eval_postprocessors(object_store &store, timer &deadline);
+    // This function below returns a reference to an internal object,
+    // however using them this way helps with testing
+    exclusion::context_policy &eval_filters(object_store &store, timer &deadline);
+    void eval_rules(object_store &store, const exclusion::context_policy &policy,
+        std::vector<rule_result> &results, timer &deadline);
+
+protected:
+    bool check_new_rule_targets(const object_store &store) const
+    {
+        // NOLINTNEXTLINE(readability-use-anyofallof)
+        for (const auto &[target, str] : ruleset_->rule_addresses) {
+            if (store.is_new_target(target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool check_new_filter_targets(const object_store &store) const
+    {
+        // NOLINTNEXTLINE(readability-use-anyofallof)
+        for (const auto &[target, str] : ruleset_->filter_addresses) {
+            if (store.is_new_target(target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // This memory resource is used primarily for the allocation of memory
+    // which will be returned to the user.
+    nonnull_ptr<memory::memory_resource> output_alloc_;
+
+    std::shared_ptr<ruleset> ruleset_;
+    attribute_collector collector_;
+
+    // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+    const std::vector<std::unique_ptr<base_processor>> &preprocessors_;
+    const std::vector<std::unique_ptr<base_processor>> &postprocessors_;
+
+    const std::vector<exclusion::rule_filter> &rule_filters_;
+    const std::vector<exclusion::input_filter> &input_filters_;
+
+    const matcher_mapper &rule_matchers_;
+    const matcher_mapper &exclusion_matchers_;
+
+    const action_mapper &actions_;
+
+    const match_obfuscator &obfuscator_;
+    // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+    using input_filter = exclusion::input_filter;
+    using rule_filter = exclusion::rule_filter;
+
+    memory::unordered_map<base_processor *, processor_cache> processor_cache_;
+
+    // Caches of filters and conditions
+    memory::unordered_map<const rule_filter *, rule_filter::cache_type> rule_filter_cache_;
+    memory::unordered_map<const input_filter *, input_filter::cache_type> input_filter_cache_;
+    exclusion::context_policy exclusion_policy_;
+
+    // Cache of modules to avoid processing once a result has been obtained
+    std::array<rule_module_cache, rule_module_count> rule_module_cache_;
+};
+
+} // namespace ddwaf


### PR DESCRIPTION
Subcontexts will be implemented by:
- Adding and enforcing a scope (`context`, `subcontext`) to the evaluation process
- Adding a scope to the data (replacing `attribute::none` and `attribute::ephemeral`)
- Creating a new `subcontext` and `subcontext_wrapper` class which will be created from the current context (and with a linked lifecycle)

To do this, the evaluation process must be refactored out of the context, so that it can be used separately within the subcontext using the correct scope. This PR does exactly this first step, splitting these from `context` into the `evaluation_engine`.

The next PR will:
- Implement the subcontext piggybacking on ephemerals.
- Remove the concept of ephemerality in favour of scope (`context`, `subcontext`).
- Split the API to create and use subcontexts.

