### PR TITLE
Add block ID to block & redirect action parameters & event

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -16,12 +16,16 @@
         },
         "grpc_status_code": {
           "type": "number"
+        },
+        "block_id": {
+          "type": "string"
         }
       },
       "required": [
         "status_code",
         "type",
-        "grpc_status_code"
+        "grpc_status_code",
+        "block_id"
       ],
       "additionalProperties": true
     },

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -128,7 +128,7 @@ void add_action_to_tracker(action_tracker &actions, std::string_view id, action_
             actions.blocking_action = id;
         }
 
-        if (type == action_type::block_request && actions.block_id.empty()) {
+        if (actions.block_id.empty()) {
             actions.block_id = uuidv4_generate_pseudo();
         }
     } else {
@@ -170,7 +170,7 @@ generated_action serialize_and_consolidate_actions(std::string_view action_overr
             if (type == action_type::monitor || is_blocking_action(type)) {
                 add_action_to_tracker(actions, action_override, type);
 
-                has_block_id = (type == action_type::block_request);
+                has_block_id = is_blocking_action(type);
             } else {
                 // Clear the action override because it's not usable
                 action_override = {};
@@ -202,7 +202,7 @@ generated_action serialize_and_consolidate_actions(std::string_view action_overr
             // The stack ID will be generated when adding the action to the tracker
             if (type == action_type::generate_stack) {
                 has_stack_id = true;
-            } else if (type == action_type::block_request) {
+            } else if (is_blocking_action(type)) {
                 has_block_id = true;
             }
         }
@@ -329,7 +329,7 @@ void serialize_action(std::string_view id, ddwaf_object &action_map, const actio
 
             ddwaf_object_map_addl(&param_map, k.data(), k.size(), &value);
         }
-        if (type == action_type::block_request) {
+        if (is_blocking_action(type)) {
             ddwaf_object_map_addl(&param_map, STRL("block_id"), to_object(tmp, actions.block_id));
         }
     } else {

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -109,6 +109,9 @@ struct action_tracker {
     // Stack trace ID
     std::string stack_id;
 
+    // Block ID
+    std::string block_id;
+
     // This set contains all remaining actions other than the blocking action
     std::unordered_set<std::string_view> non_blocking_actions;
 
@@ -124,6 +127,10 @@ void add_action_to_tracker(action_tracker &actions, std::string_view id, action_
             actions.blocking_action_type = type;
             actions.blocking_action = id;
         }
+
+        if (type == action_type::block_request) {
+            actions.block_id = uuidv4_generate_pseudo();
+        }
     } else {
         if (type == action_type::generate_stack && actions.stack_id.empty()) {
             // Stack trace actions require a dynamic stack ID, however we
@@ -135,16 +142,21 @@ void add_action_to_tracker(action_tracker &actions, std::string_view id, action_
     }
 }
 
-std::pair<ddwaf_object, /*stack id*/ bool> serialize_and_consolidate_actions(
-    std::string_view action_override, const std::vector<std::string> &rule_actions,
-    action_tracker &actions)
+struct generated_action {
+    ddwaf_object actions_array;
+    bool required_stack_id;
+    bool required_block_id;
+};
+
+generated_action serialize_and_consolidate_actions(std::string_view action_override,
+    const std::vector<std::string> &rule_actions, action_tracker &actions)
 {
     ddwaf_object tmp;
     ddwaf_object actions_array;
     ddwaf_object_array(&actions_array);
 
     if (rule_actions.empty() && action_override.empty()) {
-        return {actions_array, false};
+        return {actions_array, false, false};
     }
 
     if (!action_override.empty()) {
@@ -171,6 +183,7 @@ std::pair<ddwaf_object, /*stack id*/ bool> serialize_and_consolidate_actions(
     }
 
     bool has_stack_id = false;
+    bool has_block_id = false;
     for (const auto &action_id : rule_actions) {
         auto action_it = actions.mapper.find(action_id);
         if (action_it != actions.mapper.end()) {
@@ -186,13 +199,15 @@ std::pair<ddwaf_object, /*stack id*/ bool> serialize_and_consolidate_actions(
             // The stack ID will be generated when adding the action to the tracker
             if (type == action_type::generate_stack) {
                 has_stack_id = true;
+            } else if (type == action_type::block_request) {
+                has_block_id = true;
             }
         }
         // If an action is unspecified, add it and move on
         ddwaf_object_array_add(&actions_array, to_object(tmp, action_id));
     }
 
-    return {actions_array, has_stack_id};
+    return {actions_array, has_stack_id, has_block_id};
 }
 
 void consolidate_actions(std::string_view action_override,
@@ -247,7 +262,7 @@ void serialize_event(rule_event &event, const match_obfuscator &obfuscator,
     ddwaf_object_map_add(&rule_map, "name", to_object(tmp, event.rule.name));
     ddwaf_object_map_add(&rule_map, "tags", &tags_map);
 
-    auto [actions_array, has_stack_id] =
+    auto [actions_array, requires_stack_id, requires_block_id] =
         serialize_and_consolidate_actions(action_override, rule_actions, actions);
     ddwaf_object_map_add(&rule_map, "on_match", &actions_array);
 
@@ -266,10 +281,12 @@ void serialize_event(rule_event &event, const match_obfuscator &obfuscator,
     ddwaf_object_map(&root_map);
     ddwaf_object_map_add(&root_map, "rule", &rule_map);
     ddwaf_object_map_add(&root_map, "rule_matches", &match_array);
-    if (has_stack_id) {
+    if (requires_block_id) {
+        ddwaf_object_map_add(&root_map, "block_id", to_object(tmp, actions.block_id));
+    }
+    if (requires_stack_id) {
         ddwaf_object_map_add(&root_map, "stack_id", to_object(tmp, actions.stack_id));
     }
-
     ddwaf_object_array_add(&event_array, &root_map);
 }
 
@@ -307,9 +324,11 @@ void serialize_action(std::string_view id, ddwaf_object &action_map, const actio
 
             ddwaf_object_map_addl(&param_map, k.data(), k.size(), &value);
         }
+        if (type == action_type::block_request) {
+            ddwaf_object_map_addl(&param_map, STRL("block_id"), to_object(tmp, actions.block_id));
+        }
     } else {
-        ddwaf_object_map_addl(
-            &param_map, "stack_id", sizeof("stack_id") - 1, to_object(tmp, actions.stack_id));
+        ddwaf_object_map_addl(&param_map, STRL("stack_id"), to_object(tmp, actions.stack_id));
     }
 
     ddwaf_object_map_addl(&action_map, type_str.data(), type_str.size(), &param_map);
@@ -352,8 +371,11 @@ void collect_attributes(const object_store &store, const std::vector<rule_attrib
 void result_serializer::serialize(const object_store &store, std::vector<rule_result> &results,
     attribute_collector &collector, const timer &deadline, result_components output) const
 {
-    action_tracker actions{
-        .blocking_action = {}, .stack_id = {}, .non_blocking_actions = {}, .mapper = actions_};
+    action_tracker actions{.blocking_action = {},
+        .stack_id = {},
+        .block_id = {},
+        .non_blocking_actions = {},
+        .mapper = actions_};
 
     // First collect any pending attributes from previous runs
     collector.collect_pending(store);

--- a/tests/common/gtest_utils.cpp
+++ b/tests/common/gtest_utils.cpp
@@ -27,7 +27,8 @@ bool operator==(const event &lhs, const event &rhs)
 {
     return lhs.id == rhs.id && lhs.name == rhs.name && lhs.tags == rhs.tags &&
            lhs.actions == rhs.actions && lhs.matches == rhs.matches &&
-           lhs.stack_id.empty() == rhs.stack_id.empty();
+           lhs.stack_id.empty() == rhs.stack_id.empty() &&
+           lhs.block_id.empty() == rhs.block_id.empty();
 }
 
 namespace {
@@ -91,6 +92,7 @@ std::ostream &operator<<(std::ostream &os, const event &e)
        << indent(4) << "id: " << e.id << ",\n"
        << indent(4) << "name: " << e.name << ",\n"
        << indent(4) << "stack_id: " << e.stack_id << ",\n"
+       << indent(4) << "block_id: " << e.block_id << ",\n"
        << indent(4) << "tags: {";
     {
         bool start = true;
@@ -274,7 +276,39 @@ WafResultActionMatcher::WafResultActionMatcher(
 bool WafResultActionMatcher::MatchAndExplain(
     const ddwaf::test::action_map &obtained, ::testing::MatchResultListener * /*unused*/) const
 {
-    return obtained == expected_;
+    if (expected_.size() != obtained.size()) {
+        return false;
+    }
+
+    for (auto [expected_type, expected_params] : expected_) {
+        const auto &it = obtained.find(expected_type);
+        if (it == obtained.end()) {
+            return false;
+        }
+
+        auto obtained_params = it->second;
+
+        if (expected_params.contains("stack_id")) {
+            if (!obtained_params.contains("stack_id")) {
+                return false;
+            }
+            expected_params.erase("stack_id");
+            obtained_params.erase("stack_id");
+        }
+
+        if (expected_params.contains("block_id")) {
+            if (!obtained_params.contains("block_id")) {
+                return false;
+            }
+            expected_params.erase("block_id");
+            obtained_params.erase("block_id");
+        }
+
+        if (expected_params != obtained_params) {
+            return false;
+        }
+    }
+    return true;
 }
 
 bool WafResultDataMatcher::MatchAndExplain(
@@ -442,6 +476,7 @@ event as_if<event, void>::operator()() const
     e.actions = as<std::vector<std::string>>(rule, "on_match");
     e.matches = as<std::vector<match>>(node, "rule_matches");
     e.stack_id = as<std::string>(node, "stack_id");
+    e.block_id = as<std::string>(node, "block_id");
 
     return e;
 }

--- a/tests/common/gtest_utils.hpp
+++ b/tests/common/gtest_utils.hpp
@@ -44,6 +44,7 @@ struct event {
     std::string id;
     std::string name;
     std::string stack_id{};
+    std::string block_id{};
     std::map<std::string, std::string> tags{{"type", ""}, {"category", ""}};
     std::vector<std::string> actions{};
     std::vector<match> matches;

--- a/tests/integration/actions/test.cpp
+++ b/tests/integration/actions/test.cpp
@@ -4,6 +4,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include <regex>
+
 #include "common/gtest_utils.hpp"
 #include "ddwaf.h"
 
@@ -409,6 +411,220 @@ TEST(TestActionsIntegration, ActionTypes)
 
     ddwaf_context_destroy(context1);
     ddwaf_destroy(handle);
+}
+
+TEST(TestActionsIntegration, PreventBlockIDInjection)
+{
+    ddwaf_builder builder = ddwaf_builder_init(nullptr);
+
+    {
+        auto rule = read_file("default_actions.yaml", base_dir);
+        ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, nullptr);
+        ddwaf_object_free(&rule);
+    }
+
+    ddwaf_handle handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_object tmp;
+    {
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "block"));
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object res;
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EVENTS(res, {.id = "block-rule",
+                               .name = "block-rule",
+                               .block_id = "*",
+                               .tags = {{"type", "flow1"}, {"category", "category1"}},
+                               .actions = {"block"},
+                               .matches = {{.op = "match_regex",
+                                   .op_value = "^block",
+                                   .highlight = "block"sv,
+                                   .args = {{
+                                       .value = "block"sv,
+                                       .address = "value",
+                                   }}}}});
+
+        EXPECT_ACTIONS(
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
+        ddwaf_object_free(&res);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_destroy(handle);
+
+        auto actions = yaml_to_object(
+            R"({actions: [{id: block, type: block_request, parameters: {status_code: 404, "block_id": "this is an injected ID"}}]})");
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("actions"), &actions, nullptr);
+        ddwaf_object_free(&actions);
+    }
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "block"));
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object res;
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EVENTS(res, {.id = "block-rule",
+                               .name = "block-rule",
+                               .block_id = "*",
+                               .tags = {{"type", "flow1"}, {"category", "category1"}},
+                               .actions = {"block"},
+                               .matches = {{.op = "match_regex",
+                                   .op_value = "^block",
+                                   .highlight = "block"sv,
+                                   .args = {{
+                                       .value = "block"sv,
+                                       .address = "value",
+                                   }}}}});
+
+        EXPECT_ACTIONS(
+            res, {{"block_request", {{"status_code", 404ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
+
+        const auto *actions = ddwaf_object_find(&res, STRL("actions"));
+        ASSERT_NE(actions, nullptr);
+
+        const auto *block_params = ddwaf_object_find(actions, STRL("block_request"));
+        ASSERT_NE(block_params, nullptr);
+
+        const auto *block_id = ddwaf_object_find(block_params, STRL("block_id"));
+        ASSERT_NE(block_id, nullptr);
+
+        std::regex uuid_regex{"^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-1b[a-f0-9]{2}-[a-f0-9]{12}$",
+            std::regex_constants::icase};
+        std::string block_id_str{
+            ddwaf_object_get_string(block_id, nullptr), ddwaf_object_length(block_id)};
+
+        EXPECT_TRUE(std::regex_match(block_id_str, uuid_regex)) << block_id_str;
+
+        ddwaf_object_free(&res);
+
+        ddwaf_context_destroy(context);
+    }
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestActionsIntegration, PreventStackIDInjection)
+{
+    ddwaf_builder builder = ddwaf_builder_init(nullptr);
+
+    {
+        auto rule = read_file("default_actions.yaml", base_dir);
+        ASSERT_TRUE(rule.type != DDWAF_OBJ_INVALID);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("rules"), &rule, nullptr);
+        ddwaf_object_free(&rule);
+    }
+
+    ddwaf_handle handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_object tmp;
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "stack_trace"));
+
+        ddwaf_object res;
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EVENTS(res, {.id = "stack-trace-rule",
+                               .name = "stack-trace-rule",
+                               .stack_id = "*",
+                               .tags = {{"type", "flow2"}, {"category", "category2"}},
+                               .actions = {"stack_trace"},
+                               .matches = {{.op = "match_regex",
+                                   .op_value = "stack_trace",
+                                   .highlight = "stack_trace"sv,
+                                   .args = {{
+                                       .value = "stack_trace"sv,
+                                       .address = "value",
+                                   }}}}});
+
+        EXPECT_ACTIONS(res, {{"generate_stack", {{"stack_id", "*"}}}});
+        ddwaf_object_free(&res);
+
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_destroy(handle);
+
+        auto actions = yaml_to_object(
+            R"({actions: [{id: stack_trace, type: generate_stack, parameters: {"stack_id": "this is an injected ID"}}]})");
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("actions"), &actions, nullptr);
+        ddwaf_object_free(&actions);
+    }
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object parameter = DDWAF_OBJECT_MAP;
+        ddwaf_object_map_add(&parameter, "value", ddwaf_object_string(&tmp, "stack_trace"));
+
+        ddwaf_object res;
+        EXPECT_EQ(ddwaf_run(context, &parameter, nullptr, &res, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EVENTS(res, {.id = "stack-trace-rule",
+                               .name = "stack-trace-rule",
+                               .stack_id = "*",
+                               .tags = {{"type", "flow2"}, {"category", "category2"}},
+                               .actions = {"stack_trace"},
+                               .matches = {{.op = "match_regex",
+                                   .op_value = "stack_trace",
+                                   .highlight = "stack_trace"sv,
+                                   .args = {{
+                                       .value = "stack_trace"sv,
+                                       .address = "value",
+                                   }}}}});
+
+        EXPECT_ACTIONS(res, {{"generate_stack", {{"stack_id", "*"}}}});
+
+        const auto *actions = ddwaf_object_find(&res, STRL("actions"));
+        ASSERT_NE(actions, nullptr);
+
+        const auto *stack_params = ddwaf_object_find(actions, STRL("generate_stack"));
+        ASSERT_NE(stack_params, nullptr);
+
+        const auto *stack_id = ddwaf_object_find(stack_params, STRL("stack_id"));
+        ASSERT_NE(stack_id, nullptr);
+
+        std::regex uuid_regex{"^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-1b[a-f0-9]{2}-[a-f0-9]{12}$",
+            std::regex_constants::icase};
+        std::string stack_id_str{
+            ddwaf_object_get_string(stack_id, nullptr), ddwaf_object_length(stack_id)};
+
+        EXPECT_TRUE(std::regex_match(stack_id_str, uuid_regex)) << stack_id_str;
+
+        ddwaf_object_free(&res);
+
+        ddwaf_context_destroy(context);
+    }
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
 }
 
 } // namespace

--- a/tests/integration/actions/test.cpp
+++ b/tests/integration/actions/test.cpp
@@ -35,6 +35,7 @@ TEST(TestActionsIntegration, DefaultActions)
 
         EXPECT_EVENTS(res, {.id = "block-rule",
                                .name = "block-rule",
+                               .block_id = "*",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -46,8 +47,8 @@ TEST(TestActionsIntegration, DefaultActions)
                                    }}}}});
 
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
         ddwaf_object_free(&res);
     }
 
@@ -179,6 +180,7 @@ TEST(TestActionsIntegration, OverrideDefaultAction)
 
         EXPECT_EVENTS(res, {.id = "block-rule",
                                .name = "block-rule",
+                               .block_id = "*",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -190,8 +192,8 @@ TEST(TestActionsIntegration, OverrideDefaultAction)
                                    }}}}});
 
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
         ddwaf_object_free(&res);
 
         ddwaf_context_destroy(context);
