### PR TITLE
Add lower_equal and greater_equal operator aliases

### DIFF
--- a/src/configuration/common/expression_parser.cpp
+++ b/src/configuration/common/expression_parser.cpp
@@ -240,6 +240,14 @@ std::shared_ptr<expression> parse_expression(const raw_configuration::vector &co
                 parse_arguments<negated_exists_condition>(params, source, transformers);
             conditions.emplace_back(
                 std::make_unique<negated_exists_condition>(std::move(arguments)));
+        } else if (operator_name == "lower_equal") {
+            conditions.emplace_back(
+                build_condition<negated_scalar_condition, matcher::greater_than<>>(
+                    "greater_than", params, source, transformers));
+        } else if (operator_name == "greater_equal") {
+            conditions.emplace_back(
+                build_condition<negated_scalar_condition, matcher::lower_than<>>(
+                    "lower_than", params, source, transformers));
         } else if (operator_name.starts_with('!')) {
             conditions.emplace_back(
                 build_condition<negated_scalar_condition, matcher::ip_match, matcher::exact_match,

--- a/src/matcher/greater_than.hpp
+++ b/src/matcher/greater_than.hpp
@@ -20,7 +20,7 @@ namespace ddwaf::matcher {
 template <typename T = void> class greater_than : public base_impl<greater_than<T>> {
 public:
     static constexpr std::string_view matcher_name = "greater_than";
-    static constexpr std::string_view negated_matcher_name = "!greater_than";
+    static constexpr std::string_view negated_matcher_name = "lower_equal";
 
     explicit greater_than(T minimum)
         requires std::is_same_v<T, uint64_t> || std::is_same_v<T, int64_t> ||
@@ -60,7 +60,7 @@ protected:
 template <> class greater_than<void> : public base_impl<greater_than<void>> {
 public:
     static constexpr std::string_view matcher_name = "greater_than";
-    static constexpr std::string_view negated_matcher_name = "!greater_than";
+    static constexpr std::string_view negated_matcher_name = "lower_equal";
 
     ~greater_than() override = default;
 

--- a/src/matcher/lower_than.hpp
+++ b/src/matcher/lower_than.hpp
@@ -20,7 +20,7 @@ namespace ddwaf::matcher {
 template <typename T = void> class lower_than : public base_impl<lower_than<T>> {
 public:
     static constexpr std::string_view matcher_name = "lower_than";
-    static constexpr std::string_view negated_matcher_name = "!lower_than";
+    static constexpr std::string_view negated_matcher_name = "greater_equal";
 
     explicit lower_than(T maximum)
         requires std::is_same_v<T, uint64_t> || std::is_same_v<T, int64_t> ||
@@ -61,7 +61,7 @@ protected:
 template <> class lower_than<void> : public base_impl<lower_than<void>> {
 public:
     static constexpr std::string_view matcher_name = "lower_than";
-    static constexpr std::string_view negated_matcher_name = "!lower_than";
+    static constexpr std::string_view negated_matcher_name = "greater_equal";
 
     ~lower_than() override = default;
 

--- a/tests/unit/condition/negated_scalar_condition_test.cpp
+++ b/tests/unit/condition/negated_scalar_condition_test.cpp
@@ -6,8 +6,12 @@
 
 #include "condition/negated_scalar_condition.hpp"
 #include "exception.hpp"
+#include "matcher/greater_than.hpp"
+#include "matcher/lower_than.hpp"
 #include "matcher/regex_match.hpp"
 #include "utils.hpp"
+
+#include <cmath>
 
 #include "common/gtest_utils.hpp"
 
@@ -382,6 +386,178 @@ TEST(TestNegatedScalarCondition, SimplesubcontextMatch)
         ddwaf::timer deadline{2s};
         condition_cache cache;
         ASSERT_TRUE(cond.eval(cache, sctx_store, {}, {}, deadline));
+    }
+}
+
+// The negated form of greater_than, exposed as the "lower_equal" operator,
+// must match every value lower than or equal to the threshold
+TEST(TestNegatedScalarCondition, LowerEqual)
+{
+    negated_scalar_condition cond{std::make_unique<matcher::greater_than<int64_t>>(5), {},
+        {gen_variadic_param("server.request.query")}};
+
+    for (auto value : {-1L, 0L, 4L, 5L}) {
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", test::ddwaf_object_da::make_signed(value));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline)) << value;
+
+        ASSERT_TRUE(cache.match.has_value());
+        EXPECT_STRV(cache.match->operator_name, "lower_equal");
+        EXPECT_STR(cache.match->args[0].resolved, std::to_string(value));
+    }
+
+    for (auto value : {6L, 42L}) {
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", test::ddwaf_object_da::make_signed(value));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline)) << value;
+        EXPECT_FALSE(cache.match.has_value());
+    }
+}
+
+// The negated form of lower_than, exposed as the "greater_equal" operator, must
+// match every value greater than or equal to the threshold
+TEST(TestNegatedScalarCondition, GreaterEqual)
+{
+    negated_scalar_condition cond{std::make_unique<matcher::lower_than<int64_t>>(5), {},
+        {gen_variadic_param("server.request.query")}};
+
+    for (auto value : {5L, 6L, 42L}) {
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", test::ddwaf_object_da::make_signed(value));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline)) << value;
+
+        ASSERT_TRUE(cache.match.has_value());
+        EXPECT_STRV(cache.match->operator_name, "greater_equal");
+        EXPECT_STR(cache.match->args[0].resolved, std::to_string(value));
+    }
+
+    for (auto value : {-1L, 0L, 4L}) {
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", test::ddwaf_object_da::make_signed(value));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline)) << value;
+        EXPECT_FALSE(cache.match.has_value());
+    }
+}
+
+TEST(TestNegatedScalarCondition, LowerEqualUnsignedAndFloat)
+{
+    {
+        negated_scalar_condition cond{std::make_unique<matcher::greater_than<uint64_t>>(5), {},
+            {gen_variadic_param("server.request.query")}};
+
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", test::ddwaf_object_da::make_unsigned(5));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_STRV(cache.match->operator_name, "lower_equal");
+    }
+
+    {
+        negated_scalar_condition cond{std::make_unique<matcher::greater_than<double>>(5.0), {},
+            {gen_variadic_param("server.request.query")}};
+
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", test::ddwaf_object_da::make_float(5.0));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        ASSERT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_STRV(cache.match->operator_name, "lower_equal");
+    }
+}
+
+// Types which the matcher can't evaluate must not be considered a negated match
+TEST(TestNegatedScalarCondition, LowerEqualUnsupportedTypes)
+{
+    negated_scalar_condition cond{std::make_unique<matcher::greater_than<int64_t>>(5), {},
+        {gen_variadic_param("server.request.query")}};
+
+    std::vector<owned_object> values;
+    values.emplace_back(test::ddwaf_object_da::make_string("string"));
+    values.emplace_back(test::ddwaf_object_da::make_boolean(true));
+    values.emplace_back(test::ddwaf_object_da::make_null());
+    values.emplace_back(object_builder_da::array());
+    values.emplace_back(object_builder_da::map());
+
+    for (auto &value : values) {
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", std::move(value));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline));
+        EXPECT_FALSE(cache.match.has_value());
+    }
+}
+
+// NaN is unordered, so it is neither greater nor lower than the threshold; as
+// the operators are implemented as the negation of greater_than / lower_than,
+// it currently matches both of them
+TEST(TestNegatedScalarCondition, NotANumber)
+{
+    {
+        negated_scalar_condition cond{std::make_unique<matcher::greater_than<double>>(5.0), {},
+            {gen_variadic_param("server.request.query")}};
+
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", test::ddwaf_object_da::make_float(std::nan("")));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        EXPECT_TRUE(cond.eval(cache, store, {}, {}, deadline));
+    }
+
+    {
+        negated_scalar_condition cond{std::make_unique<matcher::lower_than<double>>(5.0), {},
+            {gen_variadic_param("server.request.query")}};
+
+        auto root = object_builder_da::map();
+        root.emplace("server.request.query", test::ddwaf_object_da::make_float(std::nan("")));
+
+        object_store store;
+        store.insert_and_apply(std::move(root));
+
+        ddwaf::timer deadline{2s};
+        condition_cache cache;
+        EXPECT_TRUE(cond.eval(cache, store, {}, {}, deadline));
     }
 }
 

--- a/tests/unit/configuration/base_rule_parser_test.cpp
+++ b/tests/unit/configuration/base_rule_parser_test.cpp
@@ -1141,4 +1141,111 @@ TEST(TestBaseRuleParser, InvalidOutputType)
     EXPECT_TRUE(cfg.rule_overrides_by_tags.empty());
 }
 
+TEST(TestBaseRuleParser, ParseRuleWithComparisonAliases)
+{
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+
+    auto rule_object = yaml_to_object<owned_object>(
+        R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: lower_equal, parameters: {inputs: [{address: arg1}], type: signed, value: 5}}, {operator: greater_equal, parameters: {inputs: [{address: arg2}], type: unsigned, value: 5}}]}])");
+
+    auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
+    parse_base_rules(rule_array, collector, section);
+
+    {
+        auto diagnostics = section.to_object();
+        raw_configuration root{diagnostics};
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 1);
+        EXPECT_NE(loaded.find("1"), loaded.end());
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 0);
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+    }
+
+    ASSERT_EQ(cfg.base_rules.size(), 1);
+    EXPECT_EQ(cfg.base_rules["1"].expr->size(), 2);
+}
+
+// Unlike greater_than and lower_than, the negated aliases are backed by
+// negated_scalar_condition, which only supports a single target
+TEST(TestBaseRuleParser, ParseRuleWithVariadicComparisonAlias)
+{
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+
+    auto rule_object = yaml_to_object<owned_object>(
+        R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: lower_equal, parameters: {inputs: [{address: arg1}, {address: arg2}], type: signed, value: 5}}]}])");
+
+    auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
+    parse_base_rules(rule_array, collector, section);
+
+    {
+        auto diagnostics = section.to_object();
+        raw_configuration root{diagnostics};
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto loaded = at<raw_configuration::string_set>(root_map, "loaded");
+        EXPECT_EQ(loaded.size(), 0);
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("1"), failed.end());
+
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        ASSERT_EQ(errors.size(), 1);
+        auto it = errors.find("multiple targets for non-variadic argument");
+        EXPECT_NE(it, errors.end());
+    }
+
+    EXPECT_TRUE(cfg.base_rules.empty());
+}
+
+// The aliases are already the negated form, so they can't be negated again
+TEST(TestBaseRuleParser, ParseRuleWithNegatedComparisonAlias)
+{
+    configuration_spec cfg;
+    configuration_change_spec change;
+    configuration_collector collector{change, cfg};
+    ruleset_info::section_info section;
+
+    auto rule_object = yaml_to_object<owned_object>(
+        R"([{id: 1, name: rule1, tags: {type: flow1, category: category1}, conditions: [{operator: "!lower_equal", parameters: {inputs: [{address: arg1}], type: signed, value: 5}}]}])");
+
+    auto rule_array = static_cast<raw_configuration::vector>(raw_configuration(rule_object));
+    parse_base_rules(rule_array, collector, section);
+
+    {
+        auto diagnostics = section.to_object();
+        raw_configuration root{diagnostics};
+
+        auto root_map = static_cast<raw_configuration::map>(root);
+
+        auto failed = at<raw_configuration::string_set>(root_map, "failed");
+        EXPECT_EQ(failed.size(), 1);
+        EXPECT_NE(failed.find("1"), failed.end());
+
+        // An unknown operator is reported as a warning rather than an error
+        auto errors = at<raw_configuration::map>(root_map, "errors");
+        EXPECT_EQ(errors.size(), 0);
+
+        auto warnings = at<raw_configuration::map>(root_map, "warnings");
+        ASSERT_EQ(warnings.size(), 1);
+        EXPECT_NE(warnings.find("unknown operator: \'lower_equal\'"), warnings.end());
+    }
+
+    EXPECT_TRUE(cfg.base_rules.empty());
+}
+
 } // namespace

