### PR TITLE
Incremental processor overrides

### DIFF
--- a/src/builder/processor_builder.cpp
+++ b/src/builder/processor_builder.cpp
@@ -28,9 +28,11 @@ std::set<const scanner *> references_to_scanners(
 {
     std::set<const scanner *> scanner_refs;
 
-    // Precedence:
-    //  - Refs by ID have precedence over refs by tags
-    //  - Exclusions have precedence over inclusions
+    // Precedence order (high to low):
+    //  - Exclusions by ID
+    //  - Inclusions by ID
+    //  - Exclusions by Tags
+    //  - Inclusions by Tags
 
     // Since exclusions have precedence, we extract them first. the exclusions
     // by id apply to inclusion by ID and tags, exclusions by tags only apply to

--- a/src/builder/processor_builder.hpp
+++ b/src/builder/processor_builder.hpp
@@ -24,8 +24,14 @@ public:
 
     bool apply_override(const processor_override_spec &ovrd)
     {
-        // TODO error if processor doesn't support scanners
-        spec_.scanners = ovrd.scanners;
+        if (spec_.type != processor_type::extract_schema) {
+            return false;
+        }
+
+        auto &[include, exclude] = spec_.scanners;
+        include.insert(include.end(), ovrd.scanners.include.begin(), ovrd.scanners.include.end());
+        exclude.insert(exclude.end(), ovrd.scanners.exclude.begin(), ovrd.scanners.exclude.end());
+
         return true;
     }
 

--- a/src/configuration/common/configuration.hpp
+++ b/src/configuration/common/configuration.hpp
@@ -75,14 +75,20 @@ struct processor_spec {
     processor_type type;
     std::shared_ptr<expression> expr;
     std::vector<processor_mapping> mappings;
-    std::vector<reference_spec> scanners;
+    struct {
+        std::vector<reference_spec> include;
+        std::vector<reference_spec> exclude;
+    } scanners;
     bool evaluate{false};
     bool output{true};
 };
 
 struct processor_override_spec {
     std::vector<reference_spec> targets;
-    std::vector<reference_spec> scanners;
+    struct {
+        std::vector<reference_spec> include;
+        std::vector<reference_spec> exclude;
+    } scanners;
 };
 
 enum class data_type : uint8_t { unknown, data_with_expiration, ip_with_expiration };

--- a/src/configuration/processor_override_parser.cpp
+++ b/src/configuration/processor_override_parser.cpp
@@ -42,11 +42,20 @@ processor_override_spec parse_override(const raw_configuration::map &node)
         current.targets.emplace_back(std::move(target_spec));
     }
 
-    auto scanners_target_array = at<raw_configuration::vector>(node, "scanners");
-    current.scanners.reserve(scanners_target_array.size());
-    for (const auto &target : scanners_target_array) {
+    auto scanners_target = at<raw_configuration::map>(node, "scanners");
+
+    auto include_scanners = at<raw_configuration::vector>(scanners_target, "include", {});
+    current.scanners.include.reserve(include_scanners.size());
+    for (const auto &target : include_scanners) {
         auto target_spec = parse_reference(static_cast<raw_configuration::map>(target));
-        current.scanners.emplace_back(std::move(target_spec));
+        current.scanners.include.emplace_back(std::move(target_spec));
+    }
+
+    auto exclude_scanners = at<raw_configuration::vector>(scanners_target, "exclude", {});
+    current.scanners.exclude.reserve(exclude_scanners.size());
+    for (const auto &target : exclude_scanners) {
+        auto target_spec = parse_reference(static_cast<raw_configuration::map>(target));
+        current.scanners.exclude.emplace_back(std::move(target_spec));
     }
 
     return current;

--- a/src/configuration/processor_parser.cpp
+++ b/src/configuration/processor_parser.cpp
@@ -174,7 +174,7 @@ void parse_processors(const raw_configuration::vector &processor_array,
             const processor_spec spec{.type = type,
                 .expr = std::move(expr),
                 .mappings = std::move(mappings),
-                .scanners = std::move(scanners),
+                .scanners = {.include = std::move(scanners), .exclude = {}},
                 .evaluate = eval,
                 .output = output};
 

--- a/tests/integration/processors/overrides/ruleset/scanners.json
+++ b/tests/integration/processors/overrides/ruleset/scanners.json
@@ -50,6 +50,30 @@
         "type": "token",
         "category": "credential"
       }
+    },
+    {
+      "id": "scanner-003",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "(?i)(api[-_ ]?key|apikey|token)",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "[A-Za-z0-9_-]{16,}",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": { "type": "api_key", "category": "auth" }
     }
   ]
 }

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -58,7 +58,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersById)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"id": "scanner-001"}]}}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -143,7 +143,7 @@ TEST(TestProcessorOverridesIntegration, AddScannersByTags)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": [{"tags": {"type":"email"}}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"tags": {"type":"email"}}]}}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -229,8 +229,8 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": [{"id": "scanner-001"}]}]})");
-    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": {"include": [{"id": "scanner-001"}], "exclude": [{"id": "scanner-002"}]}}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override1"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
     handle = ddwaf_builder_build_instance(builder);
