### PR TITLE
Fix single-char matches on phrase_match

### DIFF
--- a/src/matcher/phrase_match.cpp
+++ b/src/matcher/phrase_match.cpp
@@ -64,7 +64,7 @@ std::pair<bool, dynamic_string> phrase_match::match_impl(std::string_view patter
     auto begin = static_cast<std::size_t>(result.match_begin);
     auto end = static_cast<std::size_t>(result.match_end);
 
-    if (result.match_begin < 0 || result.match_end < 0 || begin >= end ||
+    if (result.match_begin < 0 || result.match_end < 0 ||
         (enforce_word_boundary_ && !is_bounded_word(pattern, begin, end))) {
         return {false, {}};
     }

--- a/tests/unit/matcher/phrase_match_test.cpp
+++ b/tests/unit/matcher/phrase_match_test.cpp
@@ -191,4 +191,30 @@ TEST(TestPhraseMatch, TestInvalidInput)
     EXPECT_FALSE(matcher.match(std::string_view{"*", 0}).first);
 }
 
+TEST(TestPhraseMatch, TestSingleCharMatch)
+{
+    std::vector<const char *> strings{"a", "1"};
+    std::vector<uint32_t> lengths{1, 1};
+
+    phrase_match matcher(strings, lengths);
+
+    EXPECT_STR(matcher.name(), "phrase_match");
+    EXPECT_STR(matcher.to_string(), "");
+
+    ddwaf_object param;
+    ddwaf_object_string(&param, "a");
+
+    auto [res, highlight] = matcher.match(param);
+    EXPECT_TRUE(res);
+    EXPECT_STR(highlight, "a");
+
+    ddwaf_object param2;
+    ddwaf_object_string(&param2, "2");
+
+    EXPECT_FALSE(matcher.match(param2).first);
+
+    ddwaf_object_free(&param2);
+    ddwaf_object_free(&param);
+}
+
 } // namespace


### PR DESCRIPTION
This PR fixes an issue where single-char matches on the phrase_match operator are discarded.