@@ -350,6 +352,7 @@ TEST(TestActionsIntegration, EmptyOrInvalidActions)
 
     EXPECT_EVENTS(res, {.id = "block-rule",
                            .name = "block-rule",
+                           .block_id = "*",
                            .tags = {{"type", "flow1"}, {"category", "category1"}},
                            .actions = {"block"},
                            .matches = {{.op = "match_regex",
@@ -361,7 +364,7 @@ TEST(TestActionsIntegration, EmptyOrInvalidActions)
                                }}}}});
 
     EXPECT_ACTIONS(res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
-                                               {"type", "auto"}}}});
+                                               {"type", "auto"}, {"block_id", "*"}}}});
     ddwaf_object_free(&res);
 
     ddwaf_context_destroy(context);

--- a/tests/integration/context/test.cpp
+++ b/tests/integration/context/test.cpp
@@ -649,6 +649,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndEphemeralPriority)
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
+                               .block_id = "*",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -687,6 +688,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndEphemeralNonPriority)
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
+                               .block_id = "*",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -764,6 +766,7 @@ TEST(TestContextIntegration, EphemeralNonPriorityAndPersistentPriority)
         EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
+                               .block_id = "*",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -838,6 +841,7 @@ TEST(TestContextIntegration, EphemeralPriorityAndPersistentNonPriority)
         EXPECT_EQ(ddwaf_run(context, nullptr, &ephemeral, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
+                               .block_id = "*",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -896,6 +900,7 @@ TEST(TestContextIntegration, PersistentPriorityAndEphemeralNonPriority)
         EXPECT_EQ(ddwaf_run(context, &persistent, nullptr, &ret, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(ret, {.id = "2",
                                .name = "rule2",
+                               .block_id = "*",
                                .tags = {{"type", "flow1"}, {"category", "category1"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",

--- a/tests/integration/exclusion/rule_filter/test.cpp
+++ b/tests/integration/exclusion/rule_filter/test.cpp
@@ -718,6 +718,7 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
+                           .block_id = "*",
                            .tags = {{"type", "type1"}, {"category", "category"}},
                            .actions = {"block"},
                            .matches = {{.op = "ip_match",
@@ -727,7 +728,7 @@ TEST(TestRuleFilterIntegration, UnconditionalCustomFilterMode)
                                    .address = "http.client_ip",
                                }}}}});
     EXPECT_ACTIONS(out, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
-                                               {"type", "auto"}}}})
+                                               {"type", "auto"}, {"block_id", "*"}}}})
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);
@@ -756,6 +757,7 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
+                               .block_id = "*",
                                .tags = {{"type", "type1"}, {"category", "category"}},
                                .actions = {"block"},
                                .matches = {{.op = "ip_match",
@@ -764,8 +766,9 @@ TEST(TestRuleFilterIntegration, ConditionalCustomFilterMode)
                                        .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
-        EXPECT_ACTIONS(out, {{"block_request", {{"status_code", 403ULL},
-                                                   {"grpc_status_code", 10ULL}, {"type", "auto"}}}})
+        EXPECT_ACTIONS(
+            out, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}})
 
         ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