@@ -267,8 +267,8 @@ TEST(TestProcessorOverridesIntegration, AddScannerToPopulatedProcessor)
     ddwaf_destroy(handle);
 
     ovrd = json_to_object(
-        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": []}]})");
-    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": {"exclude": [{"id": "scanner-001"}]}}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override2"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
     handle = ddwaf_builder_build_instance(builder);
@@ -352,7 +352,7 @@ TEST(TestProcessorOverridesIntegration, DisableDefaultScanners)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": []}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": {"exclude": [{"tags": {"type":"token"}}]}}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -436,7 +436,7 @@ TEST(TestProcessorOverridesIntegration, RemoveScannersAfterOverride)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"id": "scanner-001"}]}}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -554,7 +554,7 @@ TEST(TestProcessorOverridesIntegration, RemoveOverride)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"id": "scanner-001"}]}}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 
@@ -681,7 +681,7 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
     ddwaf_destroy(handle);
 
     auto ovrd = json_to_object(
-        R"({"processor_overrides": [{"target":[{"id":"extract-content"},{"id":"extract-headers"}], "scanners": [{"id":"scanner-001"}]}]})");
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"},{"id":"extract-headers"}], "scanners": {"include": [{"id":"scanner-001"}], "exclude": [{"tags": {"type": "token"}}]}}]})");
     ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
     ddwaf_object_free(&ovrd);
 

--- a/tests/integration/processors/overrides/test.cpp
+++ b/tests/integration/processors/overrides/test.cpp
@@ -730,4 +730,529 @@ TEST(TestProcessorOverridesIntegration, OverrideMultipleProcessors)
     ddwaf_builder_destroy(builder);
 }
 