--- a/tests/unit/matcher/greater_than_test.cpp
+++ b/tests/unit/matcher/greater_than_test.cpp
@@ -97,4 +97,20 @@ TEST(TestGreaterThanDouble, Basic)
     EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(5.0)).first);
 }
 
+// The negated form of greater_than is exposed as the "lower_equal" operator
+TEST(TestGreaterThan, Name)
+{
+    const matcher::greater_than<int64_t> signed_matcher(5);
+    EXPECT_STRV(signed_matcher.name(), "greater_than");
+    EXPECT_STRV(signed_matcher.negated_name(), "lower_equal");
+
+    const matcher::greater_than<uint64_t> unsigned_matcher(5);
+    EXPECT_STRV(unsigned_matcher.name(), "greater_than");
+    EXPECT_STRV(unsigned_matcher.negated_name(), "lower_equal");
+
+    const matcher::greater_than<double> float_matcher(5.0);
+    EXPECT_STRV(float_matcher.name(), "greater_than");
+    EXPECT_STRV(float_matcher.negated_name(), "lower_equal");
+}
+
 } // namespace

--- a/tests/unit/matcher/lower_than_test.cpp
+++ b/tests/unit/matcher/lower_than_test.cpp
@@ -97,4 +97,20 @@ TEST(TestlowerThanDouble, Basic)
     EXPECT_FALSE(matcher.match(test::ddwaf_object_da::make_float(6.0)).first);
 }
 