@@ -862,6 +865,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
         EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
         EXPECT_EVENTS(out, {.id = "1",
                                .name = "rule1",
+                               .block_id = "*",
                                .tags = {{"type", "type1"}, {"category", "category"}},
                                .actions = {"block2"},
                                .matches = {{.op = "ip_match",
@@ -870,8 +874,9 @@ TEST(TestRuleFilterIntegration, CustomFilterModeUnknownAction)
                                        .value = "192.168.0.1"sv,
                                        .address = "http.client_ip",
                                    }}}}});
-        EXPECT_ACTIONS(out, {{"block_request", {{"status_code", 403ULL},
-                                                   {"grpc_status_code", 10ULL}, {"type", "auto"}}}})
+        EXPECT_ACTIONS(
+            out, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}})
 
         ddwaf_object_free(&out);
         ddwaf_context_destroy(context);
@@ -906,6 +911,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
     EXPECT_EQ(ddwaf_run(context, &root, nullptr, &out, LONG_TIME), DDWAF_MATCH);
     EXPECT_EVENTS(out, {.id = "1",
                            .name = "rule1",
+                           .block_id = "*",
                            .tags = {{"type", "type1"}, {"category", "category"}},
                            .actions = {"block"},
                            .matches = {{.op = "ip_match",
@@ -915,7 +921,7 @@ TEST(TestRuleFilterIntegration, CustomFilterModeNonblockingAction)
                                    .address = "http.client_ip",
                                }}}}});
     EXPECT_ACTIONS(out, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
-                                               {"type", "auto"}}}})
+                                               {"type", "auto"}, {"block_id", "*"}}}})
 
     ddwaf_object_free(&out);
     ddwaf_context_destroy(context);

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -580,9 +580,9 @@ TEST(TestWafIntegration, UpdateActionsByID)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result1, {});
-        EXPECT_ACTIONS(result2,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result2, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -656,9 +656,9 @@ TEST(TestWafIntegration, UpdateActionsByID)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(result2,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result2, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
         EXPECT_ACTIONS(result3,
             {{"redirect_request", {{"status_code", 303ULL}, {"location", "http://google.com"}}}});
 
@@ -734,9 +734,9 @@ TEST(TestWafIntegration, UpdateActionsByTags)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result1, {});
-        EXPECT_ACTIONS(result2,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result2, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -1190,6 +1190,7 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         EXPECT_EVENTS(result2,
             {.id = "1",
                 .name = "rule1",
+                .block_id = "*",
                 .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"},
                     {"new_tag", "new_value"}},
                 .actions = {"block"},
@@ -1200,9 +1201,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                         {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
         EXPECT_ACTIONS(result1, {});
-        EXPECT_ACTIONS(result2,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result2, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result1);
         ddwaf_object_free(&result2);
@@ -1244,6 +1245,7 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
         EXPECT_EVENTS(result2,
             {.id = "1",
                 .name = "rule1",
+                .block_id = "*",
                 .tags = {{"type", "flow1"}, {"category", "category1"}, {"confidence", "1"},
                     {"new_tag", "new_value"}},
                 .actions = {"block"},
@@ -1263,9 +1265,9 @@ TEST(TestWafIntegration, UpdateOverrideByIDAndTag)
                     .args = {
                         {.name = "input", .value = "rule1"sv, .address = "value1", .path = {}}}}}});
 
-        EXPECT_ACTIONS(result2,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result2, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
         EXPECT_ACTIONS(result3, {});
 
         ddwaf_object_free(&result2);
@@ -1821,9 +1823,9 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result2, {});
-        EXPECT_ACTIONS(result3,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result3, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result2);
         ddwaf_object_free(&result3);
@@ -1889,9 +1891,9 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result3, {});
-        EXPECT_ACTIONS(result4,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result4, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result3);
         ddwaf_object_free(&result4);
@@ -1951,12 +1953,12 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(result4,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
-        EXPECT_ACTIONS(result5,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result4, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
+        EXPECT_ACTIONS(
+            result5, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result4);
         ddwaf_object_free(&result5);
@@ -2005,9 +2007,9 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(result4,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result4, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
         EXPECT_ACTIONS(result5, {});
 
         ddwaf_object_free(&result4);
@@ -2053,9 +2055,9 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result5, {});
-        EXPECT_ACTIONS(result6,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result6, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result5);
         ddwaf_object_free(&result6);
@@ -2084,12 +2086,12 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(result5,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
-        EXPECT_ACTIONS(result6,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result5, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
+        EXPECT_ACTIONS(
+            result6, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result5);
         ddwaf_object_free(&result6);
@@ -2142,9 +2144,9 @@ TEST(TestWafIntegration, UpdateEverything)
         ddwaf_object_free(&parameter);
 
         EXPECT_ACTIONS(result6, {});
-        EXPECT_ACTIONS(result7,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result7, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result6);
         ddwaf_object_free(&result7);
@@ -2181,9 +2183,9 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(result7,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result7, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
         EXPECT_ACTIONS(result8, {});
 
         ddwaf_object_free(&result7);
@@ -2213,9 +2215,9 @@ TEST(TestWafIntegration, UpdateEverything)
 
         ddwaf_object_free(&parameter);
 
-        EXPECT_ACTIONS(result7,
-            {{"block_request",
-                {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+        EXPECT_ACTIONS(
+            result7, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                            {"type", "auto"}, {"block_id", "*"}}}});
         EXPECT_ACTIONS(result8, {});
 
         ddwaf_object_free(&result7);

--- a/tests/integration/interface/waf/test.cpp
+++ b/tests/integration/interface/waf/test.cpp
@@ -660,7 +660,8 @@ TEST(TestWafIntegration, UpdateActionsByID)
             result2, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
                                             {"type", "auto"}, {"block_id", "*"}}}});
         EXPECT_ACTIONS(result3,
-            {{"redirect_request", {{"status_code", 303ULL}, {"location", "http://google.com"}}}});
+            {{"redirect_request",
+                {{"status_code", 303ULL}, {"location", "http://google.com"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&result2);
         ddwaf_object_free(&result3);

--- a/tests/integration/rules/custom_rules/test.cpp
+++ b/tests/integration/rules/custom_rules/test.cpp
@@ -161,6 +161,7 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -169,8 +170,8 @@ TEST(TestCustomRulesIntegration, PriorityCustomRulesPrecedence)
                                    .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
 
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -207,6 +208,7 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -214,8 +216,8 @@ TEST(TestCustomRulesIntegration, CustomRulesPrecedence)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -270,6 +272,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -277,8 +280,8 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
                                    .highlight = "rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -293,6 +296,7 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -300,8 +304,8 @@ TEST(TestCustomRulesIntegration, UpdateFromBaseRules)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -360,6 +364,7 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -367,8 +372,8 @@ TEST(TestCustomRulesIntegration, UpdateFromCustomRules)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -469,6 +474,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -476,8 +482,8 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -492,6 +498,7 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -499,8 +506,8 @@ TEST(TestCustomRulesIntegration, UpdateRemoveAllCustomRules)
                                    .highlight = "rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -559,6 +566,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -566,8 +574,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -582,6 +590,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -589,8 +598,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverrides)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -663,6 +672,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -670,8 +680,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
                                    .highlight = "rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -695,6 +705,7 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -702,8 +713,8 @@ TEST(TestCustomRulesIntegration, CustomRulesUnaffectedByOverridesAfterUpdate)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value4"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -763,6 +774,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
 
         EXPECT_EVENTS(res, {.id = "custom_rule4",
                                .name = "custom_rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -770,8 +782,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
                                    .highlight = "custom_rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -786,6 +798,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -793,8 +806,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusions)
                                    .highlight = "rule"sv,
                                    .args = {{.value = "custom_rule"sv, .address = "value34"}}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);
@@ -867,6 +880,7 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
 
         EXPECT_EVENTS(res, {.id = "rule4",
                                .name = "rule4",
+                               .block_id = "*",
                                .tags = {{"type", "flow34"}, {"category", "category4"}},
                                .actions = {"block"},
                                .matches = {{.op = "match_regex",
@@ -877,8 +891,8 @@ TEST(TestCustomRulesIntegration, CustomRulesAffectedByExclusionsAfterUpdate)
                                        .address = "value34",
                                    }}}}});
         EXPECT_ACTIONS(
-            res, {{"block_request",
-                     {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}}});
+            res, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                        {"type", "auto"}, {"block_id", "*"}}}});
 
         ddwaf_object_free(&res);
         ddwaf_object_free(&parameter);

--- a/tests/unit/serializer_test.cpp
+++ b/tests/unit/serializer_test.cpp
@@ -111,6 +111,7 @@ TEST(TestEventSerializer, SerializeSingleEventSingleMatch)
     serializer.serialize(store, results, collector, deadline, output);
     EXPECT_EVENTS(result_object, {.id = "xasd1022",
                                      .name = "random rule",
+                                     .block_id = "*",
                                      .tags = {{"type", "test"}, {"category", "none"}},
                                      .actions = {"block", "monitor_request"},
                                      .matches = {{.op = "random",
@@ -121,10 +122,10 @@ TEST(TestEventSerializer, SerializeSingleEventSingleMatch)
                                              .address = "query",
                                              .path = {"root", "key"}}}}}});
 