+TEST(TestProcessorOverridesIntegration, ScannersPrecedenceIdVsTagsOnEmptyProcessor)
+{
+    // Scenario A: include by tags, exclude by ID (exclude wins)
+    {
+        auto *builder = ddwaf_builder_init(nullptr);
+        ASSERT_NE(builder, nullptr);
+
+        auto processors = read_json_file("processors.json", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+        ddwaf_object_free(&processors);
+
+        auto scanners = read_json_file("scanners.json", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+        ddwaf_object_free(&scanners);
+
+        auto ovrd = json_to_object(
+            R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"tags": {"type":"email"}}], "exclude": [{"id":"scanner-001"}]}}]})");
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+        ddwaf_object_free(&ovrd);
+
+        auto *handle = ddwaf_builder_build_instance(builder);
+        ASSERT_NE(handle, nullptr);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        auto schema = test::object_to_json(*attributes);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_object_free(&out);
+        ddwaf_context_destroy(context);
+        ddwaf_destroy(handle);
+        ddwaf_builder_destroy(builder);
+    }
+
+    // Scenario B: include by ID, exclude by tags (include ID wins)
+    {
+        auto *builder = ddwaf_builder_init(nullptr);
+        ASSERT_NE(builder, nullptr);
+
+        auto processors = read_json_file("processors.json", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+        ddwaf_object_free(&processors);
+
+        auto scanners = read_json_file("scanners.json", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+        ddwaf_object_free(&scanners);
+
+        auto ovrd = json_to_object(
+            R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"id":"scanner-001"}], "exclude": [{"tags": {"type":"email"}}]}}]})");
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+        ddwaf_object_free(&ovrd);
+
+        auto *handle = ddwaf_builder_build_instance(builder);
+        ASSERT_NE(handle, nullptr);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        auto schema = test::object_to_json(*attributes);
+        EXPECT_STR(schema,
+            R"({"server.request.body.schema":[{"email":[8,{"type":"email","category":"pii"}]}]})");
+
+        ddwaf_object_free(&out);
+        ddwaf_context_destroy(context);
+        ddwaf_destroy(handle);
+        ddwaf_builder_destroy(builder);
+    }
+
+    // Scenario C: include by tags and exclude by tags (exclude tags wins)
+    {
+        auto *builder = ddwaf_builder_init(nullptr);
+        ASSERT_NE(builder, nullptr);
+
+        auto processors = read_json_file("processors.json", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+        ddwaf_object_free(&processors);
+
+        auto scanners = read_json_file("scanners.json", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+        ddwaf_object_free(&scanners);
+
+        auto ovrd = json_to_object(
+            R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"tags": {"type":"email"}}], "exclude": [{"tags": {"type":"email"}}]}}]})");
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+        ddwaf_object_free(&ovrd);
+
+        auto *handle = ddwaf_builder_build_instance(builder);
+        ASSERT_NE(handle, nullptr);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        auto schema = test::object_to_json(*attributes);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_object_free(&out);
+        ddwaf_context_destroy(context);
+        ddwaf_destroy(handle);
+        ddwaf_builder_destroy(builder);
+    }
+
+    // Scenario D: include by ID and exclude by ID (exclude ID wins)
+    {
+        auto *builder = ddwaf_builder_init(nullptr);
+        ASSERT_NE(builder, nullptr);
+
+        auto processors = read_json_file("processors.json", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+        ddwaf_object_free(&processors);
+
+        auto scanners = read_json_file("scanners.json", base_dir);
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+        ddwaf_object_free(&scanners);
+
+        auto ovrd = json_to_object(
+            R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"id":"scanner-001"}], "exclude": [{"id":"scanner-001"}]}}]})");
+        ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+        ddwaf_object_free(&ovrd);
+
+        auto *handle = ddwaf_builder_build_instance(builder);
+        ASSERT_NE(handle, nullptr);
+
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.body", &value);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        auto schema = test::object_to_json(*attributes);
+        EXPECT_STR(schema, R"({"server.request.body.schema":[{"email":[8]}]})");
+
+        ddwaf_object_free(&out);
+        ddwaf_context_destroy(context);
+        ddwaf_destroy(handle);
+        ddwaf_builder_destroy(builder);
+    }
+}
+
+TEST(TestProcessorOverridesIntegration, ScannersPrecedenceOnDefaultProcessor)
+{
+    // Start from processor with default tag-based scanners (headers -> token/credential)
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    // include token by tags but exclude its ID -> exclude ID wins, so removed
+    auto ovrd = json_to_object(
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": {"include": [{"tags": {"type":"token"}}], "exclude": [{"id":"scanner-002"}]}}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        auto schema = test::object_to_json(*attributes);
+        EXPECT_STR(schema, R"({"server.request.headers.schema":[{"email":[8]}]})");
+
+        ddwaf_object_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestProcessorOverridesIntegration, IncludeMultipleScannersById)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto ovrd = json_to_object(
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"id":"scanner-001"},{"id":"scanner-003"}]}}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object tmp;
+    ddwaf_object value;
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+
+    ddwaf_object_map(&value);
+    ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+    ddwaf_object_map_add(&value, "api_key", ddwaf_object_string(&tmp, "sk_live_1234567890abcdef"));
+    ddwaf_object_map_add(&map, "server.request.body", &value);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+    ddwaf::raw_configuration derivatives_object(*attributes);
+    auto derivatives = static_cast<ddwaf::raw_configuration::map>(derivatives_object);
+    auto body_schema = test::object_to_json(derivatives["server.request.body.schema"]);
+    EXPECT_NE(
+        body_schema.find(R"("email":[8,{"type":"email","category":"pii"}])"), std::string::npos);
+    EXPECT_NE(body_schema.find(R"("api_key":[8,{"type":"api_key","category":"auth"}])"),
+        std::string::npos);
+
+    ddwaf_object_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestProcessorOverridesIntegration, IncludeMultipleScannersByTags)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto ovrd = json_to_object(
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"tags":{"type":"email"}},{"tags":{"type":"api_key"}}]}}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object tmp;
+    ddwaf_object value;
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+
+    ddwaf_object_map(&value);
+    ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+    ddwaf_object_map_add(&value, "api_key", ddwaf_object_string(&tmp, "sk_live_1234567890abcdef"));
+    ddwaf_object_map_add(&map, "server.request.body", &value);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+    ddwaf::raw_configuration derivatives_object(*attributes);
+    auto derivatives = static_cast<ddwaf::raw_configuration::map>(derivatives_object);
+    auto body_schema = test::object_to_json(derivatives["server.request.body.schema"]);
+    EXPECT_NE(
+        body_schema.find(R"("email":[8,{"type":"email","category":"pii"}])"), std::string::npos);
+    EXPECT_NE(body_schema.find(R"("api_key":[8,{"type":"api_key","category":"auth"}])"),
+        std::string::npos);
+
+    ddwaf_object_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestProcessorOverridesIntegration, IncludeThenExcludeMultipleScannersByIdOnHeaders)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    // First, include both by ID
+    auto ovrd = json_to_object(
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": {"include": [{"id":"scanner-001"},{"id":"scanner-003"}], "exclude": [{"tags": {"category": "credential"}}]}}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override1"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(
+            &value, "api_key", ddwaf_object_string(&tmp, "sk_live_1234567890abcdef"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        ddwaf::raw_configuration derivatives_object(*attributes);
+        auto derivatives = static_cast<ddwaf::raw_configuration::map>(derivatives_object);
+        auto headers_schema = test::object_to_json(derivatives["server.request.headers.schema"]);
+        EXPECT_NE(headers_schema.find(R"("email":[8,{"type":"email","category":"pii"}])"),
+            std::string::npos);
+        EXPECT_NE(headers_schema.find(R"("api_key":[8,{"type":"api_key","category":"auth"}])"),
+            std::string::npos);
+
+        ddwaf_object_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+
+    // Then, exclude both by ID; excluded by ID wins, leaving none
+    ovrd = json_to_object(
+        R"({"processor_overrides": [{"target":[{"id":"extract-headers"}], "scanners": {"exclude": [{"id":"scanner-001"},{"id":"scanner-003"}]}}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override2"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle);
+        ASSERT_NE(context, nullptr);
+
+        ddwaf_object tmp;
+        ddwaf_object value;
+        ddwaf_object map = DDWAF_OBJECT_MAP;
+
+        ddwaf_object_map(&value);
+        ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+        ddwaf_object_map_add(
+            &value, "api_key", ddwaf_object_string(&tmp, "sk_live_1234567890abcdef"));
+        ddwaf_object_map_add(&map, "server.request.headers", &value);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+        const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+        EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+        const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+        EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+        ddwaf::raw_configuration derivatives_object(*attributes);
+        auto derivatives = static_cast<ddwaf::raw_configuration::map>(derivatives_object);
+        auto headers_schema = test::object_to_json(derivatives["server.request.headers.schema"]);
+        EXPECT_NE(headers_schema.find(R"("email":[8])"), std::string::npos);
+        EXPECT_NE(headers_schema.find(R"("api_key":[8])"), std::string::npos);
+        EXPECT_EQ(headers_schema.find(R"({"type":"email","category":"pii"})"), std::string::npos);
+        EXPECT_EQ(
+            headers_schema.find(R"({"type":"api_key","category":"auth"})"), std::string::npos);
+
+        ddwaf_object_free(&out);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
+TEST(TestProcessorOverridesIntegration, IncludeMultipleByTagsExcludeOneById)
+{
+    auto *builder = ddwaf_builder_init(nullptr);
+    ASSERT_NE(builder, nullptr);
+
+    auto processors = read_json_file("processors.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("processors"), &processors, nullptr);
+    ddwaf_object_free(&processors);
+
+    auto scanners = read_json_file("scanners.json", base_dir);
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("scanners"), &scanners, nullptr);
+    ddwaf_object_free(&scanners);
+
+    auto ovrd = json_to_object(
+        R"({"processor_overrides": [{"target":[{"id":"extract-content"}], "scanners": {"include": [{"tags":{"type":"email"}},{"tags":{"type":"api_key"}}], "exclude": [{"id":"scanner-003"}]}}]})");
+    ddwaf_builder_add_or_update_config(builder, LSTRARG("override"), &ovrd, nullptr);
+    ddwaf_object_free(&ovrd);
+
+    auto *handle = ddwaf_builder_build_instance(builder);
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object tmp;
+    ddwaf_object value;
+    ddwaf_object map = DDWAF_OBJECT_MAP;
+
+    ddwaf_object_map(&value);
+    ddwaf_object_map_add(&value, "email", ddwaf_object_string(&tmp, "employee@company.com"));
+    ddwaf_object_map_add(&value, "api_key", ddwaf_object_string(&tmp, "sk_live_1234567890abcdef"));
+    ddwaf_object_map_add(&map, "server.request.body", &value);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_run(context, &map, nullptr, &out, LONG_TIME), DDWAF_OK);
+    const auto *timeout = ddwaf_object_find(&out, STRL("timeout"));
+    EXPECT_FALSE(ddwaf_object_get_bool(timeout));
+
+    const auto *attributes = ddwaf_object_find(&out, STRL("attributes"));
+    EXPECT_EQ(ddwaf_object_size(attributes), 1);
+
+    ddwaf::raw_configuration derivatives_object(*attributes);
+    auto derivatives = static_cast<ddwaf::raw_configuration::map>(derivatives_object);
+    auto body_schema = test::object_to_json(derivatives["server.request.body.schema"]);
+    EXPECT_NE(
+        body_schema.find(R"("email":[8,{"type":"email","category":"pii"}])"), std::string::npos);
+    EXPECT_NE(body_schema.find(R"("api_key":[8])"), std::string::npos);
+    EXPECT_EQ(body_schema.find(R"("type":"api_key","category":"auth")"), std::string::npos);
+
+    ddwaf_object_free(&out);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+    ddwaf_builder_destroy(builder);
+}
+
 } // namespace

--- a/tests/unit/configuration/processor_override_parser_test.cpp
+++ b/tests/unit/configuration/processor_override_parser_test.cpp
@@ -281,6 +281,74 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerById)
     EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