+// The negated form of lower_than is exposed as the "greater_equal" operator
+TEST(TestLowerThan, Name)
+{
+    const matcher::lower_than<int64_t> signed_matcher(5);
+    EXPECT_STRV(signed_matcher.name(), "lower_than");
+    EXPECT_STRV(signed_matcher.negated_name(), "greater_equal");
+
+    const matcher::lower_than<uint64_t> unsigned_matcher(5);
+    EXPECT_STRV(unsigned_matcher.name(), "lower_than");
+    EXPECT_STRV(unsigned_matcher.negated_name(), "greater_equal");
+
+    const matcher::lower_than<double> float_matcher(5.0);
+    EXPECT_STRV(float_matcher.name(), "lower_than");
+    EXPECT_STRV(float_matcher.negated_name(), "greater_equal");
+}
+
 } // namespace

--- a/validator/runner.cpp
+++ b/validator/runner.cpp
@@ -281,8 +281,8 @@ void test_runner::validate_matches(const YAML::Node &expected, const YAML::Node 
 
     static std::set<std::string_view, std::less<>> scalar_operators{"match_regex", "phrase_match",
         "exact_match", "ip_match", "equals", "is_sqli", "is_xss", "exists", "greater_than",
-        "lower_than", "!match_regex", "!phrase_match", "!exact_match", "!ip_match", "!equals",
-        "!is_sqli", "!is_xss", "!exists"};
+        "lower_than", "lower_equal", "greater_equal", "!match_regex", "!phrase_match",
+        "!exact_match", "!ip_match", "!equals", "!is_sqli", "!is_xss", "!exists"};
 
     // Iterate through matches, assume they are in the same order as rule
     // conditions for now.