-    EXPECT_ACTIONS(result_object,
-        {{"block_request",
-             {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}},
-            {"monitor_request", {}}});
+    EXPECT_ACTIONS(
+        result_object, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                              {"type", "auto"}, {"block_id", "*"}}},
+                           {"monitor_request", {}}});
 
     ddwaf_object_free(&result_object);
 }
@@ -191,6 +192,7 @@ TEST(TestEventSerializer, SerializeSingleEventMultipleMatches)
 
     EXPECT_EVENTS(result_object, {.id = "xasd1022",
                                      .name = "random rule",
+                                     .block_id = "*",
                                      .tags = {{"type", "test"}, {"category", "none"}},
                                      .actions = {"block", "monitor_request"},
                                      .matches = {{.op = "random",
@@ -227,10 +229,10 @@ TEST(TestEventSerializer, SerializeSingleEventMultipleMatches)
                                                  .path = {"key"},
                                              }}}}});
 
-    EXPECT_ACTIONS(result_object,
-        {{"block_request",
-             {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}},
-            {"monitor_request", {}}});
+    EXPECT_ACTIONS(
+        result_object, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                              {"type", "auto"}, {"block_id", "*"}}},
+                           {"monitor_request", {}}});
 
     ddwaf_object_free(&result_object);
 }
