### PR TITLE
Load tokenizer regexes on first ruleset instantiation

### DIFF
--- a/src/condition/shi_detector.cpp
+++ b/src/condition/shi_detector.cpp
@@ -117,7 +117,9 @@ eval_result shi_detector::eval_array(const unary_argument<const ddwaf_object *> 
 
 shi_detector::shi_detector(std::vector<condition_parameter> args)
     : base_impl<shi_detector>(std::move(args))
-{}
+{
+    shell_tokenizer::initialise_regexes();
+}
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 eval_result shi_detector::eval_impl(const unary_argument<const ddwaf_object *> &resource,

--- a/src/condition/sqli_detector.cpp
+++ b/src/condition/sqli_detector.cpp
@@ -20,6 +20,7 @@
 #include "condition/base.hpp"
 #include "condition/match_iterator.hpp"
 #include "condition/sqli_detector.hpp"
+#include "condition/structured_condition.hpp"
 #include "ddwaf.h"
 #include "exception.hpp"
 #include "exclusion/common.hpp"
@@ -509,6 +510,15 @@ sqli_result sqli_impl(std::string_view resource, std::vector<sql_token> &resourc
 } // namespace
 
 } // namespace internal
+
+sqli_detector::sqli_detector(std::vector<condition_parameter> args)
+    : base_impl<sqli_detector>(std::move(args))
+{
+    generic_sql_tokenizer::initialise_regexes();
+    mysql_tokenizer::initialise_regexes();
+    pgsql_tokenizer::initialise_regexes();
+    sqlite_tokenizer::initialise_regexes();
+}
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 [[nodiscard]] eval_result sqli_detector::eval_impl(const unary_argument<std::string_view> &sql,

--- a/src/condition/sqli_detector.hpp
+++ b/src/condition/sqli_detector.hpp
@@ -16,9 +16,7 @@ public:
     static constexpr unsigned version = 3;
     static constexpr std::array<std::string_view, 3> param_names{"resource", "params", "db_type"};
 
-    explicit sqli_detector(std::vector<condition_parameter> args)
-        : base_impl<sqli_detector>(std::move(args))
-    {}
+    explicit sqli_detector(std::vector<condition_parameter> args);
 
 protected:
     [[nodiscard]] eval_result eval_impl(const unary_argument<std::string_view> &sql,

--- a/src/tokenizer/base.hpp
+++ b/src/tokenizer/base.hpp
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#include "utils.hpp"
 #include <fmt/format.h>
-#include <ostream>
 #include <re2/re2.h>
 #include <string_view>
 #include <unordered_set>

--- a/src/tokenizer/generic_sql.cpp
+++ b/src/tokenizer/generic_sql.cpp
@@ -3,6 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
+#include <memory>
 #include <stdexcept>
 #include <string_view>
 #include <unordered_set>
@@ -19,8 +20,10 @@ using namespace std::literals;
 
 namespace ddwaf {
 namespace {
-re2::RE2 identifier_regex(
-    R"((?i)^(?:(?P<keyword>SELECT|FROM|WHERE|GROUP|OFFSET|LIMIT|DISTINCT|HAVING|ORDER|ASC|DESC|UNION|NULL|ALL|ANY|BY|AS)|(?P<binary_operator>OR|AND|BETWEEN|LIKE|IN|MOD|IS|NOT)|(?P<identifier>[\x{0080}-\x{FFFF}a-zA-Z_][\x{0080}-\x{FFFF}a-zA-Z_0-9$]*))(?:\b|\s|$))");
+constexpr std::string_view identifier_regex_initialiser =
+    R"((?i)^(?:(?P<keyword>SELECT|FROM|WHERE|GROUP|OFFSET|LIMIT|DISTINCT|HAVING|ORDER|ASC|DESC|UNION|NULL|ALL|ANY|BY|AS)|(?P<binary_operator>OR|AND|BETWEEN|LIKE|IN|MOD|IS|NOT)|(?P<identifier>[\x{0080}-\x{FFFF}a-zA-Z_][\x{0080}-\x{FFFF}a-zA-Z_0-9$]*))(?:\b|\s|$))";
+
+std::unique_ptr<re2::RE2> identifier_regex;
 
 } // namespace
 
@@ -28,8 +31,14 @@ generic_sql_tokenizer::generic_sql_tokenizer(
     std::string_view str, std::unordered_set<sql_token_type> skip_tokens)
     : sql_tokenizer(str, std::move(skip_tokens))
 {
-    if (!identifier_regex.ok()) {
-        throw std::runtime_error("sql identifier regex not valid: " + identifier_regex.error_arg());
+    static const bool ret = []() {
+        identifier_regex = std::make_unique<re2::RE2>(identifier_regex_initialiser);
+        return identifier_regex && identifier_regex->ok();
+    }();
+
+    if (!ret) {
+        throw std::runtime_error(
+            "sql identifier regex not valid: " + identifier_regex->error_arg());
     }
 }
 
@@ -45,7 +54,7 @@ void generic_sql_tokenizer::tokenize_keyword_operator_or_identifier()
     std::string_view ident;
 
     const std::string_view ref(remaining_str.data(), remaining_str.size());
-    if (re2::RE2::PartialMatch(ref, identifier_regex, &keyword, &binary_op, &ident)) {
+    if (re2::RE2::PartialMatch(ref, *identifier_regex, &keyword, &binary_op, &ident)) {
         // At least one of the strings will contain a match
         if (!binary_op.empty()) {
             token.type = sql_token_type::binary_operator;

--- a/src/tokenizer/generic_sql.hpp
+++ b/src/tokenizer/generic_sql.hpp
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <memory>
-#include <ostream>
 #include <re2/re2.h>
 #include <string_view>
 #include <vector>

--- a/src/tokenizer/generic_sql.hpp
+++ b/src/tokenizer/generic_sql.hpp
@@ -19,6 +19,8 @@ public:
     explicit generic_sql_tokenizer(
         std::string_view str, std::unordered_set<sql_token_type> skip_tokens = {});
 
+    static bool initialise_regexes();
+
 protected:
     std::vector<sql_token> tokenize_impl();
 

--- a/src/tokenizer/mysql.cpp
+++ b/src/tokenizer/mysql.cpp
@@ -93,19 +93,30 @@ std::string_view extract_variable(std::string_view str)
 
 } // namespace
 
+bool mysql_tokenizer::initialise_regexes()
+{
+    static const bool ret = []() {
+        try {
+            bool const parent_init = sql_tokenizer<mysql_tokenizer>::initialise_regexes();
+            identifier_regex = std::make_unique<re2::RE2>(identifier_regex_initialiser);
+            variable_regex = std::make_unique<re2::RE2>(variable_regex_initialiser);
+            number_or_identifier_regex =
+                std::make_unique<re2::RE2>(number_or_identifier_regex_initialiser);
+            return parent_init && identifier_regex->ok() && variable_regex->ok() &&
+                   number_or_identifier_regex->ok();
+        } catch (...) {
+            return false;
+        }
+    }();
+
+    return ret;
+}
+
 mysql_tokenizer::mysql_tokenizer(
     std::string_view str, std::unordered_set<sql_token_type> skip_tokens)
     : sql_tokenizer(str, std::move(skip_tokens))
 {
-    static const bool ret = []() {
-        identifier_regex = std::make_unique<re2::RE2>(identifier_regex_initialiser);
-        variable_regex = std::make_unique<re2::RE2>(variable_regex_initialiser);
-        number_or_identifier_regex =
-            std::make_unique<re2::RE2>(number_or_identifier_regex_initialiser);
-        return identifier_regex->ok() && variable_regex->ok() && number_or_identifier_regex->ok();
-    }();
-
-    if (!ret) {
+    if (!initialise_regexes()) {
         if (!identifier_regex->ok()) {
             throw std::runtime_error(
                 "mysql identifier regex not valid: " + identifier_regex->error_arg());

--- a/src/tokenizer/mysql.hpp
+++ b/src/tokenizer/mysql.hpp
@@ -19,6 +19,8 @@ public:
     explicit mysql_tokenizer(
         std::string_view str, std::unordered_set<sql_token_type> skip_tokens = {});
 
+    static bool initialise_regexes();
+
 protected:
     std::vector<sql_token> tokenize_impl();
 

--- a/src/tokenizer/pgsql.cpp
+++ b/src/tokenizer/pgsql.cpp
@@ -42,6 +42,22 @@ std::unique_ptr<re2::RE2> parameter_regex;
 
 } // namespace
 
+bool pgsql_tokenizer::initialise_regexes()
+{
+    static const bool ret = []() {
+        try {
+            bool const parent_init = sql_tokenizer<pgsql_tokenizer>::initialise_regexes();
+            identifier_regex = std::make_unique<re2::RE2>(identifier_regex_initialiser);
+            parameter_regex = std::make_unique<re2::RE2>(parameter_regex_initialiser);
+            return parent_init && identifier_regex->ok() && parameter_regex->ok();
+        } catch (...) {
+            return false;
+        }
+    }();
+
+    return ret;
+}
+
 pgsql_tokenizer::pgsql_tokenizer(
     std::string_view str, std::unordered_set<sql_token_type> skip_tokens)
     : sql_tokenizer(str, std::move(skip_tokens))

--- a/src/tokenizer/pgsql.cpp
+++ b/src/tokenizer/pgsql.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <string_view>
 #include <unordered_set>
@@ -31,10 +32,13 @@ namespace {
  * starts or ends with an underscore, so identifiers of this form are safe against possible conflict
  * with future extensions of the standard.
  */
-re2::RE2 identifier_regex(
-    R"((?i)^(?:(?P<keyword>SELECT|FROM|WHERE|GROUP|OFFSET|LIMIT|HAVING|ORDER|PARTITION|BY|ASC|DESC|NULL)|^(?P<binary_operator>OR|XOR|AND|IN|BETWEEN|LIKE|REGEXP|SOUNDS|LIKE|NOT|IS|MOD|DIV)|^(?P<identifier>[\x{0080}-\x{FFFF}a-zA-Z_][\x{0080}-\x{FFFF}a-zA-Z_0-9$]*))(?:\b|\s|$))");
+constexpr std::string_view identifier_regex_initialiser =
+    R"((?i)^(?:(?P<keyword>SELECT|FROM|WHERE|GROUP|OFFSET|LIMIT|HAVING|ORDER|PARTITION|BY|ASC|DESC|NULL)|^(?P<binary_operator>OR|XOR|AND|IN|BETWEEN|LIKE|REGEXP|SOUNDS|LIKE|NOT|IS|MOD|DIV)|^(?P<identifier>[\x{0080}-\x{FFFF}a-zA-Z_][\x{0080}-\x{FFFF}a-zA-Z_0-9$]*))(?:\b|\s|$))";
 
-re2::RE2 parameter_regex(R"(^(?P<parameter>\$[0-9]+)(?:\b|\s|$))");
+constexpr std::string_view parameter_regex_initialiser(R"(^(?P<parameter>\$[0-9]+)(?:\b|\s|$))");
+
+std::unique_ptr<re2::RE2> identifier_regex;
+std::unique_ptr<re2::RE2> parameter_regex;
 
 } // namespace
 
@@ -42,13 +46,24 @@ pgsql_tokenizer::pgsql_tokenizer(
     std::string_view str, std::unordered_set<sql_token_type> skip_tokens)
     : sql_tokenizer(str, std::move(skip_tokens))
 {
-    if (!identifier_regex.ok()) {
-        throw std::runtime_error(
-            "pgsql identifier regex not valid: " + identifier_regex.error_arg());
-    }
+    static const bool ret = []() {
+        identifier_regex = std::make_unique<re2::RE2>(identifier_regex_initialiser);
+        parameter_regex = std::make_unique<re2::RE2>(parameter_regex_initialiser);
+        return identifier_regex->ok() && parameter_regex->ok();
+    }();
 
-    if (!parameter_regex.ok()) {
-        throw std::runtime_error("pgsql parameter regex not valid: " + parameter_regex.error_arg());
+    if (!ret) {
+        if (!identifier_regex->ok()) {
+            throw std::runtime_error(
+                "pgsql identifier regex not valid: " + identifier_regex->error_arg());
+        }
+
+        if (!parameter_regex->ok()) {
+            throw std::runtime_error(
+                "pgsql parameter regex not valid: " + parameter_regex->error_arg());
+        }
+
+        throw std::runtime_error("unknown failure on pgsql regex initialisation");
     }
 }
 
@@ -100,7 +115,7 @@ void pgsql_tokenizer::tokenize_string_keyword_operator_or_identifier()
     std::string_view ident;
 
     const std::string_view ref(remaining_str.data(), remaining_str.size());
-    if (re2::RE2::PartialMatch(ref, identifier_regex, &keyword, &binary_op, &ident)) {
+    if (re2::RE2::PartialMatch(ref, *identifier_regex, &keyword, &binary_op, &ident)) {
         // At least one of the strings will contain a match
         if (!binary_op.empty()) {
             token.type = sql_token_type::binary_operator;
@@ -231,7 +246,7 @@ void pgsql_tokenizer::tokenize_dollar_string_or_identifier()
 
         std::string_view parameter;
         const std::string_view ref(str.data(), str.size());
-        if (re2::RE2::PartialMatch(ref, parameter_regex, &parameter)) {
+        if (re2::RE2::PartialMatch(ref, *parameter_regex, &parameter)) {
             if (!parameter.empty()) {
                 add_token(sql_token_type::identifier, parameter.size());
             }

--- a/src/tokenizer/pgsql.hpp
+++ b/src/tokenizer/pgsql.hpp
@@ -19,6 +19,8 @@ public:
     explicit pgsql_tokenizer(
         std::string_view str, std::unordered_set<sql_token_type> skip_tokens = {});
 
+    static bool initialise_regexes();
+
 protected:
     std::vector<sql_token> tokenize_impl();
 

--- a/src/tokenizer/shell.hpp
+++ b/src/tokenizer/shell.hpp
@@ -67,6 +67,8 @@ public:
 
     std::vector<shell_token> tokenize();
 
+    static bool initialise_regexes();
+
 protected:
     enum class shell_scope : uint8_t {
         global,

--- a/src/tokenizer/shell.hpp
+++ b/src/tokenizer/shell.hpp
@@ -16,7 +16,7 @@
 
 namespace ddwaf {
 
-enum class shell_token_type {
+enum class shell_token_type : uint8_t {
     unknown,
     whitespace,
     executable,
@@ -68,7 +68,7 @@ public:
     std::vector<shell_token> tokenize();
 
 protected:
-    enum class shell_scope {
+    enum class shell_scope : uint8_t {
         global,
         double_quoted_string,        // " ... "
         backtick_substitution,       // ` ... `

--- a/src/tokenizer/sql_base.hpp
+++ b/src/tokenizer/sql_base.hpp
@@ -70,6 +70,8 @@ public:
 
     std::vector<sql_token> tokenize() { return static_cast<T *>(this)->tokenize_impl(); }
 
+    static bool initialise_regexes();
+
 protected:
     std::string_view extract_unescaped_string(char quote);
     std::string_view extract_conforming_string(char quote);

--- a/src/tokenizer/sql_base.hpp
+++ b/src/tokenizer/sql_base.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "tokenizer/base.hpp"
-#include "utils.hpp"
 #include <fmt/format.h>
 #include <ostream>
 #include <re2/re2.h>
@@ -17,9 +16,9 @@
 
 namespace ddwaf {
 
-enum class sql_dialect { generic, mysql, pgsql, oracle, sqlite, hsqldb, doctrine };
+enum class sql_dialect : uint8_t { generic, mysql, pgsql, oracle, sqlite, hsqldb, doctrine };
 
-enum class sql_token_type {
+enum class sql_token_type : uint8_t {
     unknown,
     keyword,
     identifier,

--- a/src/tokenizer/sqlite.cpp
+++ b/src/tokenizer/sqlite.cpp
@@ -3,6 +3,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
+#include <memory>
 #include <stdexcept>
 #include <string_view>
 #include <unordered_set>
@@ -21,8 +22,10 @@ namespace ddwaf {
 namespace {
 // https://www.sqlite.org/lang_select.html
 // Identifiers: https://sqlite.org/lang_keywords.html
-re2::RE2 identifier_regex(
-    R"((?i)^(?:(?P<keyword>SELECT|DISTINCT|ALL|FROM|WHERE|GROUP|HAVING|WINDOW|VALUES|OFFSET|LIMIT|ORDER|BY|ASC|DESC|UNION|INTERSECT|EXCEPT|NULL|AS)|(?P<binary_operator>OR|AND|IN|BETWEEN|LIKE|GLOB|ESCAPE|COLLATE|REGEXP|MATCH|NOTNULL|ISNULL|NOT|IS)|(?P<identifier>[\x{0080}-\x{FFFF}a-zA-Z_][\x{0080}-\x{FFFF}a-zA-Z_0-9$]*|\$[0-9]+))(?:\b|\s|$))");
+constexpr std::string_view identifier_regex_initialiser =
+    R"((?i)^(?:(?P<keyword>SELECT|DISTINCT|ALL|FROM|WHERE|GROUP|HAVING|WINDOW|VALUES|OFFSET|LIMIT|ORDER|BY|ASC|DESC|UNION|INTERSECT|EXCEPT|NULL|AS)|(?P<binary_operator>OR|AND|IN|BETWEEN|LIKE|GLOB|ESCAPE|COLLATE|REGEXP|MATCH|NOTNULL|ISNULL|NOT|IS)|(?P<identifier>[\x{0080}-\x{FFFF}a-zA-Z_][\x{0080}-\x{FFFF}a-zA-Z_0-9$]*|\$[0-9]+))(?:\b|\s|$))";
+
+std::unique_ptr<re2::RE2> identifier_regex;
 
 } // namespace
 
@@ -30,9 +33,14 @@ sqlite_tokenizer::sqlite_tokenizer(
     std::string_view str, std::unordered_set<sql_token_type> skip_tokens)
     : sql_tokenizer(str, std::move(skip_tokens))
 {
-    if (!identifier_regex.ok()) {
+    static const bool ret = []() {
+        identifier_regex = std::make_unique<re2::RE2>(identifier_regex_initialiser);
+        return identifier_regex->ok();
+    }();
+
+    if (!ret) {
         throw std::runtime_error(
-            "sqlite identifier regex not valid: " + identifier_regex.error_arg());
+            "sqlite identifier regex not valid: " + identifier_regex->error_arg());
     }
 }
 
@@ -48,7 +56,7 @@ void sqlite_tokenizer::tokenize_keyword_operator_or_identifier()
     std::string_view ident;
 
     const std::string_view ref(remaining_str.data(), remaining_str.size());
-    if (re2::RE2::PartialMatch(ref, identifier_regex, &keyword, &binary_op, &ident)) {
+    if (re2::RE2::PartialMatch(ref, *identifier_regex, &keyword, &binary_op, &ident)) {
         // At least one of the strings will contain a match
         if (!binary_op.empty()) {
             token.type = sql_token_type::binary_operator;

--- a/src/tokenizer/sqlite.cpp
+++ b/src/tokenizer/sqlite.cpp
@@ -29,16 +29,26 @@ std::unique_ptr<re2::RE2> identifier_regex;
 
 } // namespace
 
+bool sqlite_tokenizer::initialise_regexes()
+{
+    static const bool ret = []() {
+        try {
+            bool const parent_init = sql_tokenizer<sqlite_tokenizer>::initialise_regexes();
+            identifier_regex = std::make_unique<re2::RE2>(identifier_regex_initialiser);
+            return parent_init && identifier_regex->ok();
+        } catch (...) {
+            return false;
+        }
+    }();
+
+    return ret;
+}
+
 sqlite_tokenizer::sqlite_tokenizer(
     std::string_view str, std::unordered_set<sql_token_type> skip_tokens)
     : sql_tokenizer(str, std::move(skip_tokens))
 {
-    static const bool ret = []() {
-        identifier_regex = std::make_unique<re2::RE2>(identifier_regex_initialiser);
-        return identifier_regex->ok();
-    }();
-
-    if (!ret) {
+    if (!initialise_regexes()) {
         throw std::runtime_error(
             "sqlite identifier regex not valid: " + identifier_regex->error_arg());
     }

--- a/src/tokenizer/sqlite.hpp
+++ b/src/tokenizer/sqlite.hpp
@@ -19,6 +19,8 @@ public:
     explicit sqlite_tokenizer(
         std::string_view str, std::unordered_set<sql_token_type> skip_tokens = {});
 
+    static bool initialise_regexes();
+
 protected:
     std::vector<sql_token> tokenize_impl();
 


### PR DESCRIPTION
As the title suggests, this PR changes the initialisation process of the tokenizer regular expressions to avoid the static initialisation cost. These regular expressions are now being preloaded / instantiated on the first ruleset instantiation, which also prevent impacting request latency.