--- a/validator/tests/rules/operators/greater_equal/001_rule1_signed_greater_equal.yaml
+++ b/validator/tests/rules/operators/greater_equal/001_rule1_signed_greater_equal.yaml
@@ -1,0 +1,21 @@
+{
+  name: "Basic run with greater_equal operator",
+  runs: [
+    {
+      input: {
+        rule1-input: -41
+      },
+      rules: [
+        {
+          1: [
+            {
+              address: rule1-input,
+              value: "-41"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/greater_equal/002_rule1_signed_greater_equal_boundary.yaml
+++ b/validator/tests/rules/operators/greater_equal/002_rule1_signed_greater_equal_boundary.yaml
@@ -1,0 +1,21 @@
+{
+  name: "Run with greater_equal operator on the boundary value, which must match",
+  runs: [
+    {
+      input: {
+        rule1-input: -42
+      },
+      rules: [
+        {
+          1: [
+            {
+              address: rule1-input,
+              value: "-42"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/greater_equal/003_rule1_signed_greater_equal_no_match.yaml
+++ b/validator/tests/rules/operators/greater_equal/003_rule1_signed_greater_equal_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with greater_equal operator, no match",
+  runs: [
+    {
+      input: {
+        rule1-input: -43
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/greater_equal/004_rule2_unsigned_greater_equal.yaml
+++ b/validator/tests/rules/operators/greater_equal/004_rule2_unsigned_greater_equal.yaml
@@ -1,0 +1,21 @@
+{
+  name: "Basic run with unsigned greater_equal operator",
+  runs: [
+    {
+      input: {
+        rule2-input: 42
+      },
+      rules: [
+        {
+          2: [
+            {
+              address: rule2-input,
+              value: "42"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/greater_equal/005_rule2_unsigned_greater_equal_no_match.yaml
+++ b/validator/tests/rules/operators/greater_equal/005_rule2_unsigned_greater_equal_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with unsigned greater_equal operator, no match",
+  runs: [
+    {
+      input: {
+        rule2-input: 41
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/greater_equal/006_rule3_double_greater_equal.yaml
+++ b/validator/tests/rules/operators/greater_equal/006_rule3_double_greater_equal.yaml
@@ -1,0 +1,20 @@
+{
+  name: "Basic run with float greater_equal operator",
+  runs: [
+    {
+      input: {
+        rule3-input: 4.2
+      },
+      rules: [
+        {
+          3: [
+            {
+              address: rule3-input
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/greater_equal/007_rule3_double_greater_equal_no_match.yaml
+++ b/validator/tests/rules/operators/greater_equal/007_rule3_double_greater_equal_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with float greater_equal operator, no match",
+  runs: [
+    {
+      input: {
+        rule3-input: 4.1
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/greater_equal/008_rule1_string_no_match.yaml
+++ b/validator/tests/rules/operators/greater_equal/008_rule1_string_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "A value which the operator can't evaluate must not be a negated match",
+  runs: [
+    {
+      input: {
+        rule1-input: "not a number"
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/greater_equal/ruleset.yaml
+++ b/validator/tests/rules/operators/greater_equal/ruleset.yaml
@@ -1,0 +1,38 @@
+version: '2.1'
+rules:
+  - id: "1"
+    name: rule1-signed-greater-equal
+    tags:
+      type: flow1
+      category: category
+    conditions:
+      - operator: greater_equal
+        parameters:
+          inputs:
+            - address: rule1-input
+          type: signed
+          value: -42
+  - id: "2"
+    name: rule2-unsigned-greater-equal
+    tags:
+      type: flow1
+      category: category
+    conditions:
+      - operator: greater_equal
+        parameters:
+          inputs:
+            - address: rule2-input
+          type: unsigned
+          value: 42
+  - id: "3"
+    name: rule3-float-greater-equal
+    tags:
+      type: flow1
+      category: category
+    conditions:
+      - operator: greater_equal
+        parameters:
+          inputs:
+            - address: rule3-input
+          type: float
+          value: 4.2

--- a/validator/tests/rules/operators/lower_equal/001_rule1_signed_lower_equal.yaml
+++ b/validator/tests/rules/operators/lower_equal/001_rule1_signed_lower_equal.yaml
@@ -1,0 +1,21 @@
+{
+  name: "Basic run with lower_equal operator",
+  runs: [
+    {
+      input: {
+        rule1-input: -43
+      },
+      rules: [
+        {
+          1: [
+            {
+              address: rule1-input,
+              value: "-43"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/lower_equal/002_rule1_signed_lower_equal_boundary.yaml
+++ b/validator/tests/rules/operators/lower_equal/002_rule1_signed_lower_equal_boundary.yaml
@@ -1,0 +1,21 @@
+{
+  name: "Run with lower_equal operator on the boundary value, which must match",
+  runs: [
+    {
+      input: {
+        rule1-input: -42
+      },
+      rules: [
+        {
+          1: [
+            {
+              address: rule1-input,
+              value: "-42"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/lower_equal/003_rule1_signed_lower_equal_no_match.yaml
+++ b/validator/tests/rules/operators/lower_equal/003_rule1_signed_lower_equal_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with lower_equal operator, no match",
+  runs: [
+    {
+      input: {
+        rule1-input: -41
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/lower_equal/004_rule2_unsigned_lower_equal.yaml
+++ b/validator/tests/rules/operators/lower_equal/004_rule2_unsigned_lower_equal.yaml
@@ -1,0 +1,21 @@
+{
+  name: "Basic run with unsigned lower_equal operator",
+  runs: [
+    {
+      input: {
+        rule2-input: 42
+      },
+      rules: [
+        {
+          2: [
+            {
+              address: rule2-input,
+              value: "42"
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/lower_equal/005_rule2_unsigned_lower_equal_no_match.yaml
+++ b/validator/tests/rules/operators/lower_equal/005_rule2_unsigned_lower_equal_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with unsigned lower_equal operator, no match",
+  runs: [
+    {
+      input: {
+        rule2-input: 43
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/lower_equal/006_rule3_double_lower_equal.yaml
+++ b/validator/tests/rules/operators/lower_equal/006_rule3_double_lower_equal.yaml
@@ -1,0 +1,20 @@
+{
+  name: "Basic run with float lower_equal operator",
+  runs: [
+    {
+      input: {
+        rule3-input: 4.2
+      },
+      rules: [
+        {
+          3: [
+            {
+              address: rule3-input
+            }
+          ]
+        }
+      ],
+      code: match
+    }
+  ]
+}

--- a/validator/tests/rules/operators/lower_equal/007_rule3_double_lower_equal_no_match.yaml
+++ b/validator/tests/rules/operators/lower_equal/007_rule3_double_lower_equal_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "Basic run with float lower_equal operator, no match",
+  runs: [
+    {
+      input: {
+        rule3-input: 4.3
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/lower_equal/008_rule1_string_no_match.yaml
+++ b/validator/tests/rules/operators/lower_equal/008_rule1_string_no_match.yaml
@@ -1,0 +1,11 @@
+{
+  name: "A value which the operator can't evaluate must not be a negated match",
+  runs: [
+    {
+      input: {
+        rule1-input: "not a number"
+      },
+      code: ok
+    }
+  ]
+}

--- a/validator/tests/rules/operators/lower_equal/ruleset.yaml
+++ b/validator/tests/rules/operators/lower_equal/ruleset.yaml
@@ -1,0 +1,38 @@
+version: '2.1'
+rules:
+  - id: "1"
+    name: rule1-signed-lower-equal
+    tags:
+      type: flow1
+      category: category
+    conditions:
+      - operator: lower_equal
+        parameters:
+          inputs:
+            - address: rule1-input
+          type: signed
+          value: -42
+  - id: "2"
+    name: rule2-unsigned-lower-equal
+    tags:
+      type: flow1
+      category: category
+    conditions:
+      - operator: lower_equal
+        parameters:
+          inputs:
+            - address: rule2-input
+          type: unsigned
+          value: 42
+  - id: "3"
+    name: rule3-float-lower-equal
+    tags:
+      type: flow1
+      category: category
+    conditions:
+      - operator: lower_equal
+        parameters:
+          inputs:
+            - address: rule3-input
+          type: float
+          value: 4.2


### PR DESCRIPTION
This PR simply introduces two operator aliases:
- `lower_equal` which is an alias to `!greater_than`
- `greater_equal` which is an alias to `!lower_than`

This has been implemented at parsing time, the negated operator names themselves are not supported, however the aliases have been implemented through negation.