@@ -325,6 +327,7 @@ TEST(TestEventSerializer, SerializeMultipleEvents)
     EXPECT_EVENTS(result_object,
         {.id = "xasd1022",
             .name = "random rule",
+            .block_id = "*",
             .tags = {{"type", "test"}, {"category", "none"}},
             .actions = {"block", "monitor_request"},
             .matches = {{.op = "random",
@@ -360,10 +363,10 @@ TEST(TestEventSerializer, SerializeMultipleEvents)
                 }}}}},
         {});
 
-    EXPECT_ACTIONS(result_object,
-        {{"block_request",
-             {{"status_code", 403ULL}, {"grpc_status_code", 10ULL}, {"type", "auto"}}},
-            {"monitor_request", {}}, {"unknown", {}}});
+    EXPECT_ACTIONS(
+        result_object, {{"block_request", {{"status_code", 403ULL}, {"grpc_status_code", 10ULL},
+                                              {"type", "auto"}, {"block_id", "*"}}},
+                           {"monitor_request", {}}, {"unknown", {}}});
 
     ddwaf_object_free(&result_object);
 }

--- a/validator/tests/exclusions/rule_filter/conditional/010_rule_no_exclusions.yaml
+++ b/validator/tests/exclusions/rule_filter/conditional/010_rule_no_exclusions.yaml
@@ -20,7 +20,8 @@
         block_request: {
           status_code: 403,
           type: auto,
-          grpc_status_code: 10
+          grpc_status_code: 10,
+          block_id: "regex:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-1b[a-f0-9]{2}-[a-f0-9]{12}$"
         }
       }
     }

