### PR TITLE
Add support for transformers on RASP operators

### DIFF
--- a/src/argument_retriever.hpp
+++ b/src/argument_retriever.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <optional>
 #include <span>
@@ -19,8 +20,15 @@
 #include "object.hpp"
 #include "object_store.hpp"
 #include "traits.hpp"
+#include "transformer/base.hpp"
 
 namespace ddwaf {
+
+template <typename T>
+concept has_transformers = requires(const T &obj) {
+    requires std::same_as<std::remove_cvref_t<decltype(obj.transformers)>,
+        std::vector<transformer_id>>;
+};
 
 // A type of argument with a single address (target) mapping
 template <typename T> struct unary_argument {
@@ -29,6 +37,7 @@ template <typename T> struct unary_argument {
     std::string_view address{};
     std::span<const std::variant<std::string, int64_t>> key_path;
     T value;
+    std::span<const transformer_id> transformers;
 };
 
 template <typename T, typename = void> struct is_unary_argument : std::false_type {};
@@ -83,7 +92,13 @@ template <typename T> struct argument_retriever<unary_argument<T>> : default_arg
             return std::nullopt;
         }
 
-        return unary_argument<T>{target.name, target.key_path, std::move(converted.value())};
+        if constexpr (has_transformers<TargetType>) {
+            return unary_argument<T>{
+                target.name, target.key_path, std::move(converted.value()), target.transformers};
+        } else {
+            return unary_argument<T>{
+                target.name, target.key_path, std::move(converted.value()), {}};
+        }
     }
 };
 

--- a/src/condition/cmdi_detector.cpp
+++ b/src/condition/cmdi_detector.cpp
@@ -31,7 +31,9 @@
 #include "object_type.hpp"
 #include "platform.hpp"
 #include "tokenizer/shell.hpp"
+#include "transformer/base.hpp"
 #include "transformer/lowercase.hpp"
+#include "transformer/manager.hpp"
 #include "utils.hpp"
 
 using namespace std::literals;

