### PR TITLE
chore: remove CodeCov upload from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
   compare-artifacts:
     needs: [ windows-builds, macos-universal-package, linux-musl-build]
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'pull_request' }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
   compare-artifacts:
     needs: [ windows-builds, macos-universal-package, linux-musl-build]
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,7 +250,6 @@ jobs:
   upload-to-datadog:
     needs: [ generate-coverage ]
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,6 +250,7 @@ jobs:
   upload-to-datadog:
     needs: [ generate-coverage ]
     runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,26 +247,6 @@ jobs:
           name: coverage-xml
           path: ${{ github.workspace }}/coverage.xml
 
-  upload-to-codecov:
-    needs: [ generate-coverage ]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          submodules: recursive
-
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
-        with:
-          name: coverage-xml
-          path: .
-
-      - name: Submit coverage (CodeCov)
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
-        with:
-          flags: waf_test
-          verbose: true
-          files: coverage.xml
-
   upload-to-datadog:
     needs: [ generate-coverage ]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This repo already uploads coverage to Datadog. Remove the redundant CodeCov upload.