+TEST(TestProcessorOverrideParser, ParseOverrideWithExcludedScannerById)
+{
+    auto object = yaml_to_object(
+        R"([{"target":[{"id":"extract-content"}], "scanners": {exclude: [{"id": "scanner-001"}]}}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::processor_overrides);
+
+    EXPECT_EQ(change.processor_overrides.size(), 1);
+    EXPECT_EQ(cfg.processor_overrides.size(), 1);
+
+    auto &ovrd = cfg.processor_overrides.begin()->second;
+    EXPECT_EQ(ovrd.targets.size(), 1);
+    EXPECT_EQ(ovrd.scanners.include.size(), 0);
+    EXPECT_EQ(ovrd.scanners.exclude.size(), 1);
+
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+}
+
 TEST(TestProcessorOverrideParser, ParseOverrideWithScannerByTags)
 {
     auto object = yaml_to_object(
@@ -349,6 +417,74 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerByTags)
     EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
+TEST(TestProcessorOverrideParser, ParseOverrideWithExcludedScannerByTags)
+{
+    auto object = yaml_to_object(
+        R"([{"target":[{"id":"extract-content"}], "scanners": {exclude: [{"tags": {"type":"email"}}]}}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::processor_overrides);
+
+    EXPECT_EQ(change.processor_overrides.size(), 1);
+    EXPECT_EQ(cfg.processor_overrides.size(), 1);
+
+    auto &ovrd = cfg.processor_overrides.begin()->second;
+    EXPECT_EQ(ovrd.targets.size(), 1);
+    EXPECT_EQ(ovrd.scanners.include.size(), 0);
+    EXPECT_EQ(ovrd.scanners.exclude.size(), 1);
+
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+}
+
 TEST(TestProcessorOverrideParser, ParseOverrideWithMultipleTargets)
 {
     auto object = yaml_to_object(
@@ -391,6 +527,74 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithMultipleTargets)
     EXPECT_EQ(ovrd.targets.size(), 3);
     EXPECT_EQ(ovrd.scanners.include.size(), 1);
     EXPECT_EQ(ovrd.scanners.exclude.size(), 0);
+
+    EXPECT_TRUE(change.actions.empty());
+    EXPECT_TRUE(change.base_rules.empty());
+    EXPECT_TRUE(change.user_rules.empty());
+    EXPECT_TRUE(change.exclusion_data.empty());
+    EXPECT_TRUE(change.rule_data.empty());
+    EXPECT_TRUE(change.rule_filters.empty());
+    EXPECT_TRUE(change.input_filters.empty());
+    EXPECT_TRUE(change.processors.empty());
+    EXPECT_TRUE(change.scanners.empty());
+    EXPECT_TRUE(change.rule_overrides_by_id.empty());
+    EXPECT_TRUE(change.rule_overrides_by_tags.empty());
+
+    EXPECT_TRUE(cfg.actions.empty());
+    EXPECT_TRUE(cfg.base_rules.empty());
+    EXPECT_TRUE(cfg.user_rules.empty());
+    EXPECT_TRUE(cfg.exclusion_data.empty());
+    EXPECT_TRUE(cfg.rule_data.empty());
+    EXPECT_TRUE(cfg.rule_filters.empty());
+    EXPECT_TRUE(cfg.input_filters.empty());
+    EXPECT_TRUE(cfg.processors.empty());
+    EXPECT_TRUE(cfg.scanners.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_id.empty());
+    EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
+}
+
+TEST(TestProcessorOverrideParser, ParseOverrideWithIncludeAndExcludeScanners)
+{
+    auto object = yaml_to_object(
+        R"([{"target":[{"id":"extract-content"}], "scanners": {include: [{"id": "scanner-001"}], exclude: [{"tags": {"type":"email"}}]}}])");
+
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+    auto override_array = static_cast<raw_configuration::vector>(raw_configuration(object));
+    parse_processor_overrides(override_array, collector, section);
+    ddwaf_object_free(&object);
+
+    {
+        raw_configuration root;
+        section.to_object(root);
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("index:0"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        ddwaf_object_free(&root);
+    }
+
+    EXPECT_FALSE(change.empty());
+    EXPECT_EQ(change.content, change_set::processor_overrides);
+
+    EXPECT_EQ(change.processor_overrides.size(), 1);
+    EXPECT_EQ(cfg.processor_overrides.size(), 1);
+
+    auto &ovrd = cfg.processor_overrides.begin()->second;
+    EXPECT_EQ(ovrd.targets.size(), 1);
+    EXPECT_EQ(ovrd.scanners.include.size(), 1);
+    EXPECT_EQ(ovrd.scanners.exclude.size(), 1);
 
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());

--- a/tests/unit/configuration/processor_override_parser_test.cpp
+++ b/tests/unit/configuration/processor_override_parser_test.cpp
@@ -148,7 +148,7 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithTargetByTags)
 
 TEST(TestProcessorOverrideParser, ParseOverrideWithoutScanners)
 {
-    auto object = yaml_to_object(R"([{"target":[{"id":"extract-content"}], "scanners":[]}])");
+    auto object = yaml_to_object(R"([{"target":[{"id":"extract-content"}], "scanners":{}}])");
 
     configuration_spec cfg;
     configuration_change_spec change;
@@ -185,7 +185,8 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithoutScanners)
 
     auto &ovrd = cfg.processor_overrides.begin()->second;
     EXPECT_EQ(ovrd.targets.size(), 1);
-    EXPECT_EQ(ovrd.scanners.size(), 0);
+    EXPECT_EQ(ovrd.scanners.include.size(), 0);
+    EXPECT_EQ(ovrd.scanners.exclude.size(), 0);
 
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());
@@ -215,7 +216,7 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithoutScanners)
 TEST(TestProcessorOverrideParser, ParseOverrideWithScannerById)
 {
     auto object = yaml_to_object(
-        R"([{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]}])");
+        R"([{"target":[{"id":"extract-content"}], "scanners": {include: [{"id": "scanner-001"}]}}])");
 
     configuration_spec cfg;
     configuration_change_spec change;
@@ -252,7 +253,8 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerById)
 
     auto &ovrd = cfg.processor_overrides.begin()->second;
     EXPECT_EQ(ovrd.targets.size(), 1);