--- a/src/condition/cmdi_detector.cpp
+++ b/src/condition/cmdi_detector.cpp
@@ -357,7 +357,8 @@ std::string_view find_shell_command(std::string_view executable, object_view exe
 
 std::optional<shi_result> cmdi_impl(object_view exec_args,
     std::vector<shell_token> &resource_tokens, object_view params,
-    const object_set_ref &objects_excluded, ddwaf::timer &deadline)
+    std::span<const transformer_id> transformers, const object_set_ref &objects_excluded,
+    ddwaf::timer &deadline)
 {
     const std::string_view executable =
         trim_whitespaces(exec_args.at_value(0).as_or_default<std::string_view>({}));
@@ -390,8 +391,15 @@ std::optional<shi_result> cmdi_impl(object_view exec_args,
         }
 
         if (eval_executable) {
-            // First check if the entire executable was injected
             auto value = param.as<std::string_view>();
+
+            // TODO: transforms are done twice if there is a shell command
+            auto transformed = transformer::manager::transform(param, transformers);
+            if (transformed.has_value()) {
+                value = static_cast<std::string_view>(transformed.value());
+            }
+
+            // First check if the entire executable was injected
             value = trim_whitespaces(value);
             if (executable == value) {
                 // When the full binary has been injected, we consider it an exploit
@@ -403,7 +411,7 @@ std::optional<shi_result> cmdi_impl(object_view exec_args,
 
         if (!shell_command.empty()) {
             auto res = find_shi_from_params<std::string_view, scalar_iterator>(
-                shell_command, resource_tokens, param, objects_excluded, deadline);
+                shell_command, resource_tokens, param, transformers, objects_excluded, deadline);
             if (res.has_value()) {
                 res->key_path = it.get_current_path();
                 return res;
@@ -447,8 +455,8 @@ bool cmdi_detector::eval_impl(const unary_argument<object_view> &resource,
 
     std::vector<shell_token> resource_tokens;
     for (const auto &param : params) {
-        auto res =
-            cmdi_impl(resource.value, resource_tokens, param.value, objects_excluded, deadline);
+        auto res = cmdi_impl(resource.value, resource_tokens, param.value, param.transformers,
+            objects_excluded, deadline);
         if (res.has_value()) {
             auto &[highlight, param_kp] = res.value();
 

--- a/src/condition/lfi_detector.cpp
+++ b/src/condition/lfi_detector.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -22,6 +23,8 @@
 #include "log.hpp"
 #include "object.hpp"
 #include "platform.hpp"
+#include "transformer/base.hpp"
+#include "transformer/manager.hpp"
 #include "utils.hpp"
 
 using namespace std::literals;
@@ -96,7 +99,8 @@ bool lfi_impl_unix(std::string_view path, std::string_view param)
 }
 
 lfi_result lfi_impl(std::string_view path, object_view params,
-    const object_set_ref &objects_excluded, ddwaf::timer &deadline)
+    std::span<const transformer_id> transformers, const object_set_ref &objects_excluded,
+    ddwaf::timer &deadline)
 {
     auto *lfi_fn = &lfi_impl_unix;
     if (system_platform::current() == platform::windows) {
@@ -114,6 +118,17 @@ lfi_result lfi_impl(std::string_view path, object_view params,
             continue;
         }
 
+        auto transformed = transformer::manager::transform(param, transformers);
+        if (transformed.has_value()) {
+            auto value = static_cast<std::string_view>(transformed.value());
+            if (lfi_fn(path, value)) {
+                return {{std::string(value), it.get_current_path()}};
+            }
+
+            continue;
+        }
+        // Fallback to the original value if the transform fails
+
         const auto value = param.as<std::string_view>();
         if (lfi_fn(path, value)) {
             return {{std::string(value), it.get_current_path()}};
@@ -130,7 +145,8 @@ bool lfi_detector::eval_impl(const unary_argument<std::string_view> &path,
     const object_set_ref &objects_excluded, ddwaf::timer &deadline) const
 {
     for (const auto &param : params) {
-        auto res = lfi_impl(path.value, param.value, objects_excluded, deadline);
+        auto res =
+            lfi_impl(path.value, param.value, param.transformers, objects_excluded, deadline);
         if (res.has_value()) {
 
             auto &[highlight, param_kp] = res.value();

--- a/src/condition/match_iterator.hpp
+++ b/src/condition/match_iterator.hpp
@@ -6,12 +6,17 @@
 
 #pragma once
 
+#include "cow_string.hpp"
 #include "exclusion/common.hpp"
 #include "iterator.hpp"
 #include "object.hpp"
+#include "transformer/base.hpp"
+#include "transformer/manager.hpp"
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
+#include <span>
 #include <string_view>
 #include <utility>
 #include <variant>
@@ -25,24 +30,20 @@ class match_iterator {
 public:
     static constexpr std::size_t npos = std::string_view::npos;
 
-    explicit match_iterator(ResourceType resource, object_view obj, const object_set_ref &exclude)
-        : resource_(std::move(resource)), it_(obj, {}, exclude)
+    explicit match_iterator(ResourceType resource, object_view obj,
+        std::span<const transformer_id> transformers, const object_set_ref &exclude)
+        : resource_(std::move(resource)), it_(obj, {}, exclude), transformers_(transformers)
     {
         for (; it_; ++it_) {
-            const auto current_obj = *it_;
-            if (current_obj.is_string() && current_obj.size() >= MinLength) {
-                current_param_ = current_obj.template as<std::string_view>();
-                current_index_ = resource_.find(current_param_, 0);
-                if (current_index_ != npos) {
-                    break;
-                }
+            if (try_match_object(*it_)) {
+                break;
             }
         }
     }
 
     ~match_iterator() = default;
 
-    match_iterator(const match_iterator &) = default;
+    match_iterator(const match_iterator &) = delete;
     match_iterator(match_iterator &&) = delete;
 
     match_iterator &operator=(const match_iterator &) = delete;
@@ -50,26 +51,21 @@ public:
 
     [[nodiscard]] std::pair<std::string_view, std::size_t> operator*()
     {
-        return {current_param_, current_index_};
+        return {get_current_param_str(), current_index_};
     }
 
     bool operator++()
     {
         if (current_index_ != npos) {
-            current_index_ = resource_.find(current_param_, current_index_ + 1);
+            current_index_ = resource_.find(get_current_param_str(), current_index_ + 1);
             if (current_index_ != npos) {
                 return true;
             }
         }
 
         while (++it_) {
-            const auto current_obj = *it_;
-            if (current_obj.is_string() && current_obj.size() >= MinLength) {
-                current_param_ = current_obj.template as<std::string_view>();
-                current_index_ = resource_.find(current_param_, 0);
-                if (current_index_ != npos) {
-                    return true;
-                }
+            if (try_match_object(*it_)) {
+                return true;
             }
         }
 
@@ -84,10 +80,38 @@ public:
     }
 
 protected:
+    [[nodiscard]] std::string_view get_current_param_str() const
+    {
+        if (current_param_.has_value()) {
+            return static_cast<std::string_view>(current_param_.value());
+        }
+        return {};
+    }
+
+    bool try_match_object(object_view current_obj)
+    {
+        if (!current_obj.is_string()) {
+            return false;
+        }
+
+        current_param_ = transformer::manager::transform(current_obj, transformers_);
+        if (!current_param_.has_value()) {
+            current_param_ = cow_string{current_obj.template as<std::string_view>()};
+        }
+
+        auto value = static_cast<std::string_view>(current_param_.value());
+        if (value.size() < MinLength) {
+            return false;
+        }
+        current_index_ = resource_.find(value, 0);
+        return current_index_ != npos;
+    }
+
     ResourceType resource_;
-    std::string_view current_param_;
+    std::optional<cow_string> current_param_;
     std::size_t current_index_{npos};
     IteratorType it_;
+    std::span<const transformer_id> transformers_;
 };
 
 } // namespace ddwaf

--- a/src/condition/shi_common.hpp
+++ b/src/condition/shi_common.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -19,6 +20,7 @@
 #include "iterator.hpp"
 #include "object.hpp"
 #include "tokenizer/shell.hpp"
+#include "transformer/base.hpp"
 
 namespace ddwaf {
 
@@ -41,9 +43,11 @@ struct shell_argument_array {
 template <typename ResourceType, typename IteratorType = kv_iterator>
 std::optional<shi_result> find_shi_from_params(const ResourceType &resource,
     std::vector<shell_token> &resource_tokens, object_view params,
-    const object_set_ref &objects_excluded, ddwaf::timer &deadline)
+    std::span<const transformer_id> transformers, const object_set_ref &objects_excluded,
+    ddwaf::timer &deadline)
 {
-    match_iterator<2, IteratorType, ResourceType> it(resource, params, objects_excluded);
+    match_iterator<2, IteratorType, ResourceType> it(
+        resource, params, transformers, objects_excluded);
     for (; it; ++it) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();

--- a/src/condition/shi_detector.cpp
+++ b/src/condition/shi_detector.cpp
@@ -38,8 +38,8 @@ bool shi_detector::eval_string(const unary_argument<object_view> &resource,
 
     std::vector<shell_token> resource_tokens;
     for (const auto &param : params) {
-        auto res = find_shi_from_params(
-            resource_sv, resource_tokens, param.value, objects_excluded, deadline);
+        auto res = find_shi_from_params(resource_sv, resource_tokens, param.value,
+            param.transformers, objects_excluded, deadline);
         if (res.has_value()) {
             auto &[highlight, param_kp] = res.value();
 
@@ -76,8 +76,8 @@ bool shi_detector::eval_array(const unary_argument<object_view> &resource,
 
     std::vector<shell_token> resource_tokens;
     for (const auto &param : params) {
-        auto res = find_shi_from_params(
-            arguments, resource_tokens, param.value, objects_excluded, deadline);
+        auto res = find_shi_from_params(arguments, resource_tokens, param.value, param.transformers,
+            objects_excluded, deadline);
         if (res.has_value()) {
             auto &[highlight, param_kp] = res.value();
 

--- a/src/condition/sqli_detector.cpp
+++ b/src/condition/sqli_detector.cpp
@@ -30,6 +30,7 @@
 #include "tokenizer/pgsql.hpp"
 #include "tokenizer/sql_base.hpp"
 #include "tokenizer/sqlite.hpp"
+#include "transformer/base.hpp"
 #include "utils.hpp"
 
 using namespace std::literals;
@@ -466,12 +467,12 @@ std::vector<sql_token> tokenize(std::string_view statement, sql_dialect dialect)
 }
 
 sqli_result sqli_impl(std::string_view resource, std::vector<sql_token> &resource_tokens,
-    object_view params, sql_dialect dialect, const object_set_ref &objects_excluded,
-    ddwaf::timer &deadline)
+    object_view params, std::span<const transformer_id> transformers, sql_dialect dialect,
+    const object_set_ref &objects_excluded, ddwaf::timer &deadline)
 {
     static constexpr std::size_t min_str_len = 3;
 
-    match_iterator<min_str_len> it(resource, params, objects_excluded);
+    match_iterator<min_str_len> it(resource, params, transformers, objects_excluded);
     for (; it; ++it) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();
@@ -529,8 +530,8 @@ sqli_detector::sqli_detector(std::vector<condition_parameter> args)
     std::vector<sql_token> resource_tokens;
 
     for (const auto &param : params) {
-        auto res = internal::sqli_impl(
-            sql.value, resource_tokens, param.value, dialect, objects_excluded, deadline);
+        auto res = internal::sqli_impl(sql.value, resource_tokens, param.value, param.transformers,
+            dialect, objects_excluded, deadline);
         if (std::holds_alternative<internal::matched_param>(res)) {
             auto stripped_stmt = internal::strip_literals(sql.value, resource_tokens);
 

--- a/src/condition/ssrf_detector.cpp
+++ b/src/condition/ssrf_detector.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -27,6 +28,7 @@
 #include "log.hpp"
 #include "matcher/ip_match.hpp"
 #include "object.hpp"
+#include "transformer/base.hpp"
 #include "uri_utils.hpp"
 #include "utils.hpp"
 
@@ -165,8 +167,8 @@ bool is_forbidden_uri(const uri_decomposed &uri, const matcher::ip_match &forbid
 }
 
 ssrf_result ssrf_impl(const uri_decomposed &uri, object_view params,
-    const object_set_ref &objects_excluded, const ssrf_opts &opts,
-    const matcher::ip_match &forbidden_ip_matcher,
+    std::span<const transformer_id> transformers, const object_set_ref &objects_excluded,
+    const ssrf_opts &opts, const matcher::ip_match &forbidden_ip_matcher,
     const std::unordered_set<std::string_view> &allowed_scheme_set,
     const std::vector<std::string> &forbidden_domains, ddwaf::timer &deadline)
 {
@@ -184,7 +186,7 @@ ssrf_result ssrf_impl(const uri_decomposed &uri, object_view params,
 
     std::optional<ssrf_result> parameter_injection;
 
-    match_iterator<min_str_len> it{uri.raw, params, objects_excluded};
+    match_iterator<min_str_len> it{uri.raw, params, transformers, objects_excluded};
     for (; it; ++it) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();
@@ -321,7 +323,7 @@ bool ssrf_detector::eval_impl(const unary_argument<std::string_view> &uri,
     }
 
     for (const auto &param : params) {
-        auto res = ssrf_impl(*decomposed, param.value, objects_excluded, opts_,
+        auto res = ssrf_impl(*decomposed, param.value, param.transformers, objects_excluded, opts_,
             *forbidden_ip_matcher_, allowed_schemes_, forbidden_domains_, deadline);
         if (res.has_value()) {
             auto &[highlight, param_kp] = res.value();

--- a/src/cow_string.hpp
+++ b/src/cow_string.hpp
@@ -33,12 +33,32 @@ public:
     cow_string(const cow_string &) = delete;
     cow_string &operator=(const cow_string &) = delete;
     cow_string(cow_string &&other) noexcept
-        : buffer_(other.buffer_), length_(other.length_), capacity_(other.capacity_)
+        : alloc_(other.alloc_), buffer_(other.buffer_), length_(other.length_),
+          capacity_(other.capacity_)
     {
         other.buffer_ = nullptr;
         other.length_ = other.capacity_ = 0;
     }
-    cow_string &operator=(cow_string &&other) = delete;
+    cow_string &operator=(cow_string &&other) noexcept
+    {
+        if (&other == this) {
+            return *this;
+        }
+
+        if (capacity_ > 0 && buffer_ != nullptr) {
+            alloc_->deallocate(buffer_, capacity_, alignof(char));
+        }
+
+        buffer_ = other.buffer_;
+        length_ = other.length_;
+        capacity_ = other.capacity_;
+        alloc_ = other.alloc_;
+
+        other.buffer_ = nullptr;
+        other.length_ = other.capacity_ = 0;
+
+        return *this;
+    }
 
     ~cow_string()
     {
@@ -68,10 +88,11 @@ public:
         return false;
     }
 
-    constexpr explicit operator std::string_view() { return {buffer_, length_}; }
+    constexpr explicit operator std::string_view() const { return {buffer_, length_}; }
 
     [[nodiscard]] nonnull_ptr<memory::memory_resource> alloc() const noexcept { return alloc_; }
     [[nodiscard]] constexpr size_type length() const noexcept { return length_; }
+    [[nodiscard]] constexpr bool empty() const noexcept { return length_ == 0; }
     [[nodiscard]] constexpr const char *data() const noexcept { return buffer_; }
     [[nodiscard]] char *modifiable_data()
     {

--- a/src/transformer/manager.cpp
+++ b/src/transformer/manager.cpp
@@ -84,7 +84,7 @@ bool call_transformer(transformer_id id, cow_string &str)
 std::optional<cow_string> manager::transform(
     object_view source, const std::span<const transformer_id> &transformers)
 {
-    if (!source.is_string() || source.empty()) {
+    if (!source.is_string() || source.empty() || transformers.empty()) {
         return std::nullopt;
     }
 

--- a/tests/integration/conditions/rasp_transformers/test.cpp
+++ b/tests/integration/conditions/rasp_transformers/test.cpp
@@ -1,0 +1,389 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "common/gtest_utils.hpp"
+#include "ddwaf.h"
+
+using namespace ddwaf;
+using namespace std::literals;
+
+namespace {
+constexpr std::string_view base_dir = "integration/conditions/rasp_transformers";
+
+ddwaf_handle init_waf(std::string_view filename)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    auto rule = read_file<ddwaf_object>(filename, base_dir);
+    if (rule.type == DDWAF_OBJ_INVALID) {
+        return nullptr;
+    }
+
+    ddwaf_handle handle = ddwaf_init(&rule, nullptr);
+    ddwaf_object_destroy(&rule, alloc);
+    return handle;
+}
+
+// Builds a map with the given string entries
+void set_string_map(ddwaf_object *map,
+    const std::vector<std::pair<std::string_view, std::string_view>> &entries,
+    ddwaf_allocator alloc)
+{
+    ddwaf_object_set_map(map, static_cast<uint16_t>(entries.size()), alloc);
+    for (const auto &[key, value] : entries) {
+        ddwaf_object_set_string(ddwaf_object_insert_key(map, key.data(), key.size(), alloc),
+            value.data(), value.size(), alloc);
+    }
+}
+
+TEST(TestRaspTransformersIntegration, LfiMatchWithTransformer)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_handle handle = init_waf("rasp_transformers.yaml");
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object_set_map(&root, 2, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("server.io.fs.file"), alloc),
+        STRL("/var/www/html/../../../etc/passwd"), alloc);
+    set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.query"), alloc),
+        {{"file", "..%2F..%2F..%2Fetc%2Fpasswd"}}, alloc);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_context_eval(context, &root, alloc, &out, LONG_TIME), DDWAF_MATCH);
+
+    EXPECT_EVENTS(
+        out, {.id = "rasp-lfi",
+                 .name = "LFI Exploit detection",
+                 .tags = {{"type", "lfi"}, {"category", "exploit_detection"}, {"module", "rasp"}},
+                 .matches = {{.op = "lfi_detector",
+                     .highlight = "../../../etc/passwd"sv,
+                     .args = {{.name = "resource",
+                                  .value = "/var/www/html/../../../etc/passwd"sv,
+                                  .address = "server.io.fs.file"},
+                         {.name = "params",
+                             .value = "../../../etc/passwd"sv,
+                             .address = "server.request.query",
+                             .path = {"file"}}}}}});
+
+    ddwaf_object_destroy(&out, alloc);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+// The same payload on an address without transformers must not match
+TEST(TestRaspTransformersIntegration, LfiNoMatchWithoutTransformer)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_handle handle = init_waf("rasp_transformers.yaml");
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object_set_map(&root, 2, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("server.io.fs.file"), alloc),
+        STRL("/var/www/html/../../../etc/passwd"), alloc);
+    set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.body"), alloc),
+        {{"file", "..%2F..%2F..%2Fetc%2Fpasswd"}}, alloc);
+
+    EXPECT_EQ(ddwaf_context_eval(context, &root, alloc, nullptr, LONG_TIME), DDWAF_OK);
+
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+// A payload which doesn't require transformation must still match
+TEST(TestRaspTransformersIntegration, LfiMatchWithUnappliedTransformer)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_handle handle = init_waf("rasp_transformers.yaml");
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object_set_map(&root, 2, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("server.io.fs.file"), alloc),
+        STRL("/var/www/html/../../../etc/passwd"), alloc);
+    set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.query"), alloc),
+        {{"file", "../../../etc/passwd"}}, alloc);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_context_eval(context, &root, alloc, &out, LONG_TIME), DDWAF_MATCH);
+
+    EXPECT_EVENTS(
+        out, {.id = "rasp-lfi",
+                 .name = "LFI Exploit detection",
+                 .tags = {{"type", "lfi"}, {"category", "exploit_detection"}, {"module", "rasp"}},
+                 .matches = {{.op = "lfi_detector",
+                     .highlight = "../../../etc/passwd"sv,
+                     .args = {{.name = "resource",
+                                  .value = "/var/www/html/../../../etc/passwd"sv,
+                                  .address = "server.io.fs.file"},
+                         {.name = "params",
+                             .value = "../../../etc/passwd"sv,
+                             .address = "server.request.query",
+                             .path = {"file"}}}}}});
+
+    ddwaf_object_destroy(&out, alloc);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestRaspTransformersIntegration, SsrfMatchWithTransformer)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_handle handle = init_waf("rasp_transformers.yaml");
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object_set_map(&root, 2, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("server.io.net.url"), alloc),
+        STRL("https://internal-website.evil.com/path/to/stuffs?bla=42"), alloc);
+    set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.query"), alloc),
+        {{"path", ".evil.com%2Fpath%2Fto%2Fstuffs%3F"}}, alloc);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_context_eval(context, &root, alloc, &out, LONG_TIME), DDWAF_MATCH);
+
+    EXPECT_EVENTS(out,
+        {.id = "rasp-ssrf",
+            .name = "SSRF Exploit detection",
+            .tags = {{"type", "ssrf"}, {"category", "exploit_detection"}, {"module", "rasp"}},
+            .matches = {{.op = "ssrf_detector",
+                .highlight = ".evil.com/path/to/stuffs?"sv,
+                .args = {{.name = "resource",
+                             .value = "https://internal-website.evil.com/path/to/stuffs?bla=42"sv,
+                             .address = "server.io.net.url"},
+                    {.name = "params",
+                        .value = ".evil.com/path/to/stuffs?"sv,
+                        .address = "server.request.query",
+                        .path = {"path"}}}}}});
+
+    ddwaf_object_destroy(&out, alloc);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestRaspTransformersIntegration, SqliMatchWithTransformer)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_handle handle = init_waf("rasp_transformers.yaml");
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object_set_map(&root, 3, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("server.db.statement"), alloc),
+        STRL(R"(SELECT * FROM t WHERE id = '' OR '1'='1')"), alloc);
+    ddwaf_object_set_string(
+        ddwaf_object_insert_key(&root, STRL("server.db.system"), alloc), STRL("mysql"), alloc);
+    set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.query"), alloc),
+        {{"id", "%27%20OR%20%271%27%3D%271"}}, alloc);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_context_eval(context, &root, alloc, &out, LONG_TIME), DDWAF_MATCH);
+
+    EXPECT_EVENTS(out,
+        {.id = "rasp-sqli",
+            .name = "SQLi Exploit detection",
+            .tags = {{"type", "sqli"}, {"category", "exploit_detection"}, {"module", "rasp"}},
+            .matches = {{.op = "sqli_detector",
+                .highlight = R"(' OR '1'='1)"sv,
+                .args = {{.name = "resource",
+                             .value = R"(SELECT * FROM t WHERE id = ? OR ?=?)"sv,
+                             .address = "server.db.statement"},
+                    {.name = "params",
+                        .value = R"(' OR '1'='1)"sv,
+                        .address = "server.request.query",
+                        .path = {"id"}},
+                    {.name = "db_type", .value = "mysql"sv, .address = "server.db.system"}}}}});
+
+    ddwaf_object_destroy(&out, alloc);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+TEST(TestRaspTransformersIntegration, ShiMatchWithMultipleTransformers)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_handle handle = init_waf("rasp_transformers.yaml");
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object_set_map(&root, 2, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("server.sys.shell.cmd"), alloc),
+        STRL("ls -l; cat /etc/passwd"), alloc);
+    // base64("%3B%20cat%20%2Fetc%2Fpasswd")
+    set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.query"), alloc),
+        {{"cmd", "JTNCJTIwY2F0JTIwJTJGZXRjJTJGcGFzc3dk"}}, alloc);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_context_eval(context, &root, alloc, &out, LONG_TIME), DDWAF_MATCH);
+
+    EXPECT_EVENTS(
+        out, {.id = "rasp-shi",
+                 .name = "SHi Exploit detection",
+                 .tags = {{"type", "shi"}, {"category", "exploit_detection"}, {"module", "rasp"}},
+                 .matches = {{.op = "shi_detector",
+                     .highlight = "; cat /etc/passwd"sv,
+                     .args = {{.name = "resource",
+                                  .value = "ls -l; cat /etc/passwd"sv,
+                                  .address = "server.sys.shell.cmd"},
+                         {.name = "params",
+                             .value = "; cat /etc/passwd"sv,
+                             .address = "server.request.query",
+                             .path = {"cmd"}}}}}});
+
+    ddwaf_object_destroy(&out, alloc);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+// keys_only and values_only only alter the data source of the target, which is
+// not used by the exploit prevention operators; the remaining transformers must
+// still be applied to both keys and values
+TEST(TestRaspTransformersIntegration, SourceTransformersIgnored)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_handle handle = init_waf("source_transformers.yaml");
+    ASSERT_NE(handle, nullptr);
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
+        ASSERT_NE(context, nullptr);
+
+        // keys_only on the params of an LFI rule, payload within the value
+        ddwaf_object root;
+        ddwaf_object_set_map(&root, 2, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("server.io.fs.file"), alloc),
+            STRL("/var/www/html/../../../etc/passwd"), alloc);
+        set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.query"), alloc),
+            {{"file", "..%2F..%2F..%2Fetc%2Fpasswd"}}, alloc);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_context_eval(context, &root, alloc, &out, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EVENTS(out,
+            {.id = "rasp-lfi-keys-only",
+                .name = "LFI Exploit detection",
+                .tags = {{"type", "lfi"}, {"category", "exploit_detection"}, {"module", "rasp"}},
+                .matches = {{.op = "lfi_detector",
+                    .highlight = "../../../etc/passwd"sv,
+                    .args = {{.name = "resource",
+                                 .value = "/var/www/html/../../../etc/passwd"sv,
+                                 .address = "server.io.fs.file"},
+                        {.name = "params",
+                            .value = "../../../etc/passwd"sv,
+                            .address = "server.request.query",
+                            .path = {"file"}}}}}});
+
+        ddwaf_object_destroy(&out, alloc);
+        ddwaf_context_destroy(context);
+    }
+
+    {
+        ddwaf_context context = ddwaf_context_init(handle, alloc);
+        ASSERT_NE(context, nullptr);
+
+        // values_only on the params of a SHi rule, payload within the key
+        ddwaf_object root;
+        ddwaf_object_set_map(&root, 2, alloc);
+        ddwaf_object_set_string(ddwaf_object_insert_key(&root, STRL("server.sys.shell.cmd"), alloc),
+            STRL("ls -l; cat /etc/passwd"), alloc);
+        set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.query"), alloc),
+            {{"%3B%20cat%20%2Fetc%2Fpasswd", "value"}}, alloc);
+
+        ddwaf_object out;
+        ASSERT_EQ(ddwaf_context_eval(context, &root, alloc, &out, LONG_TIME), DDWAF_MATCH);
+
+        EXPECT_EVENTS(out,
+            {.id = "rasp-shi-values-only",
+                .name = "SHi Exploit detection",
+                .tags = {{"type", "shi"}, {"category", "exploit_detection"}, {"module", "rasp"}},
+                .matches = {{.op = "shi_detector",
+                    .highlight = "; cat /etc/passwd"sv,
+                    .args = {{.name = "resource",
+                                 .value = "ls -l; cat /etc/passwd"sv,
+                                 .address = "server.sys.shell.cmd"},
+                        {.name = "params",
+                            .value = "; cat /etc/passwd"sv,
+                            .address = "server.request.query",
+                            .path = {"%3B%20cat%20%2Fetc%2Fpasswd"}}}}}});
+
+        ddwaf_object_destroy(&out, alloc);
+        ddwaf_context_destroy(context);
+    }
+
+    ddwaf_destroy(handle);
+}
+
+TEST(TestRaspTransformersIntegration, CmdiMatchWithTransformer)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+
+    ddwaf_handle handle = init_waf("rasp_transformers.yaml");
+    ASSERT_NE(handle, nullptr);
+
+    ddwaf_context context = ddwaf_context_init(handle, alloc);
+    ASSERT_NE(context, nullptr);
+
+    ddwaf_object root;
+    ddwaf_object_set_map(&root, 2, alloc);
+
+    auto *exec = ddwaf_object_insert_key(&root, STRL("server.sys.exec.cmd"), alloc);
+    ddwaf_object_set_array(exec, 3, alloc);
+    ddwaf_object_set_string(ddwaf_object_insert(exec, alloc), STRL("/bin/sh"), alloc);
+    ddwaf_object_set_string(ddwaf_object_insert(exec, alloc), STRL("-c"), alloc);
+    ddwaf_object_set_string(ddwaf_object_insert(exec, alloc), STRL("ls -l"), alloc);
+
+    set_string_map(ddwaf_object_insert_key(&root, STRL("server.request.query"), alloc),
+        {{"cmd", "ls%20-l"}}, alloc);
+
+    ddwaf_object out;
+    ASSERT_EQ(ddwaf_context_eval(context, &root, alloc, &out, LONG_TIME), DDWAF_MATCH);
+
+    EXPECT_EVENTS(
+        out, {.id = "rasp-cmdi",
+                 .name = "CMDi Exploit detection",
+                 .tags = {{"type", "cmdi"}, {"category", "exploit_detection"}, {"module", "rasp"}},
+                 .matches = {{.op = "cmdi_detector",
+                     .highlight = "ls -l"sv,
+                     .args = {{.name = "resource",
+                                  .value = R"(/bin/sh "-c" "ls -l")"sv,
+                                  .address = "server.sys.exec.cmd"},
+                         {.name = "params",
+                             .value = "ls -l"sv,
+                             .address = "server.request.query",
+                             .path = {"cmd"}}}}}});
+
+    ddwaf_object_destroy(&out, alloc);
+    ddwaf_context_destroy(context);
+    ddwaf_destroy(handle);
+}
+
+} // namespace

--- a/tests/integration/conditions/rasp_transformers/yaml/rasp_transformers.yaml
+++ b/tests/integration/conditions/rasp_transformers/yaml/rasp_transformers.yaml
@@ -1,0 +1,89 @@
+version: '2.2'
+rules:
+  - id: rasp-lfi
+    name: LFI Exploit detection
+    tags:
+      type: lfi
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - operator: lfi_detector@v2
+        parameters:
+          resource:
+            - address: server.io.fs.file
+          params:
+            - address: server.request.query
+              transformers:
+                - url_decode
+            - address: server.request.body
+
+  - id: rasp-ssrf
+    name: SSRF Exploit detection
+    tags:
+      type: ssrf
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - operator: ssrf_detector@v1
+        parameters:
+          resource:
+            - address: server.io.net.url
+          params:
+            - address: server.request.query
+              transformers:
+                - url_decode
+            - address: server.request.body
+
+  - id: rasp-sqli
+    name: SQLi Exploit detection
+    tags:
+      type: sqli
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - operator: sqli_detector@v2
+        parameters:
+          resource:
+            - address: server.db.statement
+          params:
+            - address: server.request.query
+              transformers:
+                - url_decode
+            - address: server.request.body
+          db_type:
+            - address: server.db.system
+
+  - id: rasp-shi
+    name: SHi Exploit detection
+    tags:
+      type: shi
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - operator: shi_detector@v1
+        parameters:
+          resource:
+            - address: server.sys.shell.cmd
+          params:
+            - address: server.request.query
+              transformers:
+                - base64_decode
+                - url_decode
+            - address: server.request.body
+
+  - id: rasp-cmdi
+    name: CMDi Exploit detection
+    tags:
+      type: cmdi
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - operator: cmdi_detector@v1
+        parameters:
+          resource:
+            - address: server.sys.exec.cmd
+          params:
+            - address: server.request.query
+              transformers:
+                - url_decode
+            - address: server.request.body

--- a/tests/integration/conditions/rasp_transformers/yaml/source_transformers.yaml
+++ b/tests/integration/conditions/rasp_transformers/yaml/source_transformers.yaml
@@ -1,0 +1,35 @@
+version: '2.2'
+rules:
+  - id: rasp-lfi-keys-only
+    name: LFI Exploit detection
+    tags:
+      type: lfi
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - operator: lfi_detector@v2
+        parameters:
+          resource:
+            - address: server.io.fs.file
+          params:
+            - address: server.request.query
+              transformers:
+                - keys_only
+                - url_decode
+
+  - id: rasp-shi-values-only
+    name: SHi Exploit detection
+    tags:
+      type: shi
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - operator: shi_detector@v1
+        parameters:
+          resource:
+            - address: server.sys.shell.cmd
+          params:
+            - address: server.request.query
+              transformers:
+                - values_only
+                - url_decode

--- a/tests/integration/interface/log/test.cpp
+++ b/tests/integration/interface/log/test.cpp
@@ -29,7 +29,7 @@ TEST(TestLogging, Basic)
 
     DDWAF_TRACE("test message");
     EXPECT_EQ(lastLevel, DDWAF_LOG_TRACE);
-    EXPECT_EQ(lastFile, "test.cpp");
+    EXPECT_TRUE(lastFile.ends_with("test.cpp"));
     EXPECT_TRUE(lastFunction.find("TestBody") != std::string::npos);
     EXPECT_EQ(lastMessage, "test message");
 

--- a/tests/unit/argument_retriever_test.cpp
+++ b/tests/unit/argument_retriever_test.cpp
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "argument_retriever.hpp"
+#include "condition/base.hpp"
+#include "processor/base.hpp"
+
+#include "common/gtest_utils.hpp"
+
+using namespace ddwaf;
+using namespace ddwaf::test;
+
+namespace {
+
+// Targets which provide their own transformers
+static_assert(has_transformers<condition_target>);
+
+// Targets without transformers
+static_assert(!has_transformers<processor_target>);
+
+struct wrong_transformer_type {
+    std::vector<int> transformers;
+};
+static_assert(!has_transformers<wrong_transformer_type>);
+
+struct wrong_transformer_name {
+    std::vector<transformer_id> transformer;
+};
+static_assert(!has_transformers<wrong_transformer_name>);
+
+TEST(TestArgumentRetriever, UnaryArgumentWithTransformers)
+{
+    auto root = object_builder_da::map({{"input", "value"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    const condition_target target{.name = "input",
+        .index = get_target_index("input"),
+        .key_path = {},
+        .transformers = {transformer_id::lowercase, transformer_id::url_decode}};
+
+    auto arg = argument_retriever<unary_argument<std::string_view>>::retrieve(store, {}, target);
+    ASSERT_TRUE(arg.has_value());
+
+    EXPECT_STRV(arg->address, "input");
+    EXPECT_STRV(arg->value, "value");
+    ASSERT_EQ(arg->transformers.size(), 2);
+    EXPECT_EQ(arg->transformers[0], transformer_id::lowercase);
+    EXPECT_EQ(arg->transformers[1], transformer_id::url_decode);
+}
+
+TEST(TestArgumentRetriever, UnaryArgumentWithoutTransformers)
+{
+    auto root = object_builder_da::map({{"input", "value"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    const condition_target target{.name = "input", .index = get_target_index("input")};
+
+    auto arg = argument_retriever<unary_argument<std::string_view>>::retrieve(store, {}, target);
+    ASSERT_TRUE(arg.has_value());
+
+    EXPECT_STRV(arg->address, "input");
+    EXPECT_STRV(arg->value, "value");
+    EXPECT_TRUE(arg->transformers.empty());
+}
+
+// Targets which don't provide transformers must yield an empty span
+TEST(TestArgumentRetriever, UnaryArgumentTargetWithoutTransformerSupport)
+{
+    auto root = object_builder_da::map({{"input", "value"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    const processor_target target{
+        .index = get_target_index("input"), .name = "input", .key_path = {}};
+
+    auto arg = argument_retriever<unary_argument<std::string_view>>::retrieve(store, {}, target);
+    ASSERT_TRUE(arg.has_value());
+
+    EXPECT_STRV(arg->address, "input");
+    EXPECT_STRV(arg->value, "value");
+    EXPECT_TRUE(arg->transformers.empty());
+}
+
+TEST(TestArgumentRetriever, OptionalArgumentWithTransformers)
+{
+    auto root = object_builder_da::map({{"input", "value"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    const condition_target target{.name = "input",
+        .index = get_target_index("input"),
+        .key_path = {},
+        .transformers = {transformer_id::lowercase}};
+
+    auto arg = argument_retriever<optional_argument<std::string_view>>::retrieve(store, {}, target);
+    ASSERT_TRUE(arg.has_value());
+
+    ASSERT_EQ(arg->transformers.size(), 1);
+    EXPECT_EQ(arg->transformers[0], transformer_id::lowercase);
+}
+
+// Each target of a variadic argument keeps its own set of transformers
+TEST(TestArgumentRetriever, VariadicArgumentWithTransformers)
+{
+    auto root =
+        object_builder_da::map({{"input", "value"}, {"other", "value"}, {"another", "value"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    const std::vector<condition_target> targets{
+        {.name = "input",
+            .index = get_target_index("input"),
+            .key_path = {},
+            .transformers = {transformer_id::lowercase}},
+        {.name = "other", .index = get_target_index("other")},
+        {.name = "another",
+            .index = get_target_index("another"),
+            .key_path = {},
+            .transformers = {transformer_id::url_decode, transformer_id::base64_decode}},
+    };
+
+    auto args =
+        argument_retriever<variadic_argument<std::string_view>>::retrieve(store, {}, targets);
+    ASSERT_EQ(args.size(), 3);
+
+    EXPECT_STRV(args[0].address, "input");
+    ASSERT_EQ(args[0].transformers.size(), 1);
+    EXPECT_EQ(args[0].transformers[0], transformer_id::lowercase);
+
+    EXPECT_STRV(args[1].address, "other");
+    EXPECT_TRUE(args[1].transformers.empty());
+
+    EXPECT_STRV(args[2].address, "another");
+    ASSERT_EQ(args[2].transformers.size(), 2);
+    EXPECT_EQ(args[2].transformers[0], transformer_id::url_decode);
+    EXPECT_EQ(args[2].transformers[1], transformer_id::base64_decode);
+}
+
+} // namespace

--- a/tests/unit/condition/cmdi_detector_test.cpp
+++ b/tests/unit/condition/cmdi_detector_test.cpp
@@ -749,4 +749,248 @@ TEST(TestCmdiDetector, ShellInjectionMultipleArguments)
     EXPECT_STR(cache.match->highlights[0], "; $(cat /etc/passwd)");
 }
 
+// Generates the parameter definition of a two-argument detector, applying the
+// given transformers to the second (params) argument only
+std::vector<condition_parameter> gen_param_def_with_transformers(
+    std::string_view resource, std::string_view params, std::vector<transformer_id> transformers)
+{
+    return {condition_parameter{{condition_target{
+                .name = std::string{resource}, .index = get_target_index(resource)}}},
+        condition_parameter{{condition_target{.name = std::string{params},
+            .index = get_target_index(params),
+            .key_path = {},
+            .transformers = std::move(transformers)}}}};
+}
+
+owned_object gen_exec_root(const std::vector<std::string> &resource, std::string_view param)
+{
+    auto root = object_builder_da::map({{"server.request.query", param}});
+    auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
+    for (const auto &arg : resource) { array.emplace_back(arg); }
+    return root;
+}
+
+TEST(TestCmdiDetector, NoMatchWithoutTransformer)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{{gen_param_def("server.sys.exec.cmd", "server.request.query")}};
+
+    {
+        auto root = gen_exec_root({"/usr/bin/curl", "http://malicious"}, "%2Fusr%2Fbin%2Fcurl");
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_FALSE(cache.match);
+    }
+
+    {
+        auto root = gen_exec_root({"/bin/sh", "-c", "ls -l"}, "ls%20-l");
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_FALSE(cache.match);
+    }
+}
+
+TEST(TestCmdiDetector, MatchExecutableWithTransformer)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{gen_param_def_with_transformers(
+        "server.sys.exec.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = gen_exec_root({"/usr/bin/curl", "http://malicious"}, "%2Fusr%2Fbin%2Fcurl");
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
+    EXPECT_STR(cache.match->args[0].resolved, R"(/usr/bin/curl "http://malicious")");
+
+    EXPECT_STRV(cache.match->args[1].address, "server.request.query");
+    // The reported parameter is the transformed one
+    EXPECT_STR(cache.match->args[1].resolved, "/usr/bin/curl");
+    EXPECT_STR(cache.match->highlights[0], "/usr/bin/curl");
+}
+
+TEST(TestCmdiDetector, MatchShellCommandWithTransformer)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{gen_param_def_with_transformers(
+        "server.sys.exec.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = gen_exec_root({"/bin/sh", "-c", "ls -l"}, "ls%20-l");
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STRV(cache.match->args[0].address, "server.sys.exec.cmd");
+    EXPECT_STR(cache.match->args[0].resolved, R"(/bin/sh "-c" "ls -l")");
+
+    EXPECT_STRV(cache.match->args[1].address, "server.request.query");
+    EXPECT_STR(cache.match->args[1].resolved, "ls -l");
+    EXPECT_STR(cache.match->highlights[0], "ls -l");
+}
+
+TEST(TestCmdiDetector, MatchWithMultipleTransformers)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{gen_param_def_with_transformers("server.sys.exec.cmd",
+        "server.request.query", {transformer_id::base64_decode, transformer_id::url_decode})};
+
+    {
+        // base64("%2Fusr%2Fbin%2Fcurl")
+        auto root =
+            gen_exec_root({"/usr/bin/curl", "http://malicious"}, "JTJGdXNyJTJGYmluJTJGY3VybA==");
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_STR(cache.match->highlights[0], "/usr/bin/curl");
+    }
+
+    {
+        // base64("ls%20-l")
+        auto root = gen_exec_root({"/bin/sh", "-c", "ls -l"}, "bHMlMjAtbA==");
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_STR(cache.match->highlights[0], "ls -l");
+    }
+}
+
+// When the transformers leave the parameter untouched, the original value must
+// still be evaluated
+TEST(TestCmdiDetector, MatchWithUnappliedTransformer)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{gen_param_def_with_transformers(
+        "server.sys.exec.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    {
+        auto root = gen_exec_root({"/usr/bin/curl", "http://malicious"}, "/usr/bin/curl");
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_STR(cache.match->highlights[0], "/usr/bin/curl");
+    }
+
+    {
+        auto root = gen_exec_root({"/bin/sh", "-c", "ls -l"}, "ls -l");
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_STR(cache.match->highlights[0], "ls -l");
+    }
+}
+
+// Every parameter within the container must be transformed independently
+TEST(TestCmdiDetector, MatchWithTransformerWithinContainer)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{gen_param_def_with_transformers(
+        "server.sys.exec.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({{"server.request.query",
+        object_builder_da::map({{"harmless", "not+an+injection"}, {"cmd", "ls%20-l"}})}});
+    auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
+    array.emplace_back("/bin/sh");
+    array.emplace_back("-c");
+    array.emplace_back("ls -l");
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], "ls -l");
+    ASSERT_EQ(cache.match->args[1].key_path.size(), 1);
+    EXPECT_STR(std::get<std::string_view>(cache.match->args[1].key_path[0]), "cmd");
+}
+
+// The resource is never transformed, only the parameters
+TEST(TestCmdiDetector, ResourceNotTransformed)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{{condition_parameter{{condition_target{.name = "server.sys.exec.cmd",
+                            .index = get_target_index("server.sys.exec.cmd"),
+                            .key_path = {},
+                            .transformers = {transformer_id::url_decode}}}},
+        condition_parameter{{condition_target{
+            .name = "server.request.query", .index = get_target_index("server.request.query")}}}}};
+
+    auto root = gen_exec_root({"%2Fbin%2Fsh", "-c", "ls%20-l"}, "ls -l");
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+// A parameter reduced to an empty string by the transformers must not be
+// considered an injection
+TEST(TestCmdiDetector, NoMatchOnEmptyTransformedParameter)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{gen_param_def_with_transformers(
+        "server.sys.exec.cmd", "server.request.query", {transformer_id::remove_nulls})};
+
+    const std::string nulls("\0\0\0\0", 4);
+    auto root = gen_exec_root({"/bin/sh", "-c", "ls"}, nulls);
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
 } // namespace

--- a/tests/unit/condition/lfi_detector_test.cpp
+++ b/tests/unit/condition/lfi_detector_test.cpp
@@ -319,4 +319,254 @@ TEST(TestLFIDetector, NoParams)
     EXPECT_FALSE(cache.match);
 }
 
+// Generates the parameter definition of a two-argument detector, applying the
+// given transformers to the second (params) argument only
+std::vector<condition_parameter> gen_param_def_with_transformers(
+    std::string_view resource, std::string_view params, std::vector<transformer_id> transformers)
+{
+    return {condition_parameter{{condition_target{
+                .name = std::string{resource}, .index = get_target_index(resource)}}},
+        condition_parameter{{condition_target{.name = std::string{params},
+            .index = get_target_index(params),
+            .key_path = {},
+            .transformers = std::move(transformers)}}}};
+}
+
+TEST(TestLFIDetector, NoMatchWithoutTransformer)
+{
+    lfi_detector cond{{gen_param_def("server.io.fs.file", "server.request.query")}};
+
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+        {"server.request.query", "..%2F..%2F..%2Fetc%2Fpasswd"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+TEST(TestLFIDetector, MatchWithTransformer)
+{
+    lfi_detector cond{gen_param_def_with_transformers(
+        "server.io.fs.file", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+        {"server.request.query", "..%2F..%2F..%2Fetc%2Fpasswd"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STRV(cache.match->args[0].address, "server.io.fs.file");
+    EXPECT_STR(cache.match->args[0].resolved, "/var/www/html/../../../etc/passwd");
+
+    EXPECT_STRV(cache.match->args[1].address, "server.request.query");
+    // The reported parameter is the transformed one
+    EXPECT_STR(cache.match->args[1].resolved, "../../../etc/passwd");
+    EXPECT_STR(cache.match->highlights[0], "../../../etc/passwd");
+}
+
+TEST(TestLFIDetector, MatchWithMultipleTransformers)
+{
+    lfi_detector cond{gen_param_def_with_transformers("server.io.fs.file", "server.request.query",
+        {transformer_id::base64_decode, transformer_id::url_decode})};
+
+    // base64("..%2F..%2F..%2Fetc%2Fpasswd")
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+        {"server.request.query", "Li4lMkYuLiUyRi4uJTJGZXRjJTJGcGFzc3dk"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], "../../../etc/passwd");
+}
+
+// When the transformers leave the parameter untouched, the original value must
+// still be evaluated
+TEST(TestLFIDetector, MatchWithUnappliedTransformer)
+{
+    lfi_detector cond{gen_param_def_with_transformers(
+        "server.io.fs.file", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+        {"server.request.query", "../../../etc/passwd"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], "../../../etc/passwd");
+}
+
+// Transformers are applied to each parameter within the container, including keys
+TEST(TestLFIDetector, MatchWithTransformerWithinContainer)
+{
+    lfi_detector cond{gen_param_def_with_transformers(
+        "server.io.fs.file", "server.request.query", {transformer_id::url_decode})};
+
+    {
+        auto root =
+            object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+                {"server.request.query",
+                    object_builder_da::map({{"file", "..%2F..%2F..%2Fetc%2Fpasswd"}})}});
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+        ASSERT_TRUE(cache.match);
+        EXPECT_STR(cache.match->highlights[0], "../../../etc/passwd");
+        ASSERT_EQ(cache.match->args[1].key_path.size(), 1);
+        EXPECT_STR(std::get<std::string_view>(cache.match->args[1].key_path[0]), "file");
+    }
+
+    {
+        auto root =
+            object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+                {"server.request.query",
+                    object_builder_da::map({{"..%2F..%2F..%2Fetc%2Fpasswd", "value"}})}});
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+        ASSERT_TRUE(cache.match);
+        EXPECT_STR(cache.match->highlights[0], "../../../etc/passwd");
+    }
+}
+
+// Transformers are per-target, so a parameter without transformers must not be
+// transformed
+TEST(TestLFIDetector, TransformersArePerTarget)
+{
+    lfi_detector cond{{condition_parameter{{condition_target{
+                           .name = "server.io.fs.file",
+                           .index = get_target_index("server.io.fs.file"),
+                       }}},
+        condition_parameter{{condition_target{.name = "server.request.query",
+                                 .index = get_target_index("server.request.query"),
+                                 .key_path = {},
+                                 .transformers = {transformer_id::url_decode}},
+            condition_target{.name = "server.request.body",
+                .index = get_target_index("server.request.body")}}}}};
+
+    {
+        auto root =
+            object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+                {"server.request.query", "..%2F..%2F..%2Fetc%2Fpasswd"},
+                {"server.request.body", "..%2F..%2F..%2Fetc%2Fpasswd"}});
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+        ASSERT_TRUE(cache.match);
+        EXPECT_STRV(cache.match->args[1].address, "server.request.query");
+        EXPECT_STR(cache.match->highlights[0], "../../../etc/passwd");
+    }
+
+    {
+        // Only the body contains the encoded payload, which isn't transformed
+        auto root =
+            object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+                {"server.request.body", "..%2F..%2F..%2Fetc%2Fpasswd"}});
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_FALSE(cache.match);
+    }
+}
+
+// The resource is never transformed, only the parameters
+TEST(TestLFIDetector, ResourceNotTransformed)
+{
+    lfi_detector cond{{condition_parameter{{condition_target{.name = "server.io.fs.file",
+                           .index = get_target_index("server.io.fs.file"),
+                           .key_path = {},
+                           .transformers = {transformer_id::url_decode}}}},
+        condition_parameter{{condition_target{
+            .name = "server.request.query", .index = get_target_index("server.request.query")}}}}};
+
+    auto root =
+        object_builder_da::map({{"server.io.fs.file", "%2Fvar%2Fwww%2F..%2F..%2Fetc%2Fpasswd"},
+            {"server.request.query", "../../etc/passwd"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+// The transformed parameter replaces the original one, so a payload which is
+// present verbatim within the path is no longer detected once the transformers
+// modify it
+TEST(TestLFIDetector, NoMatchOnUntransformedParameter)
+{
+    lfi_detector cond{gen_param_def_with_transformers(
+        "server.io.fs.file", "server.request.query", {transformer_id::lowercase})};
+
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/PASSWD"},
+        {"server.request.query", "../../../etc/PASSWD"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+// A parameter reduced to an empty string by the transformers must not be
+// considered an exploit
+TEST(TestLFIDetector, NoMatchOnEmptyTransformedParameter)
+{
+    lfi_detector cond{gen_param_def_with_transformers(
+        "server.io.fs.file", "server.request.query", {transformer_id::remove_nulls})};
+
+    const std::string nulls("\0\0\0\0", 4);
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+        {"server.request.query", nulls}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
 } // namespace

--- a/tests/unit/condition/match_iterator_test.cpp
+++ b/tests/unit/condition/match_iterator_test.cpp
@@ -7,6 +7,7 @@
 #include "common/ddwaf_object_da.hpp"
 #include "common/gtest_utils.hpp"
 #include "condition/match_iterator.hpp"
+#include "transformer/base.hpp"
 
 using namespace ddwaf;
 using namespace ddwaf::test;
@@ -104,6 +105,247 @@ TEST(TestMatchIterator, OverlappingMatches)
 
         ++it;
     }
+
+    EXPECT_FALSE(++it);
+}
+
+TEST(TestMatchIterator, NoMatchWithoutTransformer)
+{
+    owned_object object = test::ddwaf_object_da::make_string("%72esource");
+
+    std::string resource = "this is the resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, {}, exclude);
+    EXPECT_FALSE((bool)it);
+
+    EXPECT_FALSE(++it);
+}
+
+TEST(TestMatchIterator, SingleMatchWithTransformer)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = test::ddwaf_object_da::make_string("%72esource");
+
+    std::string resource = "this is the resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    EXPECT_TRUE((bool)it);
+
+    auto [param, index] = *it;
+    EXPECT_STRV(param, "resource");
+    EXPECT_EQ(index, 12);
+
+    auto path = it.get_current_path();
+    EXPECT_EQ(path.size(), 0);
+
+    EXPECT_FALSE(++it);
+}
+
+TEST(TestMatchIterator, MultipleTransformers)
+{
+    const std::vector<transformer_id> transformers{
+        transformer_id::url_decode, transformer_id::lowercase};
+
+    owned_object object = test::ddwaf_object_da::make_string("%52ESOURCE");
+
+    std::string resource = "this is the resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    EXPECT_TRUE((bool)it);
+
+    auto [param, index] = *it;
+    EXPECT_STRV(param, "resource");
+    EXPECT_EQ(index, 12);
+
+    EXPECT_FALSE(++it);
+}
+
+// When none of the transformers modify the parameter, the original value must
+// still be used for matching
+TEST(TestMatchIterator, UnmodifiedByTransformer)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = test::ddwaf_object_da::make_string("resource");
+
+    std::string resource = "this is the resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    EXPECT_TRUE((bool)it);
+
+    auto [param, index] = *it;
+    EXPECT_STRV(param, "resource");
+    EXPECT_EQ(index, 12);
+
+    EXPECT_FALSE(++it);
+}
+
+TEST(TestMatchIterator, MultipleMatchesWithTransformer)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = test::ddwaf_object_da::make_string("%72esource");
+
+    std::string resource = "resource resource resource resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, transformers, exclude);
+
+    for (std::size_t i = 0; i < 4; ++i) {
+        EXPECT_TRUE((bool)it);
+        auto [param, index] = *it;
+        EXPECT_STRV(param, "resource");
+        EXPECT_EQ(index, i * 9);
+
+        ++it;
+    }
+
+    EXPECT_FALSE(++it);
+}
+
+// Each parameter must be transformed independently, regardless of whether the
+// previous one was modified by the transformers or not
+TEST(TestMatchIterator, MultipleParametersWithTransformer)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = object_builder_da::array(
+        {"unrelated", "%72esource", "no match here", "resource", "%6eothing"});
+
+    std::string resource = "this is the resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, transformers, exclude);
+
+    for (std::size_t i = 0; i < 2; ++i) {
+        EXPECT_TRUE((bool)it);
+        auto [param, index] = *it;
+        EXPECT_STRV(param, "resource");
+        EXPECT_EQ(index, 12);
+
+        auto path = it.get_current_path();
+        ASSERT_EQ(path.size(), 1);
+        EXPECT_EQ(std::get<int64_t>(path[0]), i == 0 ? 1 : 3);
+
+        ++it;
+    }
+
+    EXPECT_FALSE((bool)it);
+}
+
+// The default iterator is a kv_iterator, so keys must also be transformed
+TEST(TestMatchIterator, TransformedKey)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = object_builder_da::map({{"%72esource", "unrelated"}});
+
+    std::string resource = "this is the resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    EXPECT_TRUE((bool)it);
+
+    auto [param, index] = *it;
+    EXPECT_STRV(param, "resource");
+    EXPECT_EQ(index, 12);
+
+    EXPECT_FALSE(++it);
+}
+
+// The minimum length requirement is evaluated on the value which is actually
+// looked up within the resource, i.e. the transformed one when the transformers
+// modify the parameter and the original one otherwise
+TEST(TestMatchIterator, MinLengthAppliedToMatchedValue)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    {
+        // The parameter is left untouched by the transformers and is too short
+        owned_object object = test::ddwaf_object_da::make_string("res");
+
+        std::string resource = "this is the resource";
+        object_set_ref exclude;
+        ddwaf::match_iterator<5> it(resource, object, transformers, exclude);
+        EXPECT_FALSE((bool)it);
+    }
+
+    {
+        // The transformed value is too short and the original one, which is
+        // present within the resource, must not be evaluated instead
+        owned_object object = test::ddwaf_object_da::make_string("%72%65%73");
+
+        std::string resource = "this is the %72%65%73ource";
+        object_set_ref exclude;
+        ddwaf::match_iterator<5> it(resource, object, transformers, exclude);
+        EXPECT_FALSE((bool)it);
+
+        EXPECT_FALSE(++it);
+    }
+
+    {
+        // The transformed value satisfies the minimum length
+        owned_object object = test::ddwaf_object_da::make_string("%72esource");
+
+        std::string resource = "this is the resource";
+        object_set_ref exclude;
+        ddwaf::match_iterator<5> it(resource, object, transformers, exclude);
+        EXPECT_TRUE((bool)it);
+
+        auto [param, index] = *it;
+        EXPECT_STRV(param, "resource");
+        EXPECT_EQ(index, 12);
+    }
+}
+
+// A parameter shorter than the minimum length can still be matched if the
+// transformers make it long enough
+TEST(TestMatchIterator, MinLengthReachedAfterTransform)
+{
+    const std::vector<transformer_id> transformers{transformer_id::base64_encode};
+
+    owned_object object = test::ddwaf_object_da::make_string("ab");
+
+    // base64("ab")
+    std::string resource = "this is the YWI= resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator<4> it(resource, object, transformers, exclude);
+    EXPECT_TRUE((bool)it);
+
+    auto [param, index] = *it;
+    EXPECT_STRV(param, "YWI=");
+    EXPECT_EQ(index, 12);
+}
+
+// The transformed parameter replaces the original one, rather than being
+// evaluated in addition to it, so a parameter which is present verbatim within
+// the resource is no longer found once a transformer modifies it
+TEST(TestMatchIterator, OnlyTransformedParameterEvaluated)
+{
+    const std::vector<transformer_id> transformers{transformer_id::lowercase};
+
+    owned_object object = test::ddwaf_object_da::make_string("RESOURCE");
+
+    std::string resource = "this is the RESOURCE";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    EXPECT_FALSE((bool)it);
+
+    EXPECT_FALSE(++it);
+}
+
+// A parameter which is reduced to an empty string by the transformers must not
+// be considered a match, as std::string_view::find always succeeds on an empty
+// needle
+TEST(TestMatchIterator, EmptyTransformedParameter)
+{
+    const std::vector<transformer_id> transformers{transformer_id::remove_nulls};
+
+    const std::string nulls("\0\0\0", 3);
+    owned_object object = test::ddwaf_object_da::make_string(nulls);
+
+    std::string resource = "this is the resource";
+    object_set_ref exclude;
+    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    EXPECT_FALSE((bool)it);
 
     EXPECT_FALSE(++it);
 }

--- a/tests/unit/condition/match_iterator_test.cpp
+++ b/tests/unit/condition/match_iterator_test.cpp
@@ -19,7 +19,7 @@ TEST(TestMatchIterator, InvalidIterator)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, exclude);
+    ddwaf::match_iterator it(resource, object, {}, exclude);
     EXPECT_FALSE((bool)it);
 
     auto path = it.get_current_path();
@@ -34,7 +34,7 @@ TEST(TestMatchIterator, NoMatch)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, exclude);
+    ddwaf::match_iterator it(resource, object, {}, exclude);
     EXPECT_FALSE((bool)it);
 
     auto path = it.get_current_path();
@@ -49,7 +49,7 @@ TEST(TestMatchIterator, SingleMatch)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, exclude);
+    ddwaf::match_iterator it(resource, object, {}, exclude);
     EXPECT_TRUE((bool)it);
 
     auto [param, index] = *it;
@@ -68,7 +68,7 @@ TEST(TestMatchIterator, MultipleMatches)
 
     std::string resource = "resource resource resource resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, exclude);
+    ddwaf::match_iterator it(resource, object, {}, exclude);
 
     for (std::size_t i = 0; i < 4; ++i) {
         EXPECT_TRUE((bool)it);
@@ -91,7 +91,7 @@ TEST(TestMatchIterator, OverlappingMatches)
 
     std::string resource = "eeeeeeeeee";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, exclude);
+    ddwaf::match_iterator it(resource, object, {}, exclude);
     EXPECT_TRUE((bool)it);
 
     for (std::size_t i = 0; i < 9; ++i) {

--- a/tests/unit/condition/shi_detector_array_test.cpp
+++ b/tests/unit/condition/shi_detector_array_test.cpp
@@ -358,4 +358,130 @@ TEST(TestShiDetectorArray, OffByOnePayloadsMatch)
     }
 }
 
+// Generates the parameter definition of a two-argument detector, applying the
+// given transformers to the second (params) argument only
+std::vector<condition_parameter> gen_param_def_with_transformers(
+    std::string_view resource, std::string_view params, std::vector<transformer_id> transformers)
+{
+    return {condition_parameter{{condition_target{
+                .name = std::string{resource}, .index = get_target_index(resource)}}},
+        condition_parameter{{condition_target{.name = std::string{params},
+            .index = get_target_index(params),
+            .key_path = {},
+            .transformers = std::move(transformers)}}}};
+}
+
+owned_object gen_shell_array_root(const std::vector<std::string> &resource, owned_object params)
+{
+    auto root = object_builder_da::map();
+    root.emplace("server.request.query", std::move(params));
+    auto array = root.emplace("server.sys.shell.cmd", object_builder_da::array());
+    for (const auto &arg : resource) { array.emplace_back(arg); }
+    return root;
+}
+
+TEST(TestShiDetectorArray, NoMatchWithoutTransformer)
+{
+    shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
+
+    auto root = gen_shell_array_root(
+        {"ls", ";echo hello"}, object_builder_da::map({{"query", "%3Becho%20hello"}}));
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+TEST(TestShiDetectorArray, MatchWithTransformer)
+{
+    shi_detector cond{gen_param_def_with_transformers(
+        "server.sys.shell.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = gen_shell_array_root(
+        {"ls", ";echo hello"}, object_builder_da::map({{"query", "%3Becho%20hello"}}));
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
+    EXPECT_STR(cache.match->args[0].resolved, "ls ;echo hello");
+
+    EXPECT_STRV(cache.match->args[1].address, "server.request.query");
+    // The reported parameter is the transformed one
+    EXPECT_STR(cache.match->args[1].resolved, ";echo hello");
+    EXPECT_STR(cache.match->highlights[0], ";echo hello");
+}
+
+TEST(TestShiDetectorArray, MatchWithMultipleTransformers)
+{
+    shi_detector cond{gen_param_def_with_transformers("server.sys.shell.cmd",
+        "server.request.query", {transformer_id::base64_decode, transformer_id::url_decode})};
+
+    // base64("%3Becho%20hello")
+    auto root = gen_shell_array_root(
+        {"ls", ";echo hello"}, object_builder_da::map({{"query", "JTNCZWNobyUyMGhlbGxv"}}));
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], ";echo hello");
+}
+
+// When the transformers leave the parameter untouched, the original value must
+// still be evaluated
+TEST(TestShiDetectorArray, MatchWithUnappliedTransformer)
+{
+    shi_detector cond{gen_param_def_with_transformers(
+        "server.sys.shell.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = gen_shell_array_root(
+        {"ls", ";echo hello"}, object_builder_da::map({{"query", ";echo hello"}}));
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], ";echo hello");
+}
+
+// The resource is never transformed, only the parameters
+TEST(TestShiDetectorArray, ResourceNotTransformed)
+{
+    shi_detector cond{{condition_parameter{{condition_target{.name = "server.sys.shell.cmd",
+                           .index = get_target_index("server.sys.shell.cmd"),
+                           .key_path = {},
+                           .transformers = {transformer_id::url_decode}}}},
+        condition_parameter{{condition_target{
+            .name = "server.request.query", .index = get_target_index("server.request.query")}}}}};
+
+    auto root = gen_shell_array_root(
+        {"ls", "%3Becho%20hello"}, object_builder_da::map({{"query", ";echo hello"}}));
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
 } // namespace

--- a/tests/unit/condition/shi_detector_string_test.cpp
+++ b/tests/unit/condition/shi_detector_string_test.cpp
@@ -298,4 +298,179 @@ TEST(TestShiDetectorString, MultipleArgumentsMatch)
     }
 }
 
+// Generates the parameter definition of a two-argument detector, applying the
+// given transformers to the second (params) argument only
+std::vector<condition_parameter> gen_param_def_with_transformers(
+    std::string_view resource, std::string_view params, std::vector<transformer_id> transformers)
+{
+    return {condition_parameter{{condition_target{
+                .name = std::string{resource}, .index = get_target_index(resource)}}},
+        condition_parameter{{condition_target{.name = std::string{params},
+            .index = get_target_index(params),
+            .key_path = {},
+            .transformers = std::move(transformers)}}}};
+}
+
+TEST(TestShiDetectorString, NoMatchWithoutTransformer)
+{
+    shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
+
+    auto root = object_builder_da::map({
+        {"server.sys.shell.cmd", "ls -l; cat /etc/passwd"},
+        {"server.request.query", "%3B%20cat%20%2Fetc%2Fpasswd"},
+    });
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+TEST(TestShiDetectorString, MatchWithTransformer)
+{
+    shi_detector cond{gen_param_def_with_transformers(
+        "server.sys.shell.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({
+        {"server.sys.shell.cmd", "ls -l; cat /etc/passwd"},
+        {"server.request.query", "%3B%20cat%20%2Fetc%2Fpasswd"},
+    });
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STRV(cache.match->args[0].address, "server.sys.shell.cmd");
+    EXPECT_STR(cache.match->args[0].resolved, "ls -l; cat /etc/passwd");
+
+    EXPECT_STRV(cache.match->args[1].address, "server.request.query");
+    // The reported parameter is the transformed one
+    EXPECT_STR(cache.match->args[1].resolved, "; cat /etc/passwd");
+    EXPECT_STR(cache.match->highlights[0], "; cat /etc/passwd");
+}
+
+TEST(TestShiDetectorString, MatchWithMultipleTransformers)
+{
+    shi_detector cond{gen_param_def_with_transformers("server.sys.shell.cmd",
+        "server.request.query", {transformer_id::base64_decode, transformer_id::url_decode})};
+
+    // base64("%3B%20cat%20%2Fetc%2Fpasswd")
+    auto root = object_builder_da::map({
+        {"server.sys.shell.cmd", "ls -l; cat /etc/passwd"},
+        {"server.request.query", "JTNCJTIwY2F0JTIwJTJGZXRjJTJGcGFzc3dk"},
+    });
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], "; cat /etc/passwd");
+}
+
+// When the transformers leave the parameter untouched, the original value must
+// still be evaluated
+TEST(TestShiDetectorString, MatchWithUnappliedTransformer)
+{
+    shi_detector cond{gen_param_def_with_transformers(
+        "server.sys.shell.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({
+        {"server.sys.shell.cmd", "ls -l; cat /etc/passwd"},
+        {"server.request.query", "; cat /etc/passwd"},
+    });
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], "; cat /etc/passwd");
+}
+
+// Every parameter within the container must be transformed independently
+TEST(TestShiDetectorString, MatchWithTransformerWithinContainer)
+{
+    shi_detector cond{gen_param_def_with_transformers(
+        "server.sys.shell.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({
+        {"server.sys.shell.cmd", "ls -l; cat /etc/passwd"},
+        {"server.request.query", object_builder_da::map({{"harmless", "not an injection"},
+                                     {"payload", "%3B%20cat%20%2Fetc%2Fpasswd"}})},
+    });
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], "; cat /etc/passwd");
+    ASSERT_EQ(cache.match->args[1].key_path.size(), 1);
+    EXPECT_STR(std::get<std::string_view>(cache.match->args[1].key_path[0]), "payload");
+}
+
+// The resource is never transformed, only the parameters
+TEST(TestShiDetectorString, ResourceNotTransformed)
+{
+    shi_detector cond{{condition_parameter{{condition_target{.name = "server.sys.shell.cmd",
+                           .index = get_target_index("server.sys.shell.cmd"),
+                           .key_path = {},
+                           .transformers = {transformer_id::url_decode}}}},
+        condition_parameter{{condition_target{
+            .name = "server.request.query", .index = get_target_index("server.request.query")}}}}};
+
+    auto root = object_builder_da::map({
+        {"server.sys.shell.cmd", "ls%20-l%3B%20cat%20%2Fetc%2Fpasswd"},
+        {"server.request.query", "; cat /etc/passwd"},
+    });
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+// A parameter which is reduced to an empty string by the transformers must not
+// be considered an injection, as an empty parameter would otherwise be found at
+// every position of the resource
+TEST(TestShiDetectorString, NoMatchOnEmptyTransformedParameter)
+{
+    shi_detector cond{gen_param_def_with_transformers(
+        "server.sys.shell.cmd", "server.request.query", {transformer_id::remove_nulls})};
+
+    const std::string nulls("\0\0\0", 3);
+    auto root = object_builder_da::map({
+        {"server.sys.shell.cmd", "ls"},
+        {"server.request.query", nulls},
+    });
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
 } // namespace

--- a/tests/unit/condition/sqli_detector_test.cpp
+++ b/tests/unit/condition/sqli_detector_test.cpp
@@ -407,4 +407,192 @@ TEST(TestSqliDetectorPgSql, Tautologies)
         EXPECT_STR(cache.match->highlights[0], input);
     }
 }
