### PR TITLE
Support float status codes in configuration

### DIFF
--- a/src/configuration/actions_parser.cpp
+++ b/src/configuration/actions_parser.cpp
@@ -6,7 +6,9 @@
 
 #include <cstdint>
 #include <exception>
+#include <optional>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -36,37 +38,34 @@ bool validate_status_code_presence_and_type(
         return false;
     }
 
-    auto validate_status_code = [&validate_fn]<typename T>(T code) {
-        auto ucode = static_cast<uint64_t>(code);
-        if constexpr (std::is_same_v<T, double>) {
-            return code >= 0 && code <= 999 && code == ucode && validate_fn(ucode);
+    // NOLINTNEXTLINE(fuchsia-trailing-return)
+    auto validate_status_code = [&validate_fn](auto &&code) -> std::optional<uint64_t> {
+        using T = std::decay_t<decltype(code)>;
+        uint64_t ucode;
+        if constexpr (std::is_same_v<T, bool>) {
+            return std::nullopt;
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            if (auto [res, value] = from_string<uint64_t>(code); res) {
+                ucode = value;
+            } else {
+                return std::nullopt;
+            }
         } else {
-            return code >= 0 && code <= 999 && validate_fn(ucode);
+            ucode = static_cast<uint64_t>(code);
+            if (code < 0 || static_cast<T>(ucode) != code) {
+                return std::nullopt;
+            }
         }
+        if (ucode > 999 || !validate_fn(ucode)) {
+            return std::nullopt;
+        }
+        return ucode;
     };
 
     auto &code = it->second;
-    if (holds_alternative<uint64_t>(code) && validate_status_code(std::get<uint64_t>(code))) {
+    if (auto ucode = std::visit(validate_status_code, code); ucode.has_value()) {
+        code = ucode.value();
         return true;
-    }
-
-    if (holds_alternative<int64_t>(code) && validate_status_code(std::get<int64_t>(code))) {
-        code = static_cast<uint64_t>(std::get<int64_t>(code));
-        return true;
-    }
-
-    if (holds_alternative<double>(code) && validate_status_code(std::get<double>(code))) {
-        // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions, bugprone-narrowing-conversions)
-        code = static_cast<uint64_t>(std::get<double>(code));
-        return true;
-    }
-
-    if (holds_alternative<std::string>(code)) {
-        if (auto [res, value] = from_string<uint64_t>(std::get<std::string>(code));
-            res && validate_status_code(value)) {
-            code = value;
-            return true;
-        }
     }
 
     parameters.erase(it);

--- a/tests/unit/configuration/action_parser_test.cpp
+++ b/tests/unit/configuration/action_parser_test.cpp
@@ -315,6 +315,58 @@ TEST(TestActionParser, RedirectActionNegativeStatusCode)
     }
 }
 
+TEST(TestActionParser, RedirectActionStatusCodeOutOfRange)
+{
+    auto object = yaml_to_object(
+        R"([{id: redirect, parameters: {location: "http://www.google.com", status_code: 1000}, type: redirect_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("redirect"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("redirect"));
+    EXPECT_TRUE(cfg.actions.contains("redirect"));
+
+    {
+        const auto &spec = cfg.actions["redirect"];
+        EXPECT_EQ(spec.type, action_type::redirect_request);
+        EXPECT_EQ(spec.type_str, "redirect_request");
+        EXPECT_EQ(spec.parameters.size(), 2);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 303);
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
+    }
+}
+
 TEST(TestActionParser, RedirectActionInvalid300StatusCode)
 {
     auto object = yaml_to_object(
@@ -371,6 +423,110 @@ TEST(TestActionParser, RedirectActionStringStatusCode)
 {
     auto object = yaml_to_object(
         R"([{id: redirect, parameters: {location: "http://www.google.com", status_code: "303"}, type: redirect_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("redirect"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("redirect"));
+    EXPECT_TRUE(cfg.actions.contains("redirect"));
+
+    {
+        const auto &spec = cfg.actions["redirect"];
+        EXPECT_EQ(spec.type, action_type::redirect_request);
+        EXPECT_EQ(spec.type_str, "redirect_request");
+        EXPECT_EQ(spec.parameters.size(), 2);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 303);
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
+    }
+}
+
+TEST(TestActionParser, RedirectActionValidFloatStatusCode)
+{
+    auto object = yaml_to_object(
+        R"([{id: redirect, parameters: {location: "http://www.google.com", status_code: 307.0}, type: redirect_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("redirect"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("redirect"));
+    EXPECT_TRUE(cfg.actions.contains("redirect"));
+
+    {
+        const auto &spec = cfg.actions["redirect"];
+        EXPECT_EQ(spec.type, action_type::redirect_request);
+        EXPECT_EQ(spec.type_str, "redirect_request");
+        EXPECT_EQ(spec.parameters.size(), 2);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 307);
+        EXPECT_STR(std::get<std::string>(parameters.at("location")), "http://www.google.com");
+    }
+}
+
+TEST(TestActionParser, RedirectActionInvalidFloatStatusCode)
+{
+    auto object = yaml_to_object(
+        R"([{id: redirect, parameters: {location: "http://www.google.com", status_code: 303.33}, type: redirect_request}])");
 
     configuration_spec cfg;
     configuration_change_spec change;
@@ -838,6 +994,165 @@ TEST(TestActionParser, BlockActionStringStatusCode)
         const auto &parameters = spec.parameters;
         EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 10);
         EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 302);
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
+    }
+}
+
+TEST(TestActionParser, BlockActionInvalidFloatStatusCode)
+{
+    auto object = yaml_to_object(
+        R"([{id: block, parameters: {type: "auto", grpc_status_code: 302.33, status_code: 110.33}, type: block_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("block"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("block"));
+    EXPECT_TRUE(cfg.actions.contains("block"));
+
+    {
+        const auto &spec = cfg.actions["block"];
+        EXPECT_EQ(spec.type, action_type::block_request);
+        EXPECT_EQ(spec.type_str, "block_request");
+        EXPECT_EQ(spec.parameters.size(), 3);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 10);
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
+    }
+}
+
+TEST(TestActionParser, BlockActionValidFloatStatusCode)
+{
+    auto object = yaml_to_object(
+        R"([{id: block, parameters: {type: "auto", grpc_status_code: 302.0, status_code: 110.0}, type: block_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("block"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("block"));
+    EXPECT_TRUE(cfg.actions.contains("block"));
+
+    {
+        const auto &spec = cfg.actions["block"];
+        EXPECT_EQ(spec.type, action_type::block_request);
+        EXPECT_EQ(spec.type_str, "block_request");
+        EXPECT_EQ(spec.parameters.size(), 3);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 110);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 302);
+        EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
+    }
+}
+
+TEST(TestActionParser, BlockActionStatusCodeOutOfRange)
+{
+    auto object = yaml_to_object(
+        R"([{id: block, parameters: {type: "auto", grpc_status_code: 1000, status_code: 1000}, type: block_request}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto actions_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_actions(actions_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("block"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::actions);
+    EXPECT_EQ(change.actions.size(), 1);
+    EXPECT_EQ(cfg.actions.size(), 1);
+
+    EXPECT_TRUE(change.actions.contains("block"));
+    EXPECT_TRUE(cfg.actions.contains("block"));
+
+    {
+        const auto &spec = cfg.actions["block"];
+        EXPECT_EQ(spec.type, action_type::block_request);
+        EXPECT_EQ(spec.type_str, "block_request");
+        EXPECT_EQ(spec.parameters.size(), 3);
+
+        const auto &parameters = spec.parameters;
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("status_code")), 403);
+        EXPECT_EQ(std::get<uint64_t>(parameters.at("grpc_status_code")), 10);
         EXPECT_STR(std::get<std::string>(parameters.at("type")), "auto");
     }
 }


### PR DESCRIPTION
Following up on https://github.com/DataDog/libddwaf/pull/441, this PR adds support for validating status codes of type `float` (actually `double`).