--- a/validator/tests/rules/actions/001_rule1_match_with_actions.yaml
+++ b/validator/tests/rules/actions/001_rule1_match_with_actions.yaml
@@ -20,7 +20,8 @@
         block_request: {
           grpc_status_code: 10,
           status_code: 200,
-          type: auto
+          type: auto,
+          block_id: "regex:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-1b[a-f0-9]{2}-[a-f0-9]{12}$",
         },
         match_request: {}
       }


### PR DESCRIPTION
This PR introduces an ID to the `block_request` and `redirect_request` action parameters, as well as the underlying event. This allows the WAF caller to link an event which resulted in a blocking action to the response provided to the actual application user (.e.g by displaying the ID in the HTML). 

The generated ID is a UUIDv4 and it'll be included in the result as follows:

```yaml
events:
  - rule:
      ...
      on_match:
        - block
    rule_matches: ...
    block_id: cfe3688e-993d-11f0-b50d-c785d6db0d0e
actions:
  block_request:
    grpc_status_code: 10
    type: auto
    status_code: 403
    block_id: cfe3688e-993d-11f0-b50d-c785d6db0d0e
```

This feature is defined in RFC-1070.

Related Jiras: [APPSEC-59279]

[APPSEC-59279]: https://datadoghq.atlassian.net/browse/APPSEC-59279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