### PR TITLE
Remove default allocator arguments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 /Debug
 /Release
 /RelWithDebInfo
+/build

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -9,25 +9,28 @@ namespace YAML {
 template <> struct as_if<ddwaf_object, void> {
     explicit as_if(const Node &node_) : node(node_) {}
 
-    static ddwaf_object yaml_to_object_helper(const Node &node)
+    static ddwaf_object yaml_to_object_helper(const Node &node, ddwaf_allocator alloc)
     {
         ddwaf_object arg;
         switch (node.Type()) {
         case NodeType::Sequence:
-            ddwaf_object_array(&arg);
+            ddwaf_object_set_array(&arg, 0, alloc);
             break;
         case NodeType::Map:
-            ddwaf_object_map(&arg);
+            ddwaf_object_set_map(&arg, 0, alloc);
             break;
         case NodeType::Scalar:
-            ddwaf_object_string(&arg, node.Scalar().c_str());
+            {
+                auto scalar = node.Scalar();
+                ddwaf_object_set_string(&arg, scalar.c_str(), scalar.size(), alloc);
+            }
             break;
         case NodeType::Null:
-            ddwaf_object_null(&arg);
+            ddwaf_object_set_null(&arg);
             break;
         case NodeType::Undefined:
         default:
-            ddwaf_object_invalid(&arg);
+            ddwaf_object_set_invalid(&arg);
             break;
         }
         return arg;
@@ -35,11 +38,12 @@ template <> struct as_if<ddwaf_object, void> {
 
     ddwaf_object operator()() const
     {
-        std::list<std::tuple<ddwaf_object &, YAML::Node, YAML::Node::const_iterator>> stack;
+        auto alloc = ddwaf_get_default_allocator();
+        std::list<std::tuple<ddwaf_object *, YAML::Node, YAML::Node::const_iterator>> stack;
 
-        ddwaf_object root = yaml_to_object_helper(node);
+        ddwaf_object root = yaml_to_object_helper(node, alloc);
         if (root.type == DDWAF_OBJ_MAP || root.type == DDWAF_OBJ_ARRAY) {
-            stack.emplace_back(root, node, node.begin());
+            stack.emplace_back(&root, node, node.begin());
         }
 
         while (!stack.empty()) {
@@ -48,16 +52,18 @@ template <> struct as_if<ddwaf_object, void> {
 
             for (; it != parent_node.end(); ++it) {
                 YAML::Node child_node = parent_node.IsMap() ? it->second : *it;
-                auto child_obj = yaml_to_object_helper(child_node);
-                if (parent_obj.type == DDWAF_OBJ_MAP) {
+                auto child_obj = yaml_to_object_helper(child_node, alloc);
+                ddwaf_object *child_ptr = nullptr;
+                if (parent_obj->type == DDWAF_OBJ_MAP) {
                     auto key = it->first.as<std::string>();
-                    ddwaf_object_map_add(&parent_obj, key.c_str(), &child_obj);
-                } else if (parent_obj.type == DDWAF_OBJ_ARRAY) {
-                    ddwaf_object_array_add(&parent_obj, &child_obj);
+                    child_ptr = ddwaf_object_insert_key(parent_obj, key.c_str(), key.size(), alloc);
+                    *child_ptr = child_obj;
+                } else if (parent_obj->type == DDWAF_OBJ_ARRAY) {
+                    child_ptr = ddwaf_object_insert(parent_obj, alloc);
+                    *child_ptr = child_obj;
                 }
 
                 if (child_obj.type == DDWAF_OBJ_MAP || child_obj.type == DDWAF_OBJ_ARRAY) {
-                    auto &child_ptr = parent_obj.array[parent_obj.nbEntries - 1];
                     stack.emplace_back(child_ptr, child_node, child_node.begin());
                     ++it;
                     break;
@@ -83,19 +89,25 @@ YAML::Node object_to_yaml_helper(const ddwaf_object &obj)
     YAML::Node output;
     switch (obj.type) {
     case DDWAF_OBJ_BOOL:
-        output = obj.boolean;
+        output = ddwaf_object_get_bool(&obj);
         break;
     case DDWAF_OBJ_SIGNED:
-        output = obj.intValue;
+        output = ddwaf_object_get_signed(&obj);
         break;
     case DDWAF_OBJ_UNSIGNED:
-        output = obj.uintValue;
+        output = ddwaf_object_get_unsigned(&obj);
         break;
     case DDWAF_OBJ_FLOAT:
-        output = obj.f64;
+        output = ddwaf_object_get_float(&obj);
         break;
     case DDWAF_OBJ_STRING:
-        output = std::string{obj.stringValue, obj.nbEntries};
+    case DDWAF_OBJ_LITERAL_STRING:
+    case DDWAF_OBJ_SMALL_STRING:
+        {
+            size_t length;
+            const char* str = ddwaf_object_get_string(&obj, &length);
+            output = std::string{str, length};
+        }
         break;
     case DDWAF_OBJ_MAP:
         output = YAML::Load("{}");
@@ -126,21 +138,34 @@ YAML::Node object_to_yaml(const ddwaf_object &obj)
         auto current_depth = stack.size();
         auto &[parent_obj, parent_node, index] = stack.back();
 
-        for (; index < parent_obj.nbEntries; ++index) {
-            auto &child_obj = parent_obj.array[index];
-            auto child_node = object_to_yaml_helper(child_obj);
-
+        size_t size = ddwaf_object_get_size(&parent_obj);
+        for (; index < size; ++index) {
+            const ddwaf_object *child_obj = nullptr;
             if (parent_obj.type == DDWAF_OBJ_MAP) {
-                std::string key{child_obj.parameterName, child_obj.parameterNameLength};
-                parent_node[key] = child_node;
-            } else if (parent_obj.type == DDWAF_OBJ_ARRAY) {
-                parent_node.push_back(child_node);
-            }
+                child_obj = ddwaf_object_at_value(&parent_obj, index);
+                auto *key_obj = ddwaf_object_at_key(&parent_obj, index);
+                size_t key_len;
+                const char* key_str = ddwaf_object_get_string(key_obj, &key_len);
+                std::string key{key_str, key_len};
 
-            if (child_obj.type == DDWAF_OBJ_MAP || child_obj.type == DDWAF_OBJ_ARRAY) {
-                stack.emplace_back(child_obj, child_node, 0);
-                ++index;
-                break;
+                auto child_node = object_to_yaml_helper(*child_obj);
+                parent_node[key] = child_node;
+
+                if (child_obj->type == DDWAF_OBJ_MAP || child_obj->type == DDWAF_OBJ_ARRAY) {
+                    stack.emplace_back(*child_obj, child_node, 0);
+                    ++index;
+                    break;
+                }
+            } else if (parent_obj.type == DDWAF_OBJ_ARRAY) {
+                child_obj = ddwaf_object_at_value(&parent_obj, index);
+                auto child_node = object_to_yaml_helper(*child_obj);
+                parent_node.push_back(child_node);
+
+                if (child_obj->type == DDWAF_OBJ_MAP || child_obj->type == DDWAF_OBJ_ARRAY) {
+                    stack.emplace_back(*child_obj, child_node, 0);
+                    ++index;
+                    break;
+                }
             }
         }
 
@@ -175,29 +200,34 @@ rules:
 
 int main()
 {
-    YAML::Node doc = YAML::Load(waf_rule.data(), waf_rule.size());
+    auto alloc = ddwaf_get_default_allocator();
 
-    auto rule = doc.as<ddwaf_object>(); //= convert_yaml_to_args(doc);
-    ddwaf_handle handle = ddwaf_init(&rule, nullptr, nullptr);
+    YAML::Node doc = YAML::Load(waf_rule.data());
+
+    auto rule = doc.as<ddwaf_object>();
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
     ddwaf_object_destroy(&rule, alloc);
     if (handle == nullptr) {
         return EXIT_FAILURE;
     }
 
-    ddwaf_context context = ddwaf_context_init(handle);
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
     if (context == nullptr) {
         ddwaf_destroy(handle);
         return EXIT_FAILURE;
     }
 
     ddwaf_object root;
-    ddwaf_object tmp;
-    ddwaf_object_map(&root);
-    ddwaf_object_map_add(&root, "arg1", ddwaf_object_string(&tmp, "string 1"));
-    ddwaf_object_map_add(&root, "arg2", ddwaf_object_string(&tmp, "string 2"));
+    ddwaf_object_set_map(&root, 2, alloc);
+
+    ddwaf_object *arg1 = ddwaf_object_insert_literal_key(&root, "arg1", 4, alloc);
+    ddwaf_object_set_string_literal(arg1, "string 1", 8);
+
+    ddwaf_object *arg2 = ddwaf_object_insert_literal_key(&root, "arg2", 4, alloc);
+    ddwaf_object_set_string_literal(arg2, "string 2", 8);
 
     ddwaf_object ret;
-    auto code = ddwaf_context_eval(context, &root, nullptr, &ret, LONG_TIME);
+    auto code = ddwaf_context_eval(context, &root, alloc, &ret, LONG_TIME);
     std::cout << "Output second run: " << code << '\n';
     if (code == DDWAF_MATCH) {
         YAML::Emitter out(std::cout);

--- a/fuzzer/cmdi_detector/src/main.cpp
+++ b/fuzzer/cmdi_detector/src/main.cpp
@@ -188,11 +188,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     auto [resource, param] = deserialize(bytes, size);
 
-    auto root = owned_object::make_map();
-    root.emplace("server.request.query", owned_object::make_string(param));
+    auto root = owned_object::make_map(0, ddwaf::memory::get_default_resource());
+    root.emplace("server.request.query",
+        owned_object::make_string(param, ddwaf::memory::get_default_resource()));
 
-    auto array = root.emplace("server.sys.exec.cmd", owned_object::make_array());
-    for (auto arg : resource) { array.emplace_back(owned_object::make_string(arg)); }
+    auto array = root.emplace(
+        "server.sys.exec.cmd", owned_object::make_array(0, ddwaf::memory::get_default_resource()));
+    for (auto arg : resource) {
+        array.emplace_back(owned_object::make_string(arg, ddwaf::memory::get_default_resource()));
+    }
 
     object_store store;
     store.insert(std::move(root));

--- a/fuzzer/http_endpoint_fingerprint/src/main.cpp
+++ b/fuzzer/http_endpoint_fingerprint/src/main.cpp
@@ -17,7 +17,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 {
     random_buffer buffer{bytes, size};
 
-    auto query = owned_object::make_map();
+    auto query = owned_object::make_map(0, ddwaf::memory::get_default_resource());
     auto query_size = buffer.get<uint8_t>();
     for (uint8_t i = 0; i < query_size; ++i) {
         auto key = buffer.get<std::string_view>();
@@ -25,7 +25,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
         query.emplace(key, value);
     }
 
-    auto body = owned_object::make_map();
+    auto body = owned_object::make_map(0, ddwaf::memory::get_default_resource());
     auto body_size = buffer.get<uint8_t>();
     for (uint8_t i = 0; i < body_size; ++i) {
         auto key = buffer.get<std::string_view>();
@@ -41,8 +41,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
         gen.eval_impl({.address = {}, .key_path = {}, .value = buffer.get<std::string_view>()},
             {.address = {}, .key_path = {}, .value = buffer.get<std::string_view>()},
             {{.address = {}, .key_path = {}, .value = query}},
-            {{.address = {}, .key_path = {}, .value = body}}, cache, memory::get_default_resource(),
-            deadline);
+            {{.address = {}, .key_path = {}, .value = body}}, cache,
+            ddwaf::memory::get_default_resource(), deadline);
 
     return 0;
 }

--- a/fuzzer/http_header_fingerprint/src/main.cpp
+++ b/fuzzer/http_header_fingerprint/src/main.cpp
@@ -22,7 +22,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     random_buffer buffer{bytes, size};
 
-    auto header = owned_object::make_map();
+    auto header = owned_object::make_map(0, ddwaf::memory::get_default_resource());
     auto header_size = buffer.get<uint8_t>();
     for (uint8_t i = 0; i < header_size; ++i) {
         auto value = buffer.get<std::string_view>();
@@ -41,7 +41,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
     processor_cache cache;
     ddwaf::timer deadline{2s};
     auto output = gen.eval_impl({.address = {}, .key_path = {}, .value = header}, cache,
-        memory::get_default_resource(), deadline);
+        ddwaf::memory::get_default_resource(), deadline);
 
     return 0;
 }

--- a/fuzzer/http_network_fingerprint/src/main.cpp
+++ b/fuzzer/http_network_fingerprint/src/main.cpp
@@ -21,7 +21,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     random_buffer buffer{bytes, size};
 
-    auto header = owned_object::make_map();
+    auto header = owned_object::make_map(0, ddwaf::memory::get_default_resource());
     auto header_size = buffer.get<uint8_t>();
     for (uint8_t i = 0; i < header_size; ++i) {
         auto value = buffer.get<std::string_view>();
@@ -40,7 +40,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
     processor_cache cache;
     ddwaf::timer deadline{2s};
     auto output = gen.eval_impl({.address = {}, .key_path = {}, .value = header}, cache,
-        memory::get_default_resource(), deadline);
+        ddwaf::memory::get_default_resource(), deadline);
 
     return 0;
 }

--- a/fuzzer/jwt_decode/src/main.cpp
+++ b/fuzzer/jwt_decode/src/main.cpp
@@ -18,7 +18,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     std::string_view value{reinterpret_cast<const char *>(bytes), size};
 
-    auto headers = object_builder::map({{"authorization", value}});
+    auto headers =
+        object_builder::map({{"authorization", value}}, ddwaf::memory::get_default_resource());
 
     jwt_decode gen{"id", {}, {}, false, true};
 
@@ -26,7 +27,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
     ddwaf::timer deadline{2s};
     static const std::vector<std::variant<std::string, int64_t>> key_path{"authorization"};
     auto output = gen.eval_impl({.address = {}, .key_path = key_path, .value = headers}, cache,
-        memory::get_default_resource(), deadline);
+        ddwaf::memory::get_default_resource(), deadline);
 
     return 0;
 }

--- a/fuzzer/lfi_detector/src/main.cpp
+++ b/fuzzer/lfi_detector/src/main.cpp
@@ -111,9 +111,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
     lfi_detector cond{{gen_param_def("server.io.fs.file", "server.request.query")}};
 
     auto [resource, param] = deserialize(bytes, size);
-    auto root = owned_object::make_map();
-    root.emplace("server.request.query", owned_object::make_string(param));
-    root.emplace("server.io.fs.file", owned_object::make_string(resource));
+    auto root = owned_object::make_map(0, ddwaf::memory::get_default_resource());
+    root.emplace("server.request.query",
+        owned_object::make_string(param, ddwaf::memory::get_default_resource()));
+    root.emplace("server.io.fs.file",
+        owned_object::make_string(resource, ddwaf::memory::get_default_resource()));
 
     object_store store;
     store.insert(std::move(root));

--- a/fuzzer/session_fingerprint/src/main.cpp
+++ b/fuzzer/session_fingerprint/src/main.cpp
@@ -17,7 +17,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 {
     random_buffer buffer{bytes, size};
 
-    auto cookies = owned_object::make_map();
+    auto cookies = owned_object::make_map(0, ddwaf::memory::get_default_resource());
     auto cookies_size = buffer.get<uint8_t>();
     for (uint8_t i = 0; i < cookies_size; ++i) {
         auto key = buffer.get<std::string_view>();
@@ -34,7 +34,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
     auto output = gen.eval_impl({{.address = {}, .key_path = {}, .value = cookies}},
         {{.address = {}, .key_path = {}, .value = buffer.get<std::string_view>()}},
         {{.address = {}, .key_path = {}, .value = buffer.get<std::string_view>()}}, cache,
-        memory::get_default_resource(), deadline);
+        ddwaf::memory::get_default_resource(), deadline);
 
     return 0;
 }

--- a/fuzzer/shi_detector_array/src/main.cpp
+++ b/fuzzer/shi_detector_array/src/main.cpp
@@ -188,11 +188,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     auto [resource, param] = deserialize(bytes, size);
 
-    auto root = owned_object::make_map();
-    root.emplace("server.request.query", owned_object::make_string(param));
+    auto root = owned_object::make_map(0, ddwaf::memory::get_default_resource());
+    root.emplace("server.request.query",
+        owned_object::make_string(param, ddwaf::memory::get_default_resource()));
 
-    auto array = root.emplace("server.sys.shell.cmd", owned_object::make_array());
-    for (auto arg : resource) { array.emplace_back(owned_object::make_string(arg)); }
+    auto array = root.emplace(
+        "server.sys.shell.cmd", owned_object::make_array(0, ddwaf::memory::get_default_resource()));
+    for (auto arg : resource) {
+        array.emplace_back(owned_object::make_string(arg, ddwaf::memory::get_default_resource()));
+    }
 
     object_store store;
     store.insert(std::move(root));

--- a/fuzzer/shi_detector_string/src/main.cpp
+++ b/fuzzer/shi_detector_string/src/main.cpp
@@ -110,9 +110,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     auto [resource, param] = deserialize(bytes, size);
 
-    auto root = owned_object::make_map();
-    root.emplace("server.request.query", owned_object::make_string(param));
-    root.emplace("server.sys.shell.cmd", owned_object::make_string(resource));
+    auto root = owned_object::make_map(0, ddwaf::memory::get_default_resource());
+    root.emplace("server.request.query",
+        owned_object::make_string(param, ddwaf::memory::get_default_resource()));
+    root.emplace("server.sys.shell.cmd",
+        owned_object::make_string(resource, ddwaf::memory::get_default_resource()));
 
     object_store store;
     store.insert(std::move(root));

--- a/fuzzer/sqli_detector/src/main.cpp
+++ b/fuzzer/sqli_detector/src/main.cpp
@@ -126,10 +126,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
 
     auto dialect_str = ddwaf::sql_dialect_to_string(dialect);
 
-    auto root = owned_object::make_map();
-    root.emplace("server.request.query", owned_object::make_string(param));
-    root.emplace("server.db.system", owned_object::make_string(dialect_str));
-    root.emplace("server.db.statement", owned_object::make_string(resource));
+    auto root = owned_object::make_map(0, ddwaf::memory::get_default_resource());
+    root.emplace("server.request.query",
+        owned_object::make_string(param, ddwaf::memory::get_default_resource()));
+    root.emplace("server.db.system",
+        owned_object::make_string(dialect_str, ddwaf::memory::get_default_resource()));
+    root.emplace("server.db.statement",
+        owned_object::make_string(resource, ddwaf::memory::get_default_resource()));
 
     object_store store;
     store.insert(std::move(root));

--- a/fuzzer/ssrf_detector/src/main.cpp
+++ b/fuzzer/ssrf_detector/src/main.cpp
@@ -111,9 +111,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *bytes, size_t size)
     ssrf_detector cond{{gen_param_def("server.io.net.url", "server.request.query")}};
 
     auto [resource, param] = deserialize(bytes, size);
-    auto root = owned_object::make_map();
-    root.emplace("server.request.query", owned_object::make_string(param));
-    root.emplace("server.io.net.url", owned_object::make_string(resource));
+    auto root = owned_object::make_map(0, ddwaf::memory::get_default_resource());
+    root.emplace("server.request.query",
+        owned_object::make_string(param, ddwaf::memory::get_default_resource()));
+    root.emplace("server.io.net.url",
+        owned_object::make_string(resource, ddwaf::memory::get_default_resource()));
 
     object_store store;
     store.insert(std::move(root));

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -219,10 +219,9 @@ typedef void (*ddwaf_log_cb)(
  *
  * @return Handle to the WAF instance or NULL on error.
  *
- * @note If config is NULL, default values will be used, including the default
- *       free function (ddwaf_object_free).
- *
  * @note If ruleset is NULL, the diagnostics object will not be initialised.
+ *
+ * @note The deallocation of the diagnostics must be made with default allocator.
  **/
 ddwaf_handle ddwaf_init(const ddwaf_object *ruleset,  ddwaf_object *diagnostics);
 
@@ -279,6 +278,7 @@ const char *const *ddwaf_known_actions(const ddwaf_handle handle, uint32_t *size
  * Context object to perform matching using the provided WAF instance.
  *
  * @param handle Handle of the WAF instance containing the ruleset definition. (nonnull)
+ * @param output Allocator used to serve output objects created during evaluation (nonnull)
 
  * @return Handle to the context instance.
  *
@@ -304,6 +304,9 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle, ddwaf_allocator outp
  *    relevant address associated to the value, which can be of an arbitrary
  *    type.
  *
+ * @param alloc (nullable) Allocator used to free the data provided. If NULL,
+ *              the data will not be freed.
+ *
  * @param result (nullable) Object map containing the following items:
  *               - events: an array of the generated events.
  *               - actions: a map of the generated actions in the format:
@@ -318,6 +321,9 @@ ddwaf_context ddwaf_context_init(const ddwaf_handle handle, ddwaf_allocator outp
  *               This structure must be freed by the caller and will contain all
  *               specified keys when the value returned by ddwaf_context_eval is either
  *               DDWAF_OK or DDWAF_MATCH and will be empty otherwise.
+ *               IMPORTANT: This object is not allocated with the allocator
+ *               passed in this call. It uses the allocator given to
+ *               ddwaf_context_init instead.
  * @param timeout Maximum time budget in microseconds.
  *
  * @return Return code of the operation.
@@ -380,6 +386,9 @@ ddwaf_subcontext ddwaf_subcontext_init(ddwaf_context context);
  *    {string, <value>} in which each key represents the  relevant address
  *    associated to the value, which can be of an arbitrary type.
  *
+ * @param alloc (nullable) Allocator used to free the data provided. If NULL,
+ *              the data will not be freed.
+ *
  * @param result (nullable) Object map containing the following items:
  *               - events: an array of the generated events.
  *               - actions: a map of the generated actions in the format:
@@ -394,6 +403,9 @@ ddwaf_subcontext ddwaf_subcontext_init(ddwaf_context context);
  *               This structure must be freed by the caller and will contain all
  *               specified keys when the value returned by ddwaf_subcontext_eval is either
  *               DDWAF_OK or DDWAF_MATCH and will be empty otherwise.
+ *               IMPORTANT: This object is not allocated with the allocator
+ *               passed in this call. It uses the allocator given to
+ *               ddwaf_context_init instead.
  * @param timeout Maximum time budget in microseconds.
  *
  * @return Return code of the operation.
@@ -509,7 +521,7 @@ ddwaf_handle ddwaf_builder_build_instance(ddwaf_builder builder);
  *         of those matching the filter.
  *
  * @note This function is not thread-safe and the memory of the paths object must
- *       be freed by the caller.
+ *       be freed by the caller using the default allocator.
  **/
 uint32_t ddwaf_builder_get_config_paths(ddwaf_builder builder, ddwaf_object *paths, const char *filter, uint32_t filter_len);
 

--- a/src/attribute_collector.hpp
+++ b/src/attribute_collector.hpp
@@ -48,9 +48,20 @@ public:
     attribute_collector &operator=(attribute_collector &&other) noexcept = default;
     ~attribute_collector() = default;
 
-    template <typename T> bool insert(std::string_view key, T &&value)
+    // For types where owned_object has a single-argument constructor
+    template <typename T>
+    bool insert(std::string_view key, T &&value)
+        requires std::constructible_from<owned_object, T>
     {
         return insert(key, owned_object{std::forward<T>(value)});
+    }
+
+    // For types that require an allocator
+    template <typename T>
+    bool insert(std::string_view key, T &&value, nonnull_ptr<memory::memory_resource> alloc)
+        requires std::constructible_from<owned_object, T, nonnull_ptr<memory::memory_resource>>
+    {
+        return insert(key, owned_object{std::forward<T>(value), alloc});
     }
 
     bool insert(std::string_view key, owned_object &&object);

--- a/src/attribute_collector.hpp
+++ b/src/attribute_collector.hpp
@@ -40,7 +40,7 @@ class attribute_collector {
 public:
     explicit attribute_collector(
         nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource())
-        : attributes_(owned_object::make_map(0, alloc))
+        : attributes_(owned_object::make_map(alloc))
     {}
     attribute_collector(const attribute_collector &) = delete;
     attribute_collector &operator=(const attribute_collector &) = delete;
@@ -50,28 +50,28 @@ public:
 
     bool insert(std::string_view key, bool value)
     {
-        return insert(key, owned_object::make_boolean(value, attributes_.alloc()));
+        return insert(key, owned_object::make_boolean(value));
     }
 
     template <typename T>
     bool insert(std::string_view key, T value)
         requires std::is_integral_v<T> && std::is_signed_v<T>
     {
-        return insert(key, owned_object::make_signed(value, attributes_.alloc()));
+        return insert(key, owned_object::make_signed(value));
     }
 
     template <typename T>
     bool insert(std::string_view key, T value)
         requires std::is_integral_v<T> && std::is_unsigned_v<T> && (!std::same_as<T, bool>)
     {
-        return insert(key, owned_object::make_unsigned(value, attributes_.alloc()));
+        return insert(key, owned_object::make_unsigned(value));
     }
 
     template <typename T>
     bool insert(std::string_view key, T value)
         requires std::is_floating_point_v<T>
     {
-        return insert(key, owned_object::make_float(value, attributes_.alloc()));
+        return insert(key, owned_object::make_float(value));
     }
 
     template <typename T>
@@ -99,7 +99,7 @@ public:
     {
         auto output_object = std::move(attributes_);
         // Reset attributes
-        attributes_ = owned_object::make_map(0, output_object.alloc());
+        attributes_ = owned_object::make_map(output_object.alloc());
         inserted_.clear();
 
         return output_object;

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -7,7 +7,6 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
-
 #ifdef __linux__
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)

--- a/src/dynamic_string.cpp
+++ b/src/dynamic_string.cpp
@@ -19,7 +19,7 @@ owned_object dynamic_string::to_object(nonnull_ptr<memory::memory_resource> allo
                                         // this means alloc (the deallocator for the owned_object)
                                         // can deallocate memory from alloc_ (the allocator for
                                         // this dynamic_string)
-                              owned_object::unsafe_make_string_nocopy(buffer_, size_, alloc);
+                              owned_object::make_string_nocopy(buffer_, size_, alloc);
 
     if (should_copy) {
         alloc_->deallocate(buffer_, capacity_, alignof(char));

--- a/src/dynamic_string.cpp
+++ b/src/dynamic_string.cpp
@@ -13,14 +13,15 @@ namespace ddwaf {
 
 owned_object dynamic_string::to_object(nonnull_ptr<memory::memory_resource> alloc)
 {
-    owned_object object;
-    if (size_ == capacity_ && alloc->is_equal(*alloc_)) {
-        // safety: the allocators compare equal; by definition this means alloc
-        // (the deallocator for the owned_object) can deallocate memory from
-        // alloc_ (the allocator for this dynamic_string)
-        object = owned_object::unsafe_make_string_nocopy(buffer_, size_, alloc);
-    } else {
-        object = owned_object::make_string(buffer_, size_, alloc);
+    const bool should_copy = size_ != capacity_ || !alloc->is_equal(*alloc_);
+    owned_object object = should_copy ? owned_object::make_string(buffer_, size_, alloc)
+                                      : // safety: the allocators compare equal; by definition
+                                        // this means alloc (the deallocator for the owned_object)
+                                        // can deallocate memory from alloc_ (the allocator for
+                                        // this dynamic_string)
+                              owned_object::unsafe_make_string_nocopy(buffer_, size_, alloc);
+
+    if (should_copy) {
         alloc_->deallocate(buffer_, capacity_, alignof(char));
     }
     buffer_ = nullptr;

--- a/src/dynamic_string.cpp
+++ b/src/dynamic_string.cpp
@@ -15,7 +15,10 @@ owned_object dynamic_string::to_object(nonnull_ptr<memory::memory_resource> allo
 {
     owned_object object;
     if (size_ == capacity_ && alloc->is_equal(*alloc_)) {
-        object = owned_object::make_string_nocopy(buffer_, size_);
+        // safety: the allocators compare equal; by definition this means alloc
+        // (the deallocator for the owned_object) can deallocate memory from
+        // alloc_ (the allocator for this dynamic_string)
+        object = owned_object::unsafe_make_string_nocopy(buffer_, size_, alloc);
     } else {
         object = owned_object::make_string(buffer_, size_, alloc);
         alloc_->deallocate(buffer_, capacity_, alignof(char));

--- a/src/dynamic_string.hpp
+++ b/src/dynamic_string.hpp
@@ -122,8 +122,7 @@ public:
     }
 
     // This method moves the contents of the string into the resulting object
-    owned_object to_object(
-        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource());
+    owned_object to_object(nonnull_ptr<memory::memory_resource> alloc);
 
     [[nodiscard]] size_type size() const noexcept { return size_; }
     [[nodiscard]] bool empty() const noexcept { return size_ == 0; }

--- a/src/evaluation_engine.cpp
+++ b/src/evaluation_engine.cpp
@@ -42,7 +42,7 @@ void set_context_event_address(object_store &store)
         return;
     }
 
-    store.insert(event_addr_idx, event_addr, owned_object{true});
+    store.insert(event_addr_idx, event_addr, owned_object::make_boolean(true));
 }
 
 } // namespace

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -784,7 +784,7 @@ ddwaf_object *ddwaf_object_insert(ddwaf_object *array, ddwaf_allocator alloc)
     try {
         auto *alloc_ptr = to_alloc_ptr(alloc);
         borrowed_object container = to_borrowed(array, alloc_ptr);
-        owned_object new_element = owned_object{alloc_ptr};
+        owned_object new_element = owned_object{};
         borrowed_object inserted = container.emplace_back(std::move(new_element));
 
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -802,7 +802,7 @@ ddwaf_object *ddwaf_object_insert_key(
     try {
         auto *alloc_ptr = to_alloc_ptr(alloc);
         borrowed_object container = to_borrowed(map, alloc_ptr);
-        owned_object new_value = owned_object{alloc_ptr};
+        owned_object new_value = owned_object{};
         borrowed_object inserted =
             container.emplace(std::string_view{key, length}, std::move(new_value));
 
@@ -822,7 +822,7 @@ ddwaf_object *ddwaf_object_insert_key_nocopy(
     try {
         auto *alloc_ptr = to_alloc_ptr(alloc);
         auto key_obj = owned_object::make_string_nocopy(key, length, alloc_ptr);
-        auto value_obj = owned_object{alloc_ptr};
+        auto value_obj = owned_object{};
 
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         return reinterpret_cast<ddwaf_object *>(
@@ -845,7 +845,7 @@ ddwaf_object *ddwaf_object_insert_literal_key(
     try {
         auto *alloc_ptr = to_alloc_ptr(alloc);
         auto key_obj = owned_object::make_string_literal(key, length);
-        auto value_obj = owned_object{alloc_ptr};
+        auto value_obj = owned_object{};
 
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         return reinterpret_cast<ddwaf_object *>(

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -66,8 +66,7 @@ class object_reader_handler
     : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, object_reader_handler> {
 public:
     explicit object_reader_handler(nonnull_ptr<memory::memory_resource> alloc)
-        : alloc_(alloc), root_(owned_object::make_uninit(alloc)),
-          key_(owned_object::make_uninit(alloc))
+        : alloc_(alloc), root_(alloc), key_(alloc)
     {
         stack_.reserve(max_depth + 1);
     }
@@ -169,7 +168,7 @@ public:
             return true;
         }
 
-        return emplace(owned_object::make_map(0, alloc_));
+        return emplace(owned_object::make_map(alloc_));
     }
 
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -190,7 +189,7 @@ public:
             return true;
         }
 
-        return emplace(owned_object::make_array(0, alloc_));
+        return emplace(owned_object::make_array(alloc_));
     }
 
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -261,7 +260,7 @@ owned_object json_to_object(std::string_view json, nonnull_ptr<memory::memory_re
     const rapidjson::ParseResult res = reader.Parse(ss, handler);
     if (res.IsError()) {
         // Not interested in partial JSON for now
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 
     return handler.finalize();

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -144,7 +144,7 @@ public:
             return true;
         }
 
-        return emplace(owned_object::make_string(str, length));
+        return emplace(owned_object::make_string(str, length, alloc_));
     }
 
     bool Key(const char *str, rapidjson::SizeType length, bool /*copy*/)

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -65,7 +65,9 @@ struct string_view_stream {
 class object_reader_handler
     : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, object_reader_handler> {
 public:
-    explicit object_reader_handler(nonnull_ptr<memory::memory_resource> alloc) : alloc_(alloc)
+    explicit object_reader_handler(nonnull_ptr<memory::memory_resource> alloc)
+        : alloc_(alloc), root_(owned_object::make_uninit(alloc)),
+          key_(owned_object::make_uninit(alloc))
     {
         stack_.reserve(max_depth + 1);
     }
@@ -259,7 +261,7 @@ owned_object json_to_object(std::string_view json, nonnull_ptr<memory::memory_re
     const rapidjson::ParseResult res = reader.Parse(ss, handler);
     if (res.IsError()) {
         // Not interested in partial JSON for now
-        return {};
+        return owned_object::make_uninit(alloc);
     }
 
     return handler.finalize();

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -65,8 +65,7 @@ struct string_view_stream {
 class object_reader_handler
     : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>, object_reader_handler> {
 public:
-    explicit object_reader_handler(nonnull_ptr<memory::memory_resource> alloc)
-        : alloc_(alloc), root_(alloc), key_(alloc)
+    explicit object_reader_handler(nonnull_ptr<memory::memory_resource> alloc) : alloc_(alloc)
     {
         stack_.reserve(max_depth + 1);
     }
@@ -240,7 +239,7 @@ private:
         return true;
     }
 
-    nonnull_ptr<memory::memory_resource> alloc_{memory::get_default_resource()};
+    nonnull_ptr<memory::memory_resource> alloc_;
     owned_object root_;
     std::vector<borrowed_object> stack_;
 
@@ -260,7 +259,7 @@ owned_object json_to_object(std::string_view json, nonnull_ptr<memory::memory_re
     const rapidjson::ParseResult res = reader.Parse(ss, handler);
     if (res.IsError()) {
         // Not interested in partial JSON for now
-        return owned_object{alloc};
+        return owned_object{};
     }
 
     return handler.finalize();

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -824,8 +824,8 @@ protected:
 class owned_object final : public readable_object<owned_object>,
                            public writable_object<owned_object> {
 public:
-    explicit owned_object(nonnull_ptr<memory::memory_resource> alloc)
-        : obj_({.type = object_type::invalid}), alloc_(alloc)
+    owned_object()
+        : obj_({.type = object_type::invalid}), alloc_(memory::get_default_null_resource())
     {}
 
     // UNSAFE: Caller must ensure the object's memory is compatible with the
@@ -863,11 +863,6 @@ public:
     [[nodiscard]] detail::object *ptr() { return &obj_; }
     [[nodiscard]] const detail::object *ptr() const noexcept { return &obj_; }
     [[nodiscard]] nonnull_ptr<memory::memory_resource> alloc() const noexcept { return alloc_; }
-
-    static owned_object make_invalid()
-    {
-        return owned_object({.type = object_type::invalid}, memory::get_default_null_resource());
-    }
 
     // the variants that don't take a memory resource can't be written to
     // (have their value replaced)
@@ -1085,7 +1080,7 @@ template <typename Derived>
         default:
             break;
         }
-        return owned_object{alloc};
+        return owned_object{};
     };
 
     std::deque<std::pair<object_view, borrowed_object>> queue;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -391,8 +391,7 @@ public:
     // Convert the underlying type to the requested type
     template <typename T> T convert() const;
 
-    [[nodiscard]] owned_object clone(
-        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource()) const;
+    [[nodiscard]] owned_object clone(nonnull_ptr<memory::memory_resource> alloc) const;
 
 private:
     readable_object() = default;
@@ -790,20 +789,6 @@ private:
 class borrowed_object final : public readable_object<borrowed_object>,
                               public writable_object<borrowed_object> {
 public:
-    explicit borrowed_object(detail::object *obj,
-        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource())
-        : obj_(obj), alloc_(alloc)
-    {
-        if (obj_ == nullptr) {
-            throw std::invalid_argument("invalid borrowed object (null)");
-        }
-    }
-
-    explicit borrowed_object(detail::object &obj,
-        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource())
-        : obj_(&obj), alloc_(alloc)
-    {}
-
     explicit borrowed_object(owned_object &obj);
     borrowed_object &operator=(owned_object &&obj);
 
@@ -813,62 +798,40 @@ public:
     [[nodiscard]] const detail::object *ptr() const noexcept { return obj_; }
     [[nodiscard]] nonnull_ptr<memory::memory_resource> alloc() const noexcept { return alloc_; }
 
+    // UNSAFE: Caller must ensure the object's memory is compatible with the allocator
+    static borrowed_object create_unchecked(
+        detail::object *obj, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        if (obj == nullptr) {
+            throw std::invalid_argument("invalid borrowed object (null)");
+        }
+        return borrowed_object{obj, alloc};
+    }
+
+    // UNSAFE: Caller must ensure the object's memory is compatible with the allocator
+    static borrowed_object create_unchecked(
+        detail::object &obj, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        return borrowed_object{&obj, alloc};
+    }
+
 protected:
     detail::object *obj_;
-    nonnull_ptr<memory::memory_resource> alloc_{memory::get_default_resource()};
+    nonnull_ptr<memory::memory_resource> alloc_;
 
     friend class owned_object;
     friend class object_view;
+
+private:
+    explicit borrowed_object(detail::object *obj, nonnull_ptr<memory::memory_resource> alloc)
+        : obj_(obj), alloc_(alloc)
+    {}
 };
 
 // NOLINTNEXTLINE(fuchsia-multiple-inheritance)
 class owned_object final : public readable_object<owned_object>,
                            public writable_object<owned_object> {
 public:
-    owned_object() = default;
-
-    // do not take a bool to avoid implicit conversions from pointers
-    explicit owned_object(std::same_as<bool> auto value) { *this = make_boolean(value); }
-
-    template <typename T>
-    explicit owned_object(T value)
-        requires std::is_integral_v<T> && std::is_signed_v<T>
-    {
-        *this = make_signed(value);
-    }
-
-    template <typename T>
-    explicit owned_object(T value)
-        requires(!std::is_same_v<T, bool>) && std::is_unsigned_v<T>
-    {
-        *this = make_unsigned(value);
-    }
-
-    template <typename T>
-    explicit owned_object(T value)
-        requires std::is_floating_point_v<T>
-    {
-        *this = make_float(value);
-    }
-
-    explicit owned_object(const char *value, nonnull_ptr<memory::memory_resource> alloc)
-    {
-        *this = make_string(std::string_view{value}, alloc);
-    }
-
-    template <typename T>
-    explicit owned_object(const T &value, nonnull_ptr<memory::memory_resource> alloc)
-        requires is_type_in_set_v<T, std::string, std::string_view, dynamic_string>
-    {
-        *this = make_string(std::string_view{value}, alloc);
-    }
-
-    explicit owned_object(
-        const char *data, std::size_t size, nonnull_ptr<memory::memory_resource> alloc)
-    {
-        *this = make_string(data, size, alloc);
-    }
-
     ~owned_object() { detail::object_destroy(obj_, alloc_); }
 
     owned_object(const owned_object &) = delete;
@@ -876,7 +839,7 @@ public:
 
     owned_object(owned_object &&other) noexcept : obj_(other.obj_), alloc_(other.alloc_)
     {
-        other.obj_ = detail::object{};
+        other.obj_ = detail::object{.type = object_type::invalid};
     }
 
     owned_object &operator=(owned_object &&other) noexcept
@@ -885,7 +848,7 @@ public:
 
         obj_ = other.obj_;
         alloc_ = other.alloc_;
-        other.obj_ = detail::object{};
+        other.obj_ = detail::object{.type = object_type::invalid};
         return *this;
     }
 
@@ -895,42 +858,61 @@ public:
     [[nodiscard]] const detail::object *ptr() const noexcept { return &obj_; }
     [[nodiscard]] nonnull_ptr<memory::memory_resource> alloc() const noexcept { return alloc_; }
 
-    static owned_object make_null()
+    static owned_object make_invalid()
     {
-        return create_unchecked({.type = object_type::null}, memory::get_default_null_resource());
+        return create_unchecked(
+            {.type = object_type::invalid}, memory::get_default_null_resource());
     }
 
-    static owned_object make_boolean(bool value)
+    // variant of make_invalid() for subsequent assignment
+    static owned_object make_uninit(nonnull_ptr<memory::memory_resource> alloc)
     {
-        return create_unchecked({.via{.b8{.type = object_type::boolean, .val = value}}},
-            memory::get_default_null_resource());
+        return create_unchecked({.type = object_type::invalid}, alloc);
     }
 
-    static owned_object make_signed(int64_t value)
+    // the variants that don't take a memory resource can't be written to
+    // (have their value replaced)
+
+    static owned_object make_null(
+        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_null_resource())
     {
-        return create_unchecked({.via{.i64{.type = object_type::int64, .val = value}}},
-            memory::get_default_null_resource());
+        return create_unchecked({.type = object_type::null}, alloc);
     }
 
-    static owned_object make_unsigned(uint64_t value)
+    static owned_object make_boolean(bool value,
+        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_null_resource())
     {
-        return create_unchecked({.via{.u64{.type = object_type::uint64, .val = value}}},
-            memory::get_default_null_resource());
+        return create_unchecked({.via{.b8{.type = object_type::boolean, .val = value}}}, alloc);
     }
 
-    static owned_object make_float(double value)
+    static owned_object make_signed(int64_t value,
+        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_null_resource())
     {
-        return create_unchecked({.via{.f64{.type = object_type::float64, .val = value}}},
-            memory::get_default_null_resource());
+        return create_unchecked({.via{.i64{.type = object_type::int64, .val = value}}}, alloc);
     }
 
-    static owned_object make_string_literal(const char *str, std::uint32_t len)
+    static owned_object make_unsigned(uint64_t value,
+        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_null_resource())
+    {
+        return create_unchecked({.via{.u64{.type = object_type::uint64, .val = value}}}, alloc);
+    }
+
+    static owned_object make_float(double value,
+        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_null_resource())
+    {
+        return create_unchecked({.via{.f64{.type = object_type::float64, .val = value}}}, alloc);
+    }
+
+    // Unsafe insofar as the string is not copied - the caller must ensure
+    // the string memory remains valid for the lifetime of the object
+    static owned_object make_string_literal(const char *str, std::uint32_t len,
+        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_null_resource())
     {
         return create_unchecked({.via{.str{.type = object_type::literal_string,
                                     .size = static_cast<uint32_t>(len),
                                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                                     .ptr = const_cast<char *>(str)}}},
-            memory::get_default_null_resource());
+            alloc);
     }
 
     // UNSAFE: Does not copy the string - caller must ensure the string memory
@@ -960,7 +942,7 @@ public:
             owned_object obj = create_unchecked({.via{.sstr{.type = object_type::small_string,
                                                     .size = static_cast<uint8_t>(len),
                                                     .data = {}}}},
-                memory::get_default_null_resource());
+                alloc);
 
             if (str != nullptr && len > 0) {
                 memcpy(obj.obj_.via.sstr.data.data(), str, len);
@@ -1020,11 +1002,16 @@ public:
     detail::object move()
     {
         detail::object copy = obj_;
-        obj_ = detail::object{};
+        obj_ = detail::object{.type = object_type::invalid};
         return copy;
     }
 
-    // UNSAFE: Caller must ensure the object's memory is compatible with the allocator
+    // UNSAFE: Caller must ensure the object's memory is compatible with the
+    // allocator. In particular:
+    // 1) if it needs to be deallocated, alloc must be able to do so
+    // 2) if it is a map or array that requires resizing, allow must be able to
+    //    free the current chunk and allocate a new one
+    // 3) if it contains sub-objects, the requirements apply transitively
     static owned_object create_unchecked(
         detail::object obj, nonnull_ptr<memory::memory_resource> alloc)
     {
@@ -1032,8 +1019,8 @@ public:
     }
 
 protected:
-    detail::object obj_{.type = object_type::invalid};
-    nonnull_ptr<memory::memory_resource> alloc_{memory::get_default_resource()};
+    detail::object obj_;
+    nonnull_ptr<memory::memory_resource> alloc_;
 
     friend class borrowed_object;
     friend class object_view;
@@ -1108,7 +1095,7 @@ template <typename Derived>
         default:
             break;
         }
-        return {};
+        return owned_object::make_uninit(alloc);
     };
 
     std::deque<std::pair<object_view, borrowed_object>> queue;
@@ -1176,11 +1163,11 @@ template <typename Derived>
 
     if (container.type == object_type::map) {
         assert(idx < static_cast<std::size_t>(container.via.map.size));
-        return borrowed_object{&container.via.map.ptr[idx].val, alloc()};
+        return borrowed_object::create_unchecked(&container.via.map.ptr[idx].val, alloc());
     }
 
     assert(idx < static_cast<std::size_t>(container.via.array.size));
-    return borrowed_object{&container.via.array.ptr[idx], alloc()};
+    return borrowed_object::create_unchecked(&container.via.array.ptr[idx], alloc());
 }
 
 template <typename Derived>
@@ -1206,8 +1193,11 @@ borrowed_object writable_object<Derived>::emplace_back(owned_object &&value)
         container.via.array.capacity = new_capacity;
     }
 
-    borrowed_object slot{&container.via.array.ptr[container.via.array.size++], alloc()};
-    slot = std::move(value);
+    borrowed_object slot = borrowed_object::create_unchecked(
+        &container.via.array.ptr[container.via.array.size++], alloc());
+    // don't do slot = std::move(value) as that would attempt to destroy slot
+    // (but slot is uninitialized memory)
+    *slot.ptr() = value.move();
     return slot;
 }
 
@@ -1215,7 +1205,7 @@ template <typename Derived>
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 borrowed_object writable_object<Derived>::emplace(std::string_view key, owned_object &&value)
 {
-    return emplace(owned_object{key, alloc()}, std::move(value));
+    return emplace(owned_object::make_string(key, alloc()), std::move(value));
 }
 
 template <typename Derived>
@@ -1243,12 +1233,16 @@ borrowed_object writable_object<Derived>::emplace(owned_object &&key, owned_obje
         container.via.map.capacity = new_capacity;
     }
 
-    borrowed_object key_slot{container.via.map.ptr[container.via.map.size].key, alloc()};
-    borrowed_object val_slot{container.via.map.ptr[container.via.map.size].val, alloc()};
+    borrowed_object key_slot = borrowed_object::create_unchecked(
+        container.via.map.ptr[container.via.map.size].key, alloc());
+    borrowed_object val_slot = borrowed_object::create_unchecked(
+        container.via.map.ptr[container.via.map.size].val, alloc());
     ++container.via.map.size;
 
-    key_slot = std::move(key);
-    val_slot = std::move(value);
+    // key_slot / val_slot are uninitialized memory, so don't do
+    // key_slot = std::move(key) or val_slot = std::move(value)
+    *key_slot.ptr() = key.move();
+    *val_slot.ptr() = value.move();
 
     return val_slot;
 }
@@ -1257,10 +1251,21 @@ template <typename Derived>
 template <typename T>
 borrowed_object writable_object<Derived>::emplace_back(T &&value)
 {
-    if constexpr (std::constructible_from<owned_object, T, nonnull_ptr<memory::memory_resource>>) {
-        return emplace_back(owned_object{std::forward<T>(value), alloc()});
+    if constexpr (std::same_as<std::remove_cvref_t<T>, bool>) {
+        return emplace_back(owned_object::make_boolean(std::forward<T>(value), alloc()));
+    } else if constexpr (std::is_integral_v<std::remove_cvref_t<T>> &&
+                         std::is_signed_v<std::remove_cvref_t<T>>) {
+        return emplace_back(owned_object::make_signed(std::forward<T>(value), alloc()));
+    } else if constexpr (std::is_integral_v<std::remove_cvref_t<T>> &&
+                         std::is_unsigned_v<std::remove_cvref_t<T>>) {
+        return emplace_back(owned_object::make_unsigned(std::forward<T>(value), alloc()));
+    } else if constexpr (std::is_floating_point_v<std::remove_cvref_t<T>>) {
+        return emplace_back(owned_object::make_float(std::forward<T>(value), alloc()));
+    } else if constexpr (std::convertible_to<T, std::string_view>) {
+        return emplace_back(
+            owned_object::make_string(std::string_view(std::forward<T>(value)), alloc()));
     } else {
-        return emplace_back(owned_object{std::forward<T>(value)});
+        return emplace_back(std::forward<T>(value));
     }
 }
 
@@ -1268,10 +1273,21 @@ template <typename Derived>
 template <typename T>
 borrowed_object writable_object<Derived>::emplace(std::string_view key, T &&value)
 {
-    if constexpr (std::constructible_from<owned_object, T, nonnull_ptr<memory::memory_resource>>) {
-        return emplace(key, owned_object{std::forward<T>(value), alloc()});
+    if constexpr (std::same_as<std::remove_cvref_t<T>, bool>) {
+        return emplace(key, owned_object::make_boolean(std::forward<T>(value), alloc()));
+    } else if constexpr (std::is_integral_v<std::remove_cvref_t<T>> &&
+                         std::is_signed_v<std::remove_cvref_t<T>>) {
+        return emplace(key, owned_object::make_signed(std::forward<T>(value), alloc()));
+    } else if constexpr (std::is_integral_v<std::remove_cvref_t<T>> &&
+                         std::is_unsigned_v<std::remove_cvref_t<T>>) {
+        return emplace(key, owned_object::make_unsigned(std::forward<T>(value), alloc()));
+    } else if constexpr (std::is_floating_point_v<std::remove_cvref_t<T>>) {
+        return emplace(key, owned_object::make_float(std::forward<T>(value), alloc()));
+    } else if constexpr (std::convertible_to<T, std::string_view>) {
+        return emplace(
+            key, owned_object::make_string(std::string_view(std::forward<T>(value)), alloc()));
     } else {
-        return emplace(key, owned_object{std::forward<T>(value)});
+        return emplace(key, std::forward<T>(value));
     }
 }
 
@@ -1280,7 +1296,23 @@ inline borrowed_object::borrowed_object(owned_object &obj) : obj_(obj.ptr()), al
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 inline borrowed_object &borrowed_object::operator=(owned_object &&obj)
 {
-    alloc_ = obj.alloc();
+    if (this->obj_ == obj.ptr()) {
+        return *this;
+    }
+
+    const bool moved_from_req_alloc = detail::requires_allocator(obj.type());
+
+    // the borrowed_object is likely part of a larger owned_object, so we must
+    // ensure that the allocators are the same for types that require allocation
+    if (moved_from_req_alloc && !detail::alloc_equal(alloc_, obj.alloc())) {
+        throw std::runtime_error("borrowed_object assignment: incompatible allocators");
+    }
+
+    {
+        // destroy current object
+        detail::object_destroy(*obj_, alloc_);
+    }
+
     *obj_ = obj.move();
     return *this;
 }
@@ -1321,33 +1353,34 @@ using all_types = std::variant<bool, int16_t, int32_t, int64_t, uint16_t, uint32
     double, const char *, std::string_view, std::string, movable_object>;
 using key_value = std::pair<std::string_view, all_types>;
 
-inline owned_object array(std::initializer_list<all_types> list = {},
-    nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource())
+inline owned_object array(
+    std::initializer_list<all_types> list, nonnull_ptr<memory::memory_resource> alloc)
 {
     auto container = owned_object::make_array(static_cast<uint16_t>(list.size()), alloc);
     for (const auto &value : list) {
         if (std::holds_alternative<bool>(value)) {
-            container.emplace_back(owned_object{std::get<bool>(value)});
+            container.emplace_back(owned_object::make_boolean(std::get<bool>(value), alloc));
         } else if (std::holds_alternative<int16_t>(value)) {
-            container.emplace_back(owned_object{std::get<int16_t>(value)});
+            container.emplace_back(owned_object::make_signed(std::get<int16_t>(value), alloc));
         } else if (std::holds_alternative<uint16_t>(value)) {
-            container.emplace_back(owned_object{std::get<uint16_t>(value)});
+            container.emplace_back(owned_object::make_unsigned(std::get<uint16_t>(value), alloc));
         } else if (std::holds_alternative<int32_t>(value)) {
-            container.emplace_back(owned_object{std::get<int32_t>(value)});
+            container.emplace_back(owned_object::make_signed(std::get<int32_t>(value), alloc));
         } else if (std::holds_alternative<uint32_t>(value)) {
-            container.emplace_back(owned_object{std::get<uint32_t>(value)});
+            container.emplace_back(owned_object::make_unsigned(std::get<uint32_t>(value), alloc));
         } else if (std::holds_alternative<int64_t>(value)) {
-            container.emplace_back(owned_object{std::get<int64_t>(value)});
+            container.emplace_back(owned_object::make_signed(std::get<int64_t>(value), alloc));
         } else if (std::holds_alternative<uint64_t>(value)) {
-            container.emplace_back(owned_object{std::get<uint64_t>(value)});
+            container.emplace_back(owned_object::make_unsigned(std::get<uint64_t>(value), alloc));
         } else if (std::holds_alternative<double>(value)) {
-            container.emplace_back(owned_object{std::get<double>(value)});
+            container.emplace_back(owned_object::make_float(std::get<double>(value), alloc));
         } else if (std::holds_alternative<const char *>(value)) {
-            container.emplace_back(owned_object{std::get<const char *>(value), alloc});
+            container.emplace_back(owned_object::make_string(std::get<const char *>(value), alloc));
         } else if (std::holds_alternative<std::string_view>(value)) {
-            container.emplace_back(owned_object{std::get<std::string_view>(value), alloc});
+            container.emplace_back(
+                owned_object::make_string(std::get<std::string_view>(value), alloc));
         } else if (std::holds_alternative<std::string>(value)) {
-            container.emplace_back(owned_object{std::get<std::string>(value), alloc});
+            container.emplace_back(owned_object::make_string(std::get<std::string>(value), alloc));
         } else {
             container.emplace_back(std::move(std::get<movable_object>(value).object));
         }
@@ -1355,33 +1388,34 @@ inline owned_object array(std::initializer_list<all_types> list = {},
     return container;
 }
 
-inline owned_object map(std::initializer_list<key_value> list = {},
-    nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource())
+inline owned_object map(
+    std::initializer_list<key_value> list, nonnull_ptr<memory::memory_resource> alloc)
 {
     auto container = owned_object::make_map(static_cast<uint16_t>(list.size()), alloc);
     for (const auto &[key, value] : list) {
         if (std::holds_alternative<bool>(value)) {
-            container.emplace(key, owned_object{std::get<bool>(value)});
+            container.emplace(key, owned_object::make_boolean(std::get<bool>(value), alloc));
         } else if (std::holds_alternative<int16_t>(value)) {
-            container.emplace(key, owned_object{std::get<int16_t>(value)});
+            container.emplace(key, owned_object::make_signed(std::get<int16_t>(value), alloc));
         } else if (std::holds_alternative<uint16_t>(value)) {
-            container.emplace(key, owned_object{std::get<uint16_t>(value)});
+            container.emplace(key, owned_object::make_unsigned(std::get<uint16_t>(value), alloc));
         } else if (std::holds_alternative<int32_t>(value)) {
-            container.emplace(key, owned_object{std::get<int32_t>(value)});
+            container.emplace(key, owned_object::make_signed(std::get<int32_t>(value), alloc));
         } else if (std::holds_alternative<uint32_t>(value)) {
-            container.emplace(key, owned_object{std::get<uint32_t>(value)});
+            container.emplace(key, owned_object::make_unsigned(std::get<uint32_t>(value), alloc));
         } else if (std::holds_alternative<int64_t>(value)) {
-            container.emplace(key, owned_object{std::get<int64_t>(value)});
+            container.emplace(key, owned_object::make_signed(std::get<int64_t>(value), alloc));
         } else if (std::holds_alternative<uint64_t>(value)) {
-            container.emplace(key, owned_object{std::get<uint64_t>(value)});
+            container.emplace(key, owned_object::make_unsigned(std::get<uint64_t>(value), alloc));
         } else if (std::holds_alternative<double>(value)) {
-            container.emplace(key, owned_object{std::get<double>(value)});
+            container.emplace(key, owned_object::make_float(std::get<double>(value), alloc));
         } else if (std::holds_alternative<const char *>(value)) {
-            container.emplace(key, owned_object{std::get<const char *>(value), alloc});
+            container.emplace(key, owned_object::make_string(std::get<const char *>(value), alloc));
         } else if (std::holds_alternative<std::string_view>(value)) {
-            container.emplace(key, owned_object{std::get<std::string_view>(value), alloc});
+            container.emplace(
+                key, owned_object::make_string(std::get<std::string_view>(value), alloc));
         } else if (std::holds_alternative<std::string>(value)) {
-            container.emplace(key, owned_object{std::get<std::string>(value), alloc});
+            container.emplace(key, owned_object::make_string(std::get<std::string>(value), alloc));
         } else {
             container.emplace(key, std::move(std::get<movable_object>(value).object));
         }

--- a/src/processor/extract_schema.cpp
+++ b/src/processor/extract_schema.cpp
@@ -342,7 +342,7 @@ owned_object extract_schema::eval_impl(const unary_argument<object_view> &input,
     ddwaf::timer &deadline) const
 {
     if (!input.value.has_value()) {
-        return owned_object{alloc};
+        return owned_object{};
     }
 
     return {schema::generate(input.value, scanners_, alloc, deadline)};

--- a/src/processor/extract_schema.cpp
+++ b/src/processor/extract_schema.cpp
@@ -342,7 +342,7 @@ owned_object extract_schema::eval_impl(const unary_argument<object_view> &input,
     ddwaf::timer &deadline) const
 {
     if (!input.value.has_value()) {
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 
     return {schema::generate(input.value, scanners_, alloc, deadline)};

--- a/src/processor/extract_schema.cpp
+++ b/src/processor/extract_schema.cpp
@@ -221,9 +221,10 @@ owned_object node_serialize::operator()(const node_array_ptr &node) const
     }
 
     if (node->truncated) {
-        array.emplace_back(object_builder::map({{"len", node->length}, {"truncated", true}}));
+        array.emplace_back(
+            object_builder::map({{"len", node->length}, {"truncated", true}}, alloc));
     } else {
-        array.emplace_back(object_builder::map({{"len", node->length}}));
+        array.emplace_back(object_builder::map({{"len", node->length}}, alloc));
     }
 
     return array;
@@ -241,7 +242,7 @@ owned_object node_serialize::operator()(const node_record_ptr &node) const
     }
 
     if (node->truncated) {
-        array.emplace_back(object_builder::map({{"truncated", true}}));
+        array.emplace_back(object_builder::map({{"truncated", true}}, alloc));
     }
 
     return array;
@@ -341,7 +342,7 @@ owned_object extract_schema::eval_impl(const unary_argument<object_view> &input,
     ddwaf::timer &deadline) const
 {
     if (!input.value.has_value()) {
-        return {};
+        return owned_object::make_uninit(alloc);
     }
 
     return {schema::generate(input.value, scanners_, alloc, deadline)};

--- a/src/processor/fingerprint.cpp
+++ b/src/processor/fingerprint.cpp
@@ -528,7 +528,7 @@ owned_object http_endpoint_fingerprint::eval_impl(const unary_argument<std::stri
             optional_generator<key_hash_field>{query}, optional_generator<key_hash_field>{body});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http endpoint fingerprint: {}", e.what());
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 }
 
@@ -569,7 +569,7 @@ owned_object http_header_fingerprint::eval_impl(const unary_argument<map_view> &
             vector_hash_field{std::move(unknown_headers)});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http header fingerprint: {}", e.what());
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 }
 
@@ -619,7 +619,7 @@ owned_object http_network_fingerprint::eval_impl(const unary_argument<map_view> 
             "net", alloc, unsigned_field{ip_count}, string_field{ip_origin_bitset});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http network fingerprint: {}", e.what());
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 }
 
@@ -641,7 +641,7 @@ owned_object session_fingerprint::eval_impl(const optional_argument<map_view> &c
             optional_generator<string_hash_field>{session_id});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate session fingerprint: {}", e.what());
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 }
 

--- a/src/processor/fingerprint.cpp
+++ b/src/processor/fingerprint.cpp
@@ -528,7 +528,7 @@ owned_object http_endpoint_fingerprint::eval_impl(const unary_argument<std::stri
             optional_generator<key_hash_field>{query}, optional_generator<key_hash_field>{body});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http endpoint fingerprint: {}", e.what());
-        return owned_object{alloc};
+        return owned_object{};
     }
 }
 
@@ -569,7 +569,7 @@ owned_object http_header_fingerprint::eval_impl(const unary_argument<map_view> &
             vector_hash_field{std::move(unknown_headers)});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http header fingerprint: {}", e.what());
-        return owned_object{alloc};
+        return owned_object{};
     }
 }
 
@@ -619,7 +619,7 @@ owned_object http_network_fingerprint::eval_impl(const unary_argument<map_view> 
             "net", alloc, unsigned_field{ip_count}, string_field{ip_origin_bitset});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http network fingerprint: {}", e.what());
-        return owned_object{alloc};
+        return owned_object{};
     }
 }
 
@@ -641,7 +641,7 @@ owned_object session_fingerprint::eval_impl(const optional_argument<map_view> &c
             optional_generator<string_hash_field>{session_id});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate session fingerprint: {}", e.what());
-        return owned_object{alloc};
+        return owned_object{};
     }
 }
 

--- a/src/processor/fingerprint.cpp
+++ b/src/processor/fingerprint.cpp
@@ -522,16 +522,14 @@ owned_object http_endpoint_fingerprint::eval_impl(const unary_argument<std::stri
         stripped_uri = stripped_uri.substr(0, query_or_frag_idx);
     }
 
-    owned_object res;
     try {
-        res = generate_fragment_cached("http", alloc, cache.fingerprint.fragment_fields,
+        return generate_fragment_cached("http", alloc, cache.fingerprint.fragment_fields,
             string_field{method.value}, string_hash_field{stripped_uri},
             optional_generator<key_hash_field>{query}, optional_generator<key_hash_field>{body});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http endpoint fingerprint: {}", e.what());
+        return owned_object::make_uninit(alloc);
     }
-
-    return res;
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -565,16 +563,14 @@ owned_object http_header_fingerprint::eval_impl(const unary_argument<map_view> &
     std::sort(unknown_headers.begin(), unknown_headers.end());
 
     const uint64_t unknown_header_size = unknown_headers.size();
-    owned_object res;
     try {
-        res = generate_fragment("hdr", alloc, string_field{known_header_bitset},
+        return generate_fragment("hdr", alloc, string_field{known_header_bitset},
             string_hash_field{user_agent}, unsigned_field{unknown_header_size},
             vector_hash_field{std::move(unknown_headers)});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http header fingerprint: {}", e.what());
+        return owned_object::make_uninit(alloc);
     }
-
-    return res;
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -618,15 +614,13 @@ owned_object http_network_fingerprint::eval_impl(const unary_argument<map_view> 
         for (auto c : chosen_header_value) { ip_count += static_cast<unsigned int>(c == ','); }
     }
 
-    owned_object res;
     try {
-        res = generate_fragment(
+        return generate_fragment(
             "net", alloc, unsigned_field{ip_count}, string_field{ip_origin_bitset});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate http network fingerprint: {}", e.what());
+        return owned_object::make_uninit(alloc);
     }
-
-    return res;
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -640,17 +634,15 @@ owned_object session_fingerprint::eval_impl(const optional_argument<map_view> &c
         throw ddwaf::timeout_exception();
     }
 
-    owned_object res;
     try {
-        res = generate_fragment_cached("ssn", alloc, cache.fingerprint.fragment_fields,
+        return generate_fragment_cached("ssn", alloc, cache.fingerprint.fragment_fields,
             optional_generator<string_hash_field>{user_id},
             optional_generator<kv_hash_fields>{cookies},
             optional_generator<string_hash_field>{session_id});
     } catch (const std::out_of_range &e) {
         DDWAF_WARN("Failed to generate session fingerprint: {}", e.what());
+        return owned_object::make_uninit(alloc);
     }
-
-    return res;
 }
 
 } // namespace ddwaf

--- a/src/processor/fingerprint.cpp
+++ b/src/processor/fingerprint.cpp
@@ -403,7 +403,7 @@ owned_object generate_fragment(
         buffer.append(field);
     }
 
-    return buffer.to_object();
+    return buffer.to_object(alloc);
 }
 
 template <typename T, typename... Rest>
@@ -464,7 +464,7 @@ owned_object generate_fragment_cached(std::string_view header,
         }
     }
 
-    return buffer.to_object();
+    return buffer.to_object(alloc);
 }
 
 enum class header_type : uint8_t { unknown, standard, ip_origin, user_agent, datadog };

--- a/src/processor/jwt_decode.cpp
+++ b/src/processor/jwt_decode.cpp
@@ -72,7 +72,7 @@ owned_object decode_and_parse(std::string_view source, nonnull_ptr<memory::memor
 {
     cow_string cstr{source};
     if (!transformer::base64url_decode::transform(cstr)) {
-        return {};
+        return owned_object::make_uninit(alloc);
     }
 
     return json_to_object(static_cast<std::string_view>(cstr), alloc);
@@ -112,13 +112,13 @@ owned_object jwt_decode::eval_impl(const unary_argument<object_view> &input,
 {
     std::string_view token = find_token(input.value, input.key_path);
     if (token.empty()) {
-        return {};
+        return owned_object::make_uninit(alloc);
     }
 
     static const std::string_view prefix = "Bearer";
     if (!token.starts_with(prefix)) {
         // Unlikely to be a JWT
-        return {};
+        return owned_object::make_uninit(alloc);
     }
 
     // Remove prefix and spaces
@@ -133,13 +133,15 @@ owned_object jwt_decode::eval_impl(const unary_argument<object_view> &input,
     auto [valid, jwt] = split_token(token);
     if (!valid) {
         // Not a valid JWT
-        return {};
+        return owned_object::make_uninit(alloc);
     }
 
     // Decode header and payload and generate output
-    auto output = object_builder::map({{"header", decode_and_parse(jwt.header, alloc)},
-        {"payload", decode_and_parse(jwt.payload, alloc)},
-        {"signature", object_builder::map({{"available", !jwt.signature.empty()}}, alloc)}});
+    auto output = object_builder::map(
+        {{"header", decode_and_parse(jwt.header, alloc)},
+            {"payload", decode_and_parse(jwt.payload, alloc)},
+            {"signature", object_builder::map({{"available", !jwt.signature.empty()}}, alloc)}},
+        alloc);
 
     return output;
 }

--- a/src/processor/jwt_decode.cpp
+++ b/src/processor/jwt_decode.cpp
@@ -72,7 +72,7 @@ owned_object decode_and_parse(std::string_view source, nonnull_ptr<memory::memor
 {
     cow_string cstr{source};
     if (!transformer::base64url_decode::transform(cstr)) {
-        return owned_object{alloc};
+        return owned_object{};
     }
 
     return json_to_object(static_cast<std::string_view>(cstr), alloc);
@@ -112,13 +112,13 @@ owned_object jwt_decode::eval_impl(const unary_argument<object_view> &input,
 {
     std::string_view token = find_token(input.value, input.key_path);
     if (token.empty()) {
-        return owned_object{alloc};
+        return owned_object{};
     }
 
     static const std::string_view prefix = "Bearer";
     if (!token.starts_with(prefix)) {
         // Unlikely to be a JWT
-        return owned_object{alloc};
+        return owned_object{};
     }
 
     // Remove prefix and spaces
@@ -133,7 +133,7 @@ owned_object jwt_decode::eval_impl(const unary_argument<object_view> &input,
     auto [valid, jwt] = split_token(token);
     if (!valid) {
         // Not a valid JWT
-        return owned_object{alloc};
+        return owned_object{};
     }
 
     // Decode header and payload and generate output

--- a/src/processor/jwt_decode.cpp
+++ b/src/processor/jwt_decode.cpp
@@ -72,7 +72,7 @@ owned_object decode_and_parse(std::string_view source, nonnull_ptr<memory::memor
 {
     cow_string cstr{source};
     if (!transformer::base64url_decode::transform(cstr)) {
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 
     return json_to_object(static_cast<std::string_view>(cstr), alloc);
@@ -112,13 +112,13 @@ owned_object jwt_decode::eval_impl(const unary_argument<object_view> &input,
 {
     std::string_view token = find_token(input.value, input.key_path);
     if (token.empty()) {
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 
     static const std::string_view prefix = "Bearer";
     if (!token.starts_with(prefix)) {
         // Unlikely to be a JWT
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 
     // Remove prefix and spaces
@@ -133,7 +133,7 @@ owned_object jwt_decode::eval_impl(const unary_argument<object_view> &input,
     auto [valid, jwt] = split_token(token);
     if (!valid) {
         // Not a valid JWT
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 
     // Decode header and payload and generate output

--- a/src/processor/uri_parse.cpp
+++ b/src/processor/uri_parse.cpp
@@ -47,7 +47,7 @@ owned_object split_query_parameters(
         }
 
         std::string_view key;
-        owned_object value = owned_object{alloc};
+        owned_object value = owned_object{};
 
         // Check if it's in the key=value format
         //  - key= is considered an empty string value
@@ -109,7 +109,7 @@ owned_object uri_parse_processor::eval_impl(const unary_argument<std::string_vie
 {
     auto decomposed = uri_parse(input.value);
     if (!decomposed.has_value()) {
-        return owned_object{alloc};
+        return owned_object{};
     }
 
     auto output = owned_object::make_map(7, alloc);

--- a/src/processor/uri_parse.cpp
+++ b/src/processor/uri_parse.cpp
@@ -47,7 +47,7 @@ owned_object split_query_parameters(
         }
 
         std::string_view key;
-        owned_object value = owned_object::make_uninit(alloc);
+        owned_object value = owned_object{alloc};
 
         // Check if it's in the key=value format
         //  - key= is considered an empty string value
@@ -109,7 +109,7 @@ owned_object uri_parse_processor::eval_impl(const unary_argument<std::string_vie
 {
     auto decomposed = uri_parse(input.value);
     if (!decomposed.has_value()) {
-        return owned_object::make_uninit(alloc);
+        return owned_object{alloc};
     }
 
     auto output = owned_object::make_map(7, alloc);

--- a/src/processor/uri_parse.cpp
+++ b/src/processor/uri_parse.cpp
@@ -47,7 +47,7 @@ owned_object split_query_parameters(
         }
 
         std::string_view key;
-        owned_object value;
+        owned_object value = owned_object::make_uninit(alloc);
 
         // Check if it's in the key=value format
         //  - key= is considered an empty string value
@@ -109,7 +109,7 @@ owned_object uri_parse_processor::eval_impl(const unary_argument<std::string_vie
 {
     auto decomposed = uri_parse(input.value);
     if (!decomposed.has_value()) {
-        return {};
+        return owned_object::make_uninit(alloc);
     }
 
     auto output = owned_object::make_map(7, alloc);

--- a/src/ruleset_info.cpp
+++ b/src/ruleset_info.cpp
@@ -22,7 +22,8 @@ void ruleset_info::section_info::add_failed(
                                auto &failed_array) {
         auto it = cache.find(error);
         if (it == cache.end()) {
-            auto array = diagnostics_array.emplace(error, owned_object::make_array());
+            auto array = diagnostics_array.emplace(
+                error, owned_object::make_array(0, diagnostics_array.alloc()));
             auto index = diagnostics_array.size() - 1;
 
             auto key = object_view{diagnostics_array}.at_key(index);

--- a/src/ruleset_info.cpp
+++ b/src/ruleset_info.cpp
@@ -23,7 +23,7 @@ void ruleset_info::section_info::add_failed(
         auto it = cache.find(error);
         if (it == cache.end()) {
             auto array = diagnostics_array.emplace(
-                error, owned_object::make_array(0, diagnostics_array.alloc()));
+                error, owned_object::make_array(diagnostics_array.alloc()));
             auto index = diagnostics_array.size() - 1;
 
             auto key = object_view{diagnostics_array}.at_key(index);

--- a/src/ruleset_info.hpp
+++ b/src/ruleset_info.hpp
@@ -28,11 +28,11 @@ public:
     class section_info {
     public:
         section_info()
-            : loaded_(owned_object::make_array(0, memory::get_default_resource())),
-              failed_(owned_object::make_array(0, memory::get_default_resource())),
-              skipped_(owned_object::make_array(0, memory::get_default_resource())),
-              errors_(owned_object::make_map(0, memory::get_default_resource())),
-              warnings_(owned_object::make_map(0, memory::get_default_resource()))
+            : loaded_(owned_object::make_array(memory::get_default_resource())),
+              failed_(owned_object::make_array(memory::get_default_resource())),
+              skipped_(owned_object::make_array(memory::get_default_resource())),
+              errors_(owned_object::make_map(memory::get_default_resource())),
+              warnings_(owned_object::make_map(memory::get_default_resource()))
         {}
 
         ~section_info() = default;
@@ -144,7 +144,7 @@ public:
     // This method effectively moves the contents
     owned_object to_object()
     {
-        auto output = owned_object::make_map(0, memory::get_default_resource());
+        auto output = owned_object::make_map(memory::get_default_resource());
         if (!error_.empty()) {
             output.emplace("error", error_);
             error_.clear();

--- a/src/ruleset_info.hpp
+++ b/src/ruleset_info.hpp
@@ -28,9 +28,11 @@ public:
     class section_info {
     public:
         section_info()
-            : loaded_(owned_object::make_array()), failed_(owned_object::make_array()),
-              skipped_(owned_object::make_array()), errors_(owned_object::make_map()),
-              warnings_(owned_object::make_map())
+            : loaded_(owned_object::make_array(0, memory::get_default_resource())),
+              failed_(owned_object::make_array(0, memory::get_default_resource())),
+              skipped_(owned_object::make_array(0, memory::get_default_resource())),
+              errors_(owned_object::make_map(0, memory::get_default_resource())),
+              warnings_(owned_object::make_map(0, memory::get_default_resource()))
         {}
 
         ~section_info() = default;
@@ -74,7 +76,7 @@ public:
         // This matcher effectively moves the contents
         owned_object to_object()
         {
-            auto output = owned_object::make_map();
+            auto output = owned_object::make_map(5, memory::get_default_resource());
             if (!error_.empty()) {
                 output.emplace("error", error_);
                 error_.clear();
@@ -142,7 +144,7 @@ public:
     // This method effectively moves the contents
     owned_object to_object()
     {
-        auto output = owned_object::make_map();
+        auto output = owned_object::make_map(0, memory::get_default_resource());
         if (!error_.empty()) {
             output.emplace("error", error_);
             error_.clear();

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -359,9 +359,9 @@ void result_serializer::serialize(const object_store &store, std::vector<rule_re
 
     // Using the interface functions would replace the key contained within the
     // object. This will not be an issue in v2.
-    output.duration = owned_object::make_unsigned(deadline.elapsed().count(), alloc_);
-    output.timeout = owned_object::make_boolean(deadline.expired_before(), alloc_);
-    output.keep = owned_object::make_boolean(final_keep, alloc_);
+    output.duration = owned_object::make_unsigned(deadline.elapsed().count());
+    output.timeout = owned_object::make_boolean(deadline.expired_before());
+    output.keep = owned_object::make_boolean(final_keep);
     output.attributes = collector.get_available_attributes_and_reset();
     serialize_actions(actions, output.actions);
 }
@@ -370,10 +370,10 @@ std::pair<owned_object, result_components> result_serializer::initialise_result_
 {
     auto object = object_builder::map({{"events", object_builder::array({}, alloc_)},
                                           {"actions", object_builder::map({}, alloc_)},
-                                          {"duration", owned_object::make_unsigned(0, alloc_)},
-                                          {"timeout", owned_object::make_boolean(false, alloc_)},
+                                          {"duration", owned_object::make_unsigned(0)},
+                                          {"timeout", owned_object::make_boolean(false)},
                                           {"attributes", object_builder::map({}, alloc_)},
-                                          {"keep", owned_object::make_boolean(false, alloc_)}},
+                                          {"keep", owned_object::make_boolean(false)}},
         alloc_);
 
     const result_components res{.events = object.at(0),

--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -307,14 +307,14 @@ void serialize_actions(const action_tracker &actions, borrowed_object action_map
 }
 
 void collect_attributes(const object_store &store, const std::vector<rule_attribute> &attributes,
-    attribute_collector &collector)
+    attribute_collector &collector, nonnull_ptr<memory::memory_resource> alloc)
 {
     for (const auto &attr : attributes) {
         if (std::holds_alternative<rule_attribute::input_target>(attr.value_or_target)) {
             auto input = std::get<rule_attribute::input_target>(attr.value_or_target);
             collector.collect(store, input.index, input.key_path, attr.key);
         } else if (std::holds_alternative<std::string>(attr.value_or_target)) {
-            collector.insert(attr.key, std::get<std::string>(attr.value_or_target));
+            collector.insert(attr.key, std::get<std::string>(attr.value_or_target), alloc);
         } else if (std::holds_alternative<uint64_t>(attr.value_or_target)) {
             collector.insert(attr.key, std::get<uint64_t>(attr.value_or_target));
         } else if (std::holds_alternative<int64_t>(attr.value_or_target)) {
@@ -354,7 +354,7 @@ void result_serializer::serialize(const object_store &store, std::vector<rule_re
                 result.actions, actions, output.events);
         }
 
-        collect_attributes(store, result.attributes.get(), collector);
+        collect_attributes(store, result.attributes.get(), collector, alloc_);
     }
 
     // Using the interface functions would replace the key contained within the

--- a/src/waf.hpp
+++ b/src/waf.hpp
@@ -25,8 +25,7 @@ public:
     waf &operator=(waf &&) = default;
     ~waf() = default;
 
-    context create_context(
-        nonnull_ptr<memory::memory_resource> alloc = memory::get_default_resource())
+    context create_context(nonnull_ptr<memory::memory_resource> alloc)
     {
         return context(ruleset_, alloc);
     }

--- a/tests/common/ddwaf_object_da.hpp
+++ b/tests/common/ddwaf_object_da.hpp
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog
+// (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+
+#pragma once
+
+#include "memory_resource.hpp"
+#include "object.hpp"
+#include "pointer.hpp"
+
+namespace ddwaf::test {
+
+class ddwaf_object_da {
+public:
+    static owned_object make_null() { return owned_object::make_null(); }
+
+    static owned_object make_boolean(bool value) { return owned_object::make_boolean(value); }
+
+    static owned_object make_signed(int64_t value) { return owned_object::make_signed(value); }
+
+    static owned_object make_unsigned(uint64_t value) { return owned_object::make_unsigned(value); }
+
+    static owned_object make_float(double value) { return owned_object::make_float(value); }
+
+    static owned_object make_string_literal(const char *str, std::uint32_t len)
+    {
+        return owned_object::make_string_literal(str, len);
+    }
+
+    static owned_object make_string_literal(std::string_view str)
+    {
+        return owned_object::make_string_literal(str.data(), str.size());
+    }
+
+    static owned_object unsafe_make_string_nocopy(
+        const char *str, std::uint32_t len, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        return owned_object::unsafe_make_string_nocopy(str, len, alloc);
+    }
+
+    static owned_object unsafe_make_string_nocopy(const char *str, std::uint32_t len)
+    {
+        return owned_object::unsafe_make_string_nocopy(str, len, memory::get_default_resource());
+    }
+
+    static owned_object make_string(
+        const char *str, std::uint32_t len, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        return owned_object::make_string(str, len, alloc);
+    }
+
+    static owned_object make_string(const char *str, std::uint32_t len)
+    {
+        return owned_object::make_string(str, len, memory::get_default_resource());
+    }
+
+    static owned_object make_string(
+        std::string_view str, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        return owned_object::make_string(str, alloc);
+    }
+
+    static owned_object make_string(std::string_view str)
+    {
+        return owned_object::make_string(str, memory::get_default_resource());
+    }
+
+    static owned_object make_array(uint16_t capacity, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        return owned_object::make_array(capacity, alloc);
+    }
+
+    static owned_object make_array(uint16_t capacity = 0)
+    {
+        return owned_object::make_array(capacity, memory::get_default_resource());
+    }
+
+    static owned_object make_map(uint16_t capacity, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        return owned_object::make_map(capacity, alloc);
+    }
+
+    static owned_object make_map(uint16_t capacity = 0)
+    {
+        return owned_object::make_map(capacity, memory::get_default_resource());
+    }
+};
+
+} // namespace ddwaf::test

--- a/tests/common/ddwaf_object_da.hpp
+++ b/tests/common/ddwaf_object_da.hpp
@@ -14,6 +14,10 @@ namespace ddwaf::test {
 
 class ddwaf_object_da {
 public:
+    static owned_object make_uninit()
+    {
+        return owned_object::make_uninit(memory::get_default_resource());
+    }
     static owned_object make_null() { return owned_object::make_null(); }
 
     static owned_object make_boolean(bool value) { return owned_object::make_boolean(value); }
@@ -87,5 +91,21 @@ public:
         return owned_object::make_map(capacity, memory::get_default_resource());
     }
 };
+
+// Test-only wrappers for object_builder that use default allocator
+namespace object_builder_da {
+using all_types = object_builder::all_types;
+using key_value = object_builder::key_value;
+
+inline owned_object array(std::initializer_list<all_types> list = {})
+{
+    return object_builder::array(list, memory::get_default_resource());
+}
+
+inline owned_object map(std::initializer_list<key_value> list = {})
+{
+    return object_builder::map(list, memory::get_default_resource());
+}
+} // namespace object_builder_da
 
 } // namespace ddwaf::test

--- a/tests/common/ddwaf_object_da.hpp
+++ b/tests/common/ddwaf_object_da.hpp
@@ -14,10 +14,7 @@ namespace ddwaf::test {
 
 class ddwaf_object_da {
 public:
-    static owned_object make_uninit()
-    {
-        return owned_object::make_uninit(memory::get_default_resource());
-    }
+    static owned_object make_uninit() { return owned_object{memory::get_default_resource()}; }
     static owned_object make_null() { return owned_object::make_null(); }
 
     static owned_object make_boolean(bool value) { return owned_object::make_boolean(value); }
@@ -38,15 +35,15 @@ public:
         return owned_object::make_string_literal(str.data(), str.size());
     }
 
-    static owned_object unsafe_make_string_nocopy(
+    static owned_object make_string_nocopy(
         const char *str, std::uint32_t len, nonnull_ptr<memory::memory_resource> alloc)
     {
-        return owned_object::unsafe_make_string_nocopy(str, len, alloc);
+        return owned_object::make_string_nocopy(str, len, alloc);
     }
 
-    static owned_object unsafe_make_string_nocopy(const char *str, std::uint32_t len)
+    static owned_object make_string_nocopy(const char *str, std::uint32_t len)
     {
-        return owned_object::unsafe_make_string_nocopy(str, len, memory::get_default_resource());
+        return owned_object::make_string_nocopy(str, len, memory::get_default_resource());
     }
 
     static owned_object make_string(

--- a/tests/common/ddwaf_object_da.hpp
+++ b/tests/common/ddwaf_object_da.hpp
@@ -14,7 +14,6 @@ namespace ddwaf::test {
 
 class ddwaf_object_da {
 public:
-    static owned_object make_uninit() { return owned_object{memory::get_default_resource()}; }
     static owned_object make_null() { return owned_object::make_null(); }
 
     static owned_object make_boolean(bool value) { return owned_object::make_boolean(value); }

--- a/tests/common/gtest_utils.hpp
+++ b/tests/common/gtest_utils.hpp
@@ -13,6 +13,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include "common/base_utils.hpp"
+#include "common/ddwaf_object_da.hpp"
 #include "common/json_utils.hpp"
 #include "common/yaml_utils.hpp"
 

--- a/tests/common/yaml_utils.cpp
+++ b/tests/common/yaml_utils.cpp
@@ -134,22 +134,22 @@ owned_object node_to_owned_object(const Node &node)
         const std::string &value = node.Scalar();
         if (node.Tag() == "?") {
             try {
-                return owned_object{node.as<uint64_t>()};
+                return test::ddwaf_object_da::make_unsigned(node.as<uint64_t>());
             } catch (...) {} // NOLINT(bugprone-empty-catch)
 
             try {
-                return owned_object{node.as<int64_t>()};
+                return test::ddwaf_object_da::make_signed(node.as<int64_t>());
             } catch (...) {} // NOLINT(bugprone-empty-catch)
 
             try {
-                return owned_object{node.as<double>()};
+                return test::ddwaf_object_da::make_float(node.as<double>());
             } catch (...) {} // NOLINT(bugprone-empty-catch)
 
             try {
                 if (!value.empty() && value[0] != 'Y' && value[0] != 'y' && value[0] != 'n' &&
                     value[0] != 'N') {
                     // Skip the yes / no variants of boolean
-                    return owned_object{node.as<bool>()};
+                    return test::ddwaf_object_da::make_boolean(node.as<bool>());
                 }
             } catch (...) {} // NOLINT(bugprone-empty-catch)
         }
@@ -159,7 +159,7 @@ owned_object node_to_owned_object(const Node &node)
     case NodeType::Null:
         return owned_object::make_null();
     case NodeType::Undefined:
-        return {};
+        return ddwaf::test::ddwaf_object_da::make_uninit();
     }
 
     throw parsing_error("Invalid YAML node type");

--- a/tests/common/yaml_utils.cpp
+++ b/tests/common/yaml_utils.cpp
@@ -159,7 +159,7 @@ owned_object node_to_owned_object(const Node &node)
     case NodeType::Null:
         return owned_object::make_null();
     case NodeType::Undefined:
-        return ddwaf::test::ddwaf_object_da::make_uninit();
+        return owned_object{};
     }
 
     throw parsing_error("Invalid YAML node type");

--- a/tests/common/yaml_utils.cpp
+++ b/tests/common/yaml_utils.cpp
@@ -5,6 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 
 #include "common/yaml_utils.hpp"
+#include "common/ddwaf_object_da.hpp"
 #include "ddwaf.h"
 #include "log.hpp"
 
@@ -116,14 +117,14 @@ owned_object node_to_owned_object(const Node &node)
 {
     switch (node.Type()) {
     case NodeType::Sequence: {
-        auto parent = owned_object::make_array();
+        auto parent = test::ddwaf_object_da::make_array();
         for (auto it = node.begin(); it != node.end(); ++it) {
             parent.emplace_back(node_to_owned_object(*it));
         }
         return parent;
     }
     case NodeType::Map: {
-        auto parent = owned_object::make_map();
+        auto parent = test::ddwaf_object_da::make_map();
         for (auto it = node.begin(); it != node.end(); ++it) {
             parent.emplace(it->first.as<std::string>(), node_to_owned_object(it->second));
         }
@@ -153,7 +154,7 @@ owned_object node_to_owned_object(const Node &node)
             } catch (...) {} // NOLINT(bugprone-empty-catch)
         }
 
-        return owned_object{value};
+        return test::ddwaf_object_da::make_string(value);
     }
     case NodeType::Null:
         return owned_object::make_null();

--- a/tests/unit/attribute_collector_test.cpp
+++ b/tests/unit/attribute_collector_test.cpp
@@ -6,6 +6,7 @@
 
 #include "attribute_collector.hpp"
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
@@ -15,7 +16,7 @@ namespace {
 TEST(TestAttributeCollector, InsertNoCopy)
 {
     std::string_view expected = "value";
-    owned_object input{expected};
+    owned_object input = test::ddwaf_object_da::make_string(expected);
 
     attribute_collector collector;
     EXPECT_TRUE(collector.insert("address", std::move(input)));
@@ -36,7 +37,7 @@ TEST(TestAttributeCollector, InsertNoCopy)
 TEST(TestAttributeCollector, InsertDuplicate)
 {
     std::string_view expected = "value";
-    owned_object input{expected};
+    owned_object input = test::ddwaf_object_da::make_string(expected);
 
     attribute_collector collector;
     EXPECT_TRUE(collector.insert("address", input.clone()));

--- a/tests/unit/attribute_collector_test.cpp
+++ b/tests/unit/attribute_collector_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
@@ -40,7 +41,7 @@ TEST(TestAttributeCollector, InsertDuplicate)
     owned_object input = test::ddwaf_object_da::make_string(expected);
 
     attribute_collector collector;
-    EXPECT_TRUE(collector.insert("address", input.clone()));
+    EXPECT_TRUE(collector.insert("address", input.clone(memory::get_default_resource())));
     EXPECT_FALSE(collector.insert("address", std::move(input)));
 
     object_store store;
@@ -59,7 +60,7 @@ TEST(TestAttributeCollector, InsertDuplicate)
 TEST(TestAttributeCollector, CollectAvailableScalar)
 {
     std::string_view expected = "value";
-    auto input = object_builder::map({{"input_address", expected}});
+    auto input = object_builder_da::map({{"input_address", expected}});
 
     object_store store;
     store.insert(std::move(input));
@@ -80,8 +81,8 @@ TEST(TestAttributeCollector, CollectAvailableScalar)
 TEST(TestAttributeCollector, CollectAvailableKeyPathScalar)
 {
     std::string_view expected = "value";
-    auto input = object_builder::map({{"input_address",
-        object_builder::map({{"first", object_builder::map({{"second", expected}})}})}});
+    auto input = object_builder_da::map({{"input_address",
+        object_builder_da::map({{"first", object_builder_da::map({{"second", expected}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -104,9 +105,9 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathScalar)
 TEST(TestAttributeCollector, CollectAvailableKeyPathSingleValueArray)
 {
     std::string_view expected = "value";
-    auto input = object_builder::map({{"input_address",
-        object_builder::map(
-            {{"first", object_builder::map({{"second", object_builder::array({expected})}})}})}});
+    auto input = object_builder_da::map({{"input_address",
+        object_builder_da::map({{"first",
+            object_builder_da::map({{"second", object_builder_da::array({expected})}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -129,10 +130,10 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathSingleValueArray)
 TEST(TestAttributeCollector, CollectAvailableKeyPathMultiValueArray)
 {
     std::string_view expected = "value0";
-    auto input = object_builder::map(
-        {{"input_address", object_builder::map({{"first",
-                               object_builder::map({{"second",
-                                   object_builder::array({expected, "value1", "value2"})}})}})}});
+    auto input = object_builder_da::map({{"input_address",
+        object_builder_da::map(
+            {{"first", object_builder_da::map({{"second",
+                           object_builder_da::array({expected, "value1", "value2"})}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -155,10 +156,10 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathMultiValueArray)
 TEST(TestAttributeCollector, CollectAvailableKeyPathWithinArrayPositiveIndex)
 {
     std::string_view expected = "value1";
-    auto input = object_builder::map(
-        {{"input_address", object_builder::map({{"first",
-                               object_builder::map({{"second",
-                                   object_builder::array({"value0", expected, "value2"})}})}})}});
+    auto input = object_builder_da::map({{"input_address",
+        object_builder_da::map(
+            {{"first", object_builder_da::map({{"second",
+                           object_builder_da::array({"value0", expected, "value2"})}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -181,10 +182,10 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathWithinArrayPositiveIndex)
 TEST(TestAttributeCollector, CollectAvailableKeyPathWithinArrayNegativeIndex)
 {
     std::string_view expected = "value1";
-    auto input = object_builder::map(
-        {{"input_address", object_builder::map({{"first",
-                               object_builder::map({{"second",
-                                   object_builder::array({"value0", expected, "value2"})}})}})}});
+    auto input = object_builder_da::map({{"input_address",
+        object_builder_da::map(
+            {{"first", object_builder_da::map({{"second",
+                           object_builder_da::array({"value0", expected, "value2"})}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -206,9 +207,9 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathWithinArrayNegativeIndex)
 
 TEST(TestAttributeCollector, CollectUnavailableKeyPath)
 {
-    auto input = object_builder::map({{"input_address",
-        object_builder::map({{"first",
-            object_builder::map({{"second", object_builder::map({{"third", "value"}})}})}})}});
+    auto input = object_builder_da::map({{"input_address",
+        object_builder_da::map({{"first", object_builder_da::map({{"second",
+                                              object_builder_da::map({{"third", "value"}})}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -227,8 +228,8 @@ TEST(TestAttributeCollector, CollectUnavailableKeyPath)
 TEST(TestAttributeCollector, CollectPendingKeyPathScalar)
 {
     std::string_view expected = "value";
-    auto input = object_builder::map({{"input_address",
-        object_builder::map({{"first", object_builder::map({{"second", expected}})}})}});
+    auto input = object_builder_da::map({{"input_address",
+        object_builder_da::map({{"first", object_builder_da::map({{"second", expected}})}})}});
     object_store store;
 
     attribute_collector collector;
@@ -253,9 +254,9 @@ TEST(TestAttributeCollector, CollectPendingKeyPathScalar)
 
 TEST(TestAttributeCollector, CollectAvailableKeyPathInvalidValue)
 {
-    auto input = object_builder::map(
-        {{"input_address", object_builder::map({{"first",
-                               object_builder::map({{"second", object_builder::map()}})}})}});
+    auto input = object_builder_da::map(
+        {{"input_address", object_builder_da::map({{"first",
+                               object_builder_da::map({{"second", object_builder_da::map()}})}})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -274,7 +275,7 @@ TEST(TestAttributeCollector, CollectAvailableKeyPathInvalidValue)
 TEST(TestAttributeCollector, CollectDuplicateScalar)
 {
     std::string_view expected = "value";
-    auto input = object_builder::map({{"input_address", expected}});
+    auto input = object_builder_da::map({{"input_address", expected}});
 
     object_store store;
     store.insert(std::move(input));
@@ -296,7 +297,7 @@ TEST(TestAttributeCollector, CollectDuplicateScalar)
 TEST(TestAttributeCollector, CollectAvailableScalarFromSingleValueArray)
 {
     std::string_view expected = "value";
-    auto input = object_builder::map({{"input_address", object_builder::array({expected})}});
+    auto input = object_builder_da::map({{"input_address", object_builder_da::array({expected})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -317,8 +318,8 @@ TEST(TestAttributeCollector, CollectAvailableScalarFromSingleValueArray)
 TEST(TestAttributeCollector, CollectAvailableScalarFromMultiValueArray)
 {
     std::string_view expected = "value0";
-    auto input = object_builder::map(
-        {{"input_address", object_builder::array({expected, "value1", "value2"})}});
+    auto input = object_builder_da::map(
+        {{"input_address", object_builder_da::array({expected, "value1", "value2"})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -338,8 +339,8 @@ TEST(TestAttributeCollector, CollectAvailableScalarFromMultiValueArray)
 
 TEST(TestAttributeCollector, CollectInvalidObjectFromArray)
 {
-    auto input =
-        object_builder::map({{"input_address", object_builder::array({object_builder::map()})}});
+    auto input = object_builder_da::map(
+        {{"input_address", object_builder_da::array({object_builder_da::map()})}});
 
     object_store store;
     store.insert(std::move(input));
@@ -371,7 +372,7 @@ TEST(TestAttributeCollector, CollectUnavailableScalar)
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
     std::string_view expected = "value";
-    auto input = object_builder::map({{"input_address", expected}});
+    auto input = object_builder_da::map({{"input_address", expected}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -406,7 +407,7 @@ TEST(TestAttributeCollector, CollectUnavailableScalarFromSingleValueArray)
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
     std::string_view expected = "value";
-    auto input = object_builder::map({{"input_address", object_builder::array({expected})}});
+    auto input = object_builder_da::map({{"input_address", object_builder_da::array({expected})}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -441,8 +442,8 @@ TEST(TestAttributeCollector, CollectUnavailableScalarFromMultiValueArray)
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
     std::string_view expected = "value0";
-    auto input = object_builder::map(
-        {{"input_address", object_builder::array({expected, "value1", "value2"})}});
+    auto input = object_builder_da::map(
+        {{"input_address", object_builder_da::array({expected, "value1", "value2"})}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -478,8 +479,8 @@ TEST(TestAttributeCollector, CollectUnavailableKeyPathFromWithinArrayPositiveInd
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
     std::string_view expected = "value0";
-    auto input = object_builder::map(
-        {{"input_address", object_builder::array({expected, "value1", "value2"})}});
+    auto input = object_builder_da::map(
+        {{"input_address", object_builder_da::array({expected, "value1", "value2"})}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -515,8 +516,8 @@ TEST(TestAttributeCollector, CollectUnavailableKeyPathFromWithinArrayNegativeInd
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
     std::string_view expected = "value0";
-    auto input = object_builder::map(
-        {{"input_address", object_builder::array({expected, "value1", "value2"})}});
+    auto input = object_builder_da::map(
+        {{"input_address", object_builder_da::array({expected, "value1", "value2"})}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -550,7 +551,7 @@ TEST(TestAttributeCollector, CollectUnavailableInvalidObject)
 
     // After adding the attribute, collect_pending should extract, copy and return
     // the expected attribute
-    auto input = object_builder::map({{"input_address", object_builder::array()}});
+    auto input = object_builder_da::map({{"input_address", object_builder_da::array()}});
 
     store.insert(std::move(input));
     collector.collect_pending(store);
@@ -597,7 +598,7 @@ TEST(TestAttributeCollector, CollectMultipleUnavailableScalars)
         // After adding the attribute, collect_pending should extract, copy and return
         // the expected attribute
         std::string_view expected = "value";
-        auto input = object_builder::map({{"input_address_0", expected}});
+        auto input = object_builder_da::map({{"input_address_0", expected}});
 
         store.insert(std::move(input));
 
@@ -620,7 +621,7 @@ TEST(TestAttributeCollector, CollectMultipleUnavailableScalars)
         // the expected attribute
 
         std::string_view expected = "value";
-        auto input = object_builder::map({{"input_address_2", expected}});
+        auto input = object_builder_da::map({{"input_address_2", expected}});
         store.insert(std::move(input));
 
         collector.collect_pending(store);
@@ -639,7 +640,7 @@ TEST(TestAttributeCollector, CollectMultipleUnavailableScalars)
         // the expected attribute
 
         std::string_view expected = "value";
-        auto input = object_builder::map({{"input_address_1", expected}});
+        auto input = object_builder_da::map({{"input_address_1", expected}});
 
         store.insert(std::move(input));
 

--- a/tests/unit/builder/action_mapper_builder_test.cpp
+++ b/tests/unit/builder/action_mapper_builder_test.cpp
@@ -12,6 +12,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/builder/rule_builder_test.cpp
+++ b/tests/unit/builder/rule_builder_test.cpp
@@ -11,6 +11,7 @@
 #include "matcher/ip_match.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/checksum/luhn_checksum_test.cpp
+++ b/tests/unit/checksum/luhn_checksum_test.cpp
@@ -9,6 +9,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace ddwaf::matcher;
 
 namespace {

--- a/tests/unit/condition/cmdi_detector_test.cpp
+++ b/tests/unit/condition/cmdi_detector_test.cpp
@@ -9,6 +9,7 @@
 #include "platform.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -37,8 +38,8 @@ TEST(TestCmdiDetector, InvalidType)
 {
     cmdi_detector cond{{gen_param_def("server.sys.exec.cmd", "server.request.query")}};
 
-    auto root = object_builder::map(
-        {{"server.sys.exec.cmd", object_builder::map()}, {"server.request.query", "whatever"}});
+    auto root = object_builder_da::map(
+        {{"server.sys.exec.cmd", object_builder_da::map()}, {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -52,8 +53,8 @@ TEST(TestCmdiDetector, EmptyResource)
 {
     cmdi_detector cond{{gen_param_def("server.sys.exec.cmd", "server.request.query")}};
 
-    auto root = object_builder::map(
-        {{"server.sys.exec.cmd", object_builder::array()}, {"server.request.query", "whatever"}});
+    auto root = object_builder_da::map({{"server.sys.exec.cmd", object_builder_da::array()},
+        {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -96,9 +97,9 @@ TEST(TestCmdiDetector, NoInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({{"server.request.query", param}});
+        auto root = object_builder_da::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
         for (const auto &arg : resource) { array.emplace_back(arg); }
 
@@ -133,9 +134,9 @@ TEST(TestCmdiDetector, NoExecutableInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({{"server.request.query", param}});
+        auto root = object_builder_da::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
         for (const auto &arg : resource) { array.emplace_back(arg); }
 
@@ -187,9 +188,9 @@ TEST(TestCmdiDetector, NoShellInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({{"server.request.query", param}});
+        auto root = object_builder_da::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
         for (const auto &arg : resource) { array.emplace_back(arg); }
 
@@ -220,9 +221,9 @@ TEST(TestCmdiDetector, ExecutableInjectionLinux)
     };
 
     for (const auto &[resource, param, expected] : samples) {
-        auto root = object_builder::map({{"server.request.query", param}});
+        auto root = object_builder_da::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -268,9 +269,9 @@ TEST(TestCmdiDetector, ExecutableInjectionWindows)
     };
 
     for (const auto &[resource, param, expected] : samples) {
-        auto root = object_builder::map({{"server.request.query", param}});
+        auto root = object_builder_da::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -311,9 +312,9 @@ TEST(TestCmdiDetector, ExecutableWithSpacesInjection)
     };
 
     for (const auto &[resource, param, expected] : samples) {
-        auto root = object_builder::map({{"server.request.query", param}});
+        auto root = object_builder_da::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -537,9 +538,9 @@ TEST(TestCmdiDetector, LinuxShellInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({{"server.request.query", param}});
+        auto root = object_builder_da::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -624,9 +625,9 @@ TEST(TestCmdiDetector, WindowsShellInjection)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({{"server.request.query", param}});
+        auto root = object_builder_da::map({{"server.request.query", param}});
 
-        auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
         std::string resource_str = generate_resource_string(resource);
         for (const auto &arg : resource) { array.emplace_back(arg); }
@@ -660,12 +661,12 @@ TEST(TestCmdiDetector, ExecutableInjectionMultipleArguments)
         {"halt", "bin"}, {"-h", "usr"}, {"executable", "/usr/bin/halt"}};
     std::string resource_str = generate_resource_string(resource);
 
-    auto root = object_builder::map();
-    auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+    auto root = object_builder_da::map();
+    auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
     for (const auto &arg : resource) { array.emplace_back(arg); }
 
-    auto map = root.emplace("server.request.query", object_builder::map());
+    auto map = root.emplace("server.request.query", object_builder_da::map());
     for (const auto &[key, value] : params) { map.emplace(key, value); }
 
     object_store store;
@@ -695,12 +696,12 @@ TEST(TestCmdiDetector, EmptyExecutable)
     std::unordered_map<std::string, std::string> params{
         {"halt", "bin"}, {"-h", "usr"}, {"executable", "/usr/bin/halt"}};
 
-    auto root = object_builder::map();
-    auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+    auto root = object_builder_da::map();
+    auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
     for (const auto &arg : resource) { array.emplace_back(arg); }
 
-    auto map = root.emplace("server.request.query", object_builder::map());
+    auto map = root.emplace("server.request.query", object_builder_da::map());
     for (const auto &[key, value] : params) { map.emplace(key, value); }
 
     object_store store;
@@ -721,12 +722,12 @@ TEST(TestCmdiDetector, ShellInjectionMultipleArguments)
 
     std::string resource_str = generate_resource_string(resource);
 
-    auto root = object_builder::map();
-    auto array = root.emplace("server.sys.exec.cmd", object_builder::array());
+    auto root = object_builder_da::map();
+    auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
 
     for (const auto &arg : resource) { array.emplace_back(arg); }
 
-    auto map = root.emplace("server.request.query", object_builder::map());
+    auto map = root.emplace("server.request.query", object_builder_da::map());
     for (const auto &[key, value] : params) { map.emplace(key, value); }
 
     object_store store;

--- a/tests/unit/condition/exists_condition_test.cpp
+++ b/tests/unit/condition/exists_condition_test.cpp
@@ -24,8 +24,7 @@ TEST(TestExistsCondition, AddressAvailable)
 {
     exists_condition cond{{gen_variadic_param("server.request.uri_raw")}};
 
-    auto root = object_builder_da::map(
-        {{"server.request.uri_raw", ddwaf::test::ddwaf_object_da::make_uninit()}});
+    auto root = object_builder_da::map({{"server.request.uri_raw", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));
@@ -44,8 +43,7 @@ TEST(TestExistsCondition, KeyPathAvailable)
     auto root = object_builder_da::map({{"server.request.uri_raw",
         object_builder_da::map(
             {{"path", object_builder_da::map(
-                          {{"to", object_builder_da::map({{"object",
-                                      ddwaf::test::ddwaf_object_da::make_uninit()}})}})}})}});
+                          {{"to", object_builder_da::map({{"object", owned_object{}}})}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -59,8 +57,7 @@ TEST(TestExistsCondition, AddressNotAvaialble)
 {
     exists_condition cond{{gen_variadic_param("server.request.uri_raw")}};
 
-    auto root = object_builder_da::map(
-        {{"server.request.query", ddwaf::test::ddwaf_object_da::make_uninit()}});
+    auto root = object_builder_da::map({{"server.request.query", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));
@@ -77,8 +74,7 @@ TEST(TestExistsCondition, KeyPathNotAvailable)
         .key_path = {"path", "to", "object"}}}}}};
 
     auto root = object_builder_da::map({{"server.request.uri_raw",
-        object_builder_da::map({{"path",
-            object_builder_da::map({{"to", ddwaf::test::ddwaf_object_da::make_uninit()}})}})}});
+        object_builder_da::map({{"path", object_builder_da::map({{"to", owned_object{}}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -128,8 +124,8 @@ TEST(TestExistsCondition, KeyPathIndexOnNonArray)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {0}}}}}};
 
-    auto root = object_builder_da::map({{"server.request.uri_raw",
-        object_builder_da::map({{"path", ddwaf::test::ddwaf_object_da::make_uninit()}})}});
+    auto root = object_builder_da::map(
+        {{"server.request.uri_raw", object_builder_da::map({{"path", owned_object{}}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -148,8 +144,7 @@ TEST(TestExistsCondition, KeyPathAvailableButExcluded)
     auto root = object_builder_da::map({{"server.request.uri_raw",
         object_builder_da::map(
             {{"path", object_builder_da::map(
-                          {{"to", object_builder_da::map({{"object",
-                                      ddwaf::test::ddwaf_object_da::make_uninit()}})}})}})}});
+                          {{"to", object_builder_da::map({{"object", owned_object{}}})}})}})}});
 
     std::unordered_set<object_cache_key> excluded = {root.at(0)};
     object_store store;
@@ -170,8 +165,7 @@ TEST(TestExistsCondition, MultipleAddresses)
         {gen_variadic_param("server.request.uri_raw", "server.request.body", "usr.id")}};
 
     auto validate_address = [&](const std::string &address, bool expected = true) {
-        auto root =
-            object_builder_da::map({{address, ddwaf::test::ddwaf_object_da::make_uninit()}});
+        auto root = object_builder_da::map({{address, owned_object{}}});
 
         object_store store;
         store.insert(std::move(root));
@@ -236,8 +230,7 @@ TEST(TestNegatedExistsCondition, KeyPathAvailable)
     auto root = object_builder_da::map({{"server.request.uri_raw",
         object_builder_da::map(
             {{"path", object_builder_da::map(
-                          {{"to", object_builder_da::map({{"object",
-                                      ddwaf::test::ddwaf_object_da::make_uninit()}})}})}})}});
+                          {{"to", object_builder_da::map({{"object", owned_object{}}})}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -322,8 +315,7 @@ TEST(TestNegatedExistsCondition, KeyPathNotAvailable)
         .key_path = {"path", "to", "object"}}}}}};
 
     auto root = object_builder_da::map({{"server.request.uri_raw",
-        object_builder_da::map({{"path",
-            object_builder_da::map({{"to", ddwaf::test::ddwaf_object_da::make_uninit()}})}})}});
+        object_builder_da::map({{"path", object_builder_da::map({{"to", owned_object{}}})}})}});
     object_store store;
     store.insert(std::move(root));
 
@@ -341,8 +333,7 @@ TEST(TestNegatedExistsCondition, KeyPathAvailableButExcluded)
     auto root = object_builder_da::map({{"server.request.uri_raw",
         object_builder_da::map(
             {{"path", object_builder_da::map(
-                          {{"to", object_builder_da::map({{"object",
-                                      ddwaf::test::ddwaf_object_da::make_uninit()}})}})}})}});
+                          {{"to", object_builder_da::map({{"object", owned_object{}}})}})}})}});
 
     std::unordered_set<object_cache_key> excluded = {root.at(0)};
 

--- a/tests/unit/condition/exists_condition_test.cpp
+++ b/tests/unit/condition/exists_condition_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -23,7 +24,8 @@ TEST(TestExistsCondition, AddressAvailable)
 {
     exists_condition cond{{gen_variadic_param("server.request.uri_raw")}};
 
-    auto root = object_builder::map({{"server.request.uri_raw", owned_object{}}});
+    auto root = object_builder_da::map(
+        {{"server.request.uri_raw", ddwaf::test::ddwaf_object_da::make_uninit()}});
 
     object_store store;
     store.insert(std::move(root));
@@ -39,9 +41,11 @@ TEST(TestExistsCondition, KeyPathAvailable)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path",
-            object_builder::map({{"to", object_builder::map({{"object", owned_object{}}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map(
+            {{"path", object_builder_da::map(
+                          {{"to", object_builder_da::map({{"object",
+                                      ddwaf::test::ddwaf_object_da::make_uninit()}})}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -55,7 +59,8 @@ TEST(TestExistsCondition, AddressNotAvaialble)
 {
     exists_condition cond{{gen_variadic_param("server.request.uri_raw")}};
 
-    auto root = object_builder::map({{"server.request.query", owned_object{}}});
+    auto root = object_builder_da::map(
+        {{"server.request.query", ddwaf::test::ddwaf_object_da::make_uninit()}});
 
     object_store store;
     store.insert(std::move(root));
@@ -71,8 +76,9 @@ TEST(TestExistsCondition, KeyPathNotAvailable)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path", object_builder::map({{"to", owned_object{}}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path",
+            object_builder_da::map({{"to", ddwaf::test::ddwaf_object_da::make_uninit()}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -88,8 +94,8 @@ TEST(TestExistsCondition, KeyPathPositiveIndexOnArray)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", 0}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path", object_builder::array({"item"})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path", object_builder_da::array({"item"})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -105,8 +111,8 @@ TEST(TestExistsCondition, KeyPathNegativeIndexOnArray)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", -1}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path", object_builder::array({"item"})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path", object_builder_da::array({"item"})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -122,8 +128,8 @@ TEST(TestExistsCondition, KeyPathIndexOnNonArray)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {0}}}}}};
 
-    auto root = object_builder::map(
-        {{"server.request.uri_raw", object_builder::map({{"path", owned_object{}}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path", ddwaf::test::ddwaf_object_da::make_uninit()}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -139,9 +145,11 @@ TEST(TestExistsCondition, KeyPathAvailableButExcluded)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path",
-            object_builder::map({{"to", object_builder::map({{"object", owned_object{}}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map(
+            {{"path", object_builder_da::map(
+                          {{"to", object_builder_da::map({{"object",
+                                      ddwaf::test::ddwaf_object_da::make_uninit()}})}})}})}});
 
     std::unordered_set<object_cache_key> excluded = {root.at(0)};
     object_store store;
@@ -162,7 +170,8 @@ TEST(TestExistsCondition, MultipleAddresses)
         {gen_variadic_param("server.request.uri_raw", "server.request.body", "usr.id")}};
 
     auto validate_address = [&](const std::string &address, bool expected = true) {
-        auto root = object_builder::map({{address, owned_object{}}});
+        auto root =
+            object_builder_da::map({{address, ddwaf::test::ddwaf_object_da::make_uninit()}});
 
         object_store store;
         store.insert(std::move(root));
@@ -191,11 +200,11 @@ TEST(TestExistsCondition, MultipleAddressesAndKeyPaths)
 
     auto validate_address = [&](const std::string &address, const std::vector<std::string> &kp,
                                 bool expected = true) {
-        auto root = object_builder::map();
-        auto map = root.emplace(address, object_builder::map());
+        auto root = object_builder_da::map();
+        auto map = root.emplace(address, object_builder_da::map());
         // NOLINTNEXTLINE(modernize-loop-convert)
         for (auto it = kp.begin(); it != kp.end(); ++it) {
-            map = map.emplace(*it, object_builder::map());
+            map = map.emplace(*it, object_builder_da::map());
         }
 
         object_store store;
@@ -224,9 +233,11 @@ TEST(TestNegatedExistsCondition, KeyPathAvailable)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path",
-            object_builder::map({{"to", object_builder::map({{"object", owned_object{}}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map(
+            {{"path", object_builder_da::map(
+                          {{"to", object_builder_da::map({{"object",
+                                      ddwaf::test::ddwaf_object_da::make_uninit()}})}})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -242,8 +253,8 @@ TEST(TestNegativeExistsCondition, KeyPathAvailablePositiveIndexOnArray)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", 0}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path", object_builder::array({"item"})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path", object_builder_da::array({"item"})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -259,8 +270,8 @@ TEST(TestNegativeExistsCondition, KeyPathAvailableNegativeIndexOnArray)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", -1}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path", object_builder::array({"item"})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path", object_builder_da::array({"item"})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -276,8 +287,8 @@ TEST(TestNegativeExistsCondition, KeyPathUnvailablePositiveIndexOnArray)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", 0}}}}}};
 
-    auto root = object_builder::map(
-        {{"server.request.uri_raw", object_builder::map({{"path", object_builder::array({})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path", object_builder_da::array({})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -293,8 +304,8 @@ TEST(TestNegativeExistsCondition, KeyPathUnvailableNegativeIndexOnArray)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", -1}}}}}};
 
-    auto root = object_builder::map(
-        {{"server.request.uri_raw", object_builder::map({{"path", object_builder::array({})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path", object_builder_da::array({})}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -310,8 +321,9 @@ TEST(TestNegatedExistsCondition, KeyPathNotAvailable)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path", object_builder::map({{"to", owned_object{}}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map({{"path",
+            object_builder_da::map({{"to", ddwaf::test::ddwaf_object_da::make_uninit()}})}})}});
     object_store store;
     store.insert(std::move(root));
 
@@ -326,9 +338,11 @@ TEST(TestNegatedExistsCondition, KeyPathAvailableButExcluded)
         .index = get_target_index("server.request.uri_raw"),
         .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri_raw",
-        object_builder::map({{"path",
-            object_builder::map({{"to", object_builder::map({{"object", owned_object{}}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri_raw",
+        object_builder_da::map(
+            {{"path", object_builder_da::map(
+                          {{"to", object_builder_da::map({{"object",
+                                      ddwaf::test::ddwaf_object_da::make_uninit()}})}})}})}});
 
     std::unordered_set<object_cache_key> excluded = {root.at(0)};
 

--- a/tests/unit/condition/lfi_detector_test.cpp
+++ b/tests/unit/condition/lfi_detector_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -35,7 +36,7 @@ TEST(TestLFIDetector, MatchBasicUnix)
 
     for (const auto &[path, input] : samples) {
         auto root =
-            object_builder::map({{"server.io.fs.file", path}, {"server.request.query", input}});
+            object_builder_da::map({{"server.io.fs.file", path}, {"server.request.query", input}});
 
         object_store store;
         store.insert(std::move(root));
@@ -97,7 +98,7 @@ TEST(TestLFIDetector, MatchBasicWindows)
 
     for (const auto &[path, input] : samples) {
         auto root =
-            object_builder::map({{"server.io.fs.file", path}, {"server.request.query", input}});
+            object_builder_da::map({{"server.io.fs.file", path}, {"server.request.query", input}});
 
         object_store store;
         store.insert(std::move(root));
@@ -153,13 +154,13 @@ TEST(TestLFIDetector, PartialSubcontextMatch)
     object_store ctx_store;
     {
         auto root =
-            object_builder::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"}});
+            object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"}});
         ctx_store.insert(std::move(root));
     }
 
     auto sctx_store = object_store::from_upstream_store(ctx_store);
     {
-        auto root = object_builder::map({{"server.request.query", "../../../etc/passwd"}});
+        auto root = object_builder_da::map({{"server.request.query", "../../../etc/passwd"}});
         sctx_store.insert(std::move(root));
     }
 
@@ -195,7 +196,7 @@ TEST(TestLFIDetector, NoMatchUnix)
 
     for (const auto &[path, input] : samples) {
         auto root =
-            object_builder::map({{"server.io.fs.file", path}, {"server.request.query", input}});
+            object_builder_da::map({{"server.io.fs.file", path}, {"server.request.query", input}});
 
         object_store store;
         store.insert(std::move(root));
@@ -232,7 +233,7 @@ TEST(TestLFIDetector, NoMatchWindows)
 
     for (const auto &[path, input] : samples) {
         auto root =
-            object_builder::map({{"server.io.fs.file", path}, {"server.request.query", input}});
+            object_builder_da::map({{"server.io.fs.file", path}, {"server.request.query", input}});
 
         object_store store;
         store.insert(std::move(root));
@@ -248,11 +249,11 @@ TEST(TestLFIDetector, NoMatchExcludedPath)
 {
     lfi_detector cond{{gen_param_def("server.io.fs.file", "server.request.query")}};
 
-    auto root = object_builder::map({
+    auto root = object_builder_da::map({
         {"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
     });
     auto params_map = root.emplace(
-        "server.request.query", object_builder::map({{"endpoint", "../../../etc/passwd"}}));
+        "server.request.query", object_builder_da::map({{"endpoint", "../../../etc/passwd"}}));
 
     std::unordered_set<object_cache_key> exclusion{params_map.at(0)};
 
@@ -269,8 +270,8 @@ TEST(TestLFIDetector, NoMatchExcludedAddress)
 {
     lfi_detector cond{{gen_param_def("server.io.fs.file", "server.request.query")}};
 
-    auto root = object_builder::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
-        {"server.request.query", object_builder::map({{"endpoint", "../../../etc/passwd"}})}});
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+        {"server.request.query", object_builder_da::map({{"endpoint", "../../../etc/passwd"}})}});
 
     std::unordered_set<object_cache_key> exclusion{root.at(1)};
 
@@ -287,8 +288,8 @@ TEST(TestLFIDetector, Timeout)
 {
     lfi_detector cond{{gen_param_def("server.io.fs.file", "server.request.query")}};
 
-    auto root = object_builder::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
-        {"server.request.query", object_builder::map({{"endpoint", "../../../etc/passwd"}})}});
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+        {"server.request.query", object_builder_da::map({{"endpoint", "../../../etc/passwd"}})}});
 
     std::unordered_set<object_cache_key> exclusion{root.at(1)};
 
@@ -305,7 +306,7 @@ TEST(TestLFIDetector, NoParams)
 {
     lfi_detector cond{{gen_param_def("server.io.fs.file", "server.request.query")}};
 
-    auto root = object_builder::map({
+    auto root = object_builder_da::map({
         {"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
     });
 

--- a/tests/unit/condition/match_iterator_test.cpp
+++ b/tests/unit/condition/match_iterator_test.cpp
@@ -15,7 +15,7 @@ namespace {
 
 TEST(TestMatchIterator, InvalidIterator)
 {
-    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object object = owned_object{};
 
     std::string resource = "this is the resource";
     object_set_ref exclude;

--- a/tests/unit/condition/match_iterator_test.cpp
+++ b/tests/unit/condition/match_iterator_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "condition/match_iterator.hpp"
 
@@ -28,7 +29,7 @@ TEST(TestMatchIterator, InvalidIterator)
 
 TEST(TestMatchIterator, NoMatch)
 {
-    owned_object object{"no match"};
+    owned_object object = test::ddwaf_object_da::make_string("no match");
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
@@ -43,7 +44,7 @@ TEST(TestMatchIterator, NoMatch)
 
 TEST(TestMatchIterator, SingleMatch)
 {
-    owned_object object{"resource"};
+    owned_object object = test::ddwaf_object_da::make_string("resource");
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
@@ -62,7 +63,7 @@ TEST(TestMatchIterator, SingleMatch)
 
 TEST(TestMatchIterator, MultipleMatches)
 {
-    owned_object object{"resource"};
+    owned_object object = test::ddwaf_object_da::make_string("resource");
 
     std::string resource = "resource resource resource resource";
     object_set_ref exclude;
@@ -85,7 +86,7 @@ TEST(TestMatchIterator, MultipleMatches)
 
 TEST(TestMatchIterator, OverlappingMatches)
 {
-    owned_object object{"ee"};
+    owned_object object = test::ddwaf_object_da::make_string("ee");
 
     std::string resource = "eeeeeeeeee";
     object_set_ref exclude;

--- a/tests/unit/condition/match_iterator_test.cpp
+++ b/tests/unit/condition/match_iterator_test.cpp
@@ -9,12 +9,13 @@
 #include "condition/match_iterator.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
 TEST(TestMatchIterator, InvalidIterator)
 {
-    owned_object object;
+    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
 
     std::string resource = "this is the resource";
     object_set_ref exclude;

--- a/tests/unit/condition/negated_scalar_condition_test.cpp
+++ b/tests/unit/condition/negated_scalar_condition_test.cpp
@@ -12,6 +12,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -49,7 +50,7 @@ TEST(TestNegatedScalarCondition, NoMatch)
     negated_scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", "hello"}});
 
     object_store store;
     store.insert(root);
@@ -66,10 +67,10 @@ TEST(TestNegatedScalarCondition, NoMatchWithKeyPath)
             .index = get_target_index("server.request.uri.raw"),
             .key_path = {"path", "to", "rome"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri.raw",
-        object_builder::map({{"path",
-            object_builder::map({{"to",
-                object_builder::map({{"object", object_builder::array({{"bye"}})}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri.raw",
+        object_builder_da::map({{"path",
+            object_builder_da::map({{"to",
+                object_builder_da::map({{"object", object_builder_da::array({{"bye"}})}})}})}})}});
 
     object_store store;
     store.insert(root);
@@ -84,7 +85,7 @@ TEST(TestNegatedScalarCondition, Timeout)
     negated_scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", "hello"}});
 
     object_store store;
     store.insert(root);
@@ -99,7 +100,7 @@ TEST(TestNegatedScalarCondition, SimpleMatch)
     negated_scalar_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map({{"server.request.uri.raw", "bye"}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", "bye"}});
 
     object_store store;
     store.insert(root);
@@ -121,9 +122,9 @@ TEST(TestNegatedScalarCondition, SimpleMatchWithKeyPath)
             .index = get_target_index("server.request.uri.raw"),
             .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri.raw",
-        object_builder::map(
-            {{"path", object_builder::map({{"to", object_builder::map({{"object", "bye"}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri.raw",
+        object_builder_da::map({{"path",
+            object_builder_da::map({{"to", object_builder_da::map({{"object", "bye"}})}})}})}});
 
     object_store store;
     store.insert(root);
@@ -144,7 +145,8 @@ TEST(TestNegatedScalarCondition, SingleValueArrayMatch)
     negated_scalar_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map({{"server.request.uri.raw", object_builder::array({"bye"})}});
+    auto root =
+        object_builder_da::map({{"server.request.uri.raw", object_builder_da::array({"bye"})}});
 
     object_store store;
     store.insert(root);
@@ -167,10 +169,10 @@ TEST(TestNegatedScalarCondition, SingleValueArrayMatchWithKeyPath)
             .index = get_target_index("server.request.uri.raw"),
             .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri.raw",
-        object_builder::map({{"path",
-            object_builder::map(
-                {{"to", object_builder::map({{"object", object_builder::array({"bye"})}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri.raw",
+        object_builder_da::map({{"path",
+            object_builder_da::map({{"to",
+                object_builder_da::map({{"object", object_builder_da::array({"bye"})}})}})}})}});
 
     object_store store;
     store.insert(root);
@@ -191,8 +193,8 @@ TEST(TestNegatedScalarCondition, MultiValueArrayMatch)
     negated_scalar_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map(
-        {{"server.request.uri.raw", object_builder::array({"bye", "greetings"})}});
+    auto root = object_builder_da::map(
+        {{"server.request.uri.raw", object_builder_da::array({"bye", "greetings"})}});
 
     object_store store;
     store.insert(root);
@@ -215,10 +217,11 @@ TEST(TestNegatedScalarCondition, MultiValueArrayMatchWithKeyPath)
             .index = get_target_index("server.request.uri.raw"),
             .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri.raw",
-        object_builder::map({{"path",
-            object_builder::map({{"to", object_builder::map({{"object",
-                                            object_builder::array({"bye", "greetings"})}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri.raw",
+        object_builder_da::map(
+            {{"path", object_builder_da::map(
+                          {{"to", object_builder_da::map({{"object",
+                                      object_builder_da::array({"bye", "greetings"})}})}})}})}});
 
     object_store store;
     store.insert(root);
@@ -242,10 +245,11 @@ TEST(TestNegatedScalarCondition, ExcludedRootObject)
             .index = target_index,
             .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri.raw",
-        object_builder::map({{"path",
-            object_builder::map({{"to", object_builder::map({{"object",
-                                            object_builder::array({"bye", "greetings"})}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri.raw",
+        object_builder_da::map(
+            {{"path", object_builder_da::map(
+                          {{"to", object_builder_da::map({{"object",
+                                      object_builder_da::array({"bye", "greetings"})}})}})}})}});
 
     object_store store;
     store.insert(root);
@@ -265,10 +269,11 @@ TEST(TestNegatedScalarCondition, ExcludedIntermediateObject)
             .index = get_target_index("server.request.uri.raw"),
             .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri.raw",
-        object_builder::map({{"path",
-            object_builder::map({{"to", object_builder::map({{"object",
-                                            object_builder::array({"bye", "greetings"})}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri.raw",
+        object_builder_da::map(
+            {{"path", object_builder_da::map(
+                          {{"to", object_builder_da::map({{"object",
+                                      object_builder_da::array({"bye", "greetings"})}})}})}})}});
 
     std::vector<std::variant<std::string, int64_t>> kp{"server.request.uri.raw", "path", "to"};
 
@@ -291,10 +296,10 @@ TEST(TestNegatedScalarCondition, ExcludedFinalObject)
             .index = target_index,
             .key_path = {"path", "to", "object"}}}}}};
 
-    auto root = object_builder::map({{"server.request.uri.raw",
-        object_builder::map({{"path",
-            object_builder::map(
-                {{"to", object_builder::map({{"object", object_builder::array({"bye"})}})}})}})}});
+    auto root = object_builder_da::map({{"server.request.uri.raw",
+        object_builder_da::map({{"path",
+            object_builder_da::map({{"to",
+                object_builder_da::map({{"object", object_builder_da::array({"bye"})}})}})}})}});
 
     std::vector<std::variant<std::string, int64_t>> kp{
         "server.request.uri.raw", "path", "to", "object"};
@@ -317,7 +322,7 @@ TEST(TestNegatedScalarCondition, CachedMatch)
     ddwaf::timer deadline{2s};
     condition_cache cache;
 
-    auto root = object_builder::map({{"server.request.uri.raw", "bye"}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", "bye"}});
 
     {
         object_store store;
@@ -342,8 +347,8 @@ TEST(TestNegatedScalarCondition, SimpleMatchOnKeys)
     negated_scalar_condition cond{
         std::make_unique<matcher::regex_match>("hello", 0, true), {}, {std::move(target)}};
 
-    auto root =
-        object_builder::map({{"server.request.uri.raw", object_builder::map({{"bye", "hello"}})}});
+    auto root = object_builder_da::map(
+        {{"server.request.uri.raw", object_builder_da::map({{"bye", "hello"}})}});
 
     object_store store;
     store.insert(root);
@@ -358,7 +363,7 @@ TEST(TestNegatedScalarCondition, SimplesubcontextMatch)
     negated_scalar_condition cond{std::make_unique<matcher::regex_match>("hello.*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map({{"server.request.uri.raw", "bye"}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", "bye"}});
 
     object_store ctx_store;
     {

--- a/tests/unit/condition/scalar_condition_test.cpp
+++ b/tests/unit/condition/scalar_condition_test.cpp
@@ -41,8 +41,7 @@ TEST(TestScalarCondition, NoMatch)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder_da::map(
-        {{"server.request.uri.raw", ddwaf::test::ddwaf_object_da::make_uninit()}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));
@@ -57,8 +56,7 @@ TEST(TestScalarCondition, Timeout)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder_da::map(
-        {{"server.request.uri.raw", ddwaf::test::ddwaf_object_da::make_uninit()}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", owned_object{}}});
 
     object_store store;
     store.insert(std::move(root));

--- a/tests/unit/condition/scalar_condition_test.cpp
+++ b/tests/unit/condition/scalar_condition_test.cpp
@@ -12,6 +12,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -40,7 +41,8 @@ TEST(TestScalarCondition, NoMatch)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map({{"server.request.uri.raw", owned_object{}}});
+    auto root = object_builder_da::map(
+        {{"server.request.uri.raw", ddwaf::test::ddwaf_object_da::make_uninit()}});
 
     object_store store;
     store.insert(std::move(root));
@@ -55,7 +57,8 @@ TEST(TestScalarCondition, Timeout)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map({{"server.request.uri.raw", owned_object{}}});
+    auto root = object_builder_da::map(
+        {{"server.request.uri.raw", ddwaf::test::ddwaf_object_da::make_uninit()}});
 
     object_store store;
     store.insert(std::move(root));
@@ -70,7 +73,7 @@ TEST(TestScalarCondition, SimpleMatch)
     scalar_condition cond{std::make_unique<matcher::regex_match>(".*", 0, true), {},
         {gen_variadic_param("server.request.uri.raw")}};
 
-    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", "hello"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -88,7 +91,7 @@ TEST(TestScalarCondition, CachedMatch)
     ddwaf::timer deadline{2s};
     condition_cache cache;
 
-    auto root = object_builder::map({{"server.request.uri.raw", "hello"}});
+    auto root = object_builder_da::map({{"server.request.uri.raw", "hello"}});
 
     {
         object_store store;
@@ -113,8 +116,8 @@ TEST(TestScalarCondition, SimpleMatchOnKeys)
     scalar_condition cond{
         std::make_unique<matcher::regex_match>(".*", 0, true), {}, {std::move(param)}};
 
-    auto root = object_builder::map(
-        {{"server.request.uri.raw", object_builder::map({{"hello", "hello"}})}});
+    auto root = object_builder_da::map(
+        {{"server.request.uri.raw", object_builder_da::map({{"hello", "hello"}})}});
 
     object_store store;
     store.insert(std::move(root));

--- a/tests/unit/condition/shi_detector_array_test.cpp
+++ b/tests/unit/condition/shi_detector_array_test.cpp
@@ -8,6 +8,7 @@
 #include "condition/shi_detector.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -21,8 +22,8 @@ TEST(TestShiDetectorArray, InvalidType)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
-    auto root = object_builder::map(
-        {{"server.sys.shell.cmd", object_builder::map()}, {"server.request.query", "whatever"}});
+    auto root = object_builder_da::map(
+        {{"server.sys.shell.cmd", object_builder_da::map()}, {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -36,8 +37,8 @@ TEST(TestShiDetectorArray, EmptyResource)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
-    auto root = object_builder::map(
-        {{"server.sys.shell.cmd", object_builder::array()}, {"server.request.query", "whatever"}});
+    auto root = object_builder_da::map({{"server.sys.shell.cmd", object_builder_da::array()},
+        {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -50,9 +51,9 @@ TEST(TestShiDetectorArray, EmptyResource)
 TEST(TestShiDetectorArray, InvalidTypeWithinArray)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
-    auto root = object_builder::map({{"server.request.query", "cat /etc/passwd"},
-        {"server.sys.shell.cmd", object_builder::array({"ls", "-l", ";", 22, object_builder::map(),
-                                     "cat /etc/passwd"})}});
+    auto root = object_builder_da::map({{"server.request.query", "cat /etc/passwd"},
+        {"server.sys.shell.cmd", object_builder_da::array({"ls", "-l", ";", 22,
+                                     object_builder_da::map(), "cat /etc/passwd"})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -105,9 +106,9 @@ TEST(TestShiDetectorArray, NoMatchAndFalsePositives)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder_da::array());
         for (const auto &arg : resource) { array.emplace_back(arg); }
 
         object_store store;
@@ -141,9 +142,9 @@ TEST(TestShiDetectorArray, ExecutablesAndRedirections)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder_da::array());
         std::string resource_str;
         for (const auto &arg : resource) {
             array.emplace_back(arg);
@@ -193,9 +194,9 @@ TEST(TestShiDetectorArray, OverlappingInjections)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder_da::array());
 
         std::string resource_str;
         for (const auto &arg : resource) {
@@ -232,9 +233,9 @@ TEST(TestShiDetectorArray, InjectionsWithinCommandSubstitution)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder_da::array());
 
         std::string resource_str;
         for (const auto &arg : resource) {
@@ -275,9 +276,9 @@ TEST(TestShiDetectorArray, InjectionsWithinProcessSubstitution)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder_da::array());
 
         std::string resource_str;
         for (const auto &arg : resource) {
@@ -324,9 +325,9 @@ TEST(TestShiDetectorArray, OffByOnePayloadsMatch)
         {{"l", "-l", "-a", ";", "l -l"}, "l -l"}};
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         root.emplace("server.request.query", param);
-        auto array = root.emplace("server.sys.shell.cmd", object_builder::array());
+        auto array = root.emplace("server.sys.shell.cmd", object_builder_da::array());
 
         std::string resource_str;
         for (const auto &arg : resource) {

--- a/tests/unit/condition/shi_detector_string_test.cpp
+++ b/tests/unit/condition/shi_detector_string_test.cpp
@@ -8,6 +8,7 @@
 #include "condition/shi_detector.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -21,8 +22,10 @@ TEST(TestShiDetectorString, InvalidType)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
-    auto root = object_builder::map(
-        {{"server.sys.shell.cmd", owned_object{}}, {"server.request.query", "whatever"}});
+    auto root = object_builder_da::map(
+        {{"server.sys.shell.cmd", owned_object::create_unchecked({.type = object_type::invalid},
+                                      memory::get_default_resource())},
+            {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -36,8 +39,8 @@ TEST(TestShiDetectorString, EmptyResource)
 {
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
-    auto root =
-        object_builder::map({{"server.sys.shell.cmd", ""}, {"server.request.query", "whatever"}});
+    auto root = object_builder_da::map(
+        {{"server.sys.shell.cmd", ""}, {"server.request.query", "whatever"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -74,7 +77,7 @@ TEST(TestShiDetectorString, NoMatchAndFalsePositives)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({
+        auto root = object_builder_da::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -104,7 +107,7 @@ TEST(TestShiDetectorString, ExecutablesAndRedirections)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({
+        auto root = object_builder_da::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -146,7 +149,7 @@ TEST(TestShiDetectorString, InjectionsWithinCommandSubstitution)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({
+        auto root = object_builder_da::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -181,7 +184,7 @@ TEST(TestShiDetectorString, InjectionsWithinProcessSubstitution)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({
+        auto root = object_builder_da::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -218,7 +221,7 @@ TEST(TestShiDetectorString, OffByOnePayloadsMatch)
     };
 
     for (const auto &[resource, param] : samples) {
-        auto root = object_builder::map({
+        auto root = object_builder_da::map({
             {"server.sys.shell.cmd", resource},
             {"server.request.query", param},
         });
@@ -278,7 +281,7 @@ TEST(TestShiDetectorString, MultipleArgumentsMatch)
     };
 
     for (const auto &resource : samples) {
-        auto root = object_builder::map({{"server.sys.shell.cmd", resource},
+        auto root = object_builder_da::map({{"server.sys.shell.cmd", resource},
             {"server.request.query", yaml_to_object<owned_object>(params)}});
 
         object_store store;

--- a/tests/unit/condition/shi_detector_string_test.cpp
+++ b/tests/unit/condition/shi_detector_string_test.cpp
@@ -23,8 +23,8 @@ TEST(TestShiDetectorString, InvalidType)
     shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
 
     auto root = object_builder_da::map(
-        {{"server.sys.shell.cmd", owned_object::create_unchecked({.type = object_type::invalid},
-                                      memory::get_default_resource())},
+        {{"server.sys.shell.cmd",
+             owned_object{{.type = object_type::invalid}, memory::get_default_resource()}},
             {"server.request.query", "whatever"}});
 
     object_store store;

--- a/tests/unit/condition/sqli_detector_internals_test.cpp
+++ b/tests/unit/condition/sqli_detector_internals_test.cpp
@@ -10,6 +10,7 @@
 #include "utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/condition/sqli_detector_test.cpp
+++ b/tests/unit/condition/sqli_detector_test.cpp
@@ -8,6 +8,7 @@
 #include "condition/sqli_detector.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -34,7 +35,7 @@ TEST_P(DialectTestFixture, InvalidSql)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -58,7 +59,7 @@ TEST_P(DialectTestFixture, InjectionWithoutTokens)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -94,7 +95,7 @@ TEST_P(DialectTestFixture, BenignInjections)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -143,7 +144,7 @@ TEST_P(DialectTestFixture, MaliciousInjections)
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -212,7 +213,7 @@ TEST_P(DialectTestFixture, Tautologies)
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -255,7 +256,7 @@ TEST_P(DialectTestFixture, Comments)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", dialect}, {"server.request.query", input}});
 
         object_store store;
@@ -295,7 +296,7 @@ TEST(TestSqliDetectorMySql, Comments)
     sqli_detector cond{
         {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", "mysql"}, {"server.request.query", input}});
 
         object_store store;
@@ -338,7 +339,7 @@ TEST(TestSqliDetectorMySql, Tautologies)
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", "mysql"}, {"server.request.query", input}});
 
         object_store store;
@@ -384,7 +385,7 @@ TEST(TestSqliDetectorPgSql, Tautologies)
     };
 
     for (const auto &[statement, obfuscated, input] : samples) {
-        auto root = object_builder::map({{"server.db.statement", statement},
+        auto root = object_builder_da::map({{"server.db.statement", statement},
             {"server.db.system", "pgsql"}, {"server.request.query", input}});
 
         object_store store;

--- a/tests/unit/condition/ssrf_detector_test.cpp
+++ b/tests/unit/condition/ssrf_detector_test.cpp
@@ -8,6 +8,7 @@
 #include "condition/ssrf_detector.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -48,7 +49,7 @@ void match_path_and_input(const std::vector<std::pair<std::string, ssrf_sample>>
     }
 
     for (const auto &[path, sample] : samples) {
-        auto root = object_builder::map({{"server.io.net.url", path},
+        auto root = object_builder_da::map({{"server.io.net.url", path},
             {"server.request.query", yaml_to_object<owned_object>(sample.yaml)}});
 
         object_store store;

--- a/tests/unit/configuration/action_parser_test.cpp
+++ b/tests/unit/configuration/action_parser_test.cpp
@@ -13,6 +13,7 @@
 #include "fmt/core.h"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/base_rule_parser_test.cpp
+++ b/tests/unit/configuration/base_rule_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/rule_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/configuration_manager_test.cpp
+++ b/tests/unit/configuration/configuration_manager_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/configuration_manager.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/exclusion_data_parser_test.cpp
+++ b/tests/unit/configuration/exclusion_data_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/data_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/input_filter_parser_test.cpp
+++ b/tests/unit/configuration/input_filter_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/exclusion_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/processor_override_parser_test.cpp
+++ b/tests/unit/configuration/processor_override_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/processor_override_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/processor_parser_test.cpp
+++ b/tests/unit/configuration/processor_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/processor_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/raw_configuration_test.cpp
+++ b/tests/unit/configuration/raw_configuration_test.cpp
@@ -11,20 +11,21 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
 TEST(TestParameter, ToBool)
 {
     {
-        owned_object root{true};
+        owned_object root = test::ddwaf_object_da::make_boolean(true);
 
         bool value = static_cast<bool>(raw_configuration(root));
         EXPECT_TRUE(value);
     }
 
     {
-        owned_object root{false};
+        owned_object root = test::ddwaf_object_da::make_boolean(false);
 
         bool value = static_cast<bool>(raw_configuration(root));
         EXPECT_FALSE(value);
@@ -67,28 +68,29 @@ TEST(TestParameter, ToBool)
 TEST(TestParameter, ToUint64)
 {
     {
-        owned_object root{2123};
+        owned_object root = test::ddwaf_object_da::make_signed(2123);
 
         uint64_t value = static_cast<uint64_t>(raw_configuration(root));
         EXPECT_EQ(value, 2123);
     }
 
     {
-        owned_object root{2123};
+        owned_object root = test::ddwaf_object_da::make_signed(2123);
 
         uint64_t value = static_cast<uint64_t>(raw_configuration(root));
         EXPECT_EQ(value, 2123);
     }
 
     {
-        owned_object root{21.0};
+        owned_object root = test::ddwaf_object_da::make_float(21.0);
 
         uint64_t value = static_cast<uint64_t>(raw_configuration(root));
         EXPECT_EQ(value, 21);
     }
 
     {
-        owned_object root{static_cast<double>(std::numeric_limits<uint64_t>::max() - 1024)};
+        owned_object root = test::ddwaf_object_da::make_float(
+            static_cast<double>(std::numeric_limits<uint64_t>::max() - 1024));
 
         uint64_t value = static_cast<uint64_t>(raw_configuration(root));
         EXPECT_EQ(value, 18446744073709549568U);
@@ -108,19 +110,19 @@ TEST(TestParameter, ToUint64)
     }
 
     {
-        owned_object root{-2123};
+        owned_object root = test::ddwaf_object_da::make_signed(-2123);
 
         EXPECT_THROW((void)static_cast<uint64_t>(raw_configuration(root)), bad_cast);
     }
 
     {
-        owned_object root{-21.0};
+        owned_object root = test::ddwaf_object_da::make_float(-21.0);
 
         EXPECT_THROW((void)static_cast<uint64_t>(raw_configuration(root)), bad_cast);
     }
 
     {
-        owned_object root{std::numeric_limits<double>::max()};
+        owned_object root = test::ddwaf_object_da::make_float(std::numeric_limits<double>::max());
 
         EXPECT_THROW((void)static_cast<uint64_t>(raw_configuration(root)), bad_cast);
     }
@@ -129,28 +131,29 @@ TEST(TestParameter, ToUint64)
 TEST(TestParameter, ToInt64)
 {
     {
-        owned_object root{-2123};
+        owned_object root = test::ddwaf_object_da::make_signed(-2123);
 
         int64_t value = static_cast<int64_t>(raw_configuration(root));
         EXPECT_EQ(value, -2123);
     }
 
     {
-        owned_object root{2123};
+        owned_object root = test::ddwaf_object_da::make_signed(2123);
 
         int64_t value = static_cast<int64_t>(raw_configuration(root));
         EXPECT_EQ(value, 2123);
     }
 
     {
-        owned_object root{-21.0};
+        owned_object root = test::ddwaf_object_da::make_float(-21.0);
 
         int64_t value = static_cast<int64_t>(raw_configuration(root));
         EXPECT_EQ(value, -21);
     }
 
     {
-        owned_object root{static_cast<double>(std::numeric_limits<int64_t>::max() - 512)};
+        owned_object root = test::ddwaf_object_da::make_float(
+            static_cast<double>(std::numeric_limits<int64_t>::max() - 512));
 
         int64_t value = static_cast<int64_t>(raw_configuration(root));
         EXPECT_EQ(value, 9223372036854774784);
@@ -170,13 +173,14 @@ TEST(TestParameter, ToInt64)
     }
 
     {
-        owned_object root{std::numeric_limits<uint64_t>::max()};
+        owned_object root =
+            test::ddwaf_object_da::make_unsigned(std::numeric_limits<uint64_t>::max());
 
         EXPECT_THROW((void)static_cast<int64_t>(raw_configuration(root)), bad_cast);
     }
 
     {
-        owned_object root{std::numeric_limits<double>::max()};
+        owned_object root = test::ddwaf_object_da::make_float(std::numeric_limits<double>::max());
 
         EXPECT_THROW((void)static_cast<int64_t>(raw_configuration(root)), bad_cast);
     }
@@ -185,7 +189,7 @@ TEST(TestParameter, ToInt64)
 TEST(TestParameter, ToFloat)
 {
     {
-        owned_object root{21.23};
+        owned_object root = test::ddwaf_object_da::make_float(21.23);
 
         double value = static_cast<double>(raw_configuration(root));
         EXPECT_EQ(value, 21.23);
@@ -333,7 +337,7 @@ TEST(TestParameter, ToStringViewVector)
 
     {
         auto root = test::ddwaf_object_da::make_array();
-        root.emplace_back(50);
+        root.emplace_back(test::ddwaf_object_da::make_signed(50));
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator std::vector<std::string_view>(), malformed_object);
@@ -362,7 +366,7 @@ TEST(TestParameter, ToStringViewSet)
 
     {
         auto root = test::ddwaf_object_da::make_array();
-        root.emplace_back(50);
+        root.emplace_back(test::ddwaf_object_da::make_signed(50));
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator raw_configuration::string_set(), malformed_object);
@@ -393,7 +397,7 @@ TEST(TestParameter, ToSemanticVersion)
     }
 
     {
-        owned_object root{3};
+        owned_object root = test::ddwaf_object_da::make_signed(3);
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator semantic_version(), bad_cast);

--- a/tests/unit/configuration/raw_configuration_test.cpp
+++ b/tests/unit/configuration/raw_configuration_test.cpp
@@ -404,7 +404,7 @@ TEST(TestParameter, ToSemanticVersion)
     }
 
     {
-        auto root = test::ddwaf_object_da::unsafe_make_string_nocopy(nullptr, 0);
+        auto root = test::ddwaf_object_da::make_string_nocopy(nullptr, 0);
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator semantic_version(), std::invalid_argument);

--- a/tests/unit/configuration/raw_configuration_test.cpp
+++ b/tests/unit/configuration/raw_configuration_test.cpp
@@ -7,6 +7,7 @@
 #include "configuration/common/parser_exception.hpp"
 #include "configuration/common/raw_configuration.hpp"
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
@@ -30,35 +31,35 @@ TEST(TestParameter, ToBool)
     }
 
     {
-        owned_object root{"true"};
+        owned_object root = test::ddwaf_object_da::make_string("true");
 
         bool value = static_cast<bool>(raw_configuration(root));
         EXPECT_TRUE(value);
     }
 
     {
-        owned_object root{"TrUe"};
+        owned_object root = test::ddwaf_object_da::make_string("TrUe");
 
         bool value = static_cast<bool>(raw_configuration(root));
         EXPECT_TRUE(value);
     }
 
     {
-        owned_object root{"false"};
+        owned_object root = test::ddwaf_object_da::make_string("false");
 
         bool value = static_cast<bool>(raw_configuration(root));
         EXPECT_FALSE(value);
     }
 
     {
-        owned_object root{"FaLsE"};
+        owned_object root = test::ddwaf_object_da::make_string("FaLsE");
 
         bool value = static_cast<bool>(raw_configuration(root));
         EXPECT_FALSE(value);
     }
 
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
         EXPECT_THROW((void)static_cast<bool>(raw_configuration(root)), bad_cast);
     }
 }
@@ -94,14 +95,14 @@ TEST(TestParameter, ToUint64)
     }
 
     {
-        owned_object root{"2123"};
+        owned_object root = test::ddwaf_object_da::make_string("2123");
 
         uint64_t value = static_cast<uint64_t>(raw_configuration(root));
         EXPECT_EQ(value, 2123);
     }
 
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
 
         EXPECT_THROW((void)static_cast<uint64_t>(raw_configuration(root)), bad_cast);
     }
@@ -156,14 +157,14 @@ TEST(TestParameter, ToInt64)
     }
 
     {
-        owned_object root{"-2123"};
+        owned_object root = test::ddwaf_object_da::make_string("-2123");
 
         int64_t value = static_cast<int64_t>(raw_configuration(root));
         EXPECT_EQ(value, -2123);
     }
 
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
 
         EXPECT_THROW((void)static_cast<int64_t>(raw_configuration(root)), bad_cast);
     }
@@ -191,14 +192,14 @@ TEST(TestParameter, ToFloat)
     }
 
     {
-        owned_object root{"21.23"};
+        owned_object root = test::ddwaf_object_da::make_string("21.23");
 
         double value = static_cast<double>(raw_configuration(root));
         EXPECT_EQ(value, 21.23);
     }
 
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
 
         EXPECT_THROW((void)static_cast<double>(raw_configuration(root)), bad_cast);
     }
@@ -207,14 +208,14 @@ TEST(TestParameter, ToFloat)
 TEST(TestParameter, ToString)
 {
     {
-        owned_object root{"hello world, this is a string"};
+        owned_object root = test::ddwaf_object_da::make_string("hello world, this is a string");
 
         auto value = static_cast<std::string>(raw_configuration(root));
         EXPECT_STREQ(value.c_str(), "hello world, this is a string");
     }
 
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
 
         EXPECT_THROW((void)static_cast<std::string>(raw_configuration(root)), bad_cast);
     }
@@ -223,14 +224,14 @@ TEST(TestParameter, ToString)
 TEST(TestParameter, ToStringView)
 {
     {
-        owned_object root{"hello world, this is a string"};
+        owned_object root = test::ddwaf_object_da::make_string("hello world, this is a string");
 
         auto value = static_cast<std::string_view>(raw_configuration(root));
         EXPECT_STRV(value, "hello world, this is a string");
     }
 
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
 
         EXPECT_THROW((void)static_cast<std::string_view>(raw_configuration(root)), bad_cast);
     }
@@ -239,7 +240,7 @@ TEST(TestParameter, ToStringView)
 TEST(TestParameter, ToVector)
 {
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
         for (unsigned i = 0; i < 20; i++) { root.emplace_back(std::to_string(i)); }
 
         auto vec_param = static_cast<raw_configuration::vector>(raw_configuration(root));
@@ -254,7 +255,7 @@ TEST(TestParameter, ToVector)
     }
 
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator raw_configuration::vector(), bad_cast);
@@ -264,7 +265,7 @@ TEST(TestParameter, ToVector)
 TEST(TestParameter, ToMap)
 {
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
 
         for (unsigned i = 0; i < 20; i++) {
             root.emplace(std::to_string(i), std::to_string(i + 100));
@@ -281,7 +282,7 @@ TEST(TestParameter, ToMap)
     }
 
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator raw_configuration::map(), bad_cast);
@@ -291,7 +292,7 @@ TEST(TestParameter, ToMap)
 TEST(TestParameter, ToStringVector)
 {
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
         for (unsigned i = 0; i < 20; i++) { root.emplace_back(std::to_string(i)); }
 
         auto vec_param = static_cast<std::vector<std::string>>(raw_configuration(root));
@@ -302,14 +303,14 @@ TEST(TestParameter, ToStringVector)
     }
 
     {
-        auto root = owned_object::make_array();
-        root.emplace_back(owned_object::make_map());
+        auto root = test::ddwaf_object_da::make_array();
+        root.emplace_back(test::ddwaf_object_da::make_map());
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator std::vector<std::string>(), bad_cast);
     }
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
         raw_configuration param{root};
         EXPECT_THROW(param.operator std::vector<std::string>(), bad_cast);
     }
@@ -318,7 +319,7 @@ TEST(TestParameter, ToStringVector)
 TEST(TestParameter, ToStringViewVector)
 {
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
         for (unsigned i = 0; i < 20; i++) { root.emplace_back(std::to_string(i)); }
 
         auto vec_param = static_cast<std::vector<std::string_view>>(raw_configuration(root));
@@ -331,14 +332,14 @@ TEST(TestParameter, ToStringViewVector)
     }
 
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
         root.emplace_back(50);
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator std::vector<std::string_view>(), malformed_object);
     }
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator std::vector<std::string_view>(), bad_cast);
@@ -348,7 +349,7 @@ TEST(TestParameter, ToStringViewVector)
 TEST(TestParameter, ToStringViewSet)
 {
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
         for (unsigned i = 0; i < 20; i++) { root.emplace_back(std::to_string(i)); }
 
         auto set_param = static_cast<raw_configuration::string_set>(raw_configuration(root));
@@ -360,14 +361,14 @@ TEST(TestParameter, ToStringViewSet)
     }
 
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
         root.emplace_back(50);
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator raw_configuration::string_set(), malformed_object);
     }
     {
-        auto root = owned_object::make_map();
+        auto root = test::ddwaf_object_da::make_map();
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator raw_configuration::string_set(), bad_cast);
@@ -376,7 +377,7 @@ TEST(TestParameter, ToStringViewSet)
 
 TEST(TestParameter, ToKeyPathVectorEmpty)
 {
-    auto root = owned_object::make_array();
+    auto root = test::ddwaf_object_da::make_array();
     auto vec =
         static_cast<std::vector<std::variant<std::string, int64_t>>>(raw_configuration(root));
     EXPECT_TRUE(vec.empty());
@@ -385,7 +386,7 @@ TEST(TestParameter, ToKeyPathVectorEmpty)
 TEST(TestParameter, ToSemanticVersion)
 {
     {
-        owned_object root{"1.2.3"};
+        owned_object root = test::ddwaf_object_da::make_string("1.2.3");
 
         auto value = static_cast<semantic_version>(raw_configuration(root));
         EXPECT_EQ(value.number(), 1002003);
@@ -399,7 +400,7 @@ TEST(TestParameter, ToSemanticVersion)
     }
 
     {
-        auto root = owned_object::make_string_nocopy(nullptr, 0);
+        auto root = test::ddwaf_object_da::unsafe_make_string_nocopy(nullptr, 0);
 
         raw_configuration param{root};
         EXPECT_THROW(param.operator semantic_version(), std::invalid_argument);

--- a/tests/unit/configuration/rule_data_parser_test.cpp
+++ b/tests/unit/configuration/rule_data_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/data_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/rule_filter_parser_test.cpp
+++ b/tests/unit/configuration/rule_filter_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/exclusion_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/rule_override_parser_test.cpp
+++ b/tests/unit/configuration/rule_override_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/rule_override_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/scanner_parser_test.cpp
+++ b/tests/unit/configuration/scanner_parser_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "configuration/common/common.hpp"
 #include "configuration/common/configuration.hpp"
@@ -54,11 +55,11 @@ TEST(TestScannerParser, ParseKeyOnlyScanner)
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr.get_tags(), tags);
 
-    owned_object value{"dog@datadoghq.com"};
+    owned_object value = test::ddwaf_object_da::make_string("dog@datadoghq.com");
     EXPECT_TRUE(scnr.eval("email", value));
     EXPECT_FALSE(scnr.eval("mail", value));
 
-    value = owned_object::make_string("ansodinsod");
+    value = test::ddwaf_object_da::make_string("ansodinsod");
     EXPECT_TRUE(scnr.eval("email", value));
 }
 
@@ -102,11 +103,11 @@ TEST(TestScannerParser, ParseValueOnlyScanner)
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr.get_tags(), tags);
 
-    owned_object value{"dog@datadoghq.com"};
+    owned_object value = test::ddwaf_object_da::make_string("dog@datadoghq.com");
     EXPECT_TRUE(scnr.eval("email", value));
     EXPECT_TRUE(scnr.eval("mail", value));
 
-    value = owned_object::make_string("ansodinsod");
+    value = test::ddwaf_object_da::make_string("ansodinsod");
     EXPECT_FALSE(scnr.eval("email", value));
 }
 
@@ -150,11 +151,11 @@ TEST(TestScannerParser, ParseKeyValueScanner)
     std::unordered_map<std::string, std::string> tags{{"type", "email"}, {"category", "pii"}};
     EXPECT_EQ(scnr.get_tags(), tags);
 
-    owned_object value{"dog@datadoghq.com"};
+    owned_object value = test::ddwaf_object_da::make_string("dog@datadoghq.com");
     EXPECT_TRUE(scnr.eval("email", value));
     EXPECT_FALSE(scnr.eval("mail", value));
 
-    value = owned_object::make_string("ansodinsod");
+    value = test::ddwaf_object_da::make_string("ansodinsod");
     EXPECT_FALSE(scnr.eval("email", value));
 }
 

--- a/tests/unit/configuration/scanner_parser_test.cpp
+++ b/tests/unit/configuration/scanner_parser_test.cpp
@@ -12,6 +12,7 @@
 #include "configuration/scanner_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/configuration/transformer_parser_test.cpp
+++ b/tests/unit/configuration/transformer_parser_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage,bugprone-unchecked-optional-access)
 #define EXPECT_OPTEQ(opt, expected)                                                                \

--- a/tests/unit/configuration/user_rule_parser_test.cpp
+++ b/tests/unit/configuration/user_rule_parser_test.cpp
@@ -11,6 +11,7 @@
 #include "configuration/rule_parser.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/context_allocator_test.cpp
+++ b/tests/unit/context_allocator_test.cpp
@@ -11,6 +11,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/cow_string_test.cpp
+++ b/tests/unit/cow_string_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/dynamic_string_test.cpp
+++ b/tests/unit/dynamic_string_test.cpp
@@ -13,6 +13,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/dynamic_string_test.cpp
+++ b/tests/unit/dynamic_string_test.cpp
@@ -141,7 +141,7 @@ TEST(TestDynamicString, MoveToObject)
     dynamic_string str{"thisisastring"sv};
     EXPECT_NE(str.data(), nullptr);
 
-    auto object = str.to_object();
+    auto object = str.to_object(str.alloc());
 
     auto str_view = object.as<std::string_view>();
 
@@ -163,7 +163,7 @@ TEST(TestDynamicString, MoveToObjectDifferentCapacity)
     EXPECT_EQ(str.capacity(), 32);
     EXPECT_EQ(str.size(), 13);
 
-    auto object = str.to_object();
+    auto object = str.to_object(str.alloc());
 
     auto str_view = object.as<std::string_view>();
 

--- a/tests/unit/evaluation_engine_test.cpp
+++ b/tests/unit/evaluation_engine_test.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -37,7 +38,7 @@ TEST(TestEvaluationEngine, MatchTimeout)
     ddwaf::timer deadline{0s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     ctx.insert(std::move(root));
 
@@ -61,7 +62,7 @@ TEST(TestEvaluationEngine, NoMatch)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.2"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.2"}});
 
     ctx.insert(std::move(root));
 
@@ -86,7 +87,7 @@ TEST(TestEvaluationEngine, Match)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     ctx.insert(std::move(root));
 
@@ -127,7 +128,7 @@ TEST(TestEvaluationEngine, MatchMultipleRulesInCollectionSingleRun)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
     ctx.insert(std::move(root));
 
@@ -191,7 +192,8 @@ TEST(TestEvaluationEngine, MatchMultipleRulesWithPrioritySingleRun)
     {
         context ctx{ruleset};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         ctx.insert(std::move(root));
 
@@ -211,7 +213,8 @@ TEST(TestEvaluationEngine, MatchMultipleRulesWithPrioritySingleRun)
     {
         context ctx{ruleset};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         ctx.insert(std::move(root));
 
@@ -264,7 +267,7 @@ TEST(TestEvaluationEngine, MatchMultipleRulesInCollectionDoubleRun)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -292,7 +295,7 @@ TEST(TestEvaluationEngine, MatchMultipleRulesInCollectionDoubleRun)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -336,7 +339,7 @@ TEST(TestEvaluationEngine, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -366,7 +369,7 @@ TEST(TestEvaluationEngine, MatchMultipleRulesWithPriorityDoubleRunPriorityLast)
     {
         // An existing match in a collection will not inhibit a match in a
         // priority collection.
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -431,7 +434,7 @@ TEST(TestEvaluationEngine, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -461,7 +464,7 @@ TEST(TestEvaluationEngine, MatchMultipleRulesWithPriorityDoubleRunPriorityFirst)
     {
         // An existing match in a collection will not inhibit a match in a
         // priority collection.
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -503,7 +506,7 @@ TEST(TestEvaluationEngine, MatchMultipleCollectionsSingleRun)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
     ctx.insert(std::move(root));
 
@@ -548,7 +551,7 @@ TEST(TestEvaluationEngine, MatchPriorityCollectionsSingleRun)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
     ctx.insert(std::move(root));
 
@@ -591,7 +594,7 @@ TEST(TestEvaluationEngine, MatchMultipleCollectionsDoubleRun)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -600,7 +603,7 @@ TEST(TestEvaluationEngine, MatchMultipleCollectionsDoubleRun)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -646,7 +649,7 @@ TEST(TestEvaluationEngine, MatchMultiplePriorityCollectionsDoubleRun)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -655,7 +658,7 @@ TEST(TestEvaluationEngine, MatchMultiplePriorityCollectionsDoubleRun)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -698,7 +701,7 @@ TEST(TestEvaluationEngine, RuleFilterWithCondition)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
     ctx.insert(std::move(root));
 
@@ -745,8 +748,8 @@ TEST(TestEvaluationEngine, RuleFilterWithSubcontextConditionMatch)
     context ctx{rbuilder.build()};
 
     {
-        auto persistent = object_builder::map({{"usr.id", "admin"}});
-        auto ephemeral = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto persistent = object_builder_da::map({{"usr.id", "admin"}});
+        auto ephemeral = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
 
@@ -759,7 +762,7 @@ TEST(TestEvaluationEngine, RuleFilterWithSubcontextConditionMatch)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
         timer deadline{std::chrono::microseconds(LONG_TIME)};
         auto [code, res] = ctx.eval(deadline);
@@ -814,8 +817,8 @@ TEST(TestEvaluationEngine, OverlappingRuleFiltersSubcontextBypassPersistentMonit
     context ctx{rbuilder.build()};
 
     {
-        auto persistent = object_builder::map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
-        auto ephemeral = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto persistent = object_builder_da::map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
+        auto ephemeral = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
 
@@ -828,7 +831,7 @@ TEST(TestEvaluationEngine, OverlappingRuleFiltersSubcontextBypassPersistentMonit
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
 
         timer deadline{std::chrono::microseconds(LONG_TIME)};
@@ -886,8 +889,8 @@ TEST(TestEvaluationEngine, OverlappingRuleFiltersSubcontextMonitorPersistentBypa
     context ctx{rbuilder.build()};
 
     {
-        auto persistent = object_builder::map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
-        auto ephemeral = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto persistent = object_builder_da::map({{"usr.id", "admin"}, {"http.route", "unrouted"}});
+        auto ephemeral = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
 
@@ -900,7 +903,7 @@ TEST(TestEvaluationEngine, OverlappingRuleFiltersSubcontextMonitorPersistentBypa
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
 
         timer deadline{std::chrono::microseconds(LONG_TIME)};
@@ -943,7 +946,7 @@ TEST(TestEvaluationEngine, RuleFilterTimeout)
     ddwaf::timer deadline{0s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.1"}});
 
     ctx.insert(std::move(root));
 
@@ -984,7 +987,7 @@ TEST(TestEvaluationEngine, NoRuleFilterWithCondition)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.2"}});
+    auto root = object_builder_da::map({{"usr.id", "admin"}, {"http.client_ip", "192.168.0.2"}});
 
     ctx.insert(std::move(root));
 
@@ -1217,7 +1220,7 @@ TEST(TestEvaluationEngine, MultipleRuleFiltersNonOverlappingRulesWithConditions)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1230,7 +1233,7 @@ TEST(TestEvaluationEngine, MultipleRuleFiltersNonOverlappingRulesWithConditions)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1294,7 +1297,7 @@ TEST(TestEvaluationEngine, MultipleRuleFiltersOverlappingRulesWithConditions)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1309,7 +1312,7 @@ TEST(TestEvaluationEngine, MultipleRuleFiltersOverlappingRulesWithConditions)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto rules_to_exclude = ctx.eval_filters(deadline);
@@ -1350,7 +1353,7 @@ TEST(TestEvaluationEngine, InputFilterExclude)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     ctx.insert(std::move(root));
 
@@ -1386,7 +1389,7 @@ TEST(TestEvaluationEngine, InputFilterExcludeSubcontext)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         auto sctx = ctx.create_subcontext();
 
@@ -1397,7 +1400,7 @@ TEST(TestEvaluationEngine, InputFilterExcludeSubcontext)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         auto sctx = ctx.create_subcontext();
 
@@ -1408,7 +1411,7 @@ TEST(TestEvaluationEngine, InputFilterExcludeSubcontext)
     }
 
     {
-        auto root = object_builder::map({{"http.peer_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.peer_ip", "192.168.0.1"}});
 
         auto sctx = ctx.create_subcontext();
 
@@ -1443,7 +1446,7 @@ TEST(TestEvaluationEngine, InputFilterExcludeRule)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     ctx.insert(std::move(root));
 
@@ -1486,7 +1489,7 @@ TEST(TestEvaluationEngine, InputFilterExcludeRuleSubcontext)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     auto sctx = ctx.create_subcontext();
 
@@ -1524,7 +1527,7 @@ TEST(TestEvaluationEngine, InputFilterMonitorRuleSubcontext)
     ddwaf::timer deadline{2s};
     context ctx{rbuilder.build()};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     auto sctx = ctx.create_subcontext();
 
@@ -1563,14 +1566,14 @@ TEST(TestEvaluationEngine, InputFilterExcluderRuleSubcontextAndPersistent)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
     }
 
     auto sctx = ctx.create_subcontext();
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         sctx.insert(std::move(root));
     }
 
@@ -1607,14 +1610,14 @@ TEST(TestEvaluationEngine, InputFilterMonitorRuleSubcontextAndPersistent)
     context ctx{rbuilder.build()};
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(std::move(root));
     }
 
     auto sctx = ctx.create_subcontext();
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         sctx.insert(std::move(root));
     }
 
@@ -1663,7 +1666,7 @@ TEST(TestEvaluationEngine, InputFilterWithCondition)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         ctx.insert(std::move(root));
 
@@ -1679,7 +1682,8 @@ TEST(TestEvaluationEngine, InputFilterWithCondition)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
 
         ctx.insert(std::move(root));
 
@@ -1695,7 +1699,8 @@ TEST(TestEvaluationEngine, InputFilterWithCondition)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         ctx.insert(std::move(root));
 
@@ -1743,8 +1748,8 @@ TEST(TestEvaluationEngine, InputFilterWithSubcontextCondition)
     context ctx{rbuilder.build()};
 
     {
-        auto persistent = object_builder::map({{"http.client_ip", "192.168.0.1"}});
-        auto ephemeral = object_builder::map({{"usr.id", "admin"}});
+        auto persistent = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
+        auto ephemeral = object_builder_da::map({{"usr.id", "admin"}});
 
         EXPECT_TRUE(ctx.insert(std::move(persistent)));
 
@@ -1757,7 +1762,7 @@ TEST(TestEvaluationEngine, InputFilterWithSubcontextCondition)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         EXPECT_TRUE(ctx.insert(std::move(root)));
         timer deadline{std::chrono::microseconds(LONG_TIME)};
         auto [code, res] = ctx.eval(deadline);
@@ -1811,7 +1816,7 @@ TEST(TestEvaluationEngine, InputFilterMultipleRules)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1830,7 +1835,8 @@ TEST(TestEvaluationEngine, InputFilterMultipleRules)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1849,7 +1855,8 @@ TEST(TestEvaluationEngine, InputFilterMultipleRules)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1917,7 +1924,7 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFilters)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1937,7 +1944,8 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFilters)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admino"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -1957,7 +1965,8 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFilters)
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(std::move(root));
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2056,7 +2065,7 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFiltersMultipleObject
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         ctx.insert(object_view{root});
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2076,7 +2085,7 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFiltersMultipleObject
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
         ctx.insert(object_view{root});
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2096,8 +2105,8 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFiltersMultipleObject
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map(
-            {{"server.request.headers", object_builder::map({{"cookie", "mycookie"}})}});
+        auto root = object_builder_da::map(
+            {{"server.request.headers", object_builder_da::map({{"cookie", "mycookie"}})}});
         ctx.insert(object_view{root});
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2117,7 +2126,8 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFiltersMultipleObject
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
         ctx.insert(object_view{root});
 
         auto objects_to_exclude = ctx.eval_filters(deadline);
@@ -2137,8 +2147,8 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFiltersMultipleObject
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map(
-            {{"server.request.headers", object_builder::map({{"cookie", "mycookie"}})},
+        auto root = object_builder_da::map(
+            {{"server.request.headers", object_builder_da::map({{"cookie", "mycookie"}})},
                 {"usr.id", "admin"}});
         ctx.insert(object_view{root});
 
@@ -2159,8 +2169,8 @@ TEST(TestEvaluationEngine, InputFilterMultipleRulesMultipleFiltersMultipleObject
         ddwaf::timer deadline{2s};
         context ctx{rbuilder.build()};
 
-        auto root = object_builder::map(
-            {{"server.request.headers", object_builder::map({{"cookie", "mycookie"}})},
+        auto root = object_builder_da::map(
+            {{"server.request.headers", object_builder_da::map({{"cookie", "mycookie"}})},
                 {"usr.id", "admin"}, {"http.client_ip", "192.168.0.1"}});
         ctx.insert(object_view{root});
 

--- a/tests/unit/exclusion/common_test.cpp
+++ b/tests/unit/exclusion/common_test.cpp
@@ -9,6 +9,7 @@
 #include "object_store.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -21,7 +22,7 @@ TEST(ExclusionObjectSet, Empty)
 
 TEST(ExclusionObjectSet, NonEmpty)
 {
-    auto root = object_builder::map({{"value", "node"}});
+    auto root = object_builder_da::map({{"value", "node"}});
 
     object_set excluded{root.at(0)};
     EXPECT_FALSE(excluded.empty());
@@ -45,7 +46,7 @@ TEST(ExclusionObjectSetRef, Empty)
 
 TEST(ExclusionObjectSetRef, NonEmpty)
 {
-    auto root = object_builder::map({{"value", "node"}});
+    auto root = object_builder_da::map({{"value", "node"}});
 
     std::unordered_set<object_cache_key> persistent{root.at(0)};
     object_set_ref excluded{persistent};

--- a/tests/unit/exclusion/input_filter_test.cpp
+++ b/tests/unit/exclusion/input_filter_test.cpp
@@ -11,13 +11,14 @@
 #include "matcher/ip_match.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 TEST(TestInputFilter, InputExclusionNoConditions)
 {
     object_store store;
 
-    auto root = object_builder::map({{"query", "value"}});
+    auto root = object_builder_da::map({{"query", "value"}});
     store.insert(root);
 
     auto obj_filter = std::make_shared<object_filter>();
@@ -40,8 +41,8 @@ TEST(TestInputFilter, ObjectExclusionNoConditions)
 {
     object_store store;
 
-    auto root = object_builder::map();
-    auto child = root.emplace("query", object_builder::map());
+    auto root = object_builder_da::map();
+    auto child = root.emplace("query", object_builder_da::map());
     child.emplace("params", "param");
 
     store.insert(root);
@@ -70,7 +71,7 @@ TEST(TestInputFilter, PersistentInputExclusionWithPersistentCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
     object_store store;
     store.insert(root);
 
@@ -97,7 +98,7 @@ TEST(TestInputFilter, InputExclusionWithConditionAndTransformers)
     builder.add_target("usr.id", {}, {transformer_id::lowercase});
     builder.end_condition<matcher::exact_match>(std::vector<std::string>{"admin"});
 
-    auto root = object_builder::map({{"usr.id", "ADMIN"}});
+    auto root = object_builder_da::map({{"usr.id", "ADMIN"}});
 
     object_store store;
     store.insert(root);
@@ -125,7 +126,7 @@ TEST(TestInputFilter, InputExclusionFailedCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.2"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.2"}});
 
     object_store store;
     store.insert(root);
@@ -150,11 +151,11 @@ TEST(TestInputFilter, ObjectExclusionWithCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = object_builder::map({
+    auto root = object_builder_da::map({
         {"http.client_ip", "192.168.0.1"},
     });
 
-    auto child = root.emplace("query", object_builder::map({{"params", "value"}}));
+    auto child = root.emplace("query", object_builder_da::map({{"params", "value"}}));
 
     object_store store;
     store.insert(root);
@@ -183,8 +184,8 @@ TEST(TestInputFilter, ObjectExclusionFailedCondition)
     builder.add_target("http.client_ip");
     builder.end_condition<matcher::ip_match>(std::vector<std::string_view>{"192.168.0.1"});
 
-    auto root = object_builder::map(
-        {{"http.client_ip", "192.168.0.2"}, {"query", object_builder::map({{"params", "value"}})}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.2"},
+        {"query", object_builder_da::map({{"params", "value"}})}});
 
     object_store store;
     store.insert(root);
@@ -225,7 +226,7 @@ TEST(TestInputFilter, InputValidateCachedMatch)
     // matched on the second run.
     input_filter::cache_type cache;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         object_store store;
         store.insert(root);
@@ -235,7 +236,7 @@ TEST(TestInputFilter, InputValidateCachedMatch)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         object_store store;
         store.insert(root);
@@ -266,11 +267,11 @@ TEST(TestInputFilter, InputValidateCachedSubcontextMatch)
     // only the latest address. This ensures that the IP condition can't be
     // matched on the second run.
     std::vector<owned_object> objects;
-    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"}}));
-    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
-    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
-    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"}}));
-    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder_da::map({{"http.client_ip", "192.168.0.1"}}));
+    objects.emplace_back(object_builder_da::map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder_da::map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder_da::map({{"http.client_ip", "192.168.0.1"}}));
+    objects.emplace_back(object_builder_da::map({{"usr.id", "admin"}}));
 
     input_filter::cache_type ctx_cache;
     object_store ctx_store;
@@ -344,7 +345,7 @@ TEST(TestInputFilter, InputMatchWithoutCache)
     // In this test we validate that when the cache is empty and only one
     // address is passed, the filter doesn't match (as it should be).
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         object_store store;
         store.insert(root);
@@ -355,7 +356,7 @@ TEST(TestInputFilter, InputMatchWithoutCache)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         object_store store;
         store.insert(root);
@@ -390,8 +391,8 @@ TEST(TestInputFilter, InputNoMatchWithoutCache)
     object_store store;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"}}));
-    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder_da::map({{"http.client_ip", "192.168.0.1"}}));
+    objects.emplace_back(object_builder_da::map({{"usr.id", "admin"}}));
 
     {
         store.insert(objects[0]);
@@ -442,8 +443,8 @@ TEST(TestInputFilter, InputCachedMatchSecondRun)
 
     std::vector<owned_object> objects;
     objects.emplace_back(
-        object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}}));
-    objects.emplace_back(object_builder::map({{"random", "random"}}));
+        object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}}));
+    objects.emplace_back(object_builder_da::map({{"random", "random"}}));
 
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
@@ -490,10 +491,10 @@ TEST(TestInputFilter, ObjectValidateCachedMatch)
     input_filter::cache_type cache;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
-        {"query", object_builder::map({{"params", "value"}})}}));
-    objects.emplace_back(object_builder::map(
-        {{"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder_da::map({{"http.client_ip", "192.168.0.1"},
+        {"query", object_builder_da::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder_da::map(
+        {{"usr.id", "admin"}, {"query", object_builder_da::map({{"params", "value"}})}}));
 
     {
         object_store store;
@@ -536,8 +537,8 @@ TEST(TestInputFilter, ObjectMatchWithoutCache)
     // In this test we validate that when the cache is empty and only one
     // address is passed, the filter doesn't match (as it should be).
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"},
-            {"query", object_builder::map({{"params", "value"}})}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"},
+            {"query", object_builder_da::map({{"params", "value"}})}});
         object_store store;
         store.insert(root);
 
@@ -548,8 +549,8 @@ TEST(TestInputFilter, ObjectMatchWithoutCache)
 
     {
 
-        auto root = object_builder::map(
-            {{"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}});
+        auto root = object_builder_da::map(
+            {{"usr.id", "admin"}, {"query", object_builder_da::map({{"params", "value"}})}});
         object_store store;
         store.insert(root);
 
@@ -583,9 +584,9 @@ TEST(TestInputFilter, ObjectNoMatchWithoutCache)
     object_store store;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
-        {"query", object_builder::map({{"params", "value"}})}}));
-    objects.emplace_back(object_builder::map({{"usr.id", "admin"}}));
+    objects.emplace_back(object_builder_da::map({{"http.client_ip", "192.168.0.1"},
+        {"query", object_builder_da::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder_da::map({{"usr.id", "admin"}}));
 
     {
         store.insert(objects[0]);
@@ -632,9 +633,9 @@ TEST(TestInputFilter, ObjectCachedMatchSecondRun)
     input_filter::cache_type cache;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
-        {"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}}));
-    objects.emplace_back(object_builder::map({{"random", "random"}}));
+    objects.emplace_back(object_builder_da::map({{"http.client_ip", "192.168.0.1"},
+        {"usr.id", "admin"}, {"query", object_builder_da::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder_da::map({{"random", "random"}}));
 
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
@@ -675,10 +676,10 @@ TEST(TestInputFilter, MatchWithDynamicMatcher)
     input_filter filter("filter", builder.build(), {rule.get()}, std::move(obj_filter));
 
     std::vector<owned_object> objects;
-    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
-        {"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}}));
-    objects.emplace_back(object_builder::map({{"http.client_ip", "192.168.0.1"},
-        {"usr.id", "admin"}, {"query", object_builder::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder_da::map({{"http.client_ip", "192.168.0.1"},
+        {"usr.id", "admin"}, {"query", object_builder_da::map({{"params", "value"}})}}));
+    objects.emplace_back(object_builder_da::map({{"http.client_ip", "192.168.0.1"},
+        {"usr.id", "admin"}, {"query", object_builder_da::map({{"params", "value"}})}}));
 
     {
         object_store store;

--- a/tests/unit/exclusion/object_filter_test.cpp
+++ b/tests/unit/exclusion/object_filter_test.cpp
@@ -10,6 +10,7 @@
 #include "utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -19,8 +20,8 @@ TEST(TestObjectFilter, RootTarget)
 
     object_store store;
 
-    auto root = object_builder::map({
-        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+    auto root = object_builder_da::map({
+        {"query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
     });
     store.insert(root);
 
@@ -50,11 +51,11 @@ TEST(TestObjectFilter, DuplicateTarget)
     object_filter::cache_type cache;
 
     std::vector<owned_object> objects;
-    objects.emplace_back(object_builder::map({
-        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+    objects.emplace_back(object_builder_da::map({
+        {"query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
     }));
-    objects.emplace_back(object_builder::map({
-        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+    objects.emplace_back(object_builder_da::map({
+        {"query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
     }));
     {
         store.insert(objects[0]);
@@ -87,8 +88,8 @@ TEST(TestObjectFilter, DuplicateCachedTarget)
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
 
-    auto root = object_builder::map({
-        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+    auto root = object_builder_da::map({
+        {"query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
     });
     store.insert(root);
 
@@ -110,9 +111,9 @@ TEST(TestObjectFilter, SingleTarget)
 
     object_store store;
 
-    auto root = object_builder::map();
+    auto root = object_builder_da::map();
     auto child = root.emplace(
-        "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+        "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
     store.insert(root);
 
@@ -140,9 +141,9 @@ TEST(TestObjectFilter, DuplicateSingleTarget)
     object_filter::cache_type cache;
 
     {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         auto child = root.emplace(
-            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(std::move(root));
 
@@ -152,9 +153,9 @@ TEST(TestObjectFilter, DuplicateSingleTarget)
     }
 
     {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         auto child = root.emplace(
-            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(std::move(root));
 
@@ -171,17 +172,17 @@ TEST(TestObjectFilter, MultipleTargets)
 
     object_store store;
 
-    auto root = object_builder::map();
+    auto root = object_builder_da::map();
 
     // Query
     auto child = root.emplace(
-        "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+        "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
     // Path Params
-    auto sibling = root.emplace("path_params", object_builder::map({{"username", "Paco"}}));
+    auto sibling = root.emplace("path_params", object_builder_da::map({{"username", "Paco"}}));
 
     auto object = sibling.emplace(
-        "token", object_builder::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
+        "token", object_builder_da::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
 
     store.insert(root);
 
@@ -213,16 +214,16 @@ TEST(TestObjectFilter, DuplicateMultipleTargets)
     object_filter::cache_type cache;
 
     {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         // Query
         auto child = root.emplace(
-            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         // Path Params
-        auto sibling = root.emplace("path_params", object_builder::map({{"username", "Paco"}}));
+        auto sibling = root.emplace("path_params", object_builder_da::map({{"username", "Paco"}}));
 
-        auto object = sibling.emplace(
-            "token", object_builder::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
+        auto object = sibling.emplace("token",
+            object_builder_da::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
 
         store.insert(std::move(root));
 
@@ -234,16 +235,16 @@ TEST(TestObjectFilter, DuplicateMultipleTargets)
     }
 
     {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         // Query
         auto child = root.emplace(
-            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         // Path Params
-        auto sibling = root.emplace("path_params", object_builder::map({{"username", "Paco"}}));
+        auto sibling = root.emplace("path_params", object_builder_da::map({{"username", "Paco"}}));
 
-        auto object = sibling.emplace(
-            "token", object_builder::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
+        auto object = sibling.emplace("token",
+            object_builder_da::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
 
         store.insert(std::move(root));
 
@@ -263,10 +264,10 @@ TEST(TestObjectFilter, MissingTarget)
 
     object_store store;
 
-    auto root = object_builder::map({
-        {"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
-        {"path_params", object_builder::map({{"username", "Paco"},
-                            {"token", object_builder::map({{"value", "naskjdnakjsd"},
+    auto root = object_builder_da::map({
+        {"query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})},
+        {"path_params", object_builder_da::map({{"username", "Paco"},
+                            {"token", object_builder_da::map({{"value", "naskjdnakjsd"},
                                           {"expiration", "yesterday"}})}})},
     });
     store.insert(root);
@@ -286,9 +287,9 @@ TEST(TestObjectFilter, SingleTargetCache)
 
     object_store store;
 
-    auto root = object_builder::map();
+    auto root = object_builder_da::map();
     auto child = root.emplace(
-        "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+        "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
     store.insert(root);
 
@@ -323,9 +324,9 @@ TEST(TestObjectFilter, MultipleTargetsCache)
     ddwaf::timer deadline{2s};
     object_filter::cache_type cache;
     {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         auto child = root.emplace(
-            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(std::move(root));
 
@@ -335,12 +336,12 @@ TEST(TestObjectFilter, MultipleTargetsCache)
     }
 
     {
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         // Path Params
-        auto sibling = root.emplace("path_params", object_builder::map({{"username", "Paco"}}));
+        auto sibling = root.emplace("path_params", object_builder_da::map({{"username", "Paco"}}));
 
-        auto object = sibling.emplace(
-            "token", object_builder::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
+        auto object = sibling.emplace("token",
+            object_builder_da::map({{"value", "naskjdnakjsd"}, {"expiration", "yesterday"}}));
 
         store.insert(std::move(root));
 
@@ -366,9 +367,9 @@ TEST(TestObjectFilter, SingleGlobTarget)
     {
         object_store store;
         object_filter::cache_type cache;
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         auto child = root.emplace(
-            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(root);
 
@@ -382,9 +383,9 @@ TEST(TestObjectFilter, SingleGlobTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         auto child = root.emplace("query",
-            object_builder::map({{"params", object_builder::map({{"value", "paramsvalue"}})},
+            object_builder_da::map({{"params", object_builder_da::map({{"value", "paramsvalue"}})},
                 {"uri", "uri_value"}}));
 
         store.insert(root);
@@ -399,7 +400,8 @@ TEST(TestObjectFilter, SingleGlobTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = object_builder::map({{"query", owned_object{}}});
+        auto root =
+            object_builder_da::map({{"query", ddwaf::test::ddwaf_object_da::make_uninit()}});
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
@@ -420,9 +422,9 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         auto child = root.emplace(
-            "query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
+            "query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}}));
 
         store.insert(root);
 
@@ -436,9 +438,9 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = object_builder::map();
+        auto root = object_builder_da::map();
         auto child = root.emplace("query",
-            object_builder::map({{"params", object_builder::map({{"value", "paramsvalue"}})},
+            object_builder_da::map({{"params", object_builder_da::map({{"value", "paramsvalue"}})},
                 {"uri", "uri_value"}}));
 
         store.insert(root);
@@ -453,7 +455,8 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = object_builder::map({{"query", owned_object{}}});
+        auto root =
+            object_builder_da::map({{"query", ddwaf::test::ddwaf_object_da::make_uninit()}});
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
@@ -475,10 +478,11 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        owned_object root = object_builder::map();
-        auto child = root.emplace("query",
-            object_builder::map({{"params", object_builder::map({{"other", "paramsvalue"}})}}));
-        auto grandnephew = child.emplace("uri", object_builder::map({{"other", "paramsvalue"}}));
+        owned_object root = object_builder_da::map();
+        auto child = root.emplace(
+            "query", object_builder_da::map(
+                         {{"params", object_builder_da::map({{"other", "paramsvalue"}})}}));
+        auto grandnephew = child.emplace("uri", object_builder_da::map({{"other", "paramsvalue"}}));
 
         store.insert(root);
 
@@ -491,10 +495,11 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        owned_object root = object_builder::map();
-        auto child = root.emplace("query", object_builder::map());
-        auto grandchild = child.emplace("params", object_builder::map({{"value", "paramsvalue"}}));
-        auto grandnephew = child.emplace("uri", object_builder::map({{"value", "paramsvalue"}}));
+        owned_object root = object_builder_da::map();
+        auto child = root.emplace("query", object_builder_da::map());
+        auto grandchild =
+            child.emplace("params", object_builder_da::map({{"value", "paramsvalue"}}));
+        auto grandnephew = child.emplace("uri", object_builder_da::map({{"value", "paramsvalue"}}));
 
         store.insert(root);
 
@@ -507,9 +512,10 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
     {
         object_store store;
         object_filter::cache_type cache;
-        owned_object root = object_builder::map({{"query",
-            object_builder::map({{"value", object_builder::map({{"whatever", "paramsvalue"}})},
-                {"other", object_builder::map({{"random", "paramsvalue"}})}})}});
+        owned_object root = object_builder_da::map(
+            {{"query", object_builder_da::map(
+                           {{"value", object_builder_da::map({{"whatever", "paramsvalue"}})},
+                               {"other", object_builder_da::map({{"random", "paramsvalue"}})}})}});
 
         store.insert(root);
 
@@ -522,7 +528,7 @@ TEST(TestObjectFilter, MultipleComponentsGlobAndKeyTargets)
         object_filter::cache_type cache;
 
         owned_object root =
-            object_builder::map({{"query", object_builder::map({{"value", "value"}})}});
+            object_builder_da::map({{"query", object_builder_da::map({{"value", "value"}})}});
 
         store.insert(root);
 
@@ -544,14 +550,14 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        owned_object root = object_builder::map();
-        auto child = root.emplace("query", object_builder::map());
-        auto grandchild = child.emplace("params", object_builder::map());
+        owned_object root = object_builder_da::map();
+        auto child = root.emplace("query", object_builder_da::map());
+        auto grandchild = child.emplace("params", object_builder_da::map());
         auto greatgrandchild = grandchild.emplace("something",
-            object_builder::map({{"other", "paramsvalue"}, {"somethingelse", "paramsvalue"}}));
-        auto grandnephew = child.emplace("uri", object_builder::map());
+            object_builder_da::map({{"other", "paramsvalue"}, {"somethingelse", "paramsvalue"}}));
+        auto grandnephew = child.emplace("uri", object_builder_da::map());
         auto greatgrandnephew = grandnephew.emplace("random",
-            object_builder::map({{"other", "paramsvalue"}, {"somethingelse", "paramsvalue"}}));
+            object_builder_da::map({{"other", "paramsvalue"}, {"somethingelse", "paramsvalue"}}));
 
         store.insert(root);
 
@@ -567,9 +573,9 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = object_builder::map({{"query",
-            object_builder::map({{"params", object_builder::map({{"something", "value"}})},
-                {"uri", object_builder::map({{"random", "value"}})}})}});
+        auto root = object_builder_da::map({{"query",
+            object_builder_da::map({{"params", object_builder_da::map({{"something", "value"}})},
+                {"uri", object_builder_da::map({{"random", "value"}})}})}});
 
         store.insert(root);
 
@@ -581,8 +587,8 @@ TEST(TestObjectFilter, MultipleGlobsTargets)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root = object_builder::map(
-            {{"query", object_builder::map({{"params", "value"}, {"uri", "value"}})}});
+        auto root = object_builder_da::map(
+            {{"query", object_builder_da::map({{"params", "value"}, {"uri", "value"}})}});
 
         store.insert(root);
 
@@ -666,9 +672,9 @@ TEST(TestObjectFilter, ArrayWithGlobTargets)
     {
         object_store store;
         object_filter::cache_type cache;
-        auto root = object_builder::map({{"query",
-            object_builder::map({{"a", object_builder::array({object_builder::map(
-                                           {{"c", object_builder::map({{"d", "value"}})}})})}})}});
+        auto root = object_builder_da::map({{"query",
+            object_builder_da::map({{"a", object_builder_da::array({object_builder_da::map({{"c",
+                                              object_builder_da::map({{"d", "value"}})}})})}})}});
 
         store.insert(root);
 
@@ -684,8 +690,8 @@ TEST(TestObjectFilter, Timeout)
 
     object_store store;
 
-    auto root = object_builder::map(
-        {{"query", object_builder::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})}});
+    auto root = object_builder_da::map(
+        {{"query", object_builder_da::map({{"params", "paramsvalue"}, {"uri", "uri_value"}})}});
     store.insert(root);
 
     object_filter filter;

--- a/tests/unit/exclusion/object_filter_test.cpp
+++ b/tests/unit/exclusion/object_filter_test.cpp
@@ -400,8 +400,7 @@ TEST(TestObjectFilter, SingleGlobTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root =
-            object_builder_da::map({{"query", ddwaf::test::ddwaf_object_da::make_uninit()}});
+        auto root = object_builder_da::map({{"query", owned_object{}}});
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);
@@ -455,8 +454,7 @@ TEST(TestObjectFilter, GlobAndKeyTarget)
         object_store store;
         object_filter::cache_type cache;
 
-        auto root =
-            object_builder_da::map({{"query", ddwaf::test::ddwaf_object_da::make_uninit()}});
+        auto root = object_builder_da::map({{"query", owned_object{}}});
         store.insert(root);
 
         auto objects_filtered = filter.match(store, cache, deadline);

--- a/tests/unit/exclusion/rule_filter_test.cpp
+++ b/tests/unit/exclusion/rule_filter_test.cpp
@@ -11,6 +11,7 @@
 #include "matcher/ip_match.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -31,7 +32,7 @@ TEST(TestRuleFilter, Match)
     EXPECT_EQ(addresses.size(), 1);
     EXPECT_STREQ(addresses.begin()->second.c_str(), "http.client_ip");
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -63,7 +64,7 @@ TEST(TestRuleFilter, MatchWithDynamicMatcher)
     EXPECT_STREQ(addresses.begin()->second.c_str(), "http.client_ip");
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -76,7 +77,7 @@ TEST(TestRuleFilter, MatchWithDynamicMatcher)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -106,7 +107,7 @@ TEST(TestRuleFilter, NoMatch)
 
     ddwaf::rule_filter filter{"filter", builder.build(), {}};
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -140,7 +141,7 @@ TEST(TestRuleFilter, ValidateCachedMatch)
     // only the latest address. This ensures that the IP condition can't be
     // matched on the second run.
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -150,7 +151,7 @@ TEST(TestRuleFilter, ValidateCachedMatch)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -191,14 +192,14 @@ TEST(TestRuleFilter, CachedMatchAndSubcontextMatch)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        store.insert(object_builder::map({{"http.client_ip", "192.168.0.1"}}));
+        store.insert(object_builder_da::map({{"http.client_ip", "192.168.0.1"}}));
 
         ddwaf::timer deadline{2s};
         EXPECT_FALSE(filter.match(store, cache, {}, deadline));
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         auto sctx_store = object_store::from_upstream_store(store);
         sctx_store.insert(std::move(root));
@@ -235,7 +236,7 @@ TEST(TestRuleFilter, MatchWithoutCache)
     object_store store;
     {
         ddwaf::rule_filter::cache_type cache;
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -245,7 +246,7 @@ TEST(TestRuleFilter, MatchWithoutCache)
 
     {
         ddwaf::rule_filter::cache_type cache;
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         store.insert(std::move(root));
 
@@ -275,7 +276,7 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
     // address is passed, the filter doesn't match (as it should be).
     {
         ddwaf::rule_filter::cache_type cache;
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -286,7 +287,7 @@ TEST(TestRuleFilter, NoMatchWithoutCache)
 
     {
         ddwaf::rule_filter::cache_type cache;
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -319,7 +320,8 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
     // In this test we validate that when a match has already occurred, the
     // second run for the same filter returns nothing.
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         store.insert(std::move(root));
 
@@ -329,7 +331,7 @@ TEST(TestRuleFilter, FullCachedMatchSecondRun)
     }
 
     {
-        auto root = object_builder::map({{"random", "random"}});
+        auto root = object_builder_da::map({{"random", "random"}});
 
         store.insert(std::move(root));
 

--- a/tests/unit/expression_test.cpp
+++ b/tests/unit/expression_test.cpp
@@ -11,6 +11,7 @@
 #include "utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 TEST(TestExpression, SimpleMatch)
@@ -23,7 +24,7 @@ TEST(TestExpression, SimpleMatch)
 
     auto expr = builder.build();
 
-    auto root = object_builder::map({{"server.request.query", "value"}});
+    auto root = object_builder_da::map({{"server.request.query", "value"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -54,7 +55,7 @@ TEST(TestExpression, SimpleNegatedMatch)
 
     auto expr = builder.build();
 
-    auto root = object_builder::map({{"server.request.query", "val"}});
+    auto root = object_builder_da::map({{"server.request.query", "val"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -92,7 +93,7 @@ TEST(TestExpression, MultiInputMatchOnSecondEval)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.query", "bad"}});
+        auto root = object_builder_da::map({{"server.request.query", "bad"}});
 
         store.insert(std::move(root));
 
@@ -104,7 +105,7 @@ TEST(TestExpression, MultiInputMatchOnSecondEval)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.body", "value"}});
+        auto root = object_builder_da::map({{"server.request.body", "value"}});
 
         store.insert(std::move(root));
 
@@ -139,7 +140,7 @@ TEST(TestExpression, DuplicateInput)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.query", "bad"}});
+        auto root = object_builder_da::map({{"server.request.query", "bad"}});
 
         store.insert(std::move(root));
 
@@ -151,7 +152,7 @@ TEST(TestExpression, DuplicateInput)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.query", "value"}});
+        auto root = object_builder_da::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root));
 
@@ -175,7 +176,7 @@ TEST(TestExpression, MatchDuplicateInputNoCache)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.query", "bad"}});
+        auto root = object_builder_da::map({{"server.request.query", "bad"}});
 
         store.insert(std::move(root));
 
@@ -188,7 +189,7 @@ TEST(TestExpression, MatchDuplicateInputNoCache)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.query", "value"}});
+        auto root = object_builder_da::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root));
 
@@ -230,7 +231,7 @@ TEST(TestExpression, TwoConditionsSingleInputNoMatch)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.query", "bad_value"}});
+        auto root = object_builder_da::map({{"server.request.query", "bad_value"}});
 
         store.insert(std::move(root));
 
@@ -242,7 +243,7 @@ TEST(TestExpression, TwoConditionsSingleInputNoMatch)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.query", "value"}});
+        auto root = object_builder_da::map({{"server.request.query", "value"}});
 
         store.insert(std::move(root));
 
@@ -267,7 +268,7 @@ TEST(TestExpression, TwoConditionsSingleInputMatch)
 
     auto expr = builder.build();
 
-    auto root = object_builder::map({{"server.request.query", "value"}});
+    auto root = object_builder_da::map({{"server.request.query", "value"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -296,8 +297,8 @@ TEST(TestExpression, TwoConditionsMultiInputSingleEvalMatch)
     object_store store;
     expression::cache_type cache;
 
-    auto root =
-        object_builder::map({{"server.request.query", "query"}, {"server.request.body", "body"}});
+    auto root = object_builder_da::map(
+        {{"server.request.query", "query"}, {"server.request.body", "body"}});
 
     store.insert(std::move(root));
 
@@ -327,7 +328,7 @@ TEST(TestExpression, TwoConditionsMultiInputMultiEvalMatch)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map({{"server.request.query", "query"}});
+        auto root = object_builder_da::map({{"server.request.query", "query"}});
 
         store.insert(std::move(root));
 
@@ -339,7 +340,7 @@ TEST(TestExpression, TwoConditionsMultiInputMultiEvalMatch)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto root = object_builder::map(
+        auto root = object_builder_da::map(
             {{"server.request.query", "red-herring"}, {"server.request.body", "body"}});
 
         store.insert(std::move(root));
@@ -359,8 +360,8 @@ TEST(TestExpression, MatchWithKeyPath)
     builder.end_condition<matcher::regex_match>(".*", 0, true);
     auto expr = builder.build();
 
-    auto root =
-        object_builder::map({{"server.request.query", object_builder::map({{"key", "value"}})}});
+    auto root = object_builder_da::map(
+        {{"server.request.query", object_builder_da::map({{"key", "value"}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -389,7 +390,7 @@ TEST(TestExpression, MatchWithTransformer)
     builder.end_condition<matcher::regex_match>("value", 0, true);
     auto expr = builder.build();
 
-    auto root = object_builder::map({{"server.request.query", "VALUE"}});
+    auto root = object_builder_da::map({{"server.request.query", "VALUE"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -418,7 +419,7 @@ TEST(TestExpression, MatchWithMultipleTransformers)
     builder.end_condition<matcher::regex_match>("^ value $", 0, true);
     auto expr = builder.build();
 
-    auto root = object_builder::map({{"server.request.query", "    VALUE    "}});
+    auto root = object_builder_da::map({{"server.request.query", "    VALUE    "}});
 
     object_store store;
     store.insert(std::move(root));
@@ -446,8 +447,8 @@ TEST(TestExpression, MatchOnKeys)
     builder.end_condition<matcher::regex_match>("value", 0, true);
     auto expr = builder.build();
 
-    auto root =
-        object_builder::map({{"server.request.query", object_builder::map({{"value", "1729"}})}});
+    auto root = object_builder_da::map(
+        {{"server.request.query", object_builder_da::map({{"value", "1729"}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -476,8 +477,8 @@ TEST(TestExpression, MatchOnKeysWithTransformer)
     builder.end_condition<matcher::regex_match>("value", 0, true);
     auto expr = builder.build();
 
-    auto root =
-        object_builder::map({{"server.request.query", object_builder::map({{"VALUE", "1729"}})}});
+    auto root = object_builder_da::map(
+        {{"server.request.query", object_builder_da::map({{"VALUE", "1729"}})}});
 
     object_store store;
     store.insert(std::move(root));
@@ -506,7 +507,7 @@ TEST(TestExpression, ExcludeInput)
     builder.end_condition<matcher::regex_match>(".*", 0, true);
     auto expr = builder.build();
 
-    auto root = object_builder::map({{"server.request.query", "value"}});
+    auto root = object_builder_da::map({{"server.request.query", "value"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -527,8 +528,8 @@ TEST(TestExpression, ExcludeKeyPath)
     builder.end_condition<matcher::regex_match>(".*", 0, true);
     auto expr = builder.build();
 
-    auto root =
-        object_builder::map({{"server.request.query", object_builder::map({{"key", "value"}})}});
+    auto root = object_builder_da::map(
+        {{"server.request.query", object_builder_da::map({{"key", "value"}})}});
 
     object_store store;
     store.insert(std::move(root));

--- a/tests/unit/indexed_multivector_test.cpp
+++ b/tests/unit/indexed_multivector_test.cpp
@@ -8,6 +8,7 @@
 #include "indexed_multivector.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/indexer_test.cpp
+++ b/tests/unit/indexer_test.cpp
@@ -8,6 +8,7 @@
 #include "indexer.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/json_utils_test.cpp
+++ b/tests/unit/json_utils_test.cpp
@@ -9,6 +9,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/key_iterator_test.cpp
+++ b/tests/unit/key_iterator_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "iterator.hpp"
 
@@ -29,7 +30,7 @@ TEST(TestKeyIterator, TestInvalidIterator)
 
 TEST(TestKeyIterator, TestStringScalar)
 {
-    owned_object object{"value"};
+    owned_object object = test::ddwaf_object_da::make_string("value");
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);

--- a/tests/unit/key_iterator_test.cpp
+++ b/tests/unit/key_iterator_test.cpp
@@ -15,7 +15,7 @@ namespace {
 
 TEST(TestKeyIterator, TestInvalidIterator)
 {
-    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object object = owned_object{};
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -191,7 +191,7 @@ TEST(TestKeyIterator, TestMapMultipleNullAndInvalid)
 
         {
             auto index = std::to_string((i * 3) + 2);
-            object.emplace("key" + index, ddwaf::test::ddwaf_object_da::make_uninit());
+            object.emplace("key" + index, owned_object{});
         }
     }
 
@@ -378,7 +378,7 @@ TEST(TestKeyIterator, TestMapNoScalars)
 
 TEST(TestKeyIterator, TestInvalidObjectPath)
 {
-    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object object = owned_object{};
 
     object_set_ref exclude;
     std::vector<std::variant<std::string, int64_t>> key_path{"key", "0", "value"};

--- a/tests/unit/key_iterator_test.cpp
+++ b/tests/unit/key_iterator_test.cpp
@@ -9,12 +9,13 @@
 #include "iterator.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
 TEST(TestKeyIterator, TestInvalidIterator)
 {
-    owned_object object;
+    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -46,7 +47,7 @@ TEST(TestKeyIterator, TestStringScalar)
 
 TEST(TestKeyIterator, TestUnsignedScalar)
 {
-    owned_object object{22U};
+    owned_object object = test::ddwaf_object_da::make_unsigned(22U);
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -60,7 +61,7 @@ TEST(TestKeyIterator, TestUnsignedScalar)
 
 TEST(TestKeyIterator, TestSignedScalar)
 {
-    owned_object object{22L};
+    owned_object object = test::ddwaf_object_da::make_signed(22L);
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -74,7 +75,7 @@ TEST(TestKeyIterator, TestSignedScalar)
 
 TEST(TestKeyIterator, TestArraySingleItem)
 {
-    auto object = object_builder::array({"string"});
+    auto object = object_builder_da::array({"string"});
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -87,7 +88,7 @@ TEST(TestKeyIterator, TestArraySingleItem)
 
 TEST(TestKeyIterator, TestArrayMultipleItems)
 {
-    auto object = object_builder::array();
+    auto object = object_builder_da::array();
     for (unsigned i = 0; i < 50; i++) { object.emplace_back(std::to_string(i)); }
 
     object_set_ref exclude;
@@ -101,11 +102,11 @@ TEST(TestKeyIterator, TestArrayMultipleItems)
 
 TEST(TestKeyIterator, TestDeepArray)
 {
-    auto object = object_builder::array();
+    auto object = object_builder_da::array();
     borrowed_object array{object};
     for (unsigned i = 0; i < 10; i++) {
         array.emplace_back("val" + std::to_string(i));
-        array = array.emplace_back(object_builder::array());
+        array = array.emplace_back(object_builder_da::array());
     }
 
     object_set_ref exclude;
@@ -119,8 +120,8 @@ TEST(TestKeyIterator, TestDeepArray)
 
 TEST(TestKeyIterator, TestArrayNoScalars)
 {
-    auto object = object_builder::array();
-    for (unsigned i = 0; i < 50; i++) { object.emplace_back(object_builder::array()); }
+    auto object = object_builder_da::array();
+    for (unsigned i = 0; i < 50; i++) { object.emplace_back(object_builder_da::array()); }
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -131,7 +132,7 @@ TEST(TestKeyIterator, TestArrayNoScalars)
 
 TEST(TestKeyIterator, TestMapSingleItem)
 {
-    auto object = object_builder::map({{"key", "value"}});
+    auto object = object_builder_da::map({{"key", "value"}});
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -147,7 +148,7 @@ TEST(TestKeyIterator, TestMapSingleItem)
 
 TEST(TestKeyIterator, TestMapMultipleItems)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
 
     for (unsigned i = 0; i < 50; i++) {
         auto index = std::to_string(i);
@@ -175,7 +176,7 @@ TEST(TestKeyIterator, TestMapMultipleItems)
 
 TEST(TestKeyIterator, TestMapMultipleNullAndInvalid)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
 
     for (unsigned i = 0; i < 25; i++) {
         {
@@ -190,7 +191,7 @@ TEST(TestKeyIterator, TestMapMultipleNullAndInvalid)
 
         {
             auto index = std::to_string((i * 3) + 2);
-            object.emplace("key" + index, owned_object{});
+            object.emplace("key" + index, ddwaf::test::ddwaf_object_da::make_uninit());
         }
     }
 
@@ -243,13 +244,13 @@ TEST(TestKeyIterator, TestMapMultipleNullAndInvalid)
 
 TEST(TestKeyIterator, TestDeepMap)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
     borrowed_object map{object};
 
     for (unsigned i = 0; i < 10; i++) {
         auto index = std::to_string(i);
         map.emplace("str" + index, "val" + index);
-        map = map.emplace("map" + index, object_builder::map());
+        map = map.emplace("map" + index, object_builder_da::map());
     }
 
     object_set_ref exclude;
@@ -293,8 +294,8 @@ TEST(TestKeyIterator, TestDeepMap)
 // addesses (e.g. server.request.query).
 TEST(TestKeyIterator, TestNoRootKey)
 {
-    auto object = object_builder::map();
-    object.emplace("root", object_builder::map({{"key", "value"}}));
+    auto object = object_builder_da::map();
+    object.emplace("root", object_builder_da::map({{"key", "value"}}));
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object.at(0), {}, exclude);
@@ -356,8 +357,8 @@ TEST(TestKeyIterator, TestContainerMix)
 
 TEST(TestKeyIterator, TestMapNoScalars)
 {
-    auto object = object_builder::map();
-    for (unsigned i = 0; i < 50; i++) { object.emplace("key", object_builder::map()); }
+    auto object = object_builder_da::map();
+    for (unsigned i = 0; i < 50; i++) { object.emplace("key", object_builder_da::map()); }
 
     object_set_ref exclude;
     ddwaf::key_iterator it(object, {}, exclude);
@@ -377,7 +378,7 @@ TEST(TestKeyIterator, TestMapNoScalars)
 
 TEST(TestKeyIterator, TestInvalidObjectPath)
 {
-    owned_object object;
+    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
 
     object_set_ref exclude;
     std::vector<std::variant<std::string, int64_t>> key_path{"key", "0", "value"};
@@ -392,7 +393,7 @@ TEST(TestKeyIterator, TestInvalidObjectPath)
 
 TEST(TestKeyIterator, TestSimplePath)
 {
-    auto object = object_builder::map({{"key", "value"}, {"key1", "value"}, {"key2", "value"}});
+    auto object = object_builder_da::map({{"key", "value"}, {"key1", "value"}, {"key2", "value"}});
 
     {
         std::vector<std::variant<std::string, int64_t>> key_path{"key"};
@@ -426,9 +427,9 @@ TEST(TestKeyIterator, TestSimplePath)
 
 TEST(TestKeyIterator, TestMultiPath)
 {
-    auto object = object_builder::map(
-        {{"first", object_builder::map({{"second", object_builder::map({{"third", "final"},
-                                                       {"value", "value_third"}})},
+    auto object = object_builder_da::map(
+        {{"first", object_builder_da::map({{"second", object_builder_da::map({{"third", "final"},
+                                                          {"value", "value_third"}})},
                        {"value", "value_second"}})},
             {"value", "value_first"}});
 
@@ -632,7 +633,7 @@ TEST(TestKeyIterator, TestIntInPathSucceeds)
 
 TEST(TestKeyIterator, TestExcludeSingleObject)
 {
-    auto object = object_builder::map({{"key", "value"}});
+    auto object = object_builder_da::map({{"key", "value"}});
 
     std::unordered_set<object_cache_key> persistent{object.at(0)};
 
@@ -644,10 +645,10 @@ TEST(TestKeyIterator, TestExcludeSingleObject)
 
 TEST(TestKeyIterator, TestExcludeMultipleObjects)
 {
-    auto root = object_builder::map({{"key", "value"}});
+    auto root = object_builder_da::map({{"key", "value"}});
 
     auto map =
-        root.emplace("other", object_builder::map({{"hello_key", "hello"}, {"bye_key", "bye"}}));
+        root.emplace("other", object_builder_da::map({{"hello_key", "hello"}, {"bye_key", "bye"}}));
 
     std::unordered_set<object_cache_key> persistent{root.at(0), map.at(1)};
     object_set_ref exclude{persistent};
@@ -675,8 +676,8 @@ TEST(TestKeyIterator, TestExcludeMultipleObjects)
 
 TEST(TestKeyIterator, TestExcludeObjectInKeyPath)
 {
-    auto root = object_builder::map();
-    auto child = root.emplace("parent", object_builder::map());
+    auto root = object_builder_da::map();
+    auto child = root.emplace("parent", object_builder_da::map());
     child.emplace("child", "value");
 
     std::unordered_set<object_cache_key> persistent{child.at(0)};
@@ -691,7 +692,7 @@ TEST(TestKeyIterator, TestExcludeObjectInKeyPath)
 
 TEST(TestKeyIterator, TestExcludeRootOfKeyPath)
 {
-    auto root = object_builder::map({{"parent", object_builder::map({{"child", "value"}})}});
+    auto root = object_builder_da::map({{"parent", object_builder_da::map({{"child", "value"}})}});
 
     std::unordered_set<object_cache_key> persistent{root.at(0)};
     object_set_ref exclude{persistent};

--- a/tests/unit/kv_iterator_test.cpp
+++ b/tests/unit/kv_iterator_test.cpp
@@ -10,12 +10,13 @@
 #include "iterator.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
 TEST(TestKVIterator, TestInvalidIterator)
 {
-    owned_object object;
+    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);
@@ -49,7 +50,7 @@ TEST(TestKVIterator, TestStringScalar)
 
 TEST(TestKVIterator, TestUnsignedScalar)
 {
-    owned_object object{22U};
+    owned_object object = test::ddwaf_object_da::make_unsigned(22U);
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);
@@ -64,7 +65,7 @@ TEST(TestKVIterator, TestUnsignedScalar)
 
 TEST(TestKVIterator, TestSignedScalar)
 {
-    owned_object object{22L};
+    owned_object object = test::ddwaf_object_da::make_signed(22L);
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);
@@ -79,7 +80,7 @@ TEST(TestKVIterator, TestSignedScalar)
 
 TEST(TestKVIterator, TestArraySingleItem)
 {
-    auto object = object_builder::array({"string"});
+    auto object = object_builder_da::array({"string"});
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);
@@ -95,7 +96,7 @@ TEST(TestKVIterator, TestArraySingleItem)
 
 TEST(TestKVIterator, TestArrayMultipleItems)
 {
-    auto object = object_builder::array();
+    auto object = object_builder_da::array();
     for (unsigned i = 0; i < 50; i++) { object.emplace_back(std::to_string(i)); }
 
     std::unordered_set<object_cache_key> persistent;
@@ -119,10 +120,10 @@ TEST(TestKVIterator, TestArrayMultipleItems)
 
 TEST(TestKVIterator, TestArrayMultipleNullAndInvalid)
 {
-    auto object = object_builder::array();
+    auto object = object_builder_da::array();
     for (unsigned i = 0; i < 25; i++) {
         object.emplace_back(std::to_string(i));
-        object.emplace_back(owned_object{});
+        object.emplace_back(ddwaf::test::ddwaf_object_da::make_uninit());
         object.emplace_back(owned_object::make_null());
     }
 
@@ -149,11 +150,11 @@ TEST(TestKVIterator, TestArrayMultipleNullAndInvalid)
 
 TEST(TestKVIterator, TestDeepArray)
 {
-    auto object = object_builder::array();
+    auto object = object_builder_da::array();
     borrowed_object array{object};
     for (unsigned i = 0; i < 10; i++) {
         array.emplace_back("val" + std::to_string(i));
-        array = array.emplace_back(object_builder::array());
+        array = array.emplace_back(object_builder_da::array());
     }
 
     std::unordered_set<object_cache_key> persistent;
@@ -176,8 +177,8 @@ TEST(TestKVIterator, TestDeepArray)
 
 TEST(TestKVIterator, TestArrayNoScalars)
 {
-    auto object = object_builder::array();
-    for (unsigned i = 0; i < 50; i++) { object.emplace_back(object_builder::array()); }
+    auto object = object_builder_da::array();
+    for (unsigned i = 0; i < 50; i++) { object.emplace_back(object_builder_da::array()); }
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);
@@ -189,7 +190,7 @@ TEST(TestKVIterator, TestArrayNoScalars)
 
 TEST(TestKVIterator, TestMapSingleItem)
 {
-    auto object = object_builder::map({{"key", "value"}});
+    auto object = object_builder_da::map({{"key", "value"}});
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);
@@ -216,7 +217,7 @@ TEST(TestKVIterator, TestMapSingleItem)
 
 TEST(TestKVIterator, TestMapMultipleItems)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
 
     for (unsigned i = 0; i < 50; i++) {
         auto index = std::to_string(i);
@@ -253,7 +254,7 @@ TEST(TestKVIterator, TestMapMultipleItems)
 
 TEST(TestKVIterator, TestMapMultipleNullAndInvalid)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
 
     for (unsigned i = 0; i < 25; i++) {
         {
@@ -268,7 +269,7 @@ TEST(TestKVIterator, TestMapMultipleNullAndInvalid)
 
         {
             auto index = std::to_string(i * 3 + 2);
-            object.emplace("key" + index, owned_object{});
+            object.emplace("key" + index, ddwaf::test::ddwaf_object_da::make_uninit());
         }
     }
 
@@ -329,13 +330,13 @@ TEST(TestKVIterator, TestMapMultipleNullAndInvalid)
 
 TEST(TestKVIterator, TestDeepMap)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
     borrowed_object map{object};
 
     for (unsigned i = 0; i < 10; i++) {
         auto index = std::to_string(i);
         map.emplace("str" + index, "val" + index);
-        map = map.emplace("map" + index, object_builder::map());
+        map = map.emplace("map" + index, object_builder_da::map());
     }
 
     object_set_ref exclude;
@@ -389,8 +390,8 @@ TEST(TestKVIterator, TestDeepMap)
 // addesses (e.g. server.request.query).
 TEST(TestKVIterator, TestNoRootKey)
 {
-    auto object = object_builder::map();
-    object.emplace("root", object_builder::map({{"key", "value"}}));
+    auto object = object_builder_da::map();
+    object.emplace("root", object_builder_da::map({{"key", "value"}}));
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object.at(0), {}, exclude);
@@ -468,8 +469,8 @@ TEST(TestKVIterator, TestContainerMix)
 
 TEST(TestKVIterator, TestMapNoScalars)
 {
-    auto object = object_builder::map();
-    for (unsigned i = 0; i < 50; i++) { object.emplace("key", object_builder::map()); }
+    auto object = object_builder_da::map();
+    for (unsigned i = 0; i < 50; i++) { object.emplace("key", object_builder_da::map()); }
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);
@@ -489,7 +490,7 @@ TEST(TestKVIterator, TestMapNoScalars)
 
 TEST(TestKVIterator, TestInvalidObjectPath)
 {
-    owned_object object;
+    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
 
     object_set_ref exclude;
     std::vector<std::variant<std::string, int64_t>> key_path{"key", "0", "value"};
@@ -504,7 +505,7 @@ TEST(TestKVIterator, TestInvalidObjectPath)
 
 TEST(TestKVIterator, TestSimplePath)
 {
-    owned_object object;
+    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
 
     {
         std::vector<std::variant<std::string, int64_t>> key_path{"key"};
@@ -538,9 +539,9 @@ TEST(TestKVIterator, TestSimplePath)
 
 TEST(TestKVIterator, TestMultiPath)
 {
-    auto object = object_builder::map(
-        {{"first", object_builder::map({{"second", object_builder::map({{"third", "final"},
-                                                       {"value", "value_third"}})},
+    auto object = object_builder_da::map(
+        {{"first", object_builder_da::map({{"second", object_builder_da::map({{"third", "final"},
+                                                          {"value", "value_third"}})},
                        {"value", "value_second"}})},
             {"value", "value_first"}});
 
@@ -783,7 +784,7 @@ TEST(TestKVIterator, TestIntInPathSucceeds)
 
 TEST(TestKVIterator, TestExcludeSingleObject)
 {
-    auto object = object_builder::map({{"key", "value"}});
+    auto object = object_builder_da::map({{"key", "value"}});
 
     std::unordered_set<object_cache_key> persistent{object.at(0)};
 
@@ -795,10 +796,10 @@ TEST(TestKVIterator, TestExcludeSingleObject)
 
 TEST(TestKVIterator, TestExcludeMultipleObjects)
 {
-    auto root = object_builder::map({{"key", "value"}});
+    auto root = object_builder_da::map({{"key", "value"}});
 
     auto map =
-        root.emplace("other", object_builder::map({{"hello_key", "hello"}, {"bye_key", "bye"}}));
+        root.emplace("other", object_builder_da::map({{"hello_key", "hello"}, {"bye_key", "bye"}}));
 
     std::unordered_set<object_cache_key> persistent{root.at(0), map.at(1)};
     object_set_ref exclude{persistent};
@@ -833,8 +834,8 @@ TEST(TestKVIterator, TestExcludeMultipleObjects)
 
 TEST(TestKVIterator, TestExcludeObjectInKeyPath)
 {
-    auto root = object_builder::map();
-    auto child = root.emplace("parent", object_builder::map());
+    auto root = object_builder_da::map();
+    auto child = root.emplace("parent", object_builder_da::map());
     child.emplace("child", "value");
 
     std::unordered_set<object_cache_key> persistent{child.at(0)};
@@ -847,7 +848,7 @@ TEST(TestKVIterator, TestExcludeObjectInKeyPath)
 
 TEST(TestKVIterator, TestExcludeRootOfKeyPath)
 {
-    auto root = object_builder::map({{"parent", object_builder::map({{"child", "value"}})}});
+    auto root = object_builder_da::map({{"parent", object_builder_da::map({{"child", "value"}})}});
 
     std::unordered_set<object_cache_key> persistent{root.at(0)};
     object_set_ref exclude{persistent};

--- a/tests/unit/kv_iterator_test.cpp
+++ b/tests/unit/kv_iterator_test.cpp
@@ -16,7 +16,7 @@ namespace {
 
 TEST(TestKVIterator, TestInvalidIterator)
 {
-    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object object = owned_object{};
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);
@@ -123,7 +123,7 @@ TEST(TestKVIterator, TestArrayMultipleNullAndInvalid)
     auto object = object_builder_da::array();
     for (unsigned i = 0; i < 25; i++) {
         object.emplace_back(std::to_string(i));
-        object.emplace_back(ddwaf::test::ddwaf_object_da::make_uninit());
+        object.emplace_back(owned_object{});
         object.emplace_back(owned_object::make_null());
     }
 
@@ -269,7 +269,7 @@ TEST(TestKVIterator, TestMapMultipleNullAndInvalid)
 
         {
             auto index = std::to_string(i * 3 + 2);
-            object.emplace("key" + index, ddwaf::test::ddwaf_object_da::make_uninit());
+            object.emplace("key" + index, owned_object{});
         }
     }
 
@@ -490,7 +490,7 @@ TEST(TestKVIterator, TestMapNoScalars)
 
 TEST(TestKVIterator, TestInvalidObjectPath)
 {
-    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object object = owned_object{};
 
     object_set_ref exclude;
     std::vector<std::variant<std::string, int64_t>> key_path{"key", "0", "value"};
@@ -505,7 +505,7 @@ TEST(TestKVIterator, TestInvalidObjectPath)
 
 TEST(TestKVIterator, TestSimplePath)
 {
-    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object object = owned_object{};
 
     {
         std::vector<std::variant<std::string, int64_t>> key_path{"key"};

--- a/tests/unit/kv_iterator_test.cpp
+++ b/tests/unit/kv_iterator_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "context_allocator.hpp"
 #include "iterator.hpp"
@@ -31,7 +32,7 @@ TEST(TestKVIterator, TestInvalidIterator)
 
 TEST(TestKVIterator, TestStringScalar)
 {
-    owned_object object{"value"};
+    owned_object object = test::ddwaf_object_da::make_string("value");
 
     object_set_ref exclude;
     ddwaf::kv_iterator it(object, {}, exclude);

--- a/tests/unit/matcher/equals_test.cpp
+++ b/tests/unit/matcher/equals_test.cpp
@@ -9,6 +9,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -31,8 +32,8 @@ TEST(TestEqualsBool, Basic)
         EXPECT_FALSE(matcher.is_supported_type(object_type::null));
         EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
 
-        EXPECT_TRUE(matcher.match(owned_object{false}).first);
-        EXPECT_FALSE(matcher.match(owned_object{true}).first);
+        EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_boolean(false)).first);
+        EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_boolean(true)).first);
     }
 
     {
@@ -51,8 +52,8 @@ TEST(TestEqualsBool, Basic)
         EXPECT_FALSE(matcher.is_supported_type(object_type::null));
         EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
 
-        EXPECT_TRUE(matcher.match(owned_object{true}).first);
-        EXPECT_FALSE(matcher.match(owned_object{false}).first);
+        EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_boolean(true)).first);
+        EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_boolean(false)).first);
     }
 }
 
@@ -74,11 +75,11 @@ TEST(TestEqualsInt, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{5L}).first);
-    EXPECT_TRUE(matcher.match(owned_object{5L}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_signed(5L)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_signed(5L)).first);
 
-    EXPECT_FALSE(matcher.match(owned_object{6L}).first);
-    EXPECT_FALSE(matcher.match(owned_object{6L}).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(6L)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(6L)).first);
 }
 
 TEST(TestEqualsUint, Basic)
@@ -98,11 +99,11 @@ TEST(TestEqualsUint, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{2132132U}).first);
-    EXPECT_TRUE(matcher.match(owned_object{2132132U}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_unsigned(2132132U)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_unsigned(2132132U)).first);
 
-    EXPECT_FALSE(matcher.match(owned_object{6}).first);
-    EXPECT_FALSE(matcher.match(owned_object{6}).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(6)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(6)).first);
 }
 
 TEST(TestEqualsDouble, Basic)
@@ -123,8 +124,8 @@ TEST(TestEqualsDouble, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{5.01}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5.5}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_float(5.01)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(5.5)).first);
 }
 
 TEST(TestEqualsString, Basic)

--- a/tests/unit/matcher/greater_than_test.cpp
+++ b/tests/unit/matcher/greater_than_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
@@ -32,13 +33,13 @@ TEST(TestGreaterThanInt, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{6L}).first);
-    EXPECT_TRUE(matcher.match(owned_object{6UL}).first);
-    EXPECT_TRUE(matcher.match(owned_object{6.0}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_signed(6L)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_unsigned(6UL)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_float(6.0)).first);
 
-    EXPECT_FALSE(matcher.match(owned_object{5L}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5UL}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5.0}).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(5L)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_unsigned(5UL)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(5.0)).first);
 }
 
 TEST(TestGreaterThanUint, Basic)
@@ -59,13 +60,13 @@ TEST(TestGreaterThanUint, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{2132133L}).first);
-    EXPECT_TRUE(matcher.match(owned_object{2132133UL}).first);
-    EXPECT_TRUE(matcher.match(owned_object{2132133.1}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_signed(2132133L)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_unsigned(2132133UL)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_float(2132133.1)).first);
 
-    EXPECT_FALSE(matcher.match(owned_object{5L}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5UL}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5.0}).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(5L)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_unsigned(5UL)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(5.0)).first);
 }
 
 TEST(TestGreaterThanDouble, Basic)
@@ -87,13 +88,13 @@ TEST(TestGreaterThanDouble, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{6L}).first);
-    EXPECT_TRUE(matcher.match(owned_object{6UL}).first);
-    EXPECT_TRUE(matcher.match(owned_object{5.12}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_signed(6L)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_unsigned(6UL)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_float(5.12)).first);
 
-    EXPECT_FALSE(matcher.match(owned_object{5L}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5UL}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5.0}).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(5L)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_unsigned(5UL)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(5.0)).first);
 }
 
 } // namespace

--- a/tests/unit/matcher/hidden_ascii_match_test.cpp
+++ b/tests/unit/matcher/hidden_ascii_match_test.cpp
@@ -9,6 +9,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/matcher/is_sqli_test.cpp
+++ b/tests/unit/matcher/is_sqli_test.cpp
@@ -7,6 +7,7 @@
 #include "matcher/is_sqli.hpp"
 #include "object.hpp"
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
@@ -20,7 +21,7 @@ TEST(TestIsSQLi, TestBasic)
     EXPECT_STRV(matcher.to_string(), "");
     EXPECT_STRV(matcher.name(), "is_sqli");
 
-    owned_object param{"'OR 1=1/*"};
+    owned_object param = test::ddwaf_object_da::make_string("'OR 1=1/*");
 
     auto [res, highlight] = matcher.match(param);
     EXPECT_TRUE(res);
@@ -34,7 +35,7 @@ TEST(TestIsSQLi, TestMatch)
     auto match = {"1, -sin(1)) UNION SELECT 1"};
 
     for (const auto *pattern : match) {
-        owned_object param{pattern};
+        owned_object param = test::ddwaf_object_da::make_string(pattern);
         EXPECT_TRUE(matcher.match(param).first);
     }
 }
@@ -46,7 +47,7 @@ TEST(TestIsSQLi, TestNoMatch)
     auto no_match = {"*", "00119007249934829312950000808000953OR-240128165430155"};
 
     for (const auto *pattern : no_match) {
-        owned_object param{pattern};
+        owned_object param = test::ddwaf_object_da::make_string(pattern);
         EXPECT_FALSE(matcher.match(param).first);
     }
 }

--- a/tests/unit/matcher/is_sqli_test.cpp
+++ b/tests/unit/matcher/is_sqli_test.cpp
@@ -11,6 +11,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace ddwaf::matcher;
 
 namespace {

--- a/tests/unit/matcher/is_xss_test.cpp
+++ b/tests/unit/matcher/is_xss_test.cpp
@@ -6,6 +6,7 @@
 
 #include "matcher/is_xss.hpp"
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
@@ -18,7 +19,7 @@ TEST(TestIsXSS, TestBasic)
     EXPECT_STRV(matcher.to_string(), "");
     EXPECT_STRV(matcher.name(), "is_xss");
 
-    owned_object param{"<script>alert(1);</script>"};
+    owned_object param = test::ddwaf_object_da::make_string("<script>alert(1);</script>");
     auto [res, highlight] = matcher.match(param);
     EXPECT_TRUE(res);
     EXPECT_STR(highlight, "");
@@ -27,7 +28,7 @@ TEST(TestIsXSS, TestBasic)
 TEST(TestIsXSS, TestNoMatch)
 {
     is_xss matcher;
-    owned_object param{"non-xss"};
+    owned_object param = test::ddwaf_object_da::make_string("non-xss");
     EXPECT_FALSE(matcher.match(param).first);
 }
 

--- a/tests/unit/matcher/is_xss_test.cpp
+++ b/tests/unit/matcher/is_xss_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace ddwaf::matcher;
 
 namespace {

--- a/tests/unit/matcher/lower_than_test.cpp
+++ b/tests/unit/matcher/lower_than_test.cpp
@@ -9,6 +9,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
@@ -32,13 +33,13 @@ TEST(TestlowerThanInt, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{4L}).first);
-    EXPECT_TRUE(matcher.match(owned_object{4UL}).first);
-    EXPECT_TRUE(matcher.match(owned_object{4.0}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_signed(4L)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_unsigned(4UL)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_float(4.0)).first);
 
-    EXPECT_FALSE(matcher.match(owned_object{5L}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5UL}).first);
-    EXPECT_FALSE(matcher.match(owned_object{5.0}).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(5L)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_unsigned(5UL)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(5.0)).first);
 }
 
 TEST(TestlowerThanUint, Basic)
@@ -59,13 +60,13 @@ TEST(TestlowerThanUint, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{2132131L}).first);
-    EXPECT_TRUE(matcher.match(owned_object{2132131UL}).first);
-    EXPECT_TRUE(matcher.match(owned_object{2132131.9}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_signed(2132131L)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_unsigned(2132131UL)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_float(2132131.9)).first);
 
-    EXPECT_FALSE(matcher.match(owned_object{2132133L}).first);
-    EXPECT_FALSE(matcher.match(owned_object{2132133UL}).first);
-    EXPECT_FALSE(matcher.match(owned_object{2132132.1}).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(2132133L)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_unsigned(2132133UL)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(2132132.1)).first);
 }
 
 TEST(TestlowerThanDouble, Basic)
@@ -87,13 +88,13 @@ TEST(TestlowerThanDouble, Basic)
     EXPECT_FALSE(matcher.is_supported_type(object_type::invalid));
     EXPECT_FALSE(matcher.is_supported_type(object_type::boolean));
 
-    EXPECT_TRUE(matcher.match(owned_object{5L}).first);
-    EXPECT_TRUE(matcher.match(owned_object{5UL}).first);
-    EXPECT_TRUE(matcher.match(owned_object{5.09}).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_signed(5L)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_unsigned(5UL)).first);
+    EXPECT_TRUE(matcher.match(test::ddwaf_object_da::make_float(5.09)).first);
 
-    EXPECT_FALSE(matcher.match(owned_object{6L}).first);
-    EXPECT_FALSE(matcher.match(owned_object{6UL}).first);
-    EXPECT_FALSE(matcher.match(owned_object{6.0}).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_signed(6L)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_unsigned(6UL)).first);
+    EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(6.0)).first);
 }
 
 } // namespace

--- a/tests/unit/matcher/phrase_match_test.cpp
+++ b/tests/unit/matcher/phrase_match_test.cpp
@@ -6,6 +6,7 @@
 
 #include "matcher/phrase_match.hpp"
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
@@ -23,13 +24,13 @@ TEST(TestPhraseMatch, TestBasic)
     EXPECT_STRV(matcher.name(), "phrase_match");
     EXPECT_STRV(matcher.to_string(), "");
 
-    owned_object param{"bbbb"};
+    owned_object param = test::ddwaf_object_da::make_string("bbbb");
 
     auto [res, highlight] = matcher.match(param);
     EXPECT_TRUE(res);
     EXPECT_STR(highlight, "bbbb");
 
-    owned_object param2{"dddd"};
+    owned_object param2 = test::ddwaf_object_da::make_string("dddd");
 
     EXPECT_FALSE(matcher.match(param2).first);
 }
@@ -42,7 +43,7 @@ TEST(TestPhraseMatch, TestEmptyArrays)
 
     EXPECT_STRV(matcher.name(), "phrase_match");
 
-    owned_object param{"bbbb"};
+    owned_object param = test::ddwaf_object_da::make_string("bbbb");
 
     EXPECT_FALSE(matcher.match(param).first);
 }
@@ -64,7 +65,7 @@ TEST(TestPhraseMatch, TestComplex)
     phrase_match matcher(strings, lengths);
 
     auto run = [&matcher](const char *str, const char *expect) {
-        owned_object param{str};
+        owned_object param = test::ddwaf_object_da::make_string(str);
         if (expect != nullptr) {
             auto [res, highlight] = matcher.match(ddwaf::object_view{param});
             EXPECT_TRUE(res);
@@ -97,7 +98,7 @@ TEST(TestPhraseMatch, TestWordBoundary)
     phrase_match matcher(strings, lengths, true);
 
     auto run = [&matcher](const char *str, const char *expect) {
-        owned_object param{str};
+        owned_object param = test::ddwaf_object_da::make_string(str);
         if (expect != nullptr) {
             auto [res, highlight] = matcher.match(ddwaf::object_view{param});
             EXPECT_TRUE(res);
@@ -190,13 +191,13 @@ TEST(TestPhraseMatch, TestSingleCharMatch)
     EXPECT_STR(matcher.name(), "phrase_match");
     EXPECT_STR(matcher.to_string(), "");
 
-    owned_object param{"a"};
+    owned_object param = test::ddwaf_object_da::make_string("a");
 
     auto [res, highlight] = matcher.match(param);
     EXPECT_TRUE(res);
     EXPECT_STR(highlight, "a");
 
-    owned_object param2{"2"};
+    owned_object param2 = test::ddwaf_object_da::make_string("2");
 
     EXPECT_FALSE(matcher.match(param2).first);
 }

--- a/tests/unit/matcher/phrase_match_test.cpp
+++ b/tests/unit/matcher/phrase_match_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace ddwaf::matcher;
 
 namespace {

--- a/tests/unit/matcher/regex_match_test.cpp
+++ b/tests/unit/matcher/regex_match_test.cpp
@@ -7,6 +7,7 @@
 #include "configuration/common/parser_exception.hpp"
 #include "matcher/regex_match.hpp"
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
@@ -24,7 +25,7 @@ TEST(TestRegexMatch, TestBasicCaseInsensitive)
     EXPECT_STRV(matcher.to_string(), "^rEgEx$");
     EXPECT_STRV(matcher.name(), "match_regex");
 
-    owned_object param{"regex"};
+    owned_object param = test::ddwaf_object_da::make_string("regex");
 
     auto [res, highlight] = matcher.match(param);
     EXPECT_TRUE(res);
@@ -35,11 +36,11 @@ TEST(TestRegexMatch, TestBasicCaseSensitive)
 {
     regex_match matcher("^rEgEx$", 0, true);
 
-    owned_object param{"regex"};
+    owned_object param = test::ddwaf_object_da::make_string("regex");
 
     EXPECT_FALSE(matcher.match(param).first);
 
-    owned_object param2{"rEgEx"};
+    owned_object param2 = test::ddwaf_object_da::make_string("rEgEx");
 
     auto [res, highlight] = matcher.match(param2);
     EXPECT_TRUE(res);
@@ -50,8 +51,8 @@ TEST(TestRegexMatch, TestMinLength)
 {
     regex_match matcher("^rEgEx.*$", 6, true);
 
-    owned_object param{"rEgEx"};
-    owned_object param2{"rEgExe"};
+    owned_object param = test::ddwaf_object_da::make_string("rEgEx");
+    owned_object param2 = test::ddwaf_object_da::make_string("rEgExe");
 
     EXPECT_FALSE(matcher.match(param).first);
 

--- a/tests/unit/matcher/regex_match_test.cpp
+++ b/tests/unit/matcher/regex_match_test.cpp
@@ -11,6 +11,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace ddwaf::matcher;
 
 namespace {

--- a/tests/unit/mkmap_test.cpp
+++ b/tests/unit/mkmap_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 using rule_tag_map = ddwaf::multi_key_map<std::string_view, core_rule *>;

--- a/tests/unit/module_test.cpp
+++ b/tests/unit/module_test.cpp
@@ -12,6 +12,7 @@
 #include "module.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -50,7 +51,7 @@ TEST(TestModuleUngrouped, SingleRuleMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -62,7 +63,7 @@ TEST(TestModuleUngrouped, SingleRuleMatch)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(root);
         std::vector<rule_result> results;
@@ -115,7 +116,7 @@ TEST(TestModuleUngrouped, MultipleMonitoringRuleMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -129,7 +130,7 @@ TEST(TestModuleUngrouped, MultipleMonitoringRuleMatch)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(root);
         std::vector<rule_result> results;
@@ -183,7 +184,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -240,7 +241,7 @@ TEST(TestModuleUngrouped, MonitoringRuleMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -254,7 +255,7 @@ TEST(TestModuleUngrouped, MonitoringRuleMatch)
 
     // Check that we can still match the blocking rule
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.2"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.2"}});
         store.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -310,7 +311,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatchBasePrecedence)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -370,7 +371,7 @@ TEST(TestModuleUngrouped, BlockingRuleMatchUserPrecedence)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -409,7 +410,7 @@ TEST(TestModuleUngrouped, NonExpiringModule)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -446,7 +447,7 @@ TEST(TestModuleUngrouped, ExpiringModule)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -484,7 +485,7 @@ TEST(TestModuleUngrouped, DisabledRules)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -536,7 +537,7 @@ TEST(TestModuleGrouped, MultipleGroupsMonitoringRuleMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -592,7 +593,7 @@ TEST(TestModuleGrouped, MultipleGroupsBlockingRuleMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -647,7 +648,7 @@ TEST(TestModuleGrouped, SingleGroupBlockingRuleMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -701,7 +702,7 @@ TEST(TestModuleGrouped, SingleGroupMonitoringRuleMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -756,7 +757,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupMonitoringUserMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -811,7 +812,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupMonitoringBaseMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -867,7 +868,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupBlockingBaseMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -923,7 +924,7 @@ TEST(TestModuleGrouped, UserPrecedenceSingleGroupBlockingUserMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -979,7 +980,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupBlockingBaseMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1035,7 +1036,7 @@ TEST(TestModuleGrouped, BasePrecedenceSingleGroupBlockingUserMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1090,7 +1091,7 @@ TEST(TestModuleGrouped, UserPrecedenceMultipleGroupsMonitoringMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1146,7 +1147,7 @@ TEST(TestModuleGrouped, UserPrecedenceMultipleGroupsBlockingMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1201,7 +1202,7 @@ TEST(TestModuleGrouped, BasePrecedenceMultipleGroupsMonitoringMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1257,7 +1258,7 @@ TEST(TestModuleGrouped, BasePrecedenceMultipleGroupsBlockingMatch)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1402,7 +1403,7 @@ TEST(TestModuleGrouped, MultipleGroupsRulesAndMatches)
 
         object_store store;
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.2"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.2"}});
         store.insert(std::move(root));
 
         std::vector<rule_result> results;
@@ -1504,7 +1505,7 @@ TEST(TestModuleGrouped, MultipleGroupsSingleMatchPerGroup)
 
         object_store store;
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1607,7 +1608,7 @@ TEST(TestModuleGrouped, MultipleGroupsOnlyBlockingMatch)
 
         object_store store;
 
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1648,7 +1649,7 @@ TEST(TestModuleGrouped, DisabledRules)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1683,7 +1684,7 @@ TEST(TestModuleGrouped, NonExpiringModule)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 
@@ -1720,7 +1721,7 @@ TEST(TestModuleGrouped, ExpiringModule)
 
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         store.insert(std::move(root));
 

--- a/tests/unit/nonnull_ptr_test.cpp
+++ b/tests/unit/nonnull_ptr_test.cpp
@@ -9,6 +9,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/obfuscator_test.cpp
+++ b/tests/unit/obfuscator_test.cpp
@@ -8,6 +8,7 @@
 #include "obfuscator.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/object_store_test.cpp
+++ b/tests/unit/object_store_test.cpp
@@ -20,7 +20,7 @@ TEST(TestObjectStore, InsertInvalidObject)
     auto url = get_target_index("url");
 
     object_store store;
-    store.insert(ddwaf::test::ddwaf_object_da::make_uninit());
+    store.insert(owned_object{});
 
     EXPECT_TRUE(store.empty());
     EXPECT_FALSE(store.has_new_targets());
@@ -128,7 +128,7 @@ TEST(TestObjectStore, InsertMultipleUniqueObjects)
     }
 
     {
-        ctx_store.insert(ddwaf::test::ddwaf_object_da::make_uninit());
+        ctx_store.insert(owned_object{});
 
         EXPECT_FALSE(ctx_store.empty());
         EXPECT_TRUE(ctx_store.has_new_targets());
@@ -189,7 +189,7 @@ TEST(TestObjectStore, InsertMultipleUniqueObjectBatches)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        owned_object third = ddwaf::test::ddwaf_object_da::make_uninit();
+        owned_object third = owned_object{};
         store.insert(std::move(third));
         EXPECT_FALSE(store.empty());
         EXPECT_FALSE(store.has_new_targets());

--- a/tests/unit/object_store_test.cpp
+++ b/tests/unit/object_store_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
@@ -19,7 +20,7 @@ TEST(TestObjectStore, InsertInvalidObject)
     auto url = get_target_index("url");
 
     object_store store;
-    store.insert(owned_object{});
+    store.insert(ddwaf::test::ddwaf_object_da::make_uninit());
 
     EXPECT_TRUE(store.empty());
     EXPECT_FALSE(store.has_new_targets());
@@ -104,7 +105,7 @@ TEST(TestObjectStore, InsertMultipleUniqueObjects)
     object_store ctx_store;
 
     {
-        ctx_store.insert(object_builder::map({{"query", "hello"}}));
+        ctx_store.insert(object_builder_da::map({{"query", "hello"}}));
 
         EXPECT_FALSE(ctx_store.empty());
         EXPECT_TRUE(ctx_store.has_new_targets());
@@ -116,7 +117,7 @@ TEST(TestObjectStore, InsertMultipleUniqueObjects)
 
     {
         auto sctx_store = object_store::from_upstream_store(ctx_store);
-        sctx_store.insert(object_builder::map({{"url", "hello"}}));
+        sctx_store.insert(object_builder_da::map({{"url", "hello"}}));
 
         EXPECT_FALSE(sctx_store.empty());
         EXPECT_TRUE(sctx_store.has_new_targets());
@@ -127,7 +128,7 @@ TEST(TestObjectStore, InsertMultipleUniqueObjects)
     }
 
     {
-        ctx_store.insert(owned_object{});
+        ctx_store.insert(ddwaf::test::ddwaf_object_da::make_uninit());
 
         EXPECT_FALSE(ctx_store.empty());
         EXPECT_TRUE(ctx_store.has_new_targets());
@@ -188,7 +189,7 @@ TEST(TestObjectStore, InsertMultipleUniqueObjectBatches)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        owned_object third;
+        owned_object third = ddwaf::test::ddwaf_object_da::make_uninit();
         store.insert(std::move(third));
         EXPECT_FALSE(store.empty());
         EXPECT_FALSE(store.has_new_targets());

--- a/tests/unit/object_store_test.cpp
+++ b/tests/unit/object_store_test.cpp
@@ -6,6 +6,7 @@
 
 #include "object_store.hpp"
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
@@ -35,7 +36,7 @@ TEST(TestObjectStore, InsertStringObject)
 
     object_store store;
 
-    store.insert(owned_object::make_string("hello"));
+    store.insert(test::ddwaf_object_da::make_string("hello"));
 
     EXPECT_TRUE(store.empty());
     EXPECT_FALSE(store.has_new_targets());
@@ -50,8 +51,8 @@ TEST(TestObjectStore, InsertAndGetObject)
     auto query = get_target_index("query");
     auto url = get_target_index("url");
 
-    auto root = owned_object::make_map();
-    root.emplace("query", owned_object::make_string("hello"));
+    auto root = test::ddwaf_object_da::make_map();
+    root.emplace("query", test::ddwaf_object_da::make_string("hello"));
 
     object_store store;
     store.insert(std::move(root));
@@ -73,8 +74,8 @@ TEST(TestObjectStore, InsertAndGetSubcontextObject)
     {
         defer cleanup{[&]() { ctx_store.clear_last_batch(); }};
 
-        auto root = owned_object::make_map();
-        root.emplace("query", owned_object::make_string("hello"));
+        auto root = test::ddwaf_object_da::make_map();
+        root.emplace("query", test::ddwaf_object_da::make_string("hello"));
 
         auto sctx_store = object_store::from_upstream_store(ctx_store);
         sctx_store.insert(std::move(root));
@@ -155,8 +156,8 @@ TEST(TestObjectStore, InsertMultipleUniqueObjectBatches)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto first = owned_object::make_map();
-        first.emplace("query", owned_object::make_string("hello"));
+        auto first = test::ddwaf_object_da::make_map();
+        first.emplace("query", test::ddwaf_object_da::make_string("hello"));
 
         store.insert(std::move(first));
 
@@ -171,8 +172,8 @@ TEST(TestObjectStore, InsertMultipleUniqueObjectBatches)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto second = owned_object::make_map();
-        second.emplace("url", owned_object::make_string("hello"));
+        auto second = test::ddwaf_object_da::make_map();
+        second.emplace("url", test::ddwaf_object_da::make_string("hello"));
 
         store.insert(std::move(second));
 
@@ -207,8 +208,8 @@ TEST(TestObjectStore, InsertMultipleOverlappingObjects)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        auto first = owned_object::make_map();
-        first.emplace("query", owned_object::make_string("hello"));
+        auto first = test::ddwaf_object_da::make_map();
+        first.emplace("query", test::ddwaf_object_da::make_string("hello"));
         store.insert(std::move(first));
 
         EXPECT_FALSE(store.empty());
@@ -228,9 +229,9 @@ TEST(TestObjectStore, InsertMultipleOverlappingObjects)
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
         // Reinsert query
-        auto second = owned_object::make_map();
-        second.emplace("url", owned_object::make_string("hello"));
-        second.emplace("query", owned_object::make_string("bye"));
+        auto second = test::ddwaf_object_da::make_map();
+        second.emplace("url", test::ddwaf_object_da::make_string("hello"));
+        second.emplace("query", test::ddwaf_object_da::make_string("bye"));
         store.insert(std::move(second));
 
         EXPECT_FALSE(store.empty());
@@ -256,8 +257,8 @@ TEST(TestObjectStore, InsertMultipleOverlappingObjects)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
         // Reinsert url
-        auto third = owned_object::make_map();
-        third.emplace("url", owned_object::make_string("bye"));
+        auto third = test::ddwaf_object_da::make_map();
+        third.emplace("url", test::ddwaf_object_da::make_string("bye"));
         store.insert(std::move(third));
 
         EXPECT_FALSE(store.empty());
@@ -280,7 +281,7 @@ TEST(TestObjectStore, InsertSingleTargets)
 
     object_store ctx_store;
 
-    ctx_store.insert(query, "query", owned_object::make_string("hello"));
+    ctx_store.insert(query, "query", test::ddwaf_object_da::make_string("hello"));
 
     EXPECT_FALSE(ctx_store.empty());
     EXPECT_TRUE(ctx_store.has_new_targets());
@@ -291,7 +292,7 @@ TEST(TestObjectStore, InsertSingleTargets)
 
     {
         auto sctx_store = object_store::from_upstream_store(ctx_store);
-        sctx_store.insert(url, "url", owned_object::make_string("hello"));
+        sctx_store.insert(url, "url", test::ddwaf_object_da::make_string("hello"));
 
         EXPECT_FALSE(sctx_store.empty());
         EXPECT_TRUE(sctx_store.has_new_targets());
@@ -320,7 +321,7 @@ TEST(TestObjectStore, InsertSingleTargetBatches)
     {
         defer cleanup{[&]() { ctx_store.clear_last_batch(); }};
 
-        ctx_store.insert(query, "query", owned_object::make_string("hello"));
+        ctx_store.insert(query, "query", test::ddwaf_object_da::make_string("hello"));
 
         EXPECT_FALSE(ctx_store.empty());
         EXPECT_TRUE(ctx_store.has_new_targets());
@@ -334,7 +335,7 @@ TEST(TestObjectStore, InsertSingleTargetBatches)
         defer cleanup{[&]() { ctx_store.clear_last_batch(); }};
 
         auto sctx_store = object_store::from_upstream_store(ctx_store);
-        sctx_store.insert(url, "url", owned_object::make_string("hello"));
+        sctx_store.insert(url, "url", test::ddwaf_object_da::make_string("hello"));
 
         EXPECT_FALSE(sctx_store.empty());
         EXPECT_TRUE(sctx_store.has_new_targets());
@@ -360,7 +361,7 @@ TEST(TestObjectStore, DuplicatePersistentTarget)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        EXPECT_TRUE(store.insert(query, "query", owned_object::make_string("hello")));
+        EXPECT_TRUE(store.insert(query, "query", test::ddwaf_object_da::make_string("hello")));
 
         EXPECT_FALSE(store.empty());
         EXPECT_TRUE(store.has_new_targets());
@@ -374,7 +375,7 @@ TEST(TestObjectStore, DuplicatePersistentTarget)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
 
-        EXPECT_TRUE(store.insert(query, "query", owned_object::make_string("bye")));
+        EXPECT_TRUE(store.insert(query, "query", test::ddwaf_object_da::make_string("bye")));
 
         EXPECT_FALSE(store.empty());
         EXPECT_TRUE(store.has_new_targets());
@@ -401,7 +402,7 @@ TEST(TestObjectStore, DuplicateSubcontextTarget)
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
         {
-            EXPECT_TRUE(store.insert(query, "query", owned_object::make_string("hello")));
+            EXPECT_TRUE(store.insert(query, "query", test::ddwaf_object_da::make_string("hello")));
 
             EXPECT_FALSE(store.empty());
             EXPECT_TRUE(store.has_new_targets());
@@ -413,7 +414,7 @@ TEST(TestObjectStore, DuplicateSubcontextTarget)
         }
 
         {
-            EXPECT_TRUE(store.insert(query, "query", owned_object::make_string("bye")));
+            EXPECT_TRUE(store.insert(query, "query", test::ddwaf_object_da::make_string("bye")));
 
             EXPECT_FALSE(store.empty());
             EXPECT_TRUE(store.has_new_targets());
@@ -442,7 +443,8 @@ TEST(TestObjectStore, ReplaceSubcontextWithPersistent)
         defer cleanup{[&]() { ctx_store.clear_last_batch(); }};
         {
             object_store sctx_store;
-            EXPECT_TRUE(sctx_store.insert(query, "query", owned_object::make_string("hello")));
+            EXPECT_TRUE(
+                sctx_store.insert(query, "query", test::ddwaf_object_da::make_string("hello")));
 
             EXPECT_FALSE(sctx_store.empty());
             EXPECT_TRUE(sctx_store.has_new_targets());
@@ -454,7 +456,8 @@ TEST(TestObjectStore, ReplaceSubcontextWithPersistent)
         }
 
         {
-            EXPECT_TRUE(ctx_store.insert(query, "query", owned_object::make_string("bye")));
+            EXPECT_TRUE(
+                ctx_store.insert(query, "query", test::ddwaf_object_da::make_string("bye")));
 
             EXPECT_FALSE(ctx_store.empty());
             EXPECT_TRUE(ctx_store.has_new_targets());
@@ -482,7 +485,8 @@ TEST(TestObjectStore, ReplacePersistentWithSubcontextSameBatch)
     {
         defer cleanup{[&]() { ctx_store.clear_last_batch(); }};
         {
-            EXPECT_TRUE(ctx_store.insert(query, "query", owned_object::make_string("hello")));
+            EXPECT_TRUE(
+                ctx_store.insert(query, "query", test::ddwaf_object_da::make_string("hello")));
 
             EXPECT_FALSE(ctx_store.empty());
             EXPECT_TRUE(ctx_store.has_new_targets());
@@ -495,7 +499,8 @@ TEST(TestObjectStore, ReplacePersistentWithSubcontextSameBatch)
 
         {
             object_store sctx_store;
-            EXPECT_TRUE(sctx_store.insert(query, "query", owned_object::make_string("bye")));
+            EXPECT_TRUE(
+                sctx_store.insert(query, "query", test::ddwaf_object_da::make_string("bye")));
 
             EXPECT_FALSE(sctx_store.empty());
             EXPECT_TRUE(sctx_store.has_new_targets());
@@ -523,7 +528,7 @@ TEST(TestObjectStore, ReplacePersistentWithSubcontextDifferentBatch)
     {
         defer cleanup{[&]() { ctx_store.clear_last_batch(); }};
 
-        EXPECT_TRUE(ctx_store.insert(query, "query", owned_object::make_string("hello")));
+        EXPECT_TRUE(ctx_store.insert(query, "query", test::ddwaf_object_da::make_string("hello")));
 
         EXPECT_FALSE(ctx_store.empty());
         EXPECT_TRUE(ctx_store.has_new_targets());
@@ -536,7 +541,7 @@ TEST(TestObjectStore, ReplacePersistentWithSubcontextDifferentBatch)
 
     {
         auto sctx_store = object_store::from_upstream_store(ctx_store);
-        EXPECT_TRUE(sctx_store.insert(query, "query", owned_object::make_string("bye")));
+        EXPECT_TRUE(sctx_store.insert(query, "query", test::ddwaf_object_da::make_string("bye")));
 
         EXPECT_FALSE(sctx_store.empty());
         EXPECT_TRUE(sctx_store.has_new_targets());

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -75,7 +75,7 @@ TEST(TestObject, NullBorrowedObject)
 
 TEST(TestObject, InvalidObject)
 {
-    owned_object ow = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object ow = owned_object{};
     EXPECT_EQ(ow.type(), object_type::invalid);
     EXPECT_TRUE(ow.is_invalid());
     EXPECT_FALSE(ow.is_valid());
@@ -966,7 +966,7 @@ TEST(TestObject, ObjectWithNullAllocator)
 
 TEST(TestObject, CloneInvalid)
 {
-    owned_object input = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object input = owned_object{};
     auto output = input.clone(memory::get_default_resource());
     EXPECT_TRUE(output.is_invalid());
 }

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "memory_resource.hpp"
 #include "object.hpp"
@@ -159,7 +160,7 @@ TEST(TestObject, FloatObject)
 TEST(TestObject, StringObject)
 {
     {
-        auto ow = owned_object::make_string("this is a string");
+        auto ow = test::ddwaf_object_da::make_string("this is a string");
         EXPECT_EQ(ow.type(), object_type::string);
         EXPECT_TRUE(ow.is_string());
         EXPECT_TRUE(ow.is_valid());
@@ -167,7 +168,7 @@ TEST(TestObject, StringObject)
     }
 
     {
-        owned_object ow{"this is a string"};
+        owned_object ow = test::ddwaf_object_da::make_string("this is a string");
         EXPECT_TRUE(ow.is_string());
         EXPECT_TRUE(ow.is_valid());
         EXPECT_EQ(ow.as<std::string_view>(), "this is a string");
@@ -179,7 +180,7 @@ TEST(TestObject, StringObjectWithAllocator)
     counting_resource alloc;
 
     {
-        auto ow = owned_object::make_string("this is a string", &alloc);
+        auto ow = test::ddwaf_object_da::make_string("this is a string", &alloc);
         EXPECT_EQ(ow.type(), object_type::string);
         EXPECT_TRUE(ow.is_string());
         EXPECT_TRUE(ow.is_valid());
@@ -203,7 +204,7 @@ TEST(TestObject, StringObjectWithAllocator)
 TEST(TestObject, SmallStringObject)
 {
     {
-        auto ow = owned_object::make_string("string");
+        auto ow = test::ddwaf_object_da::make_string("string");
         EXPECT_EQ(ow.type(), object_type::small_string);
         EXPECT_TRUE(ow.is_string());
         EXPECT_TRUE(ow.is_valid());
@@ -211,7 +212,7 @@ TEST(TestObject, SmallStringObject)
     }
 
     {
-        owned_object ow{"string"};
+        owned_object ow = test::ddwaf_object_da::make_string("string");
         EXPECT_EQ(ow.type(), object_type::small_string);
         EXPECT_TRUE(ow.is_string());
         EXPECT_TRUE(ow.is_valid());
@@ -231,7 +232,7 @@ TEST(TestObject, StringLiteralObject)
 TEST(TestObject, EmptyArrayObject)
 {
     {
-        auto root = owned_object::make_array();
+        auto root = test::ddwaf_object_da::make_array();
         EXPECT_EQ(root.type(), object_type::array);
         EXPECT_TRUE(root.is_valid());
         EXPECT_TRUE(root.is_array());
@@ -240,7 +241,7 @@ TEST(TestObject, EmptyArrayObject)
     }
 
     {
-        auto root = owned_object::make_array(0);
+        auto root = test::ddwaf_object_da::make_array(0);
         EXPECT_EQ(root.type(), object_type::array);
         EXPECT_TRUE(root.is_valid());
         EXPECT_TRUE(root.is_array());
@@ -268,7 +269,7 @@ TEST(TestObject, EmptyArrayObjectWithAllocator)
 
 TEST(TestObject, EmptyPreallocatedArrayObject)
 {
-    auto root = owned_object::make_array(20);
+    auto root = test::ddwaf_object_da::make_array(20);
     EXPECT_EQ(root.type(), object_type::array);
     EXPECT_TRUE(root.is_valid());
     EXPECT_TRUE(root.is_array());
@@ -295,7 +296,7 @@ TEST(TestObject, EmptyPreallocatedArrayObjectWithAllocator)
 
 TEST(TestObject, ArrayObjectEmplaceBack)
 {
-    auto root = owned_object::make_array();
+    auto root = test::ddwaf_object_da::make_array();
     EXPECT_EQ(root.type(), object_type::array);
     EXPECT_TRUE(root.is_valid());
 
@@ -342,8 +343,8 @@ TEST(TestObject, ArrayObjectEmplaceBackWithAllocator)
         EXPECT_TRUE(root.is_valid());
 
         for (unsigned i = 0; i < 20; i++) {
-            root.emplace_back(
-                owned_object::make_string(std::to_string(i) + "_012345678901234"s, &alloc));
+            root.emplace_back(test::ddwaf_object_da::make_string(
+                std::to_string(i) + "_012345678901234"s, &alloc));
         }
 
         object_view view(root);
@@ -384,7 +385,7 @@ TEST(TestObject, ArrayObjectEmplaceBackWithAllocator)
 
 TEST(TestObject, PreallocatedArrayObjectEmplaceBack)
 {
-    auto root = owned_object::make_array(20);
+    auto root = test::ddwaf_object_da::make_array(20);
     EXPECT_EQ(root.type(), object_type::array);
     EXPECT_TRUE(root.is_valid());
 
@@ -431,8 +432,8 @@ TEST(TestObject, PreallocatedArrayObjectEmplaceBackWithAllocator)
         EXPECT_TRUE(root.is_valid());
 
         for (unsigned i = 0; i < 20; i++) {
-            root.emplace_back(
-                owned_object::make_string(std::to_string(i) + "_012345678901234"s, &alloc));
+            root.emplace_back(test::ddwaf_object_da::make_string(
+                std::to_string(i) + "_012345678901234"s, &alloc));
         }
 
         object_view view(root);
@@ -475,14 +476,14 @@ TEST(TestObject, ArrayObjectIncompatibleAllocators)
 {
     memory::monotonic_buffer_resource alloc;
 
-    auto root = owned_object::make_array(20);
-    EXPECT_THROW(root.emplace_back(owned_object::make_string("012345678901234"sv, &alloc)),
+    auto root = test::ddwaf_object_da::make_array(20);
+    EXPECT_THROW(root.emplace_back(test::ddwaf_object_da::make_string("012345678901234"sv, &alloc)),
         std::runtime_error);
 }
 
 TEST(TestObject, EmptyMapObject)
 {
-    auto root = owned_object::make_map(0);
+    auto root = test::ddwaf_object_da::make_map(0);
     EXPECT_EQ(root.type(), object_type::map);
     EXPECT_TRUE(root.is_valid());
     EXPECT_TRUE(root.empty());
@@ -505,7 +506,7 @@ TEST(TestObject, EmptyMapObjectWithAllocator)
 
 TEST(TestObject, EmptyPreallocatedMapObject)
 {
-    auto root = owned_object::make_map(20);
+    auto root = test::ddwaf_object_da::make_map(20);
     EXPECT_EQ(root.type(), object_type::map);
     EXPECT_TRUE(root.is_valid());
     EXPECT_TRUE(root.empty());
@@ -528,7 +529,7 @@ TEST(TestObject, EmptyPreallocatedMapObjectWithAllocator)
 
 TEST(TestObject, MapObjectEmplace)
 {
-    auto root = owned_object::make_map();
+    auto root = test::ddwaf_object_da::make_map();
     EXPECT_EQ(root.type(), object_type::map);
     EXPECT_TRUE(root.is_valid());
 
@@ -576,8 +577,8 @@ TEST(TestObject, MapObjectEmplaceWithAllocator)
         EXPECT_TRUE(root.is_valid());
 
         for (unsigned i = 0; i < 20; i++) {
-            root.emplace(std::to_string(i),
-                owned_object::make_string(std::to_string(i) + "_012345678901234"s, &alloc));
+            root.emplace(std::to_string(i), test::ddwaf_object_da::make_string(
+                                                std::to_string(i) + "_012345678901234"s, &alloc));
         }
 
         object_view view(root);
@@ -619,7 +620,7 @@ TEST(TestObject, MapObjectEmplaceWithAllocator)
 
 TEST(TestObject, PreallocatedMapObjectEmplace)
 {
-    auto root = owned_object::make_map(20);
+    auto root = test::ddwaf_object_da::make_map(20);
     EXPECT_EQ(root.type(), object_type::map);
     EXPECT_TRUE(root.is_valid());
 
@@ -667,8 +668,8 @@ TEST(TestObject, PreallocatedMapObjectEmplaceWithAllocator)
         EXPECT_TRUE(root.is_valid());
 
         for (unsigned i = 0; i < 20; i++) {
-            root.emplace(std::to_string(i),
-                owned_object::make_string(std::to_string(i) + "_012345678901234"s, &alloc));
+            root.emplace(std::to_string(i), test::ddwaf_object_da::make_string(
+                                                std::to_string(i) + "_012345678901234"s, &alloc));
         }
 
         object_view view(root);
@@ -712,8 +713,9 @@ TEST(TestObject, MapObjectIncompatibleAllocators)
 {
     memory::monotonic_buffer_resource alloc;
 
-    auto root = owned_object::make_map(20);
-    EXPECT_THROW(root.emplace("key"sv, owned_object::make_string("012345678901234"sv, &alloc)),
+    auto root = test::ddwaf_object_da::make_map(20);
+    EXPECT_THROW(
+        root.emplace("key"sv, test::ddwaf_object_da::make_string("012345678901234"sv, &alloc)),
         std::runtime_error);
 }
 
@@ -951,7 +953,7 @@ TEST(TestObject, ObjectWithNullAllocator)
     {
         null_counting_resource alloc;
         {
-            owned_object other{root.ref(), &alloc};
+            owned_object other = owned_object::create_unchecked(root.ref(), &alloc);
         }
         EXPECT_EQ(alloc.deallocations(), 0);
     }
@@ -1007,7 +1009,7 @@ TEST(TestObject, CloneFloat)
 
 TEST(TestObject, CloneString)
 {
-    auto input = owned_object::make_string("this is a string");
+    auto input = test::ddwaf_object_da::make_string("this is a string");
     auto output = input.clone();
     EXPECT_TRUE(output.is_string());
     EXPECT_EQ(input.as<std::string_view>(), output.as<std::string_view>());
@@ -1016,7 +1018,7 @@ TEST(TestObject, CloneString)
 
 TEST(TestObject, CloneSmallString)
 {
-    auto input = owned_object::make_string("this");
+    auto input = test::ddwaf_object_da::make_string("this");
     auto output = input.clone();
     EXPECT_TRUE(output.is_string());
     EXPECT_EQ(input.as<std::string_view>(), output.as<std::string_view>());
@@ -1034,7 +1036,7 @@ TEST(TestObject, CloneStringLiteral)
 
 TEST(TestObject, CloneEmptyArray)
 {
-    auto input = owned_object::make_array();
+    auto input = test::ddwaf_object_da::make_array();
     auto output = input.clone();
     EXPECT_EQ(output.type(), object_type::array);
     EXPECT_EQ(input.size(), output.size());
@@ -1042,7 +1044,7 @@ TEST(TestObject, CloneEmptyArray)
 
 TEST(TestObject, CloneEmptyMap)
 {
-    auto input = owned_object::make_map();
+    auto input = test::ddwaf_object_da::make_map();
     auto output = input.clone();
     EXPECT_EQ(output.type(), object_type::map);
     EXPECT_EQ(input.size(), output.size());
@@ -1050,7 +1052,7 @@ TEST(TestObject, CloneEmptyMap)
 
 TEST(TestObject, CloneArray)
 {
-    auto input = owned_object::make_array();
+    auto input = test::ddwaf_object_da::make_array();
     input.emplace_back(true);
     input.emplace_back("string");
     input.emplace_back(5L);

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -70,8 +70,7 @@ private:
 
 TEST(TestObject, NullBorrowedObject)
 {
-    EXPECT_THROW(borrowed_object::create_unchecked(nullptr, memory::get_default_resource()),
-        std::invalid_argument);
+    EXPECT_THROW(borrowed_object(nullptr, memory::get_default_resource()), std::invalid_argument);
 }
 
 TEST(TestObject, InvalidObject)
@@ -257,7 +256,7 @@ TEST(TestObject, EmptyArrayObjectWithAllocator)
     counting_resource alloc;
 
     {
-        auto root = owned_object::make_array(0, &alloc);
+        auto root = owned_object::make_array(&alloc);
         EXPECT_EQ(root.type(), object_type::array);
         EXPECT_TRUE(root.is_valid());
         EXPECT_TRUE(root.is_array());
@@ -340,7 +339,7 @@ TEST(TestObject, ArrayObjectEmplaceBackWithAllocator)
     counting_resource alloc;
 
     {
-        auto root = owned_object::make_array(0, &alloc);
+        auto root = owned_object::make_array(&alloc);
         EXPECT_EQ(root.type(), object_type::array);
         EXPECT_TRUE(root.is_valid());
 
@@ -496,7 +495,7 @@ TEST(TestObject, EmptyMapObjectWithAllocator)
     counting_resource alloc;
 
     {
-        auto root = owned_object::make_map(0, &alloc);
+        auto root = owned_object::make_map(&alloc);
         EXPECT_EQ(root.type(), object_type::map);
         EXPECT_TRUE(root.is_valid());
         EXPECT_TRUE(root.empty());
@@ -574,7 +573,7 @@ TEST(TestObject, MapObjectEmplaceWithAllocator)
     counting_resource alloc;
 
     {
-        auto root = owned_object::make_map(0, &alloc);
+        auto root = owned_object::make_map(&alloc);
         EXPECT_EQ(root.type(), object_type::map);
         EXPECT_TRUE(root.is_valid());
 
@@ -959,7 +958,7 @@ TEST(TestObject, ObjectWithNullAllocator)
     {
         null_counting_resource alloc;
         {
-            owned_object other = owned_object::create_unchecked(root.ref(), &alloc);
+            owned_object other = owned_object{root.ref(), &alloc};
         }
         EXPECT_EQ(alloc.deallocations(), 0);
     }

--- a/tests/unit/object_view_test.cpp
+++ b/tests/unit/object_view_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "object.hpp"
 
@@ -286,7 +287,7 @@ TEST(TestObjectView, FloatObject)
 
 TEST(TestObjectView, StringObject)
 {
-    owned_object original{"string_value"};
+    owned_object original = test::ddwaf_object_da::make_string("string_value");
 
     object_view view(original);
 
@@ -312,7 +313,7 @@ TEST(TestObjectView, StringObject)
 
 TEST(TestObjectView, ArrayObject)
 {
-    auto root = owned_object::make_array();
+    auto root = test::ddwaf_object_da::make_array();
     for (unsigned i = 0; i < 20; i++) { root.emplace_back(std::to_string(i + 100)); }
 
     object_view view(root);
@@ -346,7 +347,7 @@ TEST(TestObjectView, ArrayObject)
 
 TEST(TestObjectView, MapObject)
 {
-    auto root = owned_object::make_map();
+    auto root = test::ddwaf_object_da::make_map();
     for (unsigned i = 0; i < 20; i++) { root.emplace(std::to_string(i), std::to_string(i + 100)); }
 
     object_view view(root);
@@ -433,7 +434,7 @@ TEST(TestObjectView, Inequality)
 
 TEST(TestObjectView, StringEquality)
 {
-    owned_object root{"something"};
+    owned_object root = test::ddwaf_object_da::make_string("something");
 
     object_view view(root);
 
@@ -443,7 +444,7 @@ TEST(TestObjectView, StringEquality)
 
 TEST(TestObjectView, StringInequality)
 {
-    owned_object root{"something"};
+    owned_object root = test::ddwaf_object_da::make_string("something");
 
     object_view view(root);
 
@@ -508,7 +509,7 @@ TEST(TestObjectView, FloatObjectStringConversion)
 
 TEST(TestObjectView, StringtObjectStringConversion)
 {
-    owned_object original{"this is a string"};
+    owned_object original = test::ddwaf_object_da::make_string("this is a string");
     object_view view(original);
     auto converted = view.convert<std::string>();
     EXPECT_STR(converted, "this is a string");
@@ -528,7 +529,7 @@ TEST(TestObjectView, LiteralAndLongStringHandling)
 
     // Long string uses heap path (object_type::string), pointer differs from source buffer
     const std::string long_src(40, 'x');
-    auto long_obj = owned_object::make_string(std::string_view{long_src});
+    auto long_obj = test::ddwaf_object_da::make_string(std::string_view{long_src});
     object_view long_view{long_obj};
     ASSERT_TRUE(long_view.is_string());
     EXPECT_EQ(long_view.type(), object_type::string);
@@ -864,7 +865,7 @@ TEST(TestObjectView, CloneFloat)
 
 TEST(TestObjectView, CloneString)
 {
-    auto input_data = owned_object::make_string("this is a string");
+    auto input_data = test::ddwaf_object_da::make_string("this is a string");
     object_view input{input_data};
 
     auto output = input.clone();
@@ -875,7 +876,7 @@ TEST(TestObjectView, CloneString)
 
 TEST(TestObjectView, CloneEmptyArray)
 {
-    auto input_data = owned_object::make_array();
+    auto input_data = test::ddwaf_object_da::make_array();
     object_view input{input_data};
 
     auto output = input.clone();
@@ -885,7 +886,7 @@ TEST(TestObjectView, CloneEmptyArray)
 
 TEST(TestObjectView, CloneEmptyMap)
 {
-    auto input_data = owned_object::make_map();
+    auto input_data = test::ddwaf_object_da::make_map();
     object_view input{input_data};
 
     auto output = input.clone();
@@ -895,9 +896,9 @@ TEST(TestObjectView, CloneEmptyMap)
 
 TEST(TestObjectView, CloneArray)
 {
-    auto input_data = owned_object::make_array();
+    auto input_data = test::ddwaf_object_da::make_array();
     input_data.emplace_back(owned_object::make_boolean(true));
-    input_data.emplace_back(owned_object::make_string("string"));
+    input_data.emplace_back(test::ddwaf_object_da::make_string("string"));
     input_data.emplace_back(owned_object::make_signed(5));
     object_view input{input_data};
 
@@ -941,9 +942,9 @@ TEST(TestObjectView, CloneArray)
 
 TEST(TestObjectView, CloneMap)
 {
-    owned_object input_data = owned_object::make_map();
+    owned_object input_data = test::ddwaf_object_da::make_map();
     input_data.emplace("bool", owned_object::make_boolean(true));
-    input_data.emplace("string", owned_object::make_string("string"));
+    input_data.emplace("string", test::ddwaf_object_da::make_string("string"));
     input_data.emplace("signed", owned_object::make_signed(5));
     object_view input{input_data};
 
@@ -992,7 +993,7 @@ TEST(TestObjectView, CloneMap)
 
 TEST(TestArrayView, InvalidArray)
 {
-    auto root = owned_object::make_map();
+    auto root = test::ddwaf_object_da::make_map();
     EXPECT_THROW(array_view view{root}, std::invalid_argument);
     EXPECT_THROW(array_view view{nullptr}, std::invalid_argument);
 }
@@ -1008,7 +1009,7 @@ TEST(TestArrayView, Default)
 
 TEST(TestArrayView, AtAccess)
 {
-    auto root = owned_object::make_array();
+    auto root = test::ddwaf_object_da::make_array();
     for (unsigned i = 0; i < 20; i++) { root.emplace_back(std::to_string(i + 100)); }
 
     array_view view(root);
@@ -1024,7 +1025,7 @@ TEST(TestArrayView, AtAccess)
 
 TEST(TestArrayView, IteratorAccess)
 {
-    auto root = owned_object::make_array();
+    auto root = test::ddwaf_object_da::make_array();
     for (unsigned i = 0; i < 20; i++) { root.emplace_back(std::to_string(i + 100)); }
 
     array_view view(root);
@@ -1040,7 +1041,7 @@ TEST(TestArrayView, IteratorAccess)
 
 TEST(TestMapView, InvalidMap)
 {
-    auto root = owned_object::make_array();
+    auto root = test::ddwaf_object_da::make_array();
     EXPECT_THROW(map_view view{root}, std::invalid_argument);
     EXPECT_THROW(map_view view{nullptr}, std::invalid_argument);
 }
@@ -1059,7 +1060,7 @@ TEST(TestMapView, Default)
 
 TEST(TestMapView, AtAccess)
 {
-    auto root = owned_object::make_map();
+    auto root = test::ddwaf_object_da::make_map();
     for (unsigned i = 0; i < 20; i++) { root.emplace(std::to_string(i), std::to_string(i + 100)); }
 
     map_view view(root);
@@ -1089,7 +1090,7 @@ TEST(TestMapView, AtAccess)
 
 TEST(TestMapView, FindAccess)
 {
-    auto root = owned_object::make_map();
+    auto root = test::ddwaf_object_da::make_map();
     for (unsigned i = 0; i < 20; i++) { root.emplace(std::to_string(i), std::to_string(i + 100)); }
 
     map_view view(root);
@@ -1112,7 +1113,7 @@ TEST(TestMapView, FindAccess)
 
 TEST(TestMapView, IteratorAccess)
 {
-    auto root = owned_object::make_map();
+    auto root = test::ddwaf_object_da::make_map();
     for (unsigned i = 0; i < 20; i++) { root.emplace(std::to_string(i), std::to_string(i + 100)); }
 
     map_view view(root);

--- a/tests/unit/object_view_test.cpp
+++ b/tests/unit/object_view_test.cpp
@@ -9,6 +9,7 @@
 #include "object.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -21,7 +22,7 @@ TEST(TestObjectView, DefaultObject)
 
 TEST(TestObjectView, InvalidObject)
 {
-    owned_object original;
+    owned_object original = ddwaf::test::ddwaf_object_da::make_uninit();
     object_view view(original);
 
     ASSERT_TRUE(view.has_value());
@@ -70,7 +71,7 @@ TEST(TestObjectView, NullObject)
 
 TEST(TestObjectView, BooleanObject)
 {
-    owned_object original{true};
+    owned_object original = test::ddwaf_object_da::make_boolean(true);
 
     object_view view(original);
 
@@ -96,7 +97,7 @@ TEST(TestObjectView, BooleanObject)
 
 TEST(TestObjectView, SignedObject)
 {
-    owned_object original{-20};
+    owned_object original = test::ddwaf_object_da::make_signed(-20);
 
     object_view view(original);
 
@@ -123,7 +124,7 @@ TEST(TestObjectView, SignedObject)
 TEST(TestObjectView, SignedObjectCompatibility)
 {
     {
-        owned_object original{-1};
+        owned_object original = test::ddwaf_object_da::make_signed(-1);
         object_view view(original);
 
         EXPECT_TRUE(view.is<int8_t>());
@@ -133,7 +134,8 @@ TEST(TestObjectView, SignedObjectCompatibility)
     }
 
     {
-        owned_object original{std::numeric_limits<int8_t>::min() - 1};
+        owned_object original =
+            test::ddwaf_object_da::make_signed(std::numeric_limits<int8_t>::min() - 1);
         object_view view(original);
 
         EXPECT_FALSE(view.is<int8_t>());
@@ -143,7 +145,8 @@ TEST(TestObjectView, SignedObjectCompatibility)
     }
 
     {
-        owned_object original{std::numeric_limits<int8_t>::max() + 1};
+        owned_object original =
+            test::ddwaf_object_da::make_signed(std::numeric_limits<int8_t>::max() + 1);
         object_view view(original);
 
         EXPECT_FALSE(view.is<int8_t>());
@@ -153,7 +156,8 @@ TEST(TestObjectView, SignedObjectCompatibility)
     }
 
     {
-        owned_object original{std::numeric_limits<int16_t>::min() - 1};
+        owned_object original =
+            test::ddwaf_object_da::make_signed(std::numeric_limits<int16_t>::min() - 1);
         object_view view(original);
 
         EXPECT_FALSE(view.is<int8_t>());
@@ -163,7 +167,8 @@ TEST(TestObjectView, SignedObjectCompatibility)
     }
 
     {
-        owned_object original{std::numeric_limits<int16_t>::max() + 1};
+        owned_object original =
+            test::ddwaf_object_da::make_signed(std::numeric_limits<int16_t>::max() + 1);
         object_view view(original);
 
         EXPECT_FALSE(view.is<int8_t>());
@@ -173,7 +178,8 @@ TEST(TestObjectView, SignedObjectCompatibility)
     }
 
     {
-        owned_object original{static_cast<int64_t>(std::numeric_limits<int32_t>::min()) - 1};
+        owned_object original = test::ddwaf_object_da::make_signed(
+            static_cast<int64_t>(std::numeric_limits<int32_t>::min()) - 1);
         object_view view(original);
 
         EXPECT_FALSE(view.is<int8_t>());
@@ -183,7 +189,8 @@ TEST(TestObjectView, SignedObjectCompatibility)
     }
 
     {
-        owned_object original{static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1};
+        owned_object original = test::ddwaf_object_da::make_signed(
+            static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1);
         object_view view(original);
 
         EXPECT_FALSE(view.is<int8_t>());
@@ -195,7 +202,7 @@ TEST(TestObjectView, SignedObjectCompatibility)
 
 TEST(TestObjectView, UnsignedObject)
 {
-    owned_object original{20UL};
+    owned_object original = test::ddwaf_object_da::make_unsigned(20UL);
     object_view view(original);
 
     ASSERT_TRUE(view.has_value());
@@ -221,7 +228,7 @@ TEST(TestObjectView, UnsignedObject)
 TEST(TestObjectView, UnsignedObjectCompatibility)
 {
     {
-        owned_object original{1UL};
+        owned_object original = test::ddwaf_object_da::make_unsigned(1UL);
         object_view view(original);
 
         EXPECT_TRUE(view.is<uint8_t>());
@@ -231,7 +238,8 @@ TEST(TestObjectView, UnsignedObjectCompatibility)
     }
 
     {
-        owned_object original{static_cast<uint64_t>(std::numeric_limits<uint8_t>::max() + 1)};
+        owned_object original = test::ddwaf_object_da::make_unsigned(
+            static_cast<uint64_t>(std::numeric_limits<uint8_t>::max() + 1));
         object_view view(original);
 
         EXPECT_FALSE(view.is<uint8_t>());
@@ -241,7 +249,8 @@ TEST(TestObjectView, UnsignedObjectCompatibility)
     }
 
     {
-        owned_object original{static_cast<uint64_t>(std::numeric_limits<uint16_t>::max() + 1)};
+        owned_object original = test::ddwaf_object_da::make_unsigned(
+            static_cast<uint64_t>(std::numeric_limits<uint16_t>::max() + 1));
         object_view view(original);
 
         EXPECT_FALSE(view.is<uint8_t>());
@@ -251,7 +260,8 @@ TEST(TestObjectView, UnsignedObjectCompatibility)
     }
 
     {
-        owned_object original{static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1};
+        owned_object original = test::ddwaf_object_da::make_unsigned(
+            static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1);
         object_view view(original);
 
         EXPECT_FALSE(view.is<uint8_t>());
@@ -262,7 +272,7 @@ TEST(TestObjectView, UnsignedObjectCompatibility)
 }
 TEST(TestObjectView, FloatObject)
 {
-    owned_object original{20.1};
+    owned_object original = test::ddwaf_object_da::make_float(20.1);
     object_view view(original);
 
     ASSERT_TRUE(view.has_value());
@@ -382,7 +392,7 @@ TEST(TestObjectView, MapObject)
 
 TEST(TestObjectView, Equality)
 {
-    owned_object root;
+    owned_object root = ddwaf::test::ddwaf_object_da::make_uninit();
     object_view view(root);
 
     {
@@ -392,7 +402,7 @@ TEST(TestObjectView, Equality)
     }
 
     {
-        owned_object other;
+        owned_object other = ddwaf::test::ddwaf_object_da::make_uninit();
         object_view view2(other);
 
         EXPECT_FALSE(view == view2);
@@ -408,7 +418,7 @@ TEST(TestObjectView, Equality)
 
 TEST(TestObjectView, Inequality)
 {
-    owned_object root;
+    owned_object root = ddwaf::test::ddwaf_object_da::make_uninit();
     object_view view(root);
 
     {
@@ -418,7 +428,7 @@ TEST(TestObjectView, Inequality)
     }
 
     {
-        owned_object other;
+        owned_object other = ddwaf::test::ddwaf_object_da::make_uninit();
         object_view view2(other);
 
         EXPECT_TRUE(view != view2);
@@ -460,7 +470,7 @@ TEST(TestObjectView, StringComparisonEdgeCases)
     EXPECT_FALSE(empty_view != "anything"sv);
 
     // Non-string object compared to string
-    owned_object boolean_obj{true};
+    owned_object boolean_obj = owned_object::make_boolean(true);
     object_view bool_view{boolean_obj};
     EXPECT_FALSE(bool_view == "true"sv);
     EXPECT_TRUE(bool_view != "true"sv);
@@ -469,14 +479,14 @@ TEST(TestObjectView, StringComparisonEdgeCases)
 TEST(TestObjectView, BooleanObjectStringConversion)
 {
     {
-        owned_object original{true};
+        owned_object original = owned_object::make_boolean(true);
         object_view view(original);
         auto converted = view.convert<std::string>();
         EXPECT_STR(converted, "true");
     }
 
     {
-        owned_object original{false};
+        owned_object original = owned_object::make_boolean(false);
         object_view view(original);
         auto converted = view.convert<std::string>();
         EXPECT_STR(converted, "false");
@@ -485,7 +495,7 @@ TEST(TestObjectView, BooleanObjectStringConversion)
 
 TEST(TestObjectView, SignedObjectStringConversion)
 {
-    owned_object original{-123456};
+    owned_object original = test::ddwaf_object_da::make_signed(-123456);
     object_view view(original);
     auto converted = view.convert<std::string>();
     EXPECT_STR(converted, "-123456");
@@ -493,7 +503,7 @@ TEST(TestObjectView, SignedObjectStringConversion)
 
 TEST(TestObjectView, UnsignedObjectStringConversion)
 {
-    owned_object original{123456UL};
+    owned_object original = test::ddwaf_object_da::make_unsigned(123456UL);
     object_view view(original);
     auto converted = view.convert<std::string>();
     EXPECT_STR(converted, "123456");
@@ -501,7 +511,7 @@ TEST(TestObjectView, UnsignedObjectStringConversion)
 
 TEST(TestObjectView, FloatObjectStringConversion)
 {
-    owned_object original{20.1};
+    owned_object original = test::ddwaf_object_da::make_float(20.1);
     object_view view(original);
     auto converted = view.convert<std::string>();
     EXPECT_STR(converted, "20.1");
@@ -540,7 +550,7 @@ TEST(TestObjectView, LiteralAndLongStringHandling)
 
 TEST(TestObjectView, AsOrDefault)
 {
-    owned_object original;
+    owned_object original = ddwaf::test::ddwaf_object_da::make_uninit();
     object_view view(original);
 
     EXPECT_EQ(view.as_or_default<std::string_view>({}), std::string_view{});
@@ -563,10 +573,12 @@ TEST(TestObjectView, AsOrDefaultReturnsActual)
 
 TEST(TestObjectView, KeyPathAccess)
 {
-    auto root = object_builder::map({
-        {"1", object_builder::map({{"1.2", 111}, {"1.3", 123}})},
-        {"2", object_builder::map({{"2.1", object_builder::map({{"2.1.1", 9}})}})},
-        {"3", object_builder::array({"3.1"})},
+    auto root = object_builder_da::map({
+        {"1", object_builder_da::map({{"1.2", test::ddwaf_object_da::make_signed(111)},
+                  {"1.3", test::ddwaf_object_da::make_signed(123)}})},
+        {"2", object_builder_da::map({{"2.1",
+                  object_builder_da::map({{"2.1.1", test::ddwaf_object_da::make_signed(9)}})}})},
+        {"3", object_builder_da::array({"3.1"})},
     });
 
     object_view view(root);
@@ -631,8 +643,8 @@ TEST(TestObjectView, KeyPathAccess)
 TEST(TestObjectView, FindKeyPathEmptyAndExcluded)
 {
     // Build a nested structure: { "a": { "b": ["x","y"] } }
-    auto root_obj = object_builder::map({
-        {"a", object_builder::map({{"b", object_builder::array({"x", "y"})}})},
+    auto root_obj = object_builder_da::map({
+        {"a", object_builder_da::map({{"b", object_builder_da::array({"x", "y"})}})},
     });
     object_view root{root_obj};
 
@@ -664,7 +676,7 @@ TEST(TestObjectView, FindKeyPathEmptyAndExcluded)
 TEST(TestObjectView, FindKeyPathVariantNegativeIndex)
 {
     {
-        auto root = object_builder::map({{"arr", object_builder::array({"x", "y", "z"})}});
+        auto root = object_builder_da::map({{"arr", object_builder_da::array({"x", "y", "z"})}});
         object_view view(root);
 
         std::vector<std::variant<std::string, int64_t>> key_path{"arr", -1};
@@ -674,7 +686,7 @@ TEST(TestObjectView, FindKeyPathVariantNegativeIndex)
     }
 
     {
-        auto root = object_builder::array({"x", "y", "z"});
+        auto root = object_builder_da::array({"x", "y", "z"});
         object_view view(root);
 
         std::vector<std::variant<std::string, int64_t>> key_path{-1};
@@ -687,7 +699,7 @@ TEST(TestObjectView, FindKeyPathVariantNegativeIndex)
 TEST(TestObjectView, FindKeyPathVariantNegativeIndexOutOfBounds)
 {
     {
-        auto root = object_builder::map({{"arr", object_builder::array({"x", "y", "z"})}});
+        auto root = object_builder_da::map({{"arr", object_builder_da::array({"x", "y", "z"})}});
         object_view view(root);
 
         std::vector<std::variant<std::string, int64_t>> key_path{"arr", -4};
@@ -696,7 +708,7 @@ TEST(TestObjectView, FindKeyPathVariantNegativeIndexOutOfBounds)
     }
 
     {
-        auto root = object_builder::array({"x", "y", "z"});
+        auto root = object_builder_da::array({"x", "y", "z"});
         object_view view(root);
 
         std::vector<std::variant<std::string, int64_t>> key_path{-4};
@@ -708,7 +720,7 @@ TEST(TestObjectView, FindKeyPathVariantNegativeIndexOutOfBounds)
 TEST(TestObjectView, FindKeyPathVariantNegativeIndexWithExclusion)
 {
     {
-        auto root = object_builder::map({{"arr", object_builder::array({"x", "y", "z"})}});
+        auto root = object_builder_da::map({{"arr", object_builder_da::array({"x", "y", "z"})}});
         object_view view(root);
 
         std::unordered_set<object_cache_key> excluded;
@@ -721,7 +733,7 @@ TEST(TestObjectView, FindKeyPathVariantNegativeIndexWithExclusion)
     }
 
     {
-        auto root = object_builder::array({"x", "y", "z"});
+        auto root = object_builder_da::array({"x", "y", "z"});
         object_view view(root);
 
         std::unordered_set<object_cache_key> excluded;
@@ -737,7 +749,7 @@ TEST(TestObjectView, FindKeyPathVariantNegativeIndexWithExclusion)
 TEST(TestObjectView, FindKeyPathVariantPositiveIndex)
 {
     {
-        auto root = object_builder::map({{"arr", object_builder::array({"x", "y", "z"})}});
+        auto root = object_builder_da::map({{"arr", object_builder_da::array({"x", "y", "z"})}});
         object_view view(root);
 
         std::vector<std::variant<std::string, int64_t>> key_path{"arr", 1};
@@ -747,7 +759,7 @@ TEST(TestObjectView, FindKeyPathVariantPositiveIndex)
     }
 
     {
-        auto root = object_builder::array({"x", "y", "z"});
+        auto root = object_builder_da::array({"x", "y", "z"});
         object_view view(root);
 
         std::vector<std::variant<std::string, int64_t>> key_path{1};
@@ -760,7 +772,7 @@ TEST(TestObjectView, FindKeyPathVariantPositiveIndex)
 TEST(TestObjectView, FindKeyPathVariantPositiveIndexOutOfBounds)
 {
     {
-        auto root = object_builder::map({{"arr", object_builder::array({"x", "y", "z"})}});
+        auto root = object_builder_da::map({{"arr", object_builder_da::array({"x", "y", "z"})}});
         object_view view(root);
 
         std::vector<std::variant<std::string, int64_t>> key_path{"arr", 3};
@@ -768,7 +780,7 @@ TEST(TestObjectView, FindKeyPathVariantPositiveIndexOutOfBounds)
         EXPECT_FALSE(child.has_value());
     }
     {
-        auto root = object_builder::array({"x", "y", "z"});
+        auto root = object_builder_da::array({"x", "y", "z"});
         object_view view(root);
 
         std::vector<std::variant<std::string, int64_t>> key_path{3};
@@ -780,7 +792,7 @@ TEST(TestObjectView, FindKeyPathVariantPositiveIndexOutOfBounds)
 TEST(TestObjectView, FindKeyPathVariantPositiveIndexWithExclusion)
 {
     {
-        auto root = object_builder::map({{"arr", object_builder::array({"x", "y", "z"})}});
+        auto root = object_builder_da::map({{"arr", object_builder_da::array({"x", "y", "z"})}});
         object_view view(root);
 
         std::unordered_set<object_cache_key> excluded;
@@ -793,7 +805,7 @@ TEST(TestObjectView, FindKeyPathVariantPositiveIndexWithExclusion)
     }
 
     {
-        auto root = object_builder::array({"x", "y", "z"});
+        auto root = object_builder_da::array({"x", "y", "z"});
         object_view view(root);
 
         std::unordered_set<object_cache_key> excluded;
@@ -808,9 +820,9 @@ TEST(TestObjectView, FindKeyPathVariantPositiveIndexWithExclusion)
 
 TEST(TestObjectView, CloneInvalid)
 {
-    owned_object input_data;
+    owned_object input_data = ddwaf::test::ddwaf_object_da::make_uninit();
     object_view input{input_data};
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_TRUE(output.is_invalid());
 }
 
@@ -819,7 +831,7 @@ TEST(TestObjectView, CloneNull)
     auto input_data = owned_object::make_null();
     object_view input{input_data};
 
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_EQ(output.type(), object_type::null);
 }
 
@@ -828,7 +840,7 @@ TEST(TestObjectView, CloneBool)
     auto input_data = owned_object::make_boolean(true);
     object_view input{input_data};
 
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_EQ(output.type(), object_type::boolean);
     EXPECT_EQ(output.as<bool>(), true);
 }
@@ -838,7 +850,7 @@ TEST(TestObjectView, CloneSigned)
     auto input_data = owned_object::make_signed(-5);
     object_view input{input_data};
 
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_EQ(output.type(), object_type::int64);
     EXPECT_EQ(output.as<int64_t>(), -5);
 }
@@ -848,7 +860,7 @@ TEST(TestObjectView, CloneUnsigned)
     auto input_data = owned_object::make_unsigned(5);
     object_view input{input_data};
 
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_EQ(output.type(), object_type::uint64);
     EXPECT_EQ(output.as<uint64_t>(), 5);
 }
@@ -858,7 +870,7 @@ TEST(TestObjectView, CloneFloat)
     auto input_data = owned_object::make_float(5.1);
     object_view input{input_data};
 
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_EQ(output.type(), object_type::float64);
     EXPECT_EQ(output.as<double>(), 5.1);
 }
@@ -868,7 +880,7 @@ TEST(TestObjectView, CloneString)
     auto input_data = test::ddwaf_object_da::make_string("this is a string");
     object_view input{input_data};
 
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_TRUE(output.is_string());
     EXPECT_EQ(input.as<std::string_view>(), output.as<std::string_view>());
     EXPECT_EQ(input.size(), output.size());
@@ -879,7 +891,7 @@ TEST(TestObjectView, CloneEmptyArray)
     auto input_data = test::ddwaf_object_da::make_array();
     object_view input{input_data};
 
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_EQ(output.type(), object_type::array);
     EXPECT_EQ(input.size(), output.size());
 }
@@ -889,7 +901,7 @@ TEST(TestObjectView, CloneEmptyMap)
     auto input_data = test::ddwaf_object_da::make_map();
     object_view input{input_data};
 
-    auto output = input.clone();
+    auto output = input.clone(memory::get_default_resource());
     EXPECT_EQ(output.type(), object_type::map);
     EXPECT_EQ(input.size(), output.size());
 }
@@ -902,7 +914,7 @@ TEST(TestObjectView, CloneArray)
     input_data.emplace_back(owned_object::make_signed(5));
     object_view input{input_data};
 
-    auto output_data = input.clone();
+    auto output_data = input.clone(memory::get_default_resource());
     object_view output{output_data};
 
     EXPECT_EQ(output.type(), object_type::array);
@@ -948,7 +960,7 @@ TEST(TestObjectView, CloneMap)
     input_data.emplace("signed", owned_object::make_signed(5));
     object_view input{input_data};
 
-    auto output_data = input.clone();
+    auto output_data = input.clone(memory::get_default_resource());
     object_view output{output_data};
 
     EXPECT_EQ(output.type(), object_type::map);

--- a/tests/unit/object_view_test.cpp
+++ b/tests/unit/object_view_test.cpp
@@ -22,7 +22,7 @@ TEST(TestObjectView, DefaultObject)
 
 TEST(TestObjectView, InvalidObject)
 {
-    owned_object original = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object original = owned_object{};
     object_view view(original);
 
     ASSERT_TRUE(view.has_value());
@@ -392,7 +392,7 @@ TEST(TestObjectView, MapObject)
 
 TEST(TestObjectView, Equality)
 {
-    owned_object root = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object root = owned_object{};
     object_view view(root);
 
     {
@@ -402,7 +402,7 @@ TEST(TestObjectView, Equality)
     }
 
     {
-        owned_object other = ddwaf::test::ddwaf_object_da::make_uninit();
+        owned_object other = owned_object{};
         object_view view2(other);
 
         EXPECT_FALSE(view == view2);
@@ -418,7 +418,7 @@ TEST(TestObjectView, Equality)
 
 TEST(TestObjectView, Inequality)
 {
-    owned_object root = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object root = owned_object{};
     object_view view(root);
 
     {
@@ -428,7 +428,7 @@ TEST(TestObjectView, Inequality)
     }
 
     {
-        owned_object other = ddwaf::test::ddwaf_object_da::make_uninit();
+        owned_object other = owned_object{};
         object_view view2(other);
 
         EXPECT_TRUE(view != view2);
@@ -550,7 +550,7 @@ TEST(TestObjectView, LiteralAndLongStringHandling)
 
 TEST(TestObjectView, AsOrDefault)
 {
-    owned_object original = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object original = owned_object{};
     object_view view(original);
 
     EXPECT_EQ(view.as_or_default<std::string_view>({}), std::string_view{});
@@ -820,7 +820,7 @@ TEST(TestObjectView, FindKeyPathVariantPositiveIndexWithExclusion)
 
 TEST(TestObjectView, CloneInvalid)
 {
-    owned_object input_data = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object input_data = owned_object{};
     object_view input{input_data};
     auto output = input.clone(memory::get_default_resource());
     EXPECT_TRUE(output.is_invalid());

--- a/tests/unit/processor/extract_schema_test.cpp
+++ b/tests/unit/processor/extract_schema_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "matcher/regex_match.hpp"
 #include "memory_resource.hpp"
@@ -91,7 +92,7 @@ TEST(TestExtractSchema, StringScalarSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input{"string"};
+    owned_object input = test::ddwaf_object_da::make_string("string");
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -307,7 +308,7 @@ TEST(TestExtractSchema, SchemaWithSingleScanner)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input{"string"};
+    owned_object input = test::ddwaf_object_da::make_string("string");
 
     scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}}, nullptr,
         std::make_unique<matcher::regex_match>("string", 6, true)};
@@ -325,7 +326,7 @@ TEST(TestExtractSchema, SchemaWithMultipleScanners)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input{"string"};
+    owned_object input = test::ddwaf_object_da::make_string("string");
 
     scanner scnr0{"0", {{"type", "PII"}, {"category", "first"}}, nullptr,
         std::make_unique<matcher::regex_match>("strong", 6, true)};
@@ -347,7 +348,7 @@ TEST(TestExtractSchema, SchemaWithScannerNoMatch)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input{"string"};
+    owned_object input = test::ddwaf_object_da::make_string("string");
 
     scanner scnr0{"0", {{"type", "PII"}, {"category", "first"}}, nullptr,
         std::make_unique<matcher::regex_match>("strong", 6, true)};
@@ -369,7 +370,7 @@ TEST(TestExtractSchema, SchemaWithScannerSingleValueNoKey)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input{"string"};
+    owned_object input = test::ddwaf_object_da::make_string("string");
 
     scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}},
         std::make_unique<matcher::regex_match>("string", 6, true),

--- a/tests/unit/processor/extract_schema_test.cpp
+++ b/tests/unit/processor/extract_schema_test.cpp
@@ -11,6 +11,7 @@
 #include "processor/extract_schema.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -19,7 +20,7 @@ TEST(TestExtractSchema, UnknownScalarSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input;
+    owned_object input = ddwaf::test::ddwaf_object_da::make_uninit();
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -49,7 +50,7 @@ TEST(TestExtractSchema, BoolScalarSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input{true};
+    owned_object input = test::ddwaf_object_da::make_boolean(true);
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -65,7 +66,7 @@ TEST(TestExtractSchema, IntScalarSchema)
     auto *alloc = memory::get_default_resource();
 
     {
-        owned_object input{5};
+        owned_object input = test::ddwaf_object_da::make_signed(5);
 
         extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -76,7 +77,7 @@ TEST(TestExtractSchema, IntScalarSchema)
         EXPECT_SCHEMA_EQ(output.ref(), R"([4])");
     }
     {
-        owned_object input{-5};
+        owned_object input = test::ddwaf_object_da::make_signed(-5);
 
         extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -107,7 +108,7 @@ TEST(TestExtractSchema, FloatScalarSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input{1.5};
+    owned_object input = test::ddwaf_object_da::make_float(1.5);
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -122,7 +123,7 @@ TEST(TestExtractSchema, EmptyArraySchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::array();
+    auto input = object_builder_da::array();
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -137,7 +138,8 @@ TEST(TestExtractSchema, ArraySchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::array({22, "string", owned_object{}, owned_object::make_null()});
+    auto input = object_builder_da::array({test::ddwaf_object_da::make_signed(22), "string",
+        ddwaf::test::ddwaf_object_da::make_uninit(), owned_object::make_null()});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -152,7 +154,7 @@ TEST(TestExtractSchema, ArrayWithDuplicateScalarSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::array({"string", "string", "string", "string"});
+    auto input = object_builder_da::array({"string", "string", "string", "string"});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -167,9 +169,13 @@ TEST(TestExtractSchema, ArrayWithDuplicateMapsSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::array({object_builder::map({{"unsigned", 5}, {"string", "str"}}),
-        object_builder::map({{"signed", -5}}), object_builder::map({{"unsigned", 5}}),
-        object_builder::map({{"unsigned", 109}, {"string", "wahtever"}})});
+    auto input = object_builder_da::array(
+        {object_builder_da::map(
+             {{"unsigned", test::ddwaf_object_da::make_signed(5)}, {"string", "str"}}),
+            object_builder_da::map({{"signed", test::ddwaf_object_da::make_signed(-5)}}),
+            object_builder_da::map({{"unsigned", test::ddwaf_object_da::make_signed(5)}}),
+            object_builder_da::map(
+                {{"unsigned", test::ddwaf_object_da::make_signed(109)}, {"string", "wahtever"}})});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -185,9 +191,11 @@ TEST(TestExtractSchema, ArrayWithDuplicateArraysSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input =
-        object_builder::array({object_builder::array({5, "str"}), object_builder::array({-5}),
-            object_builder::array({5}), object_builder::array({109, "wahtever"})});
+    auto input = object_builder_da::array(
+        {object_builder_da::array({test::ddwaf_object_da::make_signed(5), "str"}),
+            object_builder_da::array({test::ddwaf_object_da::make_signed(-5)}),
+            object_builder_da::array({test::ddwaf_object_da::make_signed(5)}),
+            object_builder_da::array({test::ddwaf_object_da::make_signed(109), "wahtever"})});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -202,9 +210,13 @@ TEST(TestExtractSchema, ArrayWithDuplicateContainersSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::array({object_builder::map({{"unsigned", 5}, {"string", "str"}}),
-        object_builder::array({-5}), object_builder::array({5}),
-        object_builder::map({{"string", "wahtever"}, {"unsigned", 109}})});
+    auto input = object_builder_da::array(
+        {object_builder_da::map(
+             {{"unsigned", test::ddwaf_object_da::make_signed(5)}, {"string", "str"}}),
+            object_builder_da::array({test::ddwaf_object_da::make_signed(-5)}),
+            object_builder_da::array({test::ddwaf_object_da::make_signed(5)}),
+            object_builder_da::map(
+                {{"string", "wahtever"}, {"unsigned", test::ddwaf_object_da::make_signed(109)}})});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -220,7 +232,7 @@ TEST(TestExtractSchema, EmptyMapSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::map();
+    auto input = object_builder_da::map();
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -235,10 +247,12 @@ TEST(TestExtractSchema, MapSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::map({{"unsigned", 22}, {"string", "string"},
-        {"invalid", owned_object{}}, {"null", owned_object::make_null()},
-        {"map", object_builder::map({{"unsigned", 5}, {"string", "str"}})},
-        {"array", object_builder::array({-5})}});
+    auto input = object_builder_da::map({{"unsigned", test::ddwaf_object_da::make_signed(22)},
+        {"string", "string"}, {"invalid", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"null", owned_object::make_null()},
+        {"map", object_builder_da::map(
+                    {{"unsigned", test::ddwaf_object_da::make_signed(5)}, {"string", "str"}})},
+        {"array", object_builder_da::array({test::ddwaf_object_da::make_signed(-5)})}});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -254,10 +268,10 @@ TEST(TestExtractSchema, DepthLimit)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::array();
+    auto input = object_builder_da::array();
     borrowed_object parent{input};
     for (unsigned i = 0; i < extract_schema::max_container_depth + 10; ++i) {
-        parent = parent.emplace_back(object_builder::array());
+        parent = parent.emplace_back(object_builder_da::array());
     }
 
     extract_schema gen{"id", {}, {}, {}, false, true};
@@ -274,9 +288,9 @@ TEST(TestExtractSchema, ArrayNodesLimit)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::array();
+    auto input = object_builder_da::array();
     for (unsigned i = 0; i < extract_schema::max_array_nodes + 10; ++i) {
-        input.emplace_back(object_builder::array());
+        input.emplace_back(object_builder_da::array());
     }
 
     extract_schema gen{"id", {}, {}, {}, false, true};
@@ -291,9 +305,9 @@ TEST(TestExtractSchema, RecordNodesLimit)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::map();
+    auto input = object_builder_da::map();
     for (unsigned i = 0; i < extract_schema::max_record_nodes + 10; ++i) {
-        input.emplace("child", object_builder::array());
+        input.emplace("child", object_builder_da::array());
     }
 
     extract_schema gen{"id", {}, {}, {}, false, true};
@@ -389,7 +403,7 @@ TEST(TestExtractSchema, SchemaWithScannerArrayNoKey)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::array({"string"});
+    auto input = object_builder_da::array({"string"});
 
     scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}},
         std::make_unique<matcher::regex_match>("string", 6, true),
@@ -408,7 +422,7 @@ TEST(TestExtractSchema, SchemaWithScannerArrayWithKey)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::map({{"string", object_builder::array({"string"})}});
+    auto input = object_builder_da::map({{"string", object_builder_da::array({"string"})}});
 
     scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}},
         std::make_unique<matcher::regex_match>("string", 6, true),
@@ -428,8 +442,8 @@ TEST(TestExtractSchema, SchemaWithScannerNestedArrayWithKey)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input = object_builder::map(
-        {{"string", object_builder::array({object_builder::array({"string"})})}});
+    auto input = object_builder_da::map(
+        {{"string", object_builder_da::array({object_builder_da::array({"string"})})}});
 
     scanner scnr{"0", {{"type", "PII"}, {"category", "IP"}},
         std::make_unique<matcher::regex_match>("string", 6, true),

--- a/tests/unit/processor/extract_schema_test.cpp
+++ b/tests/unit/processor/extract_schema_test.cpp
@@ -20,7 +20,7 @@ TEST(TestExtractSchema, UnknownScalarSchema)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object input = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object input = owned_object{};
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -139,7 +139,7 @@ TEST(TestExtractSchema, ArraySchema)
     auto *alloc = memory::get_default_resource();
 
     auto input = object_builder_da::array({test::ddwaf_object_da::make_signed(22), "string",
-        ddwaf::test::ddwaf_object_da::make_uninit(), owned_object::make_null()});
+        owned_object{}, owned_object::make_null()});
 
     extract_schema gen{"id", {}, {}, {}, false, true};
 
@@ -248,8 +248,7 @@ TEST(TestExtractSchema, MapSchema)
     auto *alloc = memory::get_default_resource();
 
     auto input = object_builder_da::map({{"unsigned", test::ddwaf_object_da::make_signed(22)},
-        {"string", "string"}, {"invalid", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"null", owned_object::make_null()},
+        {"string", "string"}, {"invalid", owned_object{}}, {"null", owned_object::make_null()},
         {"map", object_builder_da::map(
                     {{"unsigned", test::ddwaf_object_da::make_signed(5)}, {"string", "str"}})},
         {"array", object_builder_da::array({test::ddwaf_object_da::make_signed(-5)})}});

--- a/tests/unit/processor/fingerprint_test.cpp
+++ b/tests/unit/processor/fingerprint_test.cpp
@@ -17,15 +17,14 @@ TEST(TestHttpEndpointFingerprint, Basic)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto query = object_builder_da::map({{"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"key,3", ddwaf::test::ddwaf_object_da::make_uninit()}});
+    auto query = object_builder_da::map(
+        {{"Key1", owned_object{}}, {"KEY2", owned_object{}}, {"key,3", owned_object{}}});
 
     auto body = object_builder_da::map({
-        {"KEY1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"3", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY1", owned_object{}},
+        {"KEY2", owned_object{}},
+        {"KEY", owned_object{}},
+        {"3", owned_object{}},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -49,10 +48,10 @@ TEST(TestHttpEndpointFingerprint, EmptyQuery)
     auto query = object_builder_da::map();
 
     auto body = object_builder_da::map({
-        {"KEY1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"3", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY1", owned_object{}},
+        {"KEY2", owned_object{}},
+        {"KEY", owned_object{}},
+        {"3", owned_object{}},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -74,9 +73,9 @@ TEST(TestHttpEndpointFingerprint, EmptyBody)
     auto *alloc = memory::get_default_resource();
 
     auto query = object_builder_da::map({
-        {"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"key,3", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"Key1", owned_object{}},
+        {"KEY2", owned_object{}},
+        {"key,3", owned_object{}},
     });
 
     auto body = object_builder_da::map();
@@ -119,16 +118,16 @@ TEST(TestHttpEndpointFingerprint, KeyConsistency)
     auto *alloc = memory::get_default_resource();
 
     auto query = object_builder_da::map({
-        {"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"key3,Key4", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"Key1", owned_object{}},
+        {"KEY2", owned_object{}},
+        {"key3,Key4", owned_object{}},
     });
 
     auto body = object_builder_da::map({
-        {"KeY1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"kEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY3", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KeY4", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KeY1", owned_object{}},
+        {"kEY2", owned_object{}},
+        {"KEY3", owned_object{}},
+        {"KeY4", owned_object{}},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -150,16 +149,16 @@ TEST(TestHttpEndpointFingerprint, UriRawConsistency)
     auto *alloc = memory::get_default_resource();
 
     auto query = object_builder_da::map({
-        {"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"key,3", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"Key1", owned_object{}},
+        {"KEY2", owned_object{}},
+        {"key,3", owned_object{}},
     });
 
     auto body = object_builder_da::map({
-        {"KEY1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"3", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY1", owned_object{}},
+        {"KEY2", owned_object{}},
+        {"KEY", owned_object{}},
+        {"3", owned_object{}},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -237,9 +236,9 @@ TEST(TestHttpEndpointFingerprint, Regeneration)
     auto *alloc = memory::get_default_resource();
 
     auto query = object_builder_da::map({
-        {"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"key,3", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"Key1", owned_object{}},
+        {"KEY2", owned_object{}},
+        {"key,3", owned_object{}},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -259,10 +258,10 @@ TEST(TestHttpEndpointFingerprint, Regeneration)
 
     {
         auto body = object_builder_da::map({
-            {"KEY1", ddwaf::test::ddwaf_object_da::make_uninit()},
-            {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
-            {"KEY", ddwaf::test::ddwaf_object_da::make_uninit()},
-            {"3", ddwaf::test::ddwaf_object_da::make_uninit()},
+            {"KEY1", owned_object{}},
+            {"KEY2", owned_object{}},
+            {"KEY", owned_object{}},
+            {"3", owned_object{}},
         });
 
         ddwaf::timer deadline{2s};
@@ -282,16 +281,16 @@ TEST(TestHttpHeaderFingerprint, AllKnownHeaders)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"CONNECTION", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"Accept_Encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"CONTENT-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cache-CONTROL", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"tE", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"ACCEPT_CHARSET", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accepT", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept_language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"referer", owned_object{}},
+        {"CONNECTION", owned_object{}},
+        {"Accept_Encoding", owned_object{}},
+        {"CONTENT-encoding", owned_object{}},
+        {"cache-CONTROL", owned_object{}},
+        {"tE", owned_object{}},
+        {"ACCEPT_CHARSET", owned_object{}},
+        {"content-type", owned_object{}},
+        {"accepT", owned_object{}},
+        {"accept_language", owned_object{}},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -328,12 +327,12 @@ TEST(TestHttpHeaderFingerprint, SomeKnownHeaders)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"referer", owned_object{}},
+        {"accept-encoding", owned_object{}},
+        {"cache-control", owned_object{}},
+        {"accept-charset", owned_object{}},
+        {"accept", owned_object{}},
+        {"accept-language", owned_object{}},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -353,16 +352,16 @@ TEST(TestHttpHeaderFingerprint, UserAgent)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"referer", owned_object{}},
+        {"connection", owned_object{}},
+        {"accept-encoding", owned_object{}},
+        {"content-encoding", owned_object{}},
+        {"cache-control", owned_object{}},
+        {"te", owned_object{}},
+        {"accept-charset", owned_object{}},
+        {"content-type", owned_object{}},
+        {"accept", owned_object{}},
+        {"accept-language", owned_object{}},
         {"user-agent", "Random"},
     });
 
@@ -383,16 +382,16 @@ TEST(TestHttpHeaderFingerprint, UserAgentAsArray)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"referer", owned_object{}},
+        {"connection", owned_object{}},
+        {"accept-encoding", owned_object{}},
+        {"content-encoding", owned_object{}},
+        {"cache-control", owned_object{}},
+        {"te", owned_object{}},
+        {"accept-charset", owned_object{}},
+        {"content-type", owned_object{}},
+        {"accept", owned_object{}},
+        {"accept-language", owned_object{}},
         {"user-agent", object_builder_da::array({"Random"})},
     });
 
@@ -413,16 +412,16 @@ TEST(TestHttpHeaderFingerprint, UserAgentAsArrayInvalidType)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"referer", owned_object{}},
+        {"connection", owned_object{}},
+        {"accept-encoding", owned_object{}},
+        {"content-encoding", owned_object{}},
+        {"cache-control", owned_object{}},
+        {"te", owned_object{}},
+        {"accept-charset", owned_object{}},
+        {"content-type", owned_object{}},
+        {"accept", owned_object{}},
+        {"accept-language", owned_object{}},
         {"user-agent", object_builder_da::array({42})},
     });
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -442,16 +441,16 @@ TEST(TestHttpHeaderFingerprint, MultipleUserAgents)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"referer", owned_object{}},
+        {"connection", owned_object{}},
+        {"accept-encoding", owned_object{}},
+        {"content-encoding", owned_object{}},
+        {"cache-control", owned_object{}},
+        {"te", owned_object{}},
+        {"accept-charset", owned_object{}},
+        {"content-type", owned_object{}},
+        {"accept", owned_object{}},
+        {"accept-language", owned_object{}},
         {"user-agent", object_builder_da::array({"Random", "Bot"})},
     });
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -471,30 +470,30 @@ TEST(TestHttpHeaderFingerprint, ExcludedUnknownHeaders)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"referer", owned_object{}},
+        {"connection", owned_object{}},
+        {"accept-encoding", owned_object{}},
+        {"content-encoding", owned_object{}},
+        {"cache-control", owned_object{}},
+        {"te", owned_object{}},
+        {"accept-charset", owned_object{}},
+        {"content-type", owned_object{}},
+        {"accept", owned_object{}},
+        {"accept-language", owned_object{}},
         {"user-agent", "Random"},
 
         // Should be excluded
-        {"x-datadog-trace-id", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-datadog-trace-id", owned_object{}},
+        {"x-forwarded-for", owned_object{}},
+        {"x-real-ip", owned_object{}},
+        {"true-client-ip", owned_object{}},
+        {"x-client-ip", owned_object{}},
+        {"x-forwarded", owned_object{}},
+        {"forwarded-for", owned_object{}},
+        {"x-cluster-client-ip", owned_object{}},
+        {"fastly-client-ip", owned_object{}},
+        {"cf-connecting-ip", owned_object{}},
+        {"cf-connecting-ipv6", owned_object{}},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -514,34 +513,34 @@ TEST(TestHttpHeaderFingerprint, UnknownHeaders)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"referer", owned_object{}},
+        {"connection", owned_object{}},
+        {"accept-encoding", owned_object{}},
+        {"content-encoding", owned_object{}},
+        {"cache-control", owned_object{}},
+        {"te", owned_object{}},
+        {"accept-charset", owned_object{}},
+        {"content-type", owned_object{}},
+        {"accept", owned_object{}},
+        {"accept-language", owned_object{}},
         {"user-agent", "Random"},
-        {"unknown_header", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"Authorization", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"WWW-Authenticate", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"Allow", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"unknown_header", owned_object{}},
+        {"Authorization", owned_object{}},
+        {"WWW-Authenticate", owned_object{}},
+        {"Allow", owned_object{}},
 
         // Should be excluded
-        {"x-datadog-trace-id", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-datadog-trace-id", owned_object{}},
+        {"x-forwarded-for", owned_object{}},
+        {"x-real-ip", owned_object{}},
+        {"true-client-ip", owned_object{}},
+        {"x-client-ip", owned_object{}},
+        {"x-forwarded", owned_object{}},
+        {"forwarded-for", owned_object{}},
+        {"x-cluster-client-ip", owned_object{}},
+        {"fastly-client-ip", owned_object{}},
+        {"cf-connecting-ip", owned_object{}},
+        {"cf-connecting-ipv6", owned_object{}},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -562,15 +561,15 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeaders)
 
     auto headers = object_builder_da::map({
         {"x-forwarded-for", "192.168.1.1"},
-        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-real-ip", owned_object{}},
+        {"true-client-ip", owned_object{}},
+        {"x-client-ip", owned_object{}},
+        {"x-forwarded", owned_object{}},
+        {"forwarded-for", owned_object{}},
+        {"x-cluster-client-ip", owned_object{}},
+        {"fastly-client-ip", owned_object{}},
+        {"cf-connecting-ip", owned_object{}},
+        {"cf-connecting-ipv6", owned_object{}},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -607,15 +606,15 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPs)
 
     auto headers = object_builder_da::map({
         {"x-forwarded-for", "192.168.1.1,::1,8.7.6.5"},
-        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-real-ip", owned_object{}},
+        {"true-client-ip", owned_object{}},
+        {"x-client-ip", owned_object{}},
+        {"x-forwarded", owned_object{}},
+        {"forwarded-for", owned_object{}},
+        {"x-cluster-client-ip", owned_object{}},
+        {"fastly-client-ip", owned_object{}},
+        {"cf-connecting-ip", owned_object{}},
+        {"cf-connecting-ipv6", owned_object{}},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -636,15 +635,15 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsAsArray)
 
     auto headers = object_builder_da::map({
         {"x-forwarded-for", object_builder_da::array({"192.168.1.1,::1,8.7.6.5"})},
-        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-real-ip", owned_object{}},
+        {"true-client-ip", owned_object{}},
+        {"x-client-ip", owned_object{}},
+        {"x-forwarded", owned_object{}},
+        {"forwarded-for", owned_object{}},
+        {"x-cluster-client-ip", owned_object{}},
+        {"fastly-client-ip", owned_object{}},
+        {"cf-connecting-ip", owned_object{}},
+        {"cf-connecting-ipv6", owned_object{}},
     });
     http_network_fingerprint gen{"id", {}, {}, false, true};
 
@@ -664,15 +663,15 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsAsArrayInvalidTyp
 
     auto headers = object_builder_da::map({
         {"x-forwarded-for", object_builder_da::array({42})},
-        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-real-ip", owned_object{}},
+        {"true-client-ip", owned_object{}},
+        {"x-client-ip", owned_object{}},
+        {"x-forwarded", owned_object{}},
+        {"forwarded-for", owned_object{}},
+        {"x-cluster-client-ip", owned_object{}},
+        {"fastly-client-ip", owned_object{}},
+        {"cf-connecting-ip", owned_object{}},
+        {"cf-connecting-ipv6", owned_object{}},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -693,15 +692,15 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsDuplicateXFF)
 
     auto headers = object_builder_da::map({
         {"x-forwarded-for", object_builder_da::array({"192.168.1.1,::1,8.7.6.5", "192.168.1.44"})},
-        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-real-ip", owned_object{}},
+        {"true-client-ip", owned_object{}},
+        {"x-client-ip", owned_object{}},
+        {"x-forwarded", owned_object{}},
+        {"forwarded-for", owned_object{}},
+        {"x-cluster-client-ip", owned_object{}},
+        {"fastly-client-ip", owned_object{}},
+        {"cf-connecting-ip", owned_object{}},
+        {"cf-connecting-ipv6", owned_object{}},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -721,16 +720,16 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersRandomChosenHeader)
     auto *alloc = memory::get_default_resource();
 
     auto headers = object_builder_da::map({
-        {"x-forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded-for", owned_object{}},
+        {"x-real-ip", owned_object{}},
+        {"true-client-ip", owned_object{}},
+        {"x-client-ip", owned_object{}},
+        {"x-forwarded", owned_object{}},
+        {"forwarded-for", owned_object{}},
+        {"x-cluster-client-ip", owned_object{}},
         {"fastly-client-ip", "192.168.1.1,::1,8.7.6.5"},
-        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ip", owned_object{}},
+        {"cf-connecting-ipv6", owned_object{}},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -1030,13 +1029,13 @@ TEST(TestSessionFingerprint, CookieEmptyValues)
     auto *alloc = memory::get_default_resource();
 
     auto cookies = object_builder_da::map({
-        {"name", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"theme", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"language", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"tracking_id", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"gdpr_consent", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"session_id", ddwaf::test::ddwaf_object_da::make_uninit()},
-        {"last_visit", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"name", owned_object{}},
+        {"theme", owned_object{}},
+        {"language", owned_object{}},
+        {"tracking_id", owned_object{}},
+        {"gdpr_consent", owned_object{}},
+        {"session_id", owned_object{}},
+        {"last_visit", owned_object{}},
     });
 
     session_fingerprint gen{"id", {}, {}, false, true};

--- a/tests/unit/processor/fingerprint_test.cpp
+++ b/tests/unit/processor/fingerprint_test.cpp
@@ -8,6 +8,7 @@
 #include "processor/fingerprint.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -16,14 +17,15 @@ TEST(TestHttpEndpointFingerprint, Basic)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto query = object_builder::map(
-        {{"Key1", owned_object{}}, {"KEY2", owned_object{}}, {"key,3", owned_object{}}});
+    auto query = object_builder_da::map({{"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"key,3", ddwaf::test::ddwaf_object_da::make_uninit()}});
 
-    auto body = object_builder::map({
-        {"KEY1", owned_object{}},
-        {"KEY2", owned_object{}},
-        {"KEY", owned_object{}},
-        {"3", owned_object{}},
+    auto body = object_builder_da::map({
+        {"KEY1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"3", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -44,13 +46,13 @@ TEST(TestHttpEndpointFingerprint, EmptyQuery)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto query = object_builder::map();
+    auto query = object_builder_da::map();
 
-    auto body = object_builder::map({
-        {"KEY1", owned_object{}},
-        {"KEY2", owned_object{}},
-        {"KEY", owned_object{}},
-        {"3", owned_object{}},
+    auto body = object_builder_da::map({
+        {"KEY1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"3", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -71,13 +73,13 @@ TEST(TestHttpEndpointFingerprint, EmptyBody)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto query = object_builder::map({
-        {"Key1", owned_object{}},
-        {"KEY2", owned_object{}},
-        {"key,3", owned_object{}},
+    auto query = object_builder_da::map({
+        {"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"key,3", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
-    auto body = object_builder::map();
+    auto body = object_builder_da::map();
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -96,8 +98,8 @@ TEST(TestHttpEndpointFingerprint, EmptyEverything)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto query = object_builder::map();
-    auto body = object_builder::map();
+    auto query = object_builder_da::map();
+    auto body = object_builder_da::map();
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -116,17 +118,17 @@ TEST(TestHttpEndpointFingerprint, KeyConsistency)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto query = object_builder::map({
-        {"Key1", owned_object{}},
-        {"KEY2", owned_object{}},
-        {"key3,Key4", owned_object{}},
+    auto query = object_builder_da::map({
+        {"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"key3,Key4", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
-    auto body = object_builder::map({
-        {"KeY1", owned_object{}},
-        {"kEY2", owned_object{}},
-        {"KEY3", owned_object{}},
-        {"KeY4", owned_object{}},
+    auto body = object_builder_da::map({
+        {"KeY1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"kEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY3", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KeY4", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -147,17 +149,17 @@ TEST(TestHttpEndpointFingerprint, UriRawConsistency)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto query = object_builder::map({
-        {"Key1", owned_object{}},
-        {"KEY2", owned_object{}},
-        {"key,3", owned_object{}},
+    auto query = object_builder_da::map({
+        {"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"key,3", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
-    auto body = object_builder::map({
-        {"KEY1", owned_object{}},
-        {"KEY2", owned_object{}},
-        {"KEY", owned_object{}},
-        {"3", owned_object{}},
+    auto body = object_builder_da::map({
+        {"KEY1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"3", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -234,10 +236,10 @@ TEST(TestHttpEndpointFingerprint, Regeneration)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto query = object_builder::map({
-        {"Key1", owned_object{}},
-        {"KEY2", owned_object{}},
-        {"key,3", owned_object{}},
+    auto query = object_builder_da::map({
+        {"Key1", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"key,3", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_endpoint_fingerprint gen{"id", {}, {}, false, true};
@@ -256,11 +258,11 @@ TEST(TestHttpEndpointFingerprint, Regeneration)
     }
 
     {
-        auto body = object_builder::map({
-            {"KEY1", owned_object{}},
-            {"KEY2", owned_object{}},
-            {"KEY", owned_object{}},
-            {"3", owned_object{}},
+        auto body = object_builder_da::map({
+            {"KEY1", ddwaf::test::ddwaf_object_da::make_uninit()},
+            {"KEY2", ddwaf::test::ddwaf_object_da::make_uninit()},
+            {"KEY", ddwaf::test::ddwaf_object_da::make_uninit()},
+            {"3", ddwaf::test::ddwaf_object_da::make_uninit()},
         });
 
         ddwaf::timer deadline{2s};
@@ -279,17 +281,17 @@ TEST(TestHttpHeaderFingerprint, AllKnownHeaders)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"referer", owned_object{}},
-        {"CONNECTION", owned_object{}},
-        {"Accept_Encoding", owned_object{}},
-        {"CONTENT-encoding", owned_object{}},
-        {"cache-CONTROL", owned_object{}},
-        {"tE", owned_object{}},
-        {"ACCEPT_CHARSET", owned_object{}},
-        {"content-type", owned_object{}},
-        {"accepT", owned_object{}},
-        {"accept_language", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"CONNECTION", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"Accept_Encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"CONTENT-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cache-CONTROL", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"tE", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"ACCEPT_CHARSET", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accepT", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept_language", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -308,7 +310,7 @@ TEST(TestHttpHeaderFingerprint, NoHeaders)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map();
+    auto headers = object_builder_da::map();
     http_header_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -325,13 +327,13 @@ TEST(TestHttpHeaderFingerprint, SomeKnownHeaders)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"referer", owned_object{}},
-        {"accept-encoding", owned_object{}},
-        {"cache-control", owned_object{}},
-        {"accept-charset", owned_object{}},
-        {"accept", owned_object{}},
-        {"accept-language", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -350,17 +352,17 @@ TEST(TestHttpHeaderFingerprint, UserAgent)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"referer", owned_object{}},
-        {"connection", owned_object{}},
-        {"accept-encoding", owned_object{}},
-        {"content-encoding", owned_object{}},
-        {"cache-control", owned_object{}},
-        {"te", owned_object{}},
-        {"accept-charset", owned_object{}},
-        {"content-type", owned_object{}},
-        {"accept", owned_object{}},
-        {"accept-language", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
         {"user-agent", "Random"},
     });
 
@@ -380,18 +382,18 @@ TEST(TestHttpHeaderFingerprint, UserAgentAsArray)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"referer", owned_object{}},
-        {"connection", owned_object{}},
-        {"accept-encoding", owned_object{}},
-        {"content-encoding", owned_object{}},
-        {"cache-control", owned_object{}},
-        {"te", owned_object{}},
-        {"accept-charset", owned_object{}},
-        {"content-type", owned_object{}},
-        {"accept", owned_object{}},
-        {"accept-language", owned_object{}},
-        {"user-agent", object_builder::array({"Random"})},
+    auto headers = object_builder_da::map({
+        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"user-agent", object_builder_da::array({"Random"})},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -410,18 +412,18 @@ TEST(TestHttpHeaderFingerprint, UserAgentAsArrayInvalidType)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"referer", owned_object{}},
-        {"connection", owned_object{}},
-        {"accept-encoding", owned_object{}},
-        {"content-encoding", owned_object{}},
-        {"cache-control", owned_object{}},
-        {"te", owned_object{}},
-        {"accept-charset", owned_object{}},
-        {"content-type", owned_object{}},
-        {"accept", owned_object{}},
-        {"accept-language", owned_object{}},
-        {"user-agent", object_builder::array({42})},
+    auto headers = object_builder_da::map({
+        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"user-agent", object_builder_da::array({42})},
     });
     http_header_fingerprint gen{"id", {}, {}, false, true};
 
@@ -439,18 +441,18 @@ TEST(TestHttpHeaderFingerprint, MultipleUserAgents)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"referer", owned_object{}},
-        {"connection", owned_object{}},
-        {"accept-encoding", owned_object{}},
-        {"content-encoding", owned_object{}},
-        {"cache-control", owned_object{}},
-        {"te", owned_object{}},
-        {"accept-charset", owned_object{}},
-        {"content-type", owned_object{}},
-        {"accept", owned_object{}},
-        {"accept-language", owned_object{}},
-        {"user-agent", object_builder::array({"Random", "Bot"})},
+    auto headers = object_builder_da::map({
+        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"user-agent", object_builder_da::array({"Random", "Bot"})},
     });
     http_header_fingerprint gen{"id", {}, {}, false, true};
 
@@ -468,31 +470,31 @@ TEST(TestHttpHeaderFingerprint, ExcludedUnknownHeaders)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"referer", owned_object{}},
-        {"connection", owned_object{}},
-        {"accept-encoding", owned_object{}},
-        {"content-encoding", owned_object{}},
-        {"cache-control", owned_object{}},
-        {"te", owned_object{}},
-        {"accept-charset", owned_object{}},
-        {"content-type", owned_object{}},
-        {"accept", owned_object{}},
-        {"accept-language", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
         {"user-agent", "Random"},
 
         // Should be excluded
-        {"x-datadog-trace-id", owned_object{}},
-        {"x-forwarded-for", owned_object{}},
-        {"x-real-ip", owned_object{}},
-        {"true-client-ip", owned_object{}},
-        {"x-client-ip", owned_object{}},
-        {"x-forwarded", owned_object{}},
-        {"forwarded-for", owned_object{}},
-        {"x-cluster-client-ip", owned_object{}},
-        {"fastly-client-ip", owned_object{}},
-        {"cf-connecting-ip", owned_object{}},
-        {"cf-connecting-ipv6", owned_object{}},
+        {"x-datadog-trace-id", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -511,35 +513,35 @@ TEST(TestHttpHeaderFingerprint, UnknownHeaders)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"referer", owned_object{}},
-        {"connection", owned_object{}},
-        {"accept-encoding", owned_object{}},
-        {"content-encoding", owned_object{}},
-        {"cache-control", owned_object{}},
-        {"te", owned_object{}},
-        {"accept-charset", owned_object{}},
-        {"content-type", owned_object{}},
-        {"accept", owned_object{}},
-        {"accept-language", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"referer", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"connection", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-encoding", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cache-control", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"te", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-charset", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"content-type", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"accept-language", ddwaf::test::ddwaf_object_da::make_uninit()},
         {"user-agent", "Random"},
-        {"unknown_header", owned_object{}},
-        {"Authorization", owned_object{}},
-        {"WWW-Authenticate", owned_object{}},
-        {"Allow", owned_object{}},
+        {"unknown_header", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"Authorization", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"WWW-Authenticate", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"Allow", ddwaf::test::ddwaf_object_da::make_uninit()},
 
         // Should be excluded
-        {"x-datadog-trace-id", owned_object{}},
-        {"x-forwarded-for", owned_object{}},
-        {"x-real-ip", owned_object{}},
-        {"true-client-ip", owned_object{}},
-        {"x-client-ip", owned_object{}},
-        {"x-forwarded", owned_object{}},
-        {"forwarded-for", owned_object{}},
-        {"x-cluster-client-ip", owned_object{}},
-        {"fastly-client-ip", owned_object{}},
-        {"cf-connecting-ip", owned_object{}},
-        {"cf-connecting-ipv6", owned_object{}},
+        {"x-datadog-trace-id", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_header_fingerprint gen{"id", {}, {}, false, true};
@@ -558,17 +560,17 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeaders)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
+    auto headers = object_builder_da::map({
         {"x-forwarded-for", "192.168.1.1"},
-        {"x-real-ip", owned_object{}},
-        {"true-client-ip", owned_object{}},
-        {"x-client-ip", owned_object{}},
-        {"x-forwarded", owned_object{}},
-        {"forwarded-for", owned_object{}},
-        {"x-cluster-client-ip", owned_object{}},
-        {"fastly-client-ip", owned_object{}},
-        {"cf-connecting-ip", owned_object{}},
-        {"cf-connecting-ipv6", owned_object{}},
+        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -586,7 +588,7 @@ TEST(TestHttpNetworkFingerprint, NoHeaders)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map();
+    auto headers = object_builder_da::map();
     http_network_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -603,17 +605,17 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPs)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
+    auto headers = object_builder_da::map({
         {"x-forwarded-for", "192.168.1.1,::1,8.7.6.5"},
-        {"x-real-ip", owned_object{}},
-        {"true-client-ip", owned_object{}},
-        {"x-client-ip", owned_object{}},
-        {"x-forwarded", owned_object{}},
-        {"forwarded-for", owned_object{}},
-        {"x-cluster-client-ip", owned_object{}},
-        {"fastly-client-ip", owned_object{}},
-        {"cf-connecting-ip", owned_object{}},
-        {"cf-connecting-ipv6", owned_object{}},
+        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -632,17 +634,17 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsAsArray)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"x-forwarded-for", object_builder::array({"192.168.1.1,::1,8.7.6.5"})},
-        {"x-real-ip", owned_object{}},
-        {"true-client-ip", owned_object{}},
-        {"x-client-ip", owned_object{}},
-        {"x-forwarded", owned_object{}},
-        {"forwarded-for", owned_object{}},
-        {"x-cluster-client-ip", owned_object{}},
-        {"fastly-client-ip", owned_object{}},
-        {"cf-connecting-ip", owned_object{}},
-        {"cf-connecting-ipv6", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"x-forwarded-for", object_builder_da::array({"192.168.1.1,::1,8.7.6.5"})},
+        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
     http_network_fingerprint gen{"id", {}, {}, false, true};
 
@@ -660,17 +662,17 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsAsArrayInvalidTyp
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"x-forwarded-for", object_builder::array({42})},
-        {"x-real-ip", owned_object{}},
-        {"true-client-ip", owned_object{}},
-        {"x-client-ip", owned_object{}},
-        {"x-forwarded", owned_object{}},
-        {"forwarded-for", owned_object{}},
-        {"x-cluster-client-ip", owned_object{}},
-        {"fastly-client-ip", owned_object{}},
-        {"cf-connecting-ip", owned_object{}},
-        {"cf-connecting-ipv6", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"x-forwarded-for", object_builder_da::array({42})},
+        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -689,17 +691,17 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersMultipleChosenIPsDuplicateXFF)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"x-forwarded-for", object_builder::array({"192.168.1.1,::1,8.7.6.5", "192.168.1.44"})},
-        {"x-real-ip", owned_object{}},
-        {"true-client-ip", owned_object{}},
-        {"x-client-ip", owned_object{}},
-        {"x-forwarded", owned_object{}},
-        {"forwarded-for", owned_object{}},
-        {"x-cluster-client-ip", owned_object{}},
-        {"fastly-client-ip", owned_object{}},
-        {"cf-connecting-ip", owned_object{}},
-        {"cf-connecting-ipv6", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"x-forwarded-for", object_builder_da::array({"192.168.1.1,::1,8.7.6.5", "192.168.1.44"})},
+        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"fastly-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -718,17 +720,17 @@ TEST(TestHttpNetworkFingerprint, AllXFFHeadersRandomChosenHeader)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({
-        {"x-forwarded-for", owned_object{}},
-        {"x-real-ip", owned_object{}},
-        {"true-client-ip", owned_object{}},
-        {"x-client-ip", owned_object{}},
-        {"x-forwarded", owned_object{}},
-        {"forwarded-for", owned_object{}},
-        {"x-cluster-client-ip", owned_object{}},
+    auto headers = object_builder_da::map({
+        {"x-forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-real-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"true-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-forwarded", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"forwarded-for", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"x-cluster-client-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
         {"fastly-client-ip", "192.168.1.1,::1,8.7.6.5"},
-        {"cf-connecting-ip", owned_object{}},
-        {"cf-connecting-ipv6", owned_object{}},
+        {"cf-connecting-ip", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"cf-connecting-ipv6", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     http_network_fingerprint gen{"id", {}, {}, false, true};
@@ -750,7 +752,7 @@ TEST(TestHttpNetworkFingerprint, HeaderPrecedence)
     http_network_fingerprint gen{"id", {}, {}, false, true};
 
     auto get_headers = [](std::size_t begin) {
-        auto headers = object_builder::map();
+        auto headers = object_builder_da::map();
         std::array<std::string, 10> names{"x-forwarded-for", "x-real-ip", "true-client-ip",
             "x-client-ip", "x-forwarded", "forwarded-for", "x-cluster-client-ip",
             "fastly-client-ip", "cf-connecting-ip", "cf-connecting-ipv6"};
@@ -793,7 +795,7 @@ TEST(TestSessionFingerprint, UserOnly)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map();
+    auto cookies = object_builder_da::map();
     session_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -812,7 +814,7 @@ TEST(TestSessionFingerprint, SessionOnly)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map();
+    auto cookies = object_builder_da::map();
     session_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -831,7 +833,7 @@ TEST(TestSessionFingerprint, CookiesOnly)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
+    auto cookies = object_builder_da::map({
         {"name", "albert"},
         {"theme", "dark"},
         {"language", "en-GB"},
@@ -859,7 +861,7 @@ TEST(TestSessionFingerprint, UserCookieAndSession)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
+    auto cookies = object_builder_da::map({
         {"name", "albert"},
         {"theme", "dark"},
         {"language", "en-GB"},
@@ -887,7 +889,7 @@ TEST(TestSessionFingerprint, CookieKeysNormalization)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
+    auto cookies = object_builder_da::map({
         {"nAmE", "albert"},
         {"THEME", "dark"},
         {"language,ID", "en-GB"},
@@ -915,7 +917,7 @@ TEST(TestSessionFingerprint, CookieValuesNormalization)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
+    auto cookies = object_builder_da::map({
         {"name", "albert,martinez"},
         {"theme", "dark"},
         {"language", "en-GB,en-US"},
@@ -943,14 +945,14 @@ TEST(TestSessionFingerprint, CookieValuesAsArray)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
-        {"name", object_builder::array({"albert,martinez"})},
-        {"theme", object_builder::array({"dark"})},
-        {"language", object_builder::array({"en-GB,en-US"})},
-        {"tracking_id", object_builder::array({"xyzabc"})},
-        {"gdpr_consent", object_builder::array({",yes"})},
-        {"session_id", object_builder::array({"ansd0182u2n,"})},
-        {"last_visit", object_builder::array({"2024-07-16T12:00:00Z"})},
+    auto cookies = object_builder_da::map({
+        {"name", object_builder_da::array({"albert,martinez"})},
+        {"theme", object_builder_da::array({"dark"})},
+        {"language", object_builder_da::array({"en-GB,en-US"})},
+        {"tracking_id", object_builder_da::array({"xyzabc"})},
+        {"gdpr_consent", object_builder_da::array({",yes"})},
+        {"session_id", object_builder_da::array({"ansd0182u2n,"})},
+        {"last_visit", object_builder_da::array({"2024-07-16T12:00:00Z"})},
     });
 
     session_fingerprint gen{"id", {}, {}, false, true};
@@ -971,14 +973,14 @@ TEST(TestSessionFingerprint, CookieValuesAsArrayInvalidType)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
-        {"name", object_builder::array({42})},
-        {"theme", object_builder::array({42})},
-        {"language", object_builder::array({42})},
-        {"tracking_id", object_builder::array({42})},
-        {"gdpr_consent", object_builder::array({42})},
-        {"session_id", object_builder::array({42})},
-        {"last_visit", object_builder::array({42})},
+    auto cookies = object_builder_da::map({
+        {"name", object_builder_da::array({42})},
+        {"theme", object_builder_da::array({42})},
+        {"language", object_builder_da::array({42})},
+        {"tracking_id", object_builder_da::array({42})},
+        {"gdpr_consent", object_builder_da::array({42})},
+        {"session_id", object_builder_da::array({42})},
+        {"last_visit", object_builder_da::array({42})},
     });
 
     session_fingerprint gen{"id", {}, {}, false, true};
@@ -999,14 +1001,14 @@ TEST(TestSessionFingerprint, CookieValuesArrayMultiples)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
-        {"name", object_builder::array({"albert,martinez", "albert,martinez"})},
-        {"theme", object_builder::array({"dark", "dark"})},
-        {"language", object_builder::array({"en-GB,en-US", "en-GB,en-US"})},
-        {"tracking_id", object_builder::array({"xyzabc", "xyzabc"})},
-        {"gdpr_consent", object_builder::array({",yes", ",yes"})},
-        {"session_id", object_builder::array({"ansd0182u2n,", "ansd0182u2n,"})},
-        {"last_visit", object_builder::array({"2024-07-16T12:00:00Z", "2024-07-16T12:00:00Z"})},
+    auto cookies = object_builder_da::map({
+        {"name", object_builder_da::array({"albert,martinez", "albert,martinez"})},
+        {"theme", object_builder_da::array({"dark", "dark"})},
+        {"language", object_builder_da::array({"en-GB,en-US", "en-GB,en-US"})},
+        {"tracking_id", object_builder_da::array({"xyzabc", "xyzabc"})},
+        {"gdpr_consent", object_builder_da::array({",yes", ",yes"})},
+        {"session_id", object_builder_da::array({"ansd0182u2n,", "ansd0182u2n,"})},
+        {"last_visit", object_builder_da::array({"2024-07-16T12:00:00Z", "2024-07-16T12:00:00Z"})},
     });
 
     session_fingerprint gen{"id", {}, {}, false, true};
@@ -1027,14 +1029,14 @@ TEST(TestSessionFingerprint, CookieEmptyValues)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
-        {"name", owned_object{}},
-        {"theme", owned_object{}},
-        {"language", owned_object{}},
-        {"tracking_id", owned_object{}},
-        {"gdpr_consent", owned_object{}},
-        {"session_id", owned_object{}},
-        {"last_visit", owned_object{}},
+    auto cookies = object_builder_da::map({
+        {"name", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"theme", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"language", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"tracking_id", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"gdpr_consent", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"session_id", ddwaf::test::ddwaf_object_da::make_uninit()},
+        {"last_visit", ddwaf::test::ddwaf_object_da::make_uninit()},
     });
 
     session_fingerprint gen{"id", {}, {}, false, true};
@@ -1055,7 +1057,7 @@ TEST(TestSessionFingerprint, CookieEmptyKeys)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map({
+    auto cookies = object_builder_da::map({
         {"", "albert,martinez"},
         {"", "dark"},
         {"", "en-GB,en-US"},
@@ -1083,7 +1085,7 @@ TEST(TestSessionFingerprint, EmptyEverything)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto cookies = object_builder::map();
+    auto cookies = object_builder_da::map();
     session_fingerprint gen{"id", {}, {}, false, true};
 
     ddwaf::timer deadline{2s};
@@ -1116,7 +1118,7 @@ TEST(TestSessionFingerprint, Regeneration)
     }
 
     {
-        auto cookies = object_builder::map({
+        auto cookies = object_builder_da::map({
             {"name", "albert,martinez"},
             {"theme", "dark"},
             {"language", "en-GB,en-US"},

--- a/tests/unit/processor/jwt_decode_test.cpp
+++ b/tests/unit/processor/jwt_decode_test.cpp
@@ -9,6 +9,7 @@
 #include "processor/jwt_decode.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -17,7 +18,7 @@ TEST(TestJwtDecoder, Basic)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({{"authorization",
+    auto headers = object_builder_da::map({{"authorization",
         "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
         "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -45,8 +46,8 @@ TEST(TestJwtDecoder, KeyPathLeadsToSingleValueArray)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({{"authorization",
-        object_builder::array(
+    auto headers = object_builder_da::map({{"authorization",
+        object_builder_da::array(
             {"Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
              "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
              "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -74,8 +75,8 @@ TEST(TestJwtDecoder, KeyPathLeadsToValidMultiValueArray)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({{"authorization",
-        object_builder::array(
+    auto headers = object_builder_da::map({{"authorization",
+        object_builder_da::array(
             {"Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
              "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
              "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -106,8 +107,8 @@ TEST(TestJwtDecoder, KeyPathLeadsToInvalidMultiValueArray)
 
     // Even though the token is there, we only take the first element of arrays as we're trying
     // to account for the serialisation not perform a JWT search.
-    auto headers = object_builder::map({{"authorization",
-        object_builder::array({"Arachni",
+    auto headers = object_builder_da::map({{"authorization",
+        object_builder_da::array({"Arachni",
             "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
             "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
             "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -157,7 +158,7 @@ TEST(TestJwtDecoder, EmptyHeader)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({{"authorization",
+    auto headers = object_builder_da::map({{"authorization",
         "Bearer ."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
         "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -185,7 +186,7 @@ TEST(TestJwtDecoder, EmptyPayload)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({{"authorization",
+    auto headers = object_builder_da::map({{"authorization",
         "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
         ".o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
         "8B48NpATozzMHn0j3rE0xVUldxShzy0xeJ7vYAccVXu2Gs9rnTVqouc-UZu_wJHkZiKBL67j8_"
@@ -212,7 +213,7 @@ TEST(TestJwtDecoder, LargePayloadBeyondLimit)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({{"authorization",
+    auto headers = object_builder_da::map({{"authorization",
         "Bearer "
         "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
         "eyJrZXlfMCI6eyJrZXlfMSI6eyJrZXlfMiI6eyJrZXlfMyI6eyJrZXlfNCI6eyJrZXlfNSI6eyJrZXlfNiI6ey"
@@ -238,7 +239,7 @@ TEST(TestJwtDecoder, NoSignature)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({{"authorization",
+    auto headers = object_builder_da::map({{"authorization",
         "Bearer "
         "eyJhbGciOiJub25lIn0."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
@@ -263,7 +264,7 @@ TEST(TestJwtDecoder, NoPayloadNoSignatureMissingDelim)
     auto *alloc = memory::get_default_resource();
 
     auto headers =
-        object_builder::map({{"authorization", "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."}});
+        object_builder_da::map({{"authorization", "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."}});
 
     jwt_decode gen{"id", {}, {}, false, true};
 
@@ -281,7 +282,7 @@ TEST(TestJwtDecoder, NoPayloadNoSignatureMissingAllDelim)
     auto *alloc = memory::get_default_resource();
 
     auto headers =
-        object_builder::map({{"authorization", "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9"}});
+        object_builder_da::map({{"authorization", "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9"}});
     jwt_decode gen{"id", {}, {}, false, true};
 
     std::vector<std::variant<std::string, int64_t>> key_path{"authorization"};
@@ -297,7 +298,7 @@ TEST(TestJwtDecoder, NoSignatureNoDelim)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto headers = object_builder::map({{"authorization",
+    auto headers = object_builder_da::map({{"authorization",
         "Bearer "
         "eyJhbGciOiJub25lIn0."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"

--- a/tests/unit/processor/jwt_decode_test.cpp
+++ b/tests/unit/processor/jwt_decode_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog
 // (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "processor/jwt_decode.hpp"
 
@@ -131,7 +132,7 @@ TEST(TestJwtDecoder, MissingKeypath)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object headers{
+    owned_object headers = test::ddwaf_object_da::make_string(
         "Bearer eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
         "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUx"
         "NjIzOTAyMn0.o1hC1xYbJolSyh0-bOY230w22zEQSk5TiBfc-OCvtpI2JtYlW-23-"
@@ -139,7 +140,7 @@ TEST(TestJwtDecoder, MissingKeypath)
         "61L6SXswzPAQu4kVDwAefGf5hyYBUM-80vYZwWPEpLI8K4yCBsF6I9N1yQaZAJmkMp_"
         "Iw371Menae4Mp4JusvBJS-s6LrmG2QbiZaFaxVJiW8KlUkWyUCns8-"
         "qFl5OMeYlgGFsyvvSHvXCzQrsEXqyCdS4tQJd73ayYA4SPtCb9clz76N1zE5WsV4Z0BYrxeb77oA7jJh"
-        "h994RAPzCG0hmQ"};
+        "h994RAPzCG0hmQ");
 
     jwt_decode gen{"id", {}, {}, false, true};
 

--- a/tests/unit/processor/processor_test.cpp
+++ b/tests/unit/processor/processor_test.cpp
@@ -10,6 +10,7 @@
 
 #include <gmock/gmock.h>
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using ::testing::_;
@@ -44,7 +45,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalUnconditional)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({{"input_address", "input_string"}});
     object_store store;
@@ -82,8 +83,8 @@ TEST(TestProcessor, MultiMappingOutputNoEvalUnconditional)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object first_output = owned_object::make_string("first_output_string");
-    owned_object second_output = owned_object::make_string("second_output_string");
+    owned_object first_output = test::ddwaf_object_da::make_string("first_output_string");
+    owned_object second_output = test::ddwaf_object_da::make_string("second_output_string");
 
     auto input_map = object_builder::map(
         {{"input_address", "first_input_string"}, {"input_address.second", "second_input_string"}});
@@ -137,7 +138,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalTrue)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", true}});
 
@@ -181,7 +182,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({{"enabled?", true}});
 
@@ -236,7 +237,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalFalse)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", false}});
 
@@ -274,7 +275,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({
         {"input_address", "input_string"},
@@ -321,7 +322,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", true}});
 
@@ -369,7 +370,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalFalse)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", false}});
 
@@ -409,8 +410,8 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object first_output = owned_object::make_string("first_output_string");
-    owned_object second_output = owned_object::make_string("second_output_string");
+    owned_object first_output = test::ddwaf_object_da::make_string("first_output_string");
+    owned_object second_output = test::ddwaf_object_da::make_string("second_output_string");
 
     auto input_map = object_builder::map(
         {{"input_address", "first_input_string"}, {"input_address.second", "second_input_string"}});
@@ -466,7 +467,7 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({
         {"input_address", "input_string"},
@@ -612,7 +613,7 @@ TEST(TestProcessor, OutputEvalWithoutattributesMap)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({
         {"input_address", "input_string"},

--- a/tests/unit/processor/processor_test.cpp
+++ b/tests/unit/processor/processor_test.cpp
@@ -304,7 +304,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
     processor_cache cache;
     timer deadline{2s};
 
-    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object attributes = owned_object{};
 
     {
         auto obtained = store.get_target("output_address");
@@ -356,7 +356,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
 
     timer deadline{2s};
 
-    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object attributes = owned_object{};
 
     EXPECT_FALSE(store.get_target("output_address").has_value());
 
@@ -402,7 +402,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalFalse)
     processor_cache cache;
     timer deadline{2s};
 
-    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object attributes = owned_object{};
 
     EXPECT_FALSE(store.get_target("output_address").has_value());
     attribute_collector collector;
@@ -447,7 +447,7 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
 
     processor_cache cache;
     timer deadline{2s};
-    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object attributes = owned_object{};
 
     EXPECT_FALSE(store.get_target("output_address").has_value());
     EXPECT_FALSE(store.get_target("output_address.second").has_value());
@@ -612,7 +612,7 @@ TEST(TestProcessor, EvalAlreadyAvailableInStore)
 
     processor_cache cache;
     timer deadline{2s};
-    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object attributes = owned_object{};
 
     attribute_collector collector;
     proc.eval(store, collector, cache, alloc, deadline);
@@ -648,7 +648,7 @@ TEST(TestProcessor, OutputEvalWithoutattributesMap)
     processor_cache cache;
     timer deadline{2s};
 
-    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object attributes = owned_object{};
 
     {
         auto obtained = store.get_target("output_address");
@@ -686,7 +686,7 @@ TEST(TestProcessor, Timeout)
 
     processor_cache cache;
     timer deadline{0s};
-    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object attributes = owned_object{};
 
     attribute_collector collector;
     EXPECT_THROW(proc.eval(store, collector, cache, alloc, deadline), ddwaf::timeout_exception);

--- a/tests/unit/processor/processor_test.cpp
+++ b/tests/unit/processor/processor_test.cpp
@@ -18,6 +18,7 @@ using ::testing::ByMove;
 using ::testing::Return;
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -47,7 +48,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalUnconditional)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({{"input_address", "input_string"}});
+    auto input_map = object_builder_da::map({{"input_address", "input_string"}});
     object_store store;
     store.insert(input_map);
 
@@ -86,7 +87,7 @@ TEST(TestProcessor, MultiMappingOutputNoEvalUnconditional)
     owned_object first_output = test::ddwaf_object_da::make_string("first_output_string");
     owned_object second_output = test::ddwaf_object_da::make_string("second_output_string");
 
-    auto input_map = object_builder::map(
+    auto input_map = object_builder_da::map(
         {{"input_address", "first_input_string"}, {"input_address.second", "second_input_string"}});
 
     object_store store;
@@ -140,7 +141,8 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalTrue)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", true}});
+    auto input_map =
+        object_builder_da::map({{"input_address", "input_string"}, {"enabled?", true}});
 
     object_store store;
     store.insert(input_map);
@@ -184,7 +186,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({{"enabled?", true}});
+    auto input_map = object_builder_da::map({{"enabled?", true}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -218,7 +220,7 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalCached)
     auto attributes = collector.get_available_attributes_and_reset();
     EXPECT_EQ(attributes.size(), 0);
 
-    input_map = object_builder::map({
+    input_map = object_builder_da::map({
         {"input_address", "input_string"},
     });
 
@@ -239,7 +241,8 @@ TEST(TestProcessor, SingleMappingOutputNoEvalConditionalFalse)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", false}});
+    auto input_map =
+        object_builder_da::map({{"input_address", "input_string"}, {"enabled?", false}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -277,7 +280,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({
+    auto input_map = object_builder_da::map({
         {"input_address", "input_string"},
     });
 
@@ -301,7 +304,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalUnconditional)
     processor_cache cache;
     timer deadline{2s};
 
-    owned_object attributes;
+    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
 
     {
         auto obtained = store.get_target("output_address");
@@ -324,7 +327,8 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", true}});
+    auto input_map =
+        object_builder_da::map({{"input_address", "input_string"}, {"enabled?", true}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -352,7 +356,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalTrue)
 
     timer deadline{2s};
 
-    owned_object attributes;
+    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
 
     EXPECT_FALSE(store.get_target("output_address").has_value());
 
@@ -372,7 +376,8 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalFalse)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({{"input_address", "input_string"}, {"enabled?", false}});
+    auto input_map =
+        object_builder_da::map({{"input_address", "input_string"}, {"enabled?", false}});
 
     object_store store;
     store.insert(std::move(input_map));
@@ -397,7 +402,7 @@ TEST(TestProcessor, SingleMappingNoOutputEvalConditionalFalse)
     processor_cache cache;
     timer deadline{2s};
 
-    owned_object attributes;
+    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
 
     EXPECT_FALSE(store.get_target("output_address").has_value());
     attribute_collector collector;
@@ -413,7 +418,7 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
     owned_object first_output = test::ddwaf_object_da::make_string("first_output_string");
     owned_object second_output = test::ddwaf_object_da::make_string("second_output_string");
 
-    auto input_map = object_builder::map(
+    auto input_map = object_builder_da::map(
         {{"input_address", "first_input_string"}, {"input_address.second", "second_input_string"}});
 
     object_store store;
@@ -442,7 +447,7 @@ TEST(TestProcessor, MultiMappingNoOutputEvalUnconditional)
 
     processor_cache cache;
     timer deadline{2s};
-    owned_object attributes;
+    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
 
     EXPECT_FALSE(store.get_target("output_address").has_value());
     EXPECT_FALSE(store.get_target("output_address.second").has_value());
@@ -469,7 +474,7 @@ TEST(TestProcessor, SingleMappingOutputEvalUnconditional)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({
+    auto input_map = object_builder_da::map({
         {"input_address", "input_string"},
     });
 
@@ -520,7 +525,7 @@ TEST(TestProcessor, OutputAlreadyAvailableInStore)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input_map = object_builder::map(
+    auto input_map = object_builder_da::map(
         {{"input_address", "input_string"}, {"output_address", owned_object::make_null()}});
 
     object_store store;
@@ -550,7 +555,9 @@ TEST(TestProcessor, OutputAlreadyGenerated)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input_map = object_builder::map({
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
+
+    auto input_map = object_builder_da::map({
         {"input_address", "input_string"},
     });
 
@@ -568,7 +575,9 @@ TEST(TestProcessor, OutputAlreadyGenerated)
     mock::processor proc{"id", std::make_shared<expression>(), std::move(mappings), false, true};
     EXPECT_STREQ(proc.get_id().c_str(), "id");
 
-    EXPECT_CALL(proc, eval_impl(_, _, _, _)).Times(1);
+    EXPECT_CALL(proc, eval_impl(_, _, _, _))
+        .Times(1)
+        .WillOnce(Return(ByMove(owned_object{std::move(output)})));
 
     processor_cache cache;
     timer deadline{2s};
@@ -582,7 +591,7 @@ TEST(TestProcessor, EvalAlreadyAvailableInStore)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input_map = object_builder::map(
+    auto input_map = object_builder_da::map(
         {{"input_address", "input_string"}, {"output_address", owned_object::make_null()}});
 
     object_store store;
@@ -603,7 +612,7 @@ TEST(TestProcessor, EvalAlreadyAvailableInStore)
 
     processor_cache cache;
     timer deadline{2s};
-    owned_object attributes;
+    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
 
     attribute_collector collector;
     proc.eval(store, collector, cache, alloc, deadline);
@@ -615,7 +624,7 @@ TEST(TestProcessor, OutputEvalWithoutattributesMap)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({
+    auto input_map = object_builder_da::map({
         {"input_address", "input_string"},
     });
 
@@ -639,7 +648,7 @@ TEST(TestProcessor, OutputEvalWithoutattributesMap)
     processor_cache cache;
     timer deadline{2s};
 
-    owned_object attributes;
+    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
 
     {
         auto obtained = store.get_target("output_address");
@@ -677,7 +686,7 @@ TEST(TestProcessor, Timeout)
 
     processor_cache cache;
     timer deadline{0s};
-    owned_object attributes;
+    owned_object attributes = ddwaf::test::ddwaf_object_da::make_uninit();
 
     attribute_collector collector;
     EXPECT_THROW(proc.eval(store, collector, cache, alloc, deadline), ddwaf::timeout_exception);

--- a/tests/unit/processor/structured_processor_test.cpp
+++ b/tests/unit/processor/structured_processor_test.cpp
@@ -9,6 +9,7 @@
 
 #include <gmock/gmock.h>
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 
 using ::testing::_;
@@ -45,7 +46,7 @@ TEST(TestStructuredProcessor, AllParametersAvailable)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map(
         {{"unary_address", "unary_string"}, {"optional_address", "optional_string"},
@@ -94,7 +95,7 @@ TEST(TestStructuredProcessor, OptionalParametersNotAvailable)
 {
     auto *alloc = memory::get_default_resource();
 
-    owned_object output = owned_object::make_string("output_string");
+    owned_object output = test::ddwaf_object_da::make_string("output_string");
 
     auto input_map = object_builder::map({{"unary_address", "unary_string"},
         {"variadic_address_1", 1U}, {"variadic_address_2", 1U}});

--- a/tests/unit/processor/structured_processor_test.cpp
+++ b/tests/unit/processor/structured_processor_test.cpp
@@ -17,6 +17,7 @@ using ::testing::ByMove;
 using ::testing::Return;
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -48,7 +49,7 @@ TEST(TestStructuredProcessor, AllParametersAvailable)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map(
+    auto input_map = object_builder_da::map(
         {{"unary_address", "unary_string"}, {"optional_address", "optional_string"},
             {"variadic_address_1", 1U}, {"variadic_address_2", 1U}});
     object_store store;
@@ -97,7 +98,7 @@ TEST(TestStructuredProcessor, OptionalParametersNotAvailable)
 
     owned_object output = test::ddwaf_object_da::make_string("output_string");
 
-    auto input_map = object_builder::map({{"unary_address", "unary_string"},
+    auto input_map = object_builder_da::map({{"unary_address", "unary_string"},
         {"variadic_address_1", 1U}, {"variadic_address_2", 1U}});
 
     object_store store;
@@ -144,7 +145,7 @@ TEST(TestStructuredProcessor, RequiredParameterNotAvailable)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input_map = object_builder::map({{"optional_address", "optional_string"},
+    auto input_map = object_builder_da::map({{"optional_address", "optional_string"},
         {"variadic_address_1", 1U}, {"variadic_address_2", 1U}});
 
     object_store store;
@@ -186,7 +187,7 @@ TEST(TestStructuredProcessor, NoVariadocParametersAvailable)
 {
     auto *alloc = memory::get_default_resource();
 
-    auto input_map = object_builder::map({
+    auto input_map = object_builder_da::map({
         {"unary_address", "unary_string"},
         {"optional_address", "optional_string"},
     });

--- a/tests/unit/processor/uri_parse_test.cpp
+++ b/tests/unit/processor/uri_parse_test.cpp
@@ -9,6 +9,7 @@
 #include "processor/uri_parse.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/rule_test.cpp
+++ b/tests/unit/rule_test.cpp
@@ -13,6 +13,7 @@
 #include "utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -28,7 +29,7 @@ TEST(TestRule, Match)
     std::unordered_map<std::string, std::string> tags{{"type", "type"}, {"category", "category"}};
     core_rule rule("id", "name", std::move(tags), builder.build(), {"update", "block", "passlist"});
 
-    auto root = object_builder::map();
+    auto root = object_builder_da::map();
     root.emplace("http.client_ip", "192.168.0.1");
 
     object_store store;
@@ -38,7 +39,7 @@ TEST(TestRule, Match)
     core_rule::cache_type cache;
     {
         defer cleanup{[&]() { store.clear_last_batch(); }};
-        store.insert(root.clone());
+        store.insert(root.clone(memory::get_default_resource()));
 
         auto [verdict, result] = rule.match(store, cache, {}, {}, deadline);
         ASSERT_TRUE(result.has_value());
@@ -82,7 +83,7 @@ TEST(TestRule, NoMatch)
     std::unordered_map<std::string, std::string> tags{{"type", "type"}, {"category", "category"}};
     core_rule rule("id", "name", std::move(tags), builder.build());
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
     object_store store;
     store.insert(std::move(root));
@@ -116,7 +117,7 @@ TEST(TestRule, ValidateCachedMatch)
     // only the latest address. This ensures that the IP condition can't be
     // matched on the second run.
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -127,7 +128,7 @@ TEST(TestRule, ValidateCachedMatch)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -188,7 +189,7 @@ TEST(TestRule, MatchWithoutCache)
     // the second run when there isn't a cached match.
     object_store store;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
         store.insert(std::move(root));
 
         ddwaf::timer deadline{2s};
@@ -198,7 +199,7 @@ TEST(TestRule, MatchWithoutCache)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         store.insert(std::move(root));
 
@@ -250,7 +251,7 @@ TEST(TestRule, NoMatchWithoutCache)
     // In this test we validate that when the cache is empty and only one
     // address is passed, the filter doesn't match (as it should be).
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+        auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -262,7 +263,7 @@ TEST(TestRule, NoMatchWithoutCache)
     }
 
     {
-        auto root = object_builder::map({{"usr.id", "admin"}});
+        auto root = object_builder_da::map({{"usr.id", "admin"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -296,7 +297,8 @@ TEST(TestRule, FullCachedMatchSecondRun)
 
     core_rule::cache_type cache;
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -308,7 +310,8 @@ TEST(TestRule, FullCachedMatchSecondRun)
     }
 
     {
-        auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
+        auto root =
+            object_builder_da::map({{"http.client_ip", "192.168.0.1"}, {"usr.id", "admin"}});
 
         object_store store;
         store.insert(std::move(root));
@@ -331,7 +334,7 @@ TEST(TestRule, ExcludeObject)
 
     core_rule rule("id", "name", std::move(tags), builder.build(), {"update", "block", "passlist"});
 
-    auto root = object_builder::map({{"http.client_ip", "192.168.0.1"}});
+    auto root = object_builder_da::map({{"http.client_ip", "192.168.0.1"}});
     object_store store;
     store.insert(std::move(root));
 

--- a/tests/unit/ruleset_info_test.cpp
+++ b/tests/unit/ruleset_info_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/ruleset_test.cpp
+++ b/tests/unit/ruleset_test.cpp
@@ -11,6 +11,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/scanner_test.cpp
+++ b/tests/unit/scanner_test.cpp
@@ -11,6 +11,7 @@
 #include "scanner.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/scanner_test.cpp
+++ b/tests/unit/scanner_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "matcher/exact_match.hpp"
 #include "matcher/ip_match.hpp"
@@ -27,7 +28,7 @@ TEST(TestScanner, SimpleMatch)
     EXPECT_EQ(scnr.get_tags(), tags);
 
     std::string_view key{"hello"};
-    auto value = owned_object::make_string("192.168.0.1");
+    auto value = test::ddwaf_object_da::make_string("192.168.0.1");
     EXPECT_TRUE(scnr.eval(key, value));
 }
 
@@ -42,7 +43,7 @@ TEST(TestScanner, SimpleMatchNoKeyMatcher)
     EXPECT_EQ(scnr.get_tags(), tags);
 
     std::string_view key{"hello"};
-    auto value = owned_object::make_string("192.168.0.1");
+    auto value = test::ddwaf_object_da::make_string("192.168.0.1");
 
     EXPECT_TRUE(scnr.eval(key, value));
 }
@@ -58,7 +59,7 @@ TEST(TestScanner, SimpleMatchNoValueMatcher)
     EXPECT_EQ(scnr.get_tags(), tags);
 
     std::string_view key{"hello"};
-    auto value = owned_object::make_string("192.168.0.1");
+    auto value = test::ddwaf_object_da::make_string("192.168.0.1");
 
     EXPECT_TRUE(scnr.eval(key, value));
 }
@@ -78,7 +79,7 @@ TEST(TestScanner, NoMatchOnKey)
     EXPECT_EQ(scnr.get_tags(), tags);
 
     std::string_view key{"helloo"};
-    auto value = owned_object::make_string("192.168.0.1");
+    auto value = test::ddwaf_object_da::make_string("192.168.0.1");
 
     EXPECT_FALSE(scnr.eval(key, value));
 }
@@ -97,7 +98,7 @@ TEST(TestScanner, NoMatchOnValue)
     EXPECT_EQ(scnr.get_tags(), tags);
 
     std::string_view key{"hello"};
-    auto value = owned_object::make_string("192.168.0.2");
+    auto value = test::ddwaf_object_da::make_string("192.168.0.2");
     EXPECT_FALSE(scnr.eval(key, value));
 }
 
@@ -115,7 +116,7 @@ TEST(TestScanner, InvalidKey)
     EXPECT_STRV(scnr.get_id(), "0");
     EXPECT_EQ(scnr.get_tags(), tags);
 
-    auto value = owned_object::make_string("192.168.0.1");
+    auto value = test::ddwaf_object_da::make_string("192.168.0.1");
     EXPECT_FALSE(scnr.eval({}, value));
 }
 

--- a/tests/unit/semantic_version_test.cpp
+++ b/tests/unit/semantic_version_test.cpp
@@ -13,6 +13,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/serializer_test.cpp
+++ b/tests/unit/serializer_test.cpp
@@ -12,6 +12,7 @@
 #include "utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/tokenizer/generic_tokenizer_test.cpp
+++ b/tests/unit/tokenizer/generic_tokenizer_test.cpp
@@ -8,6 +8,7 @@
 #include "tokenizer/generic_sql.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/tokenizer/mysql_tokenizer_test.cpp
+++ b/tests/unit/tokenizer/mysql_tokenizer_test.cpp
@@ -8,6 +8,7 @@
 #include "tokenizer/mysql.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/tokenizer/pgsql_tokenizer_test.cpp
+++ b/tests/unit/tokenizer/pgsql_tokenizer_test.cpp
@@ -8,6 +8,7 @@
 #include "tokenizer/pgsql.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/tokenizer/shell_tokenizer_test.cpp
+++ b/tests/unit/tokenizer/shell_tokenizer_test.cpp
@@ -8,6 +8,7 @@
 #include "tokenizer/shell.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/tokenizer/sqlite_tokenizer_test.cpp
+++ b/tests/unit/tokenizer/sqlite_tokenizer_test.cpp
@@ -8,6 +8,7 @@
 #include "tokenizer/sqlite.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {

--- a/tests/unit/transformer/base64_decode_test.cpp
+++ b/tests/unit/transformer/base64_decode_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/base64_encode_test.cpp
+++ b/tests/unit/transformer/base64_encode_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/base64url_decode_test.cpp
+++ b/tests/unit/transformer/base64url_decode_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/compress_whitespace_test.cpp
+++ b/tests/unit/transformer/compress_whitespace_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/css_decode_test.cpp
+++ b/tests/unit/transformer/css_decode_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 TEST(TestCssDecode, NameAndID)

--- a/tests/unit/transformer/html_entity_decode_test.cpp
+++ b/tests/unit/transformer/html_entity_decode_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 TEST(TestHtmlEntityDecode, NameAndID)

--- a/tests/unit/transformer/js_decode_test.cpp
+++ b/tests/unit/transformer/js_decode_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 TEST(TestJsDecode, NameAndID)

--- a/tests/unit/transformer/lowercase_test.cpp
+++ b/tests/unit/transformer/lowercase_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 TEST(TestLowercase, NameAndID)

--- a/tests/unit/transformer/manager_test.cpp
+++ b/tests/unit/transformer/manager_test.cpp
@@ -10,6 +10,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
@@ -46,8 +47,8 @@ std::optional<std::string> transform(std::string_view input, const std::vector<t
 
 TEST(TestTransformerManager, InvalidTypes)
 {
-    owned_object src(29U);
-    owned_object dst;
+    owned_object src = test::ddwaf_object_da::make_unsigned(29U);
+    owned_object dst = ddwaf::test::ddwaf_object_da::make_uninit();
 
     {
         std::vector<transformer_id> ids{transformer_id::compress_whitespace};

--- a/tests/unit/transformer/manager_test.cpp
+++ b/tests/unit/transformer/manager_test.cpp
@@ -48,7 +48,7 @@ std::optional<std::string> transform(std::string_view input, const std::vector<t
 TEST(TestTransformerManager, InvalidTypes)
 {
     owned_object src = test::ddwaf_object_da::make_unsigned(29U);
-    owned_object dst = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object dst = owned_object{};
 
     {
         std::vector<transformer_id> ids{transformer_id::compress_whitespace};

--- a/tests/unit/transformer/normalize_path_test.cpp
+++ b/tests/unit/transformer/normalize_path_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/remove_comments_test.cpp
+++ b/tests/unit/transformer/remove_comments_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/remove_nulls_test.cpp
+++ b/tests/unit/transformer/remove_nulls_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/shell_unescape_test.cpp
+++ b/tests/unit/transformer/shell_unescape_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/unicode_normalize_test.cpp
+++ b/tests/unit/transformer/unicode_normalize_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/url_basename_test.cpp
+++ b/tests/unit/transformer/url_basename_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/url_decode_test.cpp
+++ b/tests/unit/transformer/url_decode_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/url_path_test.cpp
+++ b/tests/unit/transformer/url_path_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/transformer/url_querystring_test.cpp
+++ b/tests/unit/transformer/url_querystring_test.cpp
@@ -8,6 +8,7 @@
 #include "transformer_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 

--- a/tests/unit/utils_test.cpp
+++ b/tests/unit/utils_test.cpp
@@ -11,6 +11,7 @@
 #include "common/gtest_utils.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 constexpr char char_min = std::numeric_limits<char>::min();

--- a/tests/unit/value_iterator_test.cpp
+++ b/tests/unit/value_iterator_test.cpp
@@ -4,6 +4,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+#include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "context_allocator.hpp"
 #include "iterator.hpp"
@@ -31,7 +32,7 @@ TEST(TestValueIterator, TestInvalidIterator)
 
 TEST(TestValueIterator, TestStringScalar)
 {
-    owned_object object{"value"};
+    owned_object object = test::ddwaf_object_da::make_string("value");
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};

--- a/tests/unit/value_iterator_test.cpp
+++ b/tests/unit/value_iterator_test.cpp
@@ -16,7 +16,7 @@ namespace {
 
 TEST(TestValueIterator, TestInvalidIterator)
 {
-    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object object = owned_object{};
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -127,7 +127,7 @@ TEST(TestValueIterator, TestArrayMultipleNullAndInvalid)
     auto object = object_builder_da::array();
     for (unsigned i = 0; i < 25; i++) {
         object.emplace_back(std::to_string(i));
-        object.emplace_back(ddwaf::test::ddwaf_object_da::make_uninit());
+        object.emplace_back(owned_object{});
         object.emplace_back(owned_object::make_null());
     }
 
@@ -257,7 +257,7 @@ TEST(TestValueIterator, TestMapMultipleMultipleNullAndInvalid)
 
         {
             auto index = std::to_string(i * 3 + 2);
-            object.emplace("key" + index, ddwaf::test::ddwaf_object_da::make_uninit());
+            object.emplace("key" + index, owned_object{});
         }
     }
 
@@ -372,7 +372,7 @@ TEST(TestValueIterator, TestContainerMix)
 
 TEST(TestValueIterator, TestInvalidObjectPath)
 {
-    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
+    owned_object object = owned_object{};
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};

--- a/tests/unit/value_iterator_test.cpp
+++ b/tests/unit/value_iterator_test.cpp
@@ -10,12 +10,13 @@
 #include "iterator.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 
 namespace {
 
 TEST(TestValueIterator, TestInvalidIterator)
 {
-    owned_object object;
+    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -50,7 +51,7 @@ TEST(TestValueIterator, TestStringScalar)
 
 TEST(TestValueIterator, TestUnsignedScalar)
 {
-    owned_object object{22U};
+    owned_object object = test::ddwaf_object_da::make_unsigned(22U);
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -66,7 +67,7 @@ TEST(TestValueIterator, TestUnsignedScalar)
 
 TEST(TestValueIterator, TestSignedScalar)
 {
-    owned_object object{22L};
+    owned_object object = test::ddwaf_object_da::make_signed(22L);
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -82,7 +83,7 @@ TEST(TestValueIterator, TestSignedScalar)
 
 TEST(TestValueIterator, TestArraySingleItem)
 {
-    auto object = object_builder::array({"string"});
+    auto object = object_builder_da::array({"string"});
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -99,7 +100,7 @@ TEST(TestValueIterator, TestArraySingleItem)
 
 TEST(TestValueIterator, TestArrayMultipleItems)
 {
-    auto object = object_builder::array();
+    auto object = object_builder_da::array();
     for (unsigned i = 0; i < 50; i++) { object.emplace_back(std::to_string(i)); }
 
     std::unordered_set<object_cache_key> context;
@@ -123,10 +124,10 @@ TEST(TestValueIterator, TestArrayMultipleItems)
 
 TEST(TestValueIterator, TestArrayMultipleNullAndInvalid)
 {
-    auto object = object_builder::array();
+    auto object = object_builder_da::array();
     for (unsigned i = 0; i < 25; i++) {
         object.emplace_back(std::to_string(i));
-        object.emplace_back(owned_object{});
+        object.emplace_back(ddwaf::test::ddwaf_object_da::make_uninit());
         object.emplace_back(owned_object::make_null());
     }
 
@@ -153,11 +154,11 @@ TEST(TestValueIterator, TestArrayMultipleNullAndInvalid)
 
 TEST(TestValueIterator, TestDeepArray)
 {
-    auto object = object_builder::array();
+    auto object = object_builder_da::array();
     borrowed_object array{object};
     for (unsigned i = 0; i < 10; i++) {
         array.emplace_back("val" + std::to_string(i));
-        array = array.emplace_back(object_builder::array());
+        array = array.emplace_back(object_builder_da::array());
     }
 
     std::unordered_set<object_cache_key> context;
@@ -180,8 +181,8 @@ TEST(TestValueIterator, TestDeepArray)
 
 TEST(TestValueIterator, TestArrayNoScalars)
 {
-    auto object = object_builder::array();
-    for (unsigned i = 0; i < 50; i++) { object.emplace_back(object_builder::array()); }
+    auto object = object_builder_da::array();
+    for (unsigned i = 0; i < 50; i++) { object.emplace_back(object_builder_da::array()); }
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -193,7 +194,7 @@ TEST(TestValueIterator, TestArrayNoScalars)
 
 TEST(TestValueIterator, TestMapSingleItem)
 {
-    auto object = object_builder::map({{"key", "value"}});
+    auto object = object_builder_da::map({{"key", "value"}});
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -211,7 +212,7 @@ TEST(TestValueIterator, TestMapSingleItem)
 
 TEST(TestValueIterator, TestMapMultipleItems)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
 
     for (unsigned i = 0; i < 50; i++) {
         auto index = std::to_string(i);
@@ -241,7 +242,7 @@ TEST(TestValueIterator, TestMapMultipleItems)
 
 TEST(TestValueIterator, TestMapMultipleMultipleNullAndInvalid)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
 
     for (unsigned i = 0; i < 25; i++) {
         {
@@ -256,7 +257,7 @@ TEST(TestValueIterator, TestMapMultipleMultipleNullAndInvalid)
 
         {
             auto index = std::to_string(i * 3 + 2);
-            object.emplace("key" + index, owned_object{});
+            object.emplace("key" + index, ddwaf::test::ddwaf_object_da::make_uninit());
         }
     }
 
@@ -283,13 +284,13 @@ TEST(TestValueIterator, TestMapMultipleMultipleNullAndInvalid)
 
 TEST(TestValueIterator, TestDeepMap)
 {
-    auto object = object_builder::map();
+    auto object = object_builder_da::map();
     borrowed_object map{object};
 
     for (unsigned i = 0; i < 10; i++) {
         auto index = std::to_string(i);
         map.emplace("str" + index, "val" + index);
-        map = map.emplace("map" + index, object_builder::map());
+        map = map.emplace("map" + index, object_builder_da::map());
     }
 
     std::unordered_set<object_cache_key> context;
@@ -315,8 +316,8 @@ TEST(TestValueIterator, TestDeepMap)
 
 TEST(TestValueIterator, TestMapNoScalars)
 {
-    auto object = object_builder::map();
-    for (unsigned i = 0; i < 50; i++) { object.emplace("key", object_builder::map()); }
+    auto object = object_builder_da::map();
+    for (unsigned i = 0; i < 50; i++) { object.emplace("key", object_builder_da::map()); }
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -371,7 +372,7 @@ TEST(TestValueIterator, TestContainerMix)
 
 TEST(TestValueIterator, TestInvalidObjectPath)
 {
-    owned_object object;
+    owned_object object = ddwaf::test::ddwaf_object_da::make_uninit();
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -411,7 +412,7 @@ TEST(TestValueIterator, TestInvalidObjectPath)
 
 TEST(TestValueIterator, TestSimplePath)
 {
-    auto object = object_builder::map({{"key", "value"}, {"key1", "value"}, {"key2", "value"}});
+    auto object = object_builder_da::map({{"key", "value"}, {"key1", "value"}, {"key2", "value"}});
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -453,9 +454,9 @@ TEST(TestValueIterator, TestSimplePath)
 
 TEST(TestValueIterator, TestMultiPath)
 {
-    auto object = object_builder::map(
-        {{"first", object_builder::map({{"second", object_builder::map({{"third", "final"},
-                                                       {"value", "value_third"}})},
+    auto object = object_builder_da::map(
+        {{"first", object_builder_da::map({{"second", object_builder_da::map({{"third", "final"},
+                                                          {"value", "value_third"}})},
                        {"value", "value_second"}})},
             {"value", "value_first"}});
 
@@ -658,7 +659,7 @@ TEST(TestValueIterator, TestContainerMixInvalidPath)
 
 TEST(TestValueIterator, TestExcludeSingleObject)
 {
-    auto object = object_builder::map({{"key", "value"}});
+    auto object = object_builder_da::map({{"key", "value"}});
 
     std::unordered_set<object_cache_key> context{object.at(0)};
     object_set_ref exclude{context};
@@ -669,9 +670,9 @@ TEST(TestValueIterator, TestExcludeSingleObject)
 
 TEST(TestValueIterator, TestExcludeMultipleObjects)
 {
-    auto root = object_builder::map({{"key", "value"}});
+    auto root = object_builder_da::map({{"key", "value"}});
 
-    auto map = root.emplace("other", object_builder::array({"hello", "bye"}));
+    auto map = root.emplace("other", object_builder_da::array({"hello", "bye"}));
 
     std::unordered_set<object_cache_key> context{root.at(0), map.at(1)};
     object_set_ref exclude{context};
@@ -690,8 +691,8 @@ TEST(TestValueIterator, TestExcludeMultipleObjects)
 
 TEST(TestValueIterator, TestExcludeObjectInKeyPath)
 {
-    auto root = object_builder::map();
-    auto child = root.emplace("parent", object_builder::map());
+    auto root = object_builder_da::map();
+    auto child = root.emplace("parent", object_builder_da::map());
     child.emplace("child", "value");
 
     std::unordered_set<object_cache_key> context{child.at(0)};
@@ -704,7 +705,7 @@ TEST(TestValueIterator, TestExcludeObjectInKeyPath)
 
 TEST(TestValueIterator, TestExcludeRootOfKeyPath)
 {
-    auto root = object_builder::map({{"parent", object_builder::map({{"child", "value"}})}});
+    auto root = object_builder_da::map({{"parent", object_builder_da::map({{"child", "value"}})}});
 
     std::unordered_set<object_cache_key> context{root.at(0)};
 
@@ -717,8 +718,8 @@ TEST(TestValueIterator, TestExcludeRootOfKeyPath)
 
 TEST(TestValueIterator, TestNegativeIndexInPath)
 {
-    auto object = object_builder::map(
-        {{"root", object_builder::map({{"arr", object_builder::array({"a", "b", "c"})}})}});
+    auto object = object_builder_da::map(
+        {{"root", object_builder_da::map({{"arr", object_builder_da::array({"a", "b", "c"})}})}});
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};
@@ -737,8 +738,8 @@ TEST(TestValueIterator, TestNegativeIndexInPath)
 
 TEST(TestValueIterator, TestPositiveIndexInPath)
 {
-    auto object = object_builder::map(
-        {{"root", object_builder::map({{"arr", object_builder::array({"a", "b", "c"})}})}});
+    auto object = object_builder_da::map(
+        {{"root", object_builder_da::map({{"arr", object_builder_da::array({"a", "b", "c"})}})}});
 
     std::unordered_set<object_cache_key> context;
     object_set_ref exclude{context};

--- a/tests/unit/waf_test.cpp
+++ b/tests/unit/waf_test.cpp
@@ -9,6 +9,7 @@
 #include "waf.hpp"
 
 using namespace ddwaf;
+using namespace ddwaf::test;
 using namespace std::literals;
 
 namespace {
@@ -49,8 +50,8 @@ TEST(TestWaf, BasicContextRun)
 {
     auto instance = build_instance("interface.yaml");
 
-    auto root = object_builder::map({{"value1", "rule1"}});
-    auto ctx = instance.create_context();
+    auto root = object_builder_da::map({{"value1", "rule1"}});
+    auto ctx = instance.create_context(memory::get_default_resource());
 
     EXPECT_TRUE(ctx.insert(std::move(root)));
     ddwaf::timer deadline{2s};

--- a/tools/infer_schema_bench.cpp
+++ b/tools/infer_schema_bench.cpp
@@ -5,7 +5,7 @@
 // Copyright 2021 Datadog, Inc.
 #include "common/utils.hpp"
 #include "ddwaf.h"
-#include "generator/extract_schema.hpp"
+#include "processor/extract_schema.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -23,10 +23,12 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+    auto alloc = ddwaf_get_default_allocator();
+
     std::string raw_payload = read_file(argv[1]);
     auto payload = YAML::Load(raw_payload).as<ddwaf_object>();
 
-    ddwaf::generator::extract_schema generator;
+    ddwaf::extract_schema generator;
     auto start = std::chrono::system_clock::now();
     auto schema = generator.generate(&payload);
 


### PR DESCRIPTION
The default allocator argument caused runtime exceptions "emplace: incompatible allocators" (from writable_object::emplace/emplace_back in src/object.hpp:1179, 1216) when converting a dynamic_string to an object with a mismatched allocator.

By making the allocator parameter required, such bugs will be caught at compile time instead of causing runtime exceptions.

This change fixes two instances in fingerprint.cpp where the allocator was not being passed, which triggered these allocator mismatch exceptions, and updates tests to explicitly pass allocators.