-    EXPECT_EQ(ovrd.scanners.size(), 1);
+    EXPECT_EQ(ovrd.scanners.include.size(), 1);
+    EXPECT_EQ(ovrd.scanners.exclude.size(), 0);
 
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());
@@ -282,7 +284,7 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerById)
 TEST(TestProcessorOverrideParser, ParseOverrideWithScannerByTags)
 {
     auto object = yaml_to_object(
-        R"([{"target":[{"id":"extract-content"}], "scanners": [{"tags": {"type":"email"}}]}])");
+        R"([{"target":[{"id":"extract-content"}], "scanners": {include: [{"tags": {"type":"email"}}]}}])");
 
     configuration_spec cfg;
     configuration_change_spec change;
@@ -319,7 +321,8 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerByTags)
 
     auto &ovrd = cfg.processor_overrides.begin()->second;
     EXPECT_EQ(ovrd.targets.size(), 1);
-    EXPECT_EQ(ovrd.scanners.size(), 1);
+    EXPECT_EQ(ovrd.scanners.include.size(), 1);
+    EXPECT_EQ(ovrd.scanners.exclude.size(), 0);
 
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());
@@ -349,7 +352,7 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithScannerByTags)
 TEST(TestProcessorOverrideParser, ParseOverrideWithMultipleTargets)
 {
     auto object = yaml_to_object(
-        R"([{"target":[{"id":"extract-content"}, {"id": "something-else"}, {"id": "extract-headers"}], "scanners": [{"id": "scanner-001"}]}])");
+        R"([{"target":[{"id":"extract-content"}, {"id": "something-else"}, {"id": "extract-headers"}], "scanners": {include: [{"id": "scanner-001"}]}}])");
 
     configuration_spec cfg;
     configuration_change_spec change;