+
+// Generates the parameter definition of the sqli detector, applying the given
+// transformers to the params argument only
+std::vector<condition_parameter> gen_sqli_param_def_with_transformers(
+    std::vector<transformer_id> transformers)
+{
+    return {condition_parameter{{condition_target{
+                .name = "server.db.statement", .index = get_target_index("server.db.statement")}}},
+        condition_parameter{{condition_target{.name = "server.request.query",
+            .index = get_target_index("server.request.query"),
+            .key_path = {},
+            .transformers = std::move(transformers)}}},
+        condition_parameter{{condition_target{
+            .name = "server.db.system", .index = get_target_index("server.db.system")}}}};
+}
+
+constexpr std::string_view sqli_statement = R"(SELECT * FROM t WHERE id = '' OR '1'='1')";
+constexpr std::string_view sqli_obfuscated = R"(SELECT * FROM t WHERE id = ? OR ?=?)";
+constexpr std::string_view sqli_payload = R"(' OR '1'='1)";
+
+TEST(TestSqliDetectorTransformers, NoMatchWithoutTransformer)
+{
+    sqli_detector cond{
+        {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
+
+    auto root = object_builder_da::map({{"server.db.statement", sqli_statement},
+        {"server.db.system", "mysql"}, {"server.request.query", "%27%20OR%20%271%27%3D%271"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+TEST(TestSqliDetectorTransformers, MatchWithTransformer)
+{
+    sqli_detector cond{gen_sqli_param_def_with_transformers({transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({{"server.db.statement", sqli_statement},
+        {"server.db.system", "mysql"}, {"server.request.query", "%27%20OR%20%271%27%3D%271"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STRV(cache.match->args[0].address, "server.db.statement");
+    EXPECT_STR(cache.match->args[0].resolved, sqli_obfuscated);
+
+    EXPECT_STRV(cache.match->args[1].address, "server.request.query");
+    // The reported parameter is the transformed one
+    EXPECT_STR(cache.match->args[1].resolved, sqli_payload);
+    EXPECT_STR(cache.match->highlights[0], sqli_payload);
+}
+
+TEST(TestSqliDetectorTransformers, MatchWithMultipleTransformers)
+{
+    sqli_detector cond{gen_sqli_param_def_with_transformers(
+        {transformer_id::base64_decode, transformer_id::url_decode})};
+
+    // base64("%27%20OR%20%271%27%3D%271")
+    auto root = object_builder_da::map(
+        {{"server.db.statement", sqli_statement}, {"server.db.system", "mysql"},
+            {"server.request.query", "JTI3JTIwT1IlMjAlMjcxJTI3JTNEJTI3MQ=="}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], sqli_payload);
+}
+
+// When the transformers leave the parameter untouched, the original value must
+// still be evaluated
+TEST(TestSqliDetectorTransformers, MatchWithUnappliedTransformer)
+{
+    sqli_detector cond{gen_sqli_param_def_with_transformers({transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({{"server.db.statement", sqli_statement},
+        {"server.db.system", "mysql"}, {"server.request.query", sqli_payload}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], sqli_payload);
+}
+
+// Every parameter within the container must be transformed independently
+TEST(TestSqliDetectorTransformers, MatchWithTransformerWithinContainer)
+{
+    sqli_detector cond{gen_sqli_param_def_with_transformers({transformer_id::url_decode})};
+
+    auto root = object_builder_da::map(
+        {{"server.db.statement", sqli_statement}, {"server.db.system", "mysql"},
+            {"server.request.query", object_builder_da::map({{"harmless", "not+an+injection"},
+                                         {"payload", "%27%20OR%20%271%27%3D%271"}})}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], sqli_payload);
+    ASSERT_EQ(cache.match->args[1].key_path.size(), 1);
+    EXPECT_STR(std::get<std::string_view>(cache.match->args[1].key_path[0]), "payload");
+}
+
+// Neither the statement nor the database type are transformed
+TEST(TestSqliDetectorTransformers, ResourceNotTransformed)
+{
+    sqli_detector cond{{condition_parameter{{condition_target{.name = "server.db.statement",
+                            .index = get_target_index("server.db.statement"),
+                            .key_path = {},
+                            .transformers = {transformer_id::url_decode}}}},
+        condition_parameter{{condition_target{
+            .name = "server.request.query", .index = get_target_index("server.request.query")}}},
+        condition_parameter{{condition_target{
+            .name = "server.db.system", .index = get_target_index("server.db.system")}}}}};
+
+    auto root = object_builder_da::map(
+        {{"server.db.statement", R"(SELECT%20*%20FROM%20t%20WHERE%20id%20=%20''%20OR%20'1'='1')"},
+            {"server.db.system", "mysql"}, {"server.request.query", sqli_payload}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+// The transformed parameter replaces the original one, so a payload which is
+// present verbatim within the statement is no longer detected once the
+// transformers modify it
+TEST(TestSqliDetectorTransformers, NoMatchOnUntransformedParameter)
+{
+    sqli_detector cond{gen_sqli_param_def_with_transformers({transformer_id::lowercase})};
+
+    auto root = object_builder_da::map({{"server.db.statement", sqli_statement},
+        {"server.db.system", "mysql"}, {"server.request.query", sqli_payload}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+// A parameter reduced to an empty string by the transformers must not be
+// considered an injection
+TEST(TestSqliDetectorTransformers, NoMatchOnEmptyTransformedParameter)
+{
+    sqli_detector cond{gen_sqli_param_def_with_transformers({transformer_id::remove_nulls})};
+
+    const std::string nulls("\0\0\0\0", 4);
+    auto root = object_builder_da::map({{"server.db.statement", sqli_statement},
+        {"server.db.system", "mysql"}, {"server.request.query", nulls}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
 } // namespace

--- a/tests/unit/condition/ssrf_detector_test.cpp
+++ b/tests/unit/condition/ssrf_detector_test.cpp
@@ -552,4 +552,145 @@ TEST(TestSSRFDetector, ForbidFullUrlInjection)
         false, ssrf_opts{.forbid_full_url_injection = false});
 }
 
+// Generates the parameter definition of the ssrf detector, applying the given
+// transformers to the params argument only
+std::vector<condition_parameter> gen_ssrf_param_def_with_transformers(
+    std::vector<transformer_id> transformers)
+{
+    return {condition_parameter{{condition_target{
+                .name = "server.io.net.url", .index = get_target_index("server.io.net.url")}}},
+        condition_parameter{{condition_target{.name = "server.request.query",
+            .index = get_target_index("server.request.query"),
+            .key_path = {},
+            .transformers = std::move(transformers)}}}};
+}
+
+constexpr std::string_view ssrf_url = "https://internal-website.evil.com/path/to/stuffs?bla=42";
+constexpr std::string_view ssrf_payload = ".evil.com/path/to/stuffs?";
+
+TEST(TestSSRFDetectorTransformers, NoMatchWithoutTransformer)
+{
+    ssrf_detector cond{{gen_param_def("server.io.net.url", "server.request.query")}};
+
+    auto root = object_builder_da::map({{"server.io.net.url", ssrf_url},
+        {"server.request.query", ".evil.com%2Fpath%2Fto%2Fstuffs%3F"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
+TEST(TestSSRFDetectorTransformers, MatchWithTransformer)
+{
+    ssrf_detector cond{gen_ssrf_param_def_with_transformers({transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({{"server.io.net.url", ssrf_url},
+        {"server.request.query", ".evil.com%2Fpath%2Fto%2Fstuffs%3F"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STRV(cache.match->args[0].address, "server.io.net.url");
+    EXPECT_STR(cache.match->args[0].resolved, ssrf_url);
+
+    EXPECT_STRV(cache.match->args[1].address, "server.request.query");
+    // The reported parameter is the transformed one
+    EXPECT_STR(cache.match->args[1].resolved, ssrf_payload);
+    EXPECT_STR(cache.match->highlights[0], ssrf_payload);
+}
+
+TEST(TestSSRFDetectorTransformers, MatchWithMultipleTransformers)
+{
+    ssrf_detector cond{gen_ssrf_param_def_with_transformers(
+        {transformer_id::base64_decode, transformer_id::url_decode})};
+
+    // base64(".evil.com%2Fpath%2Fto%2Fstuffs%3F")
+    auto root = object_builder_da::map({{"server.io.net.url", ssrf_url},
+        {"server.request.query", "LmV2aWwuY29tJTJGcGF0aCUyRnRvJTJGc3R1ZmZzJTNG"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], ssrf_payload);
+}
+
+// When the transformers leave the parameter untouched, the original value must
+// still be evaluated
+TEST(TestSSRFDetectorTransformers, MatchWithUnappliedTransformer)
+{
+    ssrf_detector cond{gen_ssrf_param_def_with_transformers({transformer_id::url_decode})};
+
+    auto root = object_builder_da::map(
+        {{"server.io.net.url", ssrf_url}, {"server.request.query", ssrf_payload}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], ssrf_payload);
+}
+
+// Every parameter within the container must be transformed independently
+TEST(TestSSRFDetectorTransformers, MatchWithTransformerWithinContainer)
+{
+    ssrf_detector cond{gen_ssrf_param_def_with_transformers({transformer_id::url_decode})};
+
+    auto root = object_builder_da::map({{"server.io.net.url", ssrf_url},
+        {"server.request.query", object_builder_da::map({{"harmless", "nothing+to+see+here"},
+                                     {"path", ".evil.com%2Fpath%2Fto%2Fstuffs%3F"}})}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+
+    ASSERT_TRUE(cache.match);
+    EXPECT_STR(cache.match->highlights[0], ssrf_payload);
+    ASSERT_EQ(cache.match->args[1].key_path.size(), 1);
+    EXPECT_STR(std::get<std::string_view>(cache.match->args[1].key_path[0]), "path");
+}
+
+// The resource is never transformed, only the parameters
+TEST(TestSSRFDetectorTransformers, ResourceNotTransformed)
+{
+    ssrf_detector cond{{condition_parameter{{condition_target{.name = "server.io.net.url",
+                            .index = get_target_index("server.io.net.url"),
+                            .key_path = {},
+                            .transformers = {transformer_id::url_decode}}}},
+        condition_parameter{{condition_target{
+            .name = "server.request.query", .index = get_target_index("server.request.query")}}}}};
+
+    auto root = object_builder_da::map(
+        {{"server.io.net.url", "https://internal-website%2Eevil%2Ecom/path/to/stuffs?bla=42"},
+            {"server.request.query", ssrf_payload}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+    EXPECT_FALSE(cache.match);
+}
+
 } // namespace

--- a/tests/unit/cow_string_test.cpp
+++ b/tests/unit/cow_string_test.cpp
@@ -116,6 +116,99 @@ TEST(TestCoWString, MoveUnmodified)
     EXPECT_EQ(str.data(), nullptr);
 }
 
+TEST(TestCoWString, MoveConstructUnmodified)
+{
+    cow_string str("value");
+
+    cow_string other{std::move(str)};
+    EXPECT_EQ(other.length(), 5);
+    EXPECT_FALSE(other.modified());
+    EXPECT_STRV(static_cast<std::string_view>(other), "value");
+}
+
+TEST(TestCoWString, MoveConstructModified)
+{
+    cow_string str("value");
+    str[3] = 'e';
+    EXPECT_TRUE(str.modified());
+
+    cow_string other{std::move(str)};
+    EXPECT_EQ(other.length(), 5);
+    EXPECT_TRUE(other.modified());
+    EXPECT_STRV(static_cast<std::string_view>(other), "valee");
+}
+
+TEST(TestCoWString, MoveAssignUnmodified)
+{
+    cow_string str("value");
+    cow_string other("other value");
+
+    other = std::move(str);
+    EXPECT_EQ(other.length(), 5);
+    EXPECT_FALSE(other.modified());
+    EXPECT_STRV(static_cast<std::string_view>(other), "value");
+}
+
+// The buffer owned by the assignee must be released on assignment
+TEST(TestCoWString, MoveAssignOverModified)
+{
+    cow_string str("value");
+
+    cow_string other("other value");
+    other[0] = 'O';
+    EXPECT_TRUE(other.modified());
+
+    other = std::move(str);
+    EXPECT_EQ(other.length(), 5);
+    EXPECT_FALSE(other.modified());
+    EXPECT_STRV(static_cast<std::string_view>(other), "value");
+}
+
+TEST(TestCoWString, MoveAssignModified)
+{
+    cow_string str("value");
+    str[3] = 'e';
+    EXPECT_TRUE(str.modified());
+
+    cow_string other("other value");
+    other[0] = 'O';
+    EXPECT_TRUE(other.modified());
+
+    other = std::move(str);
+    EXPECT_EQ(other.length(), 5);
+    EXPECT_TRUE(other.modified());
+    EXPECT_STRV(static_cast<std::string_view>(other), "valee");
+}
+
+// std::optional<cow_string> relies on both move construction and move
+// assignment, which is how transformed parameters are stored during evaluation
+TEST(TestCoWString, MoveAssignWithinOptional)
+{
+    std::optional<cow_string> str;
+
+    str = cow_string{"value"};
+    ASSERT_TRUE(str.has_value());
+    EXPECT_STRV(static_cast<std::string_view>(*str), "value");
+
+    (*str)[0] = 'V';
+    EXPECT_TRUE(str->modified());
+    EXPECT_STRV(static_cast<std::string_view>(*str), "Value");
+
+    str = cow_string{"another value"};
+    ASSERT_TRUE(str.has_value());
+    EXPECT_FALSE(str->modified());
+    EXPECT_STRV(static_cast<std::string_view>(*str), "another value");
+
+    str.reset();
+    EXPECT_FALSE(str.has_value());
+}
+
+TEST(TestCoWString, ConstStringView)
+{
+    const cow_string str("value");
+    EXPECT_STRV(static_cast<std::string_view>(str), "value");
+}
+
 TEST(TestCoWString, MoveAfterTruncate)
 {
     cow_string str("value");
@@ -131,6 +224,18 @@ TEST(TestCoWString, MoveAfterTruncate)
     EXPECT_EQ(str.length(), 0);
     EXPECT_FALSE(str.modified());
     EXPECT_EQ(str.data(), nullptr);
+}
+
+TEST(TestCoWString, Empty)
+{
+    cow_string str("value");
+    EXPECT_FALSE(str.empty());
+
+    str.truncate(0);
+    EXPECT_TRUE(str.empty());
+
+    cow_string empty_str("");
+    EXPECT_TRUE(empty_str.empty());
 }
 
 } // namespace

--- a/tests/unit/transformer/manager_test.cpp
+++ b/tests/unit/transformer/manager_test.cpp
@@ -248,4 +248,10 @@ TEST(TestTransformerManager, InvalidMultipleTransforms)
         transformer_id::compress_whitespace);
 }
 
+TEST(TestTransformerManager, NoTransformers)
+{
+    auto src = owned_object::make_string_literal(STRL("  LoWeRCase  "));
+    EXPECT_FALSE(transformer::manager::transform(src, {}));
+}
+
 } // namespace

--- a/validator/tests/rules/structured/018_lfi_match_with_transformer.yaml
+++ b/validator/tests/rules/structured/018_lfi_match_with_transformer.yaml
@@ -1,0 +1,28 @@
+{
+  name: "LFI match on a url-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.io.fs.file: "documents/../../../../../../../../../etc/passwd",
+        server.request.cookies: [ "..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd" ]
+      },
+      rules: [
+        {
+          "rsp-931-001": [
+            {
+              resource: {
+                address: "server.io.fs.file",
+                value: "documents/../../../../../../../../../etc/passwd"
+              },
+              params: {
+                address: "server.request.cookies",
+                value: "../../../../../../../../../etc/passwd"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/019_lfi_no_match_without_transformer.yaml
+++ b/validator/tests/rules/structured/019_lfi_no_match_without_transformer.yaml
@@ -1,0 +1,12 @@
+{
+  name: "LFI no match, the encoded parameter is on an address without transformers",
+  runs: [
+    {
+      input: {
+        server.io.fs.file: "documents/../../../../../../../../../etc/passwd",
+        server.request.headers.no_cookies: [ "..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd" ]
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/structured/020_lfi_match_with_unapplied_transformer.yaml
+++ b/validator/tests/rules/structured/020_lfi_match_with_unapplied_transformer.yaml
@@ -1,0 +1,28 @@
+{
+  name: "LFI match on a parameter left untouched by the transformers",
+  runs: [
+    {
+      input: {
+        server.io.fs.file: "documents/../../../../../../../../../etc/passwd",
+        server.request.cookies: [ "../../../../../../../../../etc/passwd" ]
+      },
+      rules: [
+        {
+          "rsp-931-001": [
+            {
+              resource: {
+                address: "server.io.fs.file",
+                value: "documents/../../../../../../../../../etc/passwd"
+              },
+              params: {
+                address: "server.request.cookies",
+                value: "../../../../../../../../../etc/passwd"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/021_ssrf_match_with_transformer.yaml
+++ b/validator/tests/rules/structured/021_ssrf_match_with_transformer.yaml
@@ -1,0 +1,29 @@
+{
+  name: "SSRF match on a url-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.io.net.url: "https://internal-website.evil.com/path/to/stuffs?bla=42",
+        server.request.cookies: { path: ".evil.com%2Fpath%2Fto%2Fstuffs%3F" }
+      },
+      rules: [
+        {
+          "rsp-931-002": [
+            {
+              resource: {
+                address: "server.io.net.url",
+                value: "https://internal-website.evil.com/path/to/stuffs?bla=42"
+              },
+              params: {
+                address: "server.request.cookies",
+                key_path: [ "path" ],
+                value: ".evil.com/path/to/stuffs?"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/022_sqli_match_with_transformer.yaml
+++ b/validator/tests/rules/structured/022_sqli_match_with_transformer.yaml
@@ -1,0 +1,33 @@
+{
+  name: "SQLi match on a url-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.db.statement: "SELECT * FROM users WHERE id ='' OR 1=1; -- ';",
+        server.request.cookies: [ "%27%20OR%201%3D1%3B%20--" ],
+        server.db.system: "mysql"
+      },
+      rules: [
+        {
+          "rsp-931-003": [
+            {
+              resource: {
+                address: "server.db.statement",
+                value: "SELECT * FROM users WHERE id =? OR ?=?; -- ';"
+              },
+              params: {
+                address: "server.request.cookies",
+                value: "' OR 1=1; --"
+              },
+              db_type: {
+                address: "server.db.system",
+                value: "mysql"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/023_shi_match_with_multiple_transformers.yaml
+++ b/validator/tests/rules/structured/023_shi_match_with_multiple_transformers.yaml
@@ -1,0 +1,29 @@
+{
+  name: "SHi match on a base64 and url-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.sys.shell.cmd: "ls -l; cat /etc/passwd",
+        server.request.cookies: { cmd: "JTNCJTIwY2F0JTIwJTJGZXRjJTJGcGFzc3dk" }
+      },
+      rules: [
+        {
+          "rsp-931-004": [
+            {
+              resource: {
+                address: "server.sys.shell.cmd",
+                value: "ls -l; cat /etc/passwd"
+              },
+              params: {
+                address: "server.request.cookies",
+                key_path: [ "cmd" ],
+                value: "; cat /etc/passwd"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/024_shi_no_match_without_transformer.yaml
+++ b/validator/tests/rules/structured/024_shi_no_match_without_transformer.yaml
@@ -1,0 +1,12 @@
+{
+  name: "SHi no match, the encoded parameter is on an address without transformers",
+  runs: [
+    {
+      input: {
+        server.sys.shell.cmd: "ls -l; cat /etc/passwd",
+        server.request.headers.no_cookies: { cmd: "JTNCJTIwY2F0JTIwJTJGZXRjJTJGcGFzc3dk" }
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/structured/025_cmdi_match_with_transformer.yaml
+++ b/validator/tests/rules/structured/025_cmdi_match_with_transformer.yaml
@@ -1,0 +1,29 @@
+{
+  name: "CMDi match on a url-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.sys.exec.cmd: [ "/bin/sh", "-c", "ls -l" ],
+        server.request.cookies: { cmd: "ls%20-l" }
+      },
+      rules: [
+        {
+          "rsp-931-005": [
+            {
+              resource: {
+                address: "server.sys.exec.cmd",
+                value: "/bin/sh \"-c\" \"ls -l\""
+              },
+              params: {
+                address: "server.request.cookies",
+                key_path: [ "cmd" ],
+                value: "ls -l"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/026_cmdi_no_match_without_transformer.yaml
+++ b/validator/tests/rules/structured/026_cmdi_no_match_without_transformer.yaml
@@ -1,0 +1,12 @@
+{
+  name: "CMDi no match, the encoded parameter is on an address without transformers",
+  runs: [
+    {
+      input: {
+        server.sys.exec.cmd: [ "/bin/sh", "-c", "ls -l" ],
+        server.request.headers.no_cookies: { cmd: "ls%20-l" }
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/structured/027_lfi_match_with_base64_transformer.yaml
+++ b/validator/tests/rules/structured/027_lfi_match_with_base64_transformer.yaml
@@ -1,0 +1,29 @@
+{
+  name: "LFI match on a base64-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.io.fs.file: "documents/../../../../../../../../../etc/passwd",
+        server.request.trailers: { file: "Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZA==" }
+      },
+      rules: [
+        {
+          "rsp-931-001": [
+            {
+              resource: {
+                address: "server.io.fs.file",
+                value: "documents/../../../../../../../../../etc/passwd"
+              },
+              params: {
+                address: "server.request.trailers",
+                key_path: [ "file" ],
+                value: "../../../../../../../../../etc/passwd"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/028_lfi_match_with_unencoded_parameter.yaml
+++ b/validator/tests/rules/structured/028_lfi_match_with_unencoded_parameter.yaml
@@ -1,0 +1,29 @@
+{
+  name: "LFI match on a parameter which isn't valid base64, so it is left untouched",
+  runs: [
+    {
+      input: {
+        server.io.fs.file: "documents/../../../../../../../../../etc/passwd",
+        server.request.trailers: { file: "../../../../../../../../../etc/passwd" }
+      },
+      rules: [
+        {
+          "rsp-931-001": [
+            {
+              resource: {
+                address: "server.io.fs.file",
+                value: "documents/../../../../../../../../../etc/passwd"
+              },
+              params: {
+                address: "server.request.trailers",
+                key_path: [ "file" ],
+                value: "../../../../../../../../../etc/passwd"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/029_lfi_no_match_without_base64_transformer.yaml
+++ b/validator/tests/rules/structured/029_lfi_no_match_without_base64_transformer.yaml
@@ -1,0 +1,12 @@
+{
+  name: "LFI no match, the base64-encoded parameter is on an address without transformers",
+  runs: [
+    {
+      input: {
+        server.io.fs.file: "documents/../../../../../../../../../etc/passwd",
+        server.request.headers.no_cookies: { file: "Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZA==" }
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/structured/030_ssrf_match_with_base64_transformer.yaml
+++ b/validator/tests/rules/structured/030_ssrf_match_with_base64_transformer.yaml
@@ -1,0 +1,29 @@
+{
+  name: "SSRF match on a base64-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.io.net.url: "https://internal-website.evil.com/path/to/stuffs?bla=42",
+        server.request.trailers: { path: "LmV2aWwuY29tL3BhdGgvdG8vc3R1ZmZzPw==" }
+      },
+      rules: [
+        {
+          "rsp-931-002": [
+            {
+              resource: {
+                address: "server.io.net.url",
+                value: "https://internal-website.evil.com/path/to/stuffs?bla=42"
+              },
+              params: {
+                address: "server.request.trailers",
+                key_path: [ "path" ],
+                value: ".evil.com/path/to/stuffs?"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/031_sqli_match_with_base64_transformer.yaml
+++ b/validator/tests/rules/structured/031_sqli_match_with_base64_transformer.yaml
@@ -1,0 +1,34 @@
+{
+  name: "SQLi match on a base64-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.db.statement: "SELECT * FROM users WHERE id ='' OR 1=1; -- ';",
+        server.request.trailers: { id: "JyBPUiAxPTE7IC0t" },
+        server.db.system: "mysql"
+      },
+      rules: [
+        {
+          "rsp-931-003": [
+            {
+              resource: {
+                address: "server.db.statement",
+                value: "SELECT * FROM users WHERE id =? OR ?=?; -- ';"
+              },
+              params: {
+                address: "server.request.trailers",
+                key_path: [ "id" ],
+                value: "' OR 1=1; --"
+              },
+              db_type: {
+                address: "server.db.system",
+                value: "mysql"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/032_shi_match_with_base64_transformer.yaml
+++ b/validator/tests/rules/structured/032_shi_match_with_base64_transformer.yaml
@@ -1,0 +1,29 @@
+{
+  name: "SHi match on a base64-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.sys.shell.cmd: "ls -l; cat /etc/passwd",
+        server.request.trailers: { cmd: "OyBjYXQgL2V0Yy9wYXNzd2Q=" }
+      },
+      rules: [
+        {
+          "rsp-931-004": [
+            {
+              resource: {
+                address: "server.sys.shell.cmd",
+                value: "ls -l; cat /etc/passwd"
+              },
+              params: {
+                address: "server.request.trailers",
+                key_path: [ "cmd" ],
+                value: "; cat /etc/passwd"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/033_cmdi_match_with_base64_transformer.yaml
+++ b/validator/tests/rules/structured/033_cmdi_match_with_base64_transformer.yaml
@@ -1,0 +1,29 @@
+{
+  name: "CMDi match on a base64-encoded parameter",
+  runs: [
+    {
+      input: {
+        server.sys.exec.cmd: [ "/bin/sh", "-c", "ls -l" ],
+        server.request.trailers: { cmd: "bHMgLWw=" }
+      },
+      rules: [
+        {
+          "rsp-931-005": [
+            {
+              resource: {
+                address: "server.sys.exec.cmd",
+                value: "/bin/sh \"-c\" \"ls -l\""
+              },
+              params: {
+                address: "server.request.trailers",
+                key_path: [ "cmd" ],
+                value: "ls -l"
+              }
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/structured/ruleset.yaml
+++ b/validator/tests/rules/structured/ruleset.yaml
@@ -94,3 +94,104 @@ rules:
             - address: graphql.server.all_resolvers
             - address: graphql.server.resolver
         operator: cmdi_detector@v1
+  # The rules below mirror the ones above, but apply transformers to one of the
+  # parameter addresses. They rely on parameter addresses which aren't used by
+  # any of the rules above so that both sets can be tested independently.
+  - id: rsp-931-001
+    name: LFI Exploit detection with transformers
+    tags:
+      type: lfi
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - parameters:
+          resource:
+            - address: server.io.fs.file
+          params:
+            - address: server.request.cookies
+              transformers:
+                - url_decode
+            - address: server.request.trailers
+              transformers:
+                - base64_decode
+            - address: server.request.headers.no_cookies
+        operator: lfi_detector@v2
+  - id: rsp-931-002
+    name: SSRF Exploit detection with transformers
+    tags:
+      type: ssrf
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - parameters:
+          resource:
+            - address: server.io.net.url
+          params:
+            - address: server.request.cookies
+              transformers:
+                - url_decode
+            - address: server.request.trailers
+              transformers:
+                - base64_decode
+            - address: server.request.headers.no_cookies
+        operator: ssrf_detector@v1
+  - id: rsp-931-003
+    name: SQLi Exploit detection with transformers
+    tags:
+      type: sqli
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - parameters:
+          resource:
+            - address: server.db.statement
+          params:
+            - address: server.request.cookies
+              transformers:
+                - url_decode
+            - address: server.request.trailers
+              transformers:
+                - base64_decode
+            - address: server.request.headers.no_cookies
+          db_type:
+            - address: server.db.system
+        operator: sqli_detector@v2
+  - id: rsp-931-004
+    name: SHi Exploit detection with transformers
+    tags:
+      type: shi
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - parameters:
+          resource:
+            - address: server.sys.shell.cmd
+          params:
+            - address: server.request.cookies
+              transformers:
+                - base64_decode
+                - url_decode
+            - address: server.request.trailers
+              transformers:
+                - base64_decode
+            - address: server.request.headers.no_cookies
+        operator: shi_detector@v1
+  - id: rsp-931-005
+    name: CMDi Exploit detection with transformers
+    tags:
+      type: cmdi
+      category: exploit_detection
+      module: rasp
+    conditions:
+      - parameters:
+          resource:
+            - address: server.sys.exec.cmd
+          params:
+            - address: server.request.cookies
+              transformers:
+                - url_decode
+            - address: server.request.trailers
+              transformers:
+                - base64_decode
+            - address: server.request.headers.no_cookies
+        operator: cmdi_detector@v1


### PR DESCRIPTION
Overview
--
This PR introduces support for transformers on the request inputs provided to RASP operators (shi, cmdi, ssrf, sqli and lfi), for example, the following rule attempts to base64 decode all query parameters before performing a match against the provided resource:

```json
    {
      "id": "rasp-cmdi",
      "name": "Shell command injection exploit",
      "tags": {
        "type": "command_injection",
        "category": "vulnerability_trigger",
      },
      "conditions": [
        {
          "parameters": {
            "resource": [
              {
                "address": "server.sys.shell.cmd"
              }
            ],
            "params": [
              {
                "address": "server.request.query",
                "transformers": [ "base64_decode" ]
              }
            ]
          },
          "operator": "shi_detector"
        }
      ],
    },
```

Modifiers such as `keys_only` or `values_only` are not supported.