### PR TITLE
Replace manual datadog-ci install with coverage-upload-github-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,7 +285,7 @@ jobs:
           path: .
 
       - name: Submit coverage (DataDog)
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           files: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,17 +284,11 @@ jobs:
           name: coverage-xml
           path: .
 
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903
-        with:
-          node-version: 24
-
-      - name: Install datadog-ci
-        run: npm install -g @datadog/datadog-ci
-
       - name: Submit coverage (DataDog)
-        run: datadog-ci coverage upload coverage.xml
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        uses: DataDog/coverage-upload-github-action@v1
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          files: coverage.xml
 
   lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Replace the manual Node.js setup + `npm install @datadog/datadog-ci` steps in the `upload-to-datadog` job with `DataDog/coverage-upload-github-action@v1`
- The action installs the `datadog-ci` standalone binary internally (no Node.js dependency needed), simplifying the workflow
- Functionally equivalent: same API key, same coverage file (`coverage.xml`)

## Test plan
- [ ] Verify the `upload-to-datadog` job runs successfully on a merge to `master`
- [ ] Confirm coverage data appears in Datadog after the upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)