@@ -386,7 +389,8 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithMultipleTargets)
 
     auto &ovrd = cfg.processor_overrides.begin()->second;
     EXPECT_EQ(ovrd.targets.size(), 3);
-    EXPECT_EQ(ovrd.scanners.size(), 1);
+    EXPECT_EQ(ovrd.scanners.include.size(), 1);
+    EXPECT_EQ(ovrd.scanners.exclude.size(), 0);
 
     EXPECT_TRUE(change.actions.empty());
     EXPECT_TRUE(change.base_rules.empty());
@@ -416,7 +420,7 @@ TEST(TestProcessorOverrideParser, ParseOverrideWithMultipleTargets)
 TEST(TestProcessorOverrideParser, ParseOverrideWithMultipleTargetsAndScanners)
 {
     auto object = yaml_to_object(
-        R"([{"target":[{"id":"extract-content"}], "scanners": [{"id": "scanner-001"}]},{"target":[{"id": "something-else"}], "scanners": [{"tags": {"type": "value"}}]},{"target":[{"id": "extract-headers"}], "scanners": [{"id": "scanner-002"}]}])");
+        R"([{"target":[{"id":"extract-content"}], "scanners": {include: [{"id": "scanner-001"}]}},{"target":[{"id": "something-else"}], "scanners": {include: [{"tags": {"type": "value"}}]}},{"target":[{"id": "extract-headers"}], "scanners": {include: [{"id": "scanner-002"}]}}])");
 
     configuration_spec cfg;
     configuration_change_spec change;


### PR DESCRIPTION
This PR updates processor overrides to the new definition which adds or removes scanners to a given processor rather than fully replacing the whole set. The existing implementation is not currently in use, therefore there is no risk for existing users. More information can be found in RFC-1071.

An example processor override, adding and removing scanners, can be seen below:

```json
{
  "processor_overrides": [
    {
      "target": [{ "id": "extract-headers" }, { "id": "extract-content" }],
      "scanners": {
        "include": [
          {
            "tags": {
              "category": "pii"
            }
          },
          { "id": "mastercard-2x2" }
        ],
        "exclude": [{ "id": "mastercard-4x4" }]
      },
    }
  ]
}

```

Related Jiras: [APPSEC-59429]

[APPSEC-59429]: https://datadoghq.atlassian.net/browse/APPSEC-59429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