### PR TITLE
Improvements on RASP operator transformer support

### DIFF
--- a/src/condition/cmdi_detector.cpp
+++ b/src/condition/cmdi_detector.cpp
@@ -22,6 +22,7 @@
 #include "condition/cmdi_detector.hpp"
 #include "condition/shi_common.hpp"
 #include "condition/structured_condition.hpp"
+#include "condition/transforming_iterator.hpp"
 #include "cow_string.hpp"
 #include "exception.hpp"
 #include "exclusion/common.hpp"
@@ -33,7 +34,6 @@
 #include "tokenizer/shell.hpp"
 #include "transformer/base.hpp"
 #include "transformer/lowercase.hpp"
-#include "transformer/manager.hpp"
 #include "utils.hpp"
 
 using namespace std::literals;
@@ -381,28 +381,15 @@ std::optional<shi_result> cmdi_impl(object_view exec_args,
         return std::nullopt;
     }
 
-    kv_iterator it(params, {}, objects_excluded);
+    transforming_iterator<kv_iterator> it(params, transformers, objects_excluded, deadline);
     for (; it; ++it) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();
         }
 
-        const object_view param = *it;
-        if (!param.is_string()) {
-            continue;
-        }
-
         if (eval_executable) {
-            auto value = param.as<std::string_view>();
-
-            // TODO: transforms are done twice if there is a shell command
-            auto transformed = transformer::manager::transform(param, transformers);
-            if (transformed.has_value()) {
-                value = static_cast<std::string_view>(transformed.value());
-            }
-
             // First check if the entire executable was injected
-            value = trim_whitespaces(value);
+            auto value = trim_whitespaces(it.current_value());
             if (executable == value) {
                 // When the full binary has been injected, we consider it an exploit
                 // although bear in mind that this can also be a vulnerable-by-design
@@ -413,7 +400,7 @@ std::optional<shi_result> cmdi_impl(object_view exec_args,
 
         if (!shell_command.empty()) {
             auto res = find_shi_from_params<std::string_view, scalar_iterator>(
-                shell_command, resource_tokens, param, transformers, objects_excluded, deadline);
+                shell_command, resource_tokens, *it, {}, objects_excluded, deadline);
             if (res.has_value()) {
                 res->key_path = it.get_current_path();
                 return res;

--- a/src/condition/lfi_detector.cpp
+++ b/src/condition/lfi_detector.cpp
@@ -17,6 +17,7 @@
 #include "clock.hpp"
 #include "condition/base.hpp"
 #include "condition/lfi_detector.hpp"
+#include "condition/transforming_iterator.hpp"
 #include "exception.hpp"
 #include "exclusion/common.hpp"
 #include "iterator.hpp"
@@ -24,7 +25,6 @@
 #include "object.hpp"
 #include "platform.hpp"
 #include "transformer/base.hpp"
-#include "transformer/manager.hpp"
 #include "utils.hpp"
 
 using namespace std::literals;
@@ -107,29 +107,13 @@ lfi_result lfi_impl(std::string_view path, object_view params,
         lfi_fn = &lfi_impl_windows;
     }
 
-    kv_iterator it(params, {}, objects_excluded);
+    transforming_iterator<kv_iterator> it(params, transformers, objects_excluded, deadline);
     for (; it; ++it) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();
         }
 
-        const auto param = *it;
-        if (!param.is_string()) {
-            continue;
-        }
-
-        auto transformed = transformer::manager::transform(param, transformers);
-        if (transformed.has_value()) {
-            auto value = static_cast<std::string_view>(transformed.value());
-            if (lfi_fn(path, value)) {
-                return {{std::string(value), it.get_current_path()}};
-            }
-
-            continue;
-        }
-        // Fallback to the original value if the transform fails
-
-        const auto value = param.as<std::string_view>();
+        const auto value = it.current_value();
         if (lfi_fn(path, value)) {
             return {{std::string(value), it.get_current_path()}};
         }

--- a/src/condition/match_iterator.hpp
+++ b/src/condition/match_iterator.hpp
@@ -6,16 +6,15 @@
 
 #pragma once
 
-#include "cow_string.hpp"
+#include "clock.hpp"
+#include "condition/transforming_iterator.hpp"
 #include "exclusion/common.hpp"
 #include "iterator.hpp"
 #include "object.hpp"
 #include "transformer/base.hpp"
-#include "transformer/manager.hpp"
 
 #include <cstddef>
 #include <cstdint>
-#include <optional>
 #include <span>
 #include <string_view>
 #include <utility>
@@ -31,11 +30,12 @@ public:
     static constexpr std::size_t npos = std::string_view::npos;
 
     explicit match_iterator(ResourceType resource, object_view obj,
-        std::span<const transformer_id> transformers, const object_set_ref &exclude)
-        : resource_(std::move(resource)), it_(obj, {}, exclude), transformers_(transformers)
+        std::span<const transformer_id> transformers, const object_set_ref &exclude,
+        ddwaf::timer &deadline)
+        : resource_(std::move(resource)), it_(obj, transformers, exclude, deadline)
     {
         for (; it_; ++it_) {
-            if (try_match_object(*it_)) {
+            if (try_match_current()) {
                 break;
             }
         }
@@ -51,20 +51,22 @@ public:
 
     [[nodiscard]] std::pair<std::string_view, std::size_t> operator*()
     {
-        return {get_current_param_str(), current_index_};
+        return {it_.current_value(), current_index_};
     }
 
     bool operator++()
     {
         if (current_index_ != npos) {
-            current_index_ = resource_.find(get_current_param_str(), current_index_ + 1);
+            current_index_ = resource_.find(it_.current_value(), current_index_ + 1);
             if (current_index_ != npos) {
                 return true;
             }
         }
 
+        // Values which don't match are skipped by advancing the underlying
+        // iterator, which is also responsible for evaluating the deadline
         while (++it_) {
-            if (try_match_object(*it_)) {
+            if (try_match_current()) {
                 return true;
             }
         }
@@ -80,38 +82,22 @@ public:
     }
 
 protected:
-    [[nodiscard]] std::string_view get_current_param_str() const
+    // Looks up the value the underlying iterator is currently positioned on
+    // within the resource
+    bool try_match_current()
     {
-        if (current_param_.has_value()) {
-            return static_cast<std::string_view>(current_param_.value());
-        }
-        return {};
-    }
-
-    bool try_match_object(object_view current_obj)
-    {
-        if (!current_obj.is_string()) {
-            return false;
-        }
-
-        current_param_ = transformer::manager::transform(current_obj, transformers_);
-        if (!current_param_.has_value()) {
-            current_param_ = cow_string{current_obj.template as<std::string_view>()};
-        }
-
-        auto value = static_cast<std::string_view>(current_param_.value());
+        auto value = it_.current_value();
         if (value.size() < MinLength) {
             return false;
         }
+
         current_index_ = resource_.find(value, 0);
         return current_index_ != npos;
     }
 
     ResourceType resource_;
-    std::optional<cow_string> current_param_;
     std::size_t current_index_{npos};
-    IteratorType it_;
-    std::span<const transformer_id> transformers_;
+    transforming_iterator<IteratorType> it_;
 };
 
 } // namespace ddwaf

--- a/src/condition/match_iterator.hpp
+++ b/src/condition/match_iterator.hpp
@@ -34,11 +34,7 @@ public:
         ddwaf::timer &deadline)
         : resource_(std::move(resource)), it_(obj, transformers, exclude, deadline)
     {
-        for (; it_; ++it_) {
-            if (try_match_current()) {
-                break;
-            }
-        }
+        find_next_match();
     }
 
     ~match_iterator() = default;
@@ -56,6 +52,7 @@ public:
 
     bool operator++()
     {
+        // Look for further occurrences of the current value within the resource
         if (current_index_ != npos) {
             current_index_ = resource_.find(it_.current_value(), current_index_ + 1);
             if (current_index_ != npos) {
@@ -63,15 +60,8 @@ public:
             }
         }
 
-        // Values which don't match are skipped by advancing the underlying
-        // iterator, which is also responsible for evaluating the deadline
-        while (++it_) {
-            if (try_match_current()) {
-                return true;
-            }
-        }
-
-        return false;
+        ++it_;
+        return find_next_match();
     }
 
     [[nodiscard]] explicit operator bool() const { return static_cast<bool>(it_); }
@@ -82,17 +72,25 @@ public:
     }
 
 protected:
-    // Looks up the value the underlying iterator is currently positioned on
-    // within the resource
-    bool try_match_current()
+    // Advances the underlying iterator until its current value is found within
+    // the resource. Returns false if the iterator was exhausted before finding
+    // one. Note that values which don't match are skipped by advancing the
+    // underlying iterator, which is also responsible for evaluating the deadline.
+    bool find_next_match()
     {
-        auto value = it_.current_value();
-        if (value.size() < MinLength) {
-            return false;
+        for (; it_; ++it_) {
+            auto value = it_.current_value();
+            if (value.size() < MinLength) {
+                continue;
+            }
+
+            current_index_ = resource_.find(value, 0);
+            if (current_index_ != npos) {
+                return true;
+            }
         }
 
-        current_index_ = resource_.find(value, 0);
-        return current_index_ != npos;
+        return false;
     }
 
     ResourceType resource_;

--- a/src/condition/shi_common.hpp
+++ b/src/condition/shi_common.hpp
@@ -47,7 +47,7 @@ std::optional<shi_result> find_shi_from_params(const ResourceType &resource,
     ddwaf::timer &deadline)
 {
     match_iterator<2, IteratorType, ResourceType> it(
-        resource, params, transformers, objects_excluded);
+        resource, params, transformers, objects_excluded, deadline);
     for (; it; ++it) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();

--- a/src/condition/sqli_detector.cpp
+++ b/src/condition/sqli_detector.cpp
@@ -472,7 +472,7 @@ sqli_result sqli_impl(std::string_view resource, std::vector<sql_token> &resourc
 {
     static constexpr std::size_t min_str_len = 3;
 
-    match_iterator<min_str_len> it(resource, params, transformers, objects_excluded);
+    match_iterator<min_str_len> it(resource, params, transformers, objects_excluded, deadline);
     for (; it; ++it) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();

--- a/src/condition/ssrf_detector.cpp
+++ b/src/condition/ssrf_detector.cpp
@@ -186,7 +186,7 @@ ssrf_result ssrf_impl(const uri_decomposed &uri, object_view params,
 
     std::optional<ssrf_result> parameter_injection;
 
-    match_iterator<min_str_len> it{uri.raw, params, transformers, objects_excluded};
+    match_iterator<min_str_len> it{uri.raw, params, transformers, objects_excluded, deadline};
     for (; it; ++it) {
         if (deadline.expired()) {
             throw ddwaf::timeout_exception();

--- a/src/condition/transforming_iterator.hpp
+++ b/src/condition/transforming_iterator.hpp
@@ -1,0 +1,123 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#pragma once
+
+#include "clock.hpp"
+#include "cow_string.hpp"
+#include "exception.hpp"
+#include "exclusion/common.hpp"
+#include "iterator.hpp"
+#include "object.hpp"
+#include "transformer/base.hpp"
+#include "transformer/manager.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+namespace ddwaf {
+
+template <typename IteratorType = kv_iterator> class transforming_iterator {
+public:
+    explicit transforming_iterator(object_view obj, std::span<const transformer_id> transformers,
+        const object_set_ref &exclude, ddwaf::timer &deadline)
+        : it_(obj, {}, exclude), transformers_(transformers), deadline_(deadline)
+    {
+        for (; it_; ++it_) {
+            // Objects which can't be transformed are skipped within this
+            // iterator, so the deadline must be evaluated here rather than
+            // relying on the caller doing so once per yielded value
+            if (deadline_.expired()) {
+                throw ddwaf::timeout_exception();
+            }
+
+            if (transform_current_object(*it_)) {
+                break;
+            }
+        }
+    }
+
+    ~transforming_iterator() = default;
+
+    transforming_iterator(const transforming_iterator &) = delete;
+    transforming_iterator(transforming_iterator &&) = delete;
+
+    transforming_iterator &operator=(const transforming_iterator &) = delete;
+    transforming_iterator &operator=(transforming_iterator &&) = delete;
+
+    // The returned view is only valid until the next call to operator++, as the
+    // underlying buffer is replaced on every advance
+    [[nodiscard]] std::string_view current_value() const
+    {
+        if (current_param_.has_value()) {
+            return static_cast<std::string_view>(current_param_.value());
+        }
+        return {};
+    }
+
+    // Wraps the current value in a string object, for the benefit of callers
+    // which require an object rather than a view. As with current_value(), the
+    // returned object is only valid until the next call to operator++.
+    [[nodiscard]] object_view operator*()
+    {
+        auto value = current_value();
+        // A transformer can yield an empty string with no underlying buffer,
+        // e.g. remove_comments on a value which is entirely a comment. String
+        // objects are expected to always provide a valid pointer, so an empty
+        // literal is used instead.
+        const char *data = value.data() != nullptr ? value.data() : "";
+        current_object_ = owned_object::make_string_literal(data, value.size());
+        return current_object_;
+    }
+
+    bool operator++()
+    {
+        while (++it_) {
+            if (deadline_.expired()) {
+                throw ddwaf::timeout_exception();
+            }
+
+            if (transform_current_object(*it_)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    [[nodiscard]] explicit operator bool() const { return static_cast<bool>(it_); }
+
+    [[nodiscard]] std::vector<std::variant<std::string_view, int64_t>> get_current_path() const
+    {
+        return it_.get_current_path();
+    }
+
+protected:
+    bool transform_current_object(object_view current_obj)
+    {
+        if (!current_obj.is_string()) {
+            return false;
+        }
+
+        current_param_ = transformer::manager::transform(current_obj, transformers_);
+        if (!current_param_.has_value()) {
+            current_param_ = cow_string{current_obj.template as<std::string_view>()};
+        }
+
+        return true;
+    }
+
+    std::optional<cow_string> current_param_;
+    owned_object current_object_;
+    IteratorType it_;
+    std::span<const transformer_id> transformers_;
+    ddwaf::timer &deadline_;
+};
+
+} // namespace ddwaf

--- a/src/condition/transforming_iterator.hpp
+++ b/src/condition/transforming_iterator.hpp
@@ -30,18 +30,7 @@ public:
         const object_set_ref &exclude, ddwaf::timer &deadline)
         : it_(obj, {}, exclude), transformers_(transformers), deadline_(deadline)
     {
-        for (; it_; ++it_) {
-            // Objects which can't be transformed are skipped within this
-            // iterator, so the deadline must be evaluated here rather than
-            // relying on the caller doing so once per yielded value
-            if (deadline_.expired()) {
-                throw ddwaf::timeout_exception();
-            }
-
-            if (transform_current_object(*it_)) {
-                break;
-            }
-        }
+        advance_to_transformable_object();
     }
 
     ~transforming_iterator() = default;
@@ -79,16 +68,8 @@ public:
 
     bool operator++()
     {
-        while (++it_) {
-            if (deadline_.expired()) {
-                throw ddwaf::timeout_exception();
-            }
-
-            if (transform_current_object(*it_)) {
-                return true;
-            }
-        }
-        return false;
+        ++it_;
+        return advance_to_transformable_object();
     }
 
     [[nodiscard]] explicit operator bool() const { return static_cast<bool>(it_); }
@@ -99,18 +80,33 @@ public:
     }
 
 protected:
-    bool transform_current_object(object_view current_obj)
+    // Advances the underlying iterator until it lands on a string, which is
+    // then transformed and made the current value. Returns false if the
+    // iterator was exhausted before finding one.
+    bool advance_to_transformable_object()
     {
-        if (!current_obj.is_string()) {
-            return false;
+        for (; it_; ++it_) {
+            // Objects which can't be transformed are skipped within this
+            // iterator, so the deadline must be evaluated here rather than
+            // relying on the caller doing so once per yielded value
+            if (deadline_.expired()) {
+                throw ddwaf::timeout_exception();
+            }
+
+            const object_view current_obj = *it_;
+            if (!current_obj.is_string()) {
+                continue;
+            }
+
+            current_param_ = transformer::manager::transform(current_obj, transformers_);
+            if (!current_param_.has_value()) {
+                current_param_ = cow_string{current_obj.template as<std::string_view>()};
+            }
+
+            return true;
         }
 
-        current_param_ = transformer::manager::transform(current_obj, transformers_);
-        if (!current_param_.has_value()) {
-            current_param_ = cow_string{current_obj.template as<std::string_view>()};
-        }
-
-        return true;
+        return false;
     }
 
     std::optional<cow_string> current_param_;

--- a/tests/unit/condition/cmdi_detector_test.cpp
+++ b/tests/unit/condition/cmdi_detector_test.cpp
@@ -993,4 +993,50 @@ TEST(TestCmdiDetector, NoMatchOnEmptyTransformedParameter)
     EXPECT_FALSE(cache.match);
 }
 
+// A parameter reduced to an empty string by the transformers leaves a
+// cow_string with no underlying buffer; feeding it to the shell command lookup
+// must not abort the evaluation
+TEST(TestCmdiDetector, CommentOnlyTransformedParameter)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{gen_param_def_with_transformers(
+        "server.sys.exec.cmd", "server.request.query", {transformer_id::remove_comments})};
+
+    auto root = gen_exec_root({"/bin/sh", "-c", "ls -l"}, "#");
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_NO_THROW(EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline)));
+    EXPECT_FALSE(cache.match);
+}
+
+// Parameters which can't be transformed are skipped within the iterator, so the
+// deadline must be honoured even when the container holds no strings at all
+TEST(TestCmdiDetector, TimeoutWithNonStringParams)
+{
+    system_platform_override spo{platform::linux};
+
+    cmdi_detector cond{gen_param_def_with_transformers(
+        "server.sys.exec.cmd", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = object_builder_da::map();
+    auto params = root.emplace("server.request.query", object_builder_da::array());
+    for (unsigned i = 0; i < 1024; ++i) { params.emplace_back(owned_object::make_signed(i)); }
+    auto array = root.emplace("server.sys.exec.cmd", object_builder_da::array());
+    array.emplace_back("/bin/sh");
+    array.emplace_back("-c");
+    array.emplace_back("ls -l");
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{0s};
+    condition_cache cache;
+    EXPECT_THROW(cond.eval(cache, store, {}, {}, deadline), ddwaf::timeout_exception);
+}
+
 } // namespace

--- a/tests/unit/condition/lfi_detector_test.cpp
+++ b/tests/unit/condition/lfi_detector_test.cpp
@@ -569,4 +569,43 @@ TEST(TestLFIDetector, NoMatchOnEmptyTransformedParameter)
     EXPECT_FALSE(cache.match);
 }
 
+// Parameters which can't be transformed are skipped within the iterator, so the
+// deadline must be honoured even when the container holds no strings at all
+TEST(TestLFIDetector, TimeoutWithNonStringParams)
+{
+    lfi_detector cond{gen_param_def_with_transformers(
+        "server.io.fs.file", "server.request.query", {transformer_id::url_decode})};
+
+    auto root = object_builder_da::map();
+    root.emplace("server.io.fs.file", "/var/www/html/../../../etc/passwd");
+    auto array = root.emplace("server.request.query", object_builder_da::array());
+    for (unsigned i = 0; i < 1024; ++i) { array.emplace_back(owned_object::make_signed(i)); }
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{0s};
+    condition_cache cache;
+    EXPECT_THROW(cond.eval(cache, store, {}, {}, deadline), ddwaf::timeout_exception);
+}
+
+// A parameter reduced to an empty string by the transformers must not abort the
+// evaluation; remove_comments leaves a cow_string with no underlying buffer
+TEST(TestLFIDetector, CommentOnlyTransformedParameter)
+{
+    lfi_detector cond{gen_param_def_with_transformers(
+        "server.io.fs.file", "server.request.query", {transformer_id::remove_comments})};
+
+    auto root = object_builder_da::map({{"server.io.fs.file", "/var/www/html/../../../etc/passwd"},
+        {"server.request.query", "#"}});
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{2s};
+    condition_cache cache;
+    EXPECT_NO_THROW(EXPECT_FALSE(cond.eval(cache, store, {}, {}, deadline)));
+    EXPECT_FALSE(cache.match);
+}
+
 } // namespace

--- a/tests/unit/condition/match_iterator_test.cpp
+++ b/tests/unit/condition/match_iterator_test.cpp
@@ -11,6 +11,7 @@
 
 using namespace ddwaf;
 using namespace ddwaf::test;
+using namespace std::literals;
 
 namespace {
 
@@ -20,7 +21,8 @@ TEST(TestMatchIterator, InvalidIterator)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, {}, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, {}, exclude, deadline);
     EXPECT_FALSE((bool)it);
 
     auto path = it.get_current_path();
@@ -35,7 +37,8 @@ TEST(TestMatchIterator, NoMatch)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, {}, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, {}, exclude, deadline);
     EXPECT_FALSE((bool)it);
 
     auto path = it.get_current_path();
@@ -50,7 +53,8 @@ TEST(TestMatchIterator, SingleMatch)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, {}, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, {}, exclude, deadline);
     EXPECT_TRUE((bool)it);
 
     auto [param, index] = *it;
@@ -69,7 +73,8 @@ TEST(TestMatchIterator, MultipleMatches)
 
     std::string resource = "resource resource resource resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, {}, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, {}, exclude, deadline);
 
     for (std::size_t i = 0; i < 4; ++i) {
         EXPECT_TRUE((bool)it);
@@ -92,7 +97,8 @@ TEST(TestMatchIterator, OverlappingMatches)
 
     std::string resource = "eeeeeeeeee";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, {}, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, {}, exclude, deadline);
     EXPECT_TRUE((bool)it);
 
     for (std::size_t i = 0; i < 9; ++i) {
@@ -115,7 +121,8 @@ TEST(TestMatchIterator, NoMatchWithoutTransformer)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, {}, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, {}, exclude, deadline);
     EXPECT_FALSE((bool)it);
 
     EXPECT_FALSE(++it);
@@ -129,7 +136,8 @@ TEST(TestMatchIterator, SingleMatchWithTransformer)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, transformers, exclude, deadline);
     EXPECT_TRUE((bool)it);
 
     auto [param, index] = *it;
@@ -151,7 +159,8 @@ TEST(TestMatchIterator, MultipleTransformers)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, transformers, exclude, deadline);
     EXPECT_TRUE((bool)it);
 
     auto [param, index] = *it;
@@ -171,7 +180,8 @@ TEST(TestMatchIterator, UnmodifiedByTransformer)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, transformers, exclude, deadline);
     EXPECT_TRUE((bool)it);
 
     auto [param, index] = *it;
@@ -189,7 +199,8 @@ TEST(TestMatchIterator, MultipleMatchesWithTransformer)
 
     std::string resource = "resource resource resource resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, transformers, exclude, deadline);
 
     for (std::size_t i = 0; i < 4; ++i) {
         EXPECT_TRUE((bool)it);
@@ -214,7 +225,8 @@ TEST(TestMatchIterator, MultipleParametersWithTransformer)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, transformers, exclude, deadline);
 
     for (std::size_t i = 0; i < 2; ++i) {
         EXPECT_TRUE((bool)it);
@@ -241,7 +253,8 @@ TEST(TestMatchIterator, TransformedKey)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, transformers, exclude, deadline);
     EXPECT_TRUE((bool)it);
 
     auto [param, index] = *it;
@@ -264,7 +277,8 @@ TEST(TestMatchIterator, MinLengthAppliedToMatchedValue)
 
         std::string resource = "this is the resource";
         object_set_ref exclude;
-        ddwaf::match_iterator<5> it(resource, object, transformers, exclude);
+        ddwaf::timer deadline{2s};
+        ddwaf::match_iterator<5> it(resource, object, transformers, exclude, deadline);
         EXPECT_FALSE((bool)it);
     }
 
@@ -275,7 +289,8 @@ TEST(TestMatchIterator, MinLengthAppliedToMatchedValue)
 
         std::string resource = "this is the %72%65%73ource";
         object_set_ref exclude;
-        ddwaf::match_iterator<5> it(resource, object, transformers, exclude);
+        ddwaf::timer deadline{2s};
+        ddwaf::match_iterator<5> it(resource, object, transformers, exclude, deadline);
         EXPECT_FALSE((bool)it);
 
         EXPECT_FALSE(++it);
@@ -287,7 +302,8 @@ TEST(TestMatchIterator, MinLengthAppliedToMatchedValue)
 
         std::string resource = "this is the resource";
         object_set_ref exclude;
-        ddwaf::match_iterator<5> it(resource, object, transformers, exclude);
+        ddwaf::timer deadline{2s};
+        ddwaf::match_iterator<5> it(resource, object, transformers, exclude, deadline);
         EXPECT_TRUE((bool)it);
 
         auto [param, index] = *it;
@@ -307,7 +323,8 @@ TEST(TestMatchIterator, MinLengthReachedAfterTransform)
     // base64("ab")
     std::string resource = "this is the YWI= resource";
     object_set_ref exclude;
-    ddwaf::match_iterator<4> it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator<4> it(resource, object, transformers, exclude, deadline);
     EXPECT_TRUE((bool)it);
 
     auto [param, index] = *it;
@@ -326,7 +343,8 @@ TEST(TestMatchIterator, OnlyTransformedParameterEvaluated)
 
     std::string resource = "this is the RESOURCE";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, transformers, exclude, deadline);
     EXPECT_FALSE((bool)it);
 
     EXPECT_FALSE(++it);
@@ -344,7 +362,8 @@ TEST(TestMatchIterator, EmptyTransformedParameter)
 
     std::string resource = "this is the resource";
     object_set_ref exclude;
-    ddwaf::match_iterator it(resource, object, transformers, exclude);
+    ddwaf::timer deadline{2s};
+    ddwaf::match_iterator it(resource, object, transformers, exclude, deadline);
     EXPECT_FALSE((bool)it);
 
     EXPECT_FALSE(++it);

--- a/tests/unit/condition/shi_detector_string_test.cpp
+++ b/tests/unit/condition/shi_detector_string_test.cpp
@@ -473,4 +473,25 @@ TEST(TestShiDetectorString, NoMatchOnEmptyTransformedParameter)
     EXPECT_FALSE(cache.match);
 }
 
+// Parameters which don't match are skipped within the match iterator, so the
+// deadline must be honoured even when nothing matches
+TEST(TestShiDetectorString, TimeoutWithNonMatchingParams)
+{
+    shi_detector cond{{gen_param_def("server.sys.shell.cmd", "server.request.query")}};
+
+    auto root = object_builder_da::map();
+    root.emplace("server.sys.shell.cmd", "ls -l; cat /etc/passwd");
+    auto array = root.emplace("server.request.query", object_builder_da::array());
+    for (unsigned i = 0; i < 1024; ++i) {
+        array.emplace_back("no-injection-here-" + std::to_string(i));
+    }
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{0s};
+    condition_cache cache;
+    EXPECT_THROW(cond.eval(cache, store, {}, {}, deadline), ddwaf::timeout_exception);
+}
+
 } // namespace

--- a/tests/unit/condition/sqli_detector_test.cpp
+++ b/tests/unit/condition/sqli_detector_test.cpp
@@ -595,4 +595,28 @@ TEST(TestSqliDetectorTransformers, NoMatchOnEmptyTransformedParameter)
     EXPECT_FALSE(cache.match);
 }
 
+// Parameters which don't match are skipped within the match iterator, each one
+// requiring a transformation and a lookup within the statement, so the deadline
+// must be honoured even when nothing matches
+TEST(TestSqliDetectorTransformers, TimeoutWithNonMatchingParams)
+{
+    sqli_detector cond{
+        {gen_param_def("server.db.statement", "server.request.query", "server.db.system")}};
+
+    auto root = object_builder_da::map();
+    root.emplace("server.db.statement", sqli_statement);
+    root.emplace("server.db.system", "mysql");
+    auto array = root.emplace("server.request.query", object_builder_da::array());
+    for (unsigned i = 0; i < 1024; ++i) {
+        array.emplace_back("no-injection-here-" + std::to_string(i));
+    }
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{0s};
+    condition_cache cache;
+    EXPECT_THROW(cond.eval(cache, store, {}, {}, deadline), ddwaf::timeout_exception);
+}
+
 } // namespace

--- a/tests/unit/condition/ssrf_detector_test.cpp
+++ b/tests/unit/condition/ssrf_detector_test.cpp
@@ -693,4 +693,25 @@ TEST(TestSSRFDetectorTransformers, ResourceNotTransformed)
     EXPECT_FALSE(cache.match);
 }
 
+// Parameters which don't match are skipped within the match iterator, so the
+// deadline must be honoured even when nothing matches
+TEST(TestSSRFDetectorTransformers, TimeoutWithNonMatchingParams)
+{
+    ssrf_detector cond{{gen_param_def("server.io.net.url", "server.request.query")}};
+
+    auto root = object_builder_da::map();
+    root.emplace("server.io.net.url", ssrf_url);
+    auto array = root.emplace("server.request.query", object_builder_da::array());
+    for (unsigned i = 0; i < 1024; ++i) {
+        array.emplace_back("no-injection-here-" + std::to_string(i));
+    }
+
+    object_store store;
+    store.insert_and_apply(std::move(root));
+
+    ddwaf::timer deadline{0s};
+    condition_cache cache;
+    EXPECT_THROW(cond.eval(cache, store, {}, {}, deadline), ddwaf::timeout_exception);
+}
+
 } // namespace

--- a/tests/unit/condition/transforming_iterator_test.cpp
+++ b/tests/unit/condition/transforming_iterator_test.cpp
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are
+// dual-licensed under the Apache-2.0 License or BSD-3-Clause License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021 Datadog, Inc.
+
+#include "common/ddwaf_object_da.hpp"
+#include "common/gtest_utils.hpp"
+#include "condition/transforming_iterator.hpp"
+#include "transformer/base.hpp"
+
+using namespace ddwaf;
+using namespace ddwaf::test;
+using namespace std::literals;
+
+namespace {
+
+TEST(TestTransformingIterator, NoTransformers)
+{
+    owned_object object = object_builder_da::array({"value"});
+
+    object_set_ref exclude;
+    ddwaf::timer deadline{2s};
+    transforming_iterator<kv_iterator> it(object, {}, exclude, deadline);
+    ASSERT_TRUE((bool)it);
+
+    EXPECT_STRV((*it).as<std::string_view>(), "value");
+    EXPECT_FALSE(++it);
+}
+
+TEST(TestTransformingIterator, TransformedValue)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = object_builder_da::array({"%72esource"});
+
+    object_set_ref exclude;
+    ddwaf::timer deadline{2s};
+    transforming_iterator<kv_iterator> it(object, transformers, exclude, deadline);
+    ASSERT_TRUE((bool)it);
+
+    EXPECT_STRV((*it).as<std::string_view>(), "resource");
+    EXPECT_FALSE(++it);
+}
+
+// When none of the transformers modify the value, the original one is yielded
+TEST(TestTransformingIterator, UnmodifiedValue)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = object_builder_da::array({"resource"});
+
+    object_set_ref exclude;
+    ddwaf::timer deadline{2s};
+    transforming_iterator<kv_iterator> it(object, transformers, exclude, deadline);
+    ASSERT_TRUE((bool)it);
+
+    EXPECT_STRV((*it).as<std::string_view>(), "resource");
+    EXPECT_FALSE(++it);
+}
+
+// Non-string objects are skipped, including the keys of their parent map
+TEST(TestTransformingIterator, NonStringValuesSkipped)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = object_builder_da::array({22, "%72esource", 4.2, true});
+
+    object_set_ref exclude;
+    ddwaf::timer deadline{2s};
+    transforming_iterator<kv_iterator> it(object, transformers, exclude, deadline);
+    ASSERT_TRUE((bool)it);
+
+    EXPECT_STRV((*it).as<std::string_view>(), "resource");
+    EXPECT_FALSE(++it);
+}
+
+// A transformer may reduce a value to an empty string with no underlying
+// buffer; the yielded object must still expose a valid pointer, as the rest of
+// the codebase assumes string objects are never null
+TEST(TestTransformingIterator, EmptyTransformedValue)
+{
+    const std::vector<transformer_id> transformers{transformer_id::remove_comments};
+
+    owned_object object = object_builder_da::array({"#"});
+
+    object_set_ref exclude;
+    ddwaf::timer deadline{2s};
+    transforming_iterator<kv_iterator> it(object, transformers, exclude, deadline);
+    ASSERT_TRUE((bool)it);
+
+    auto value = (*it).as<std::string_view>();
+    EXPECT_EQ(value.size(), 0);
+    EXPECT_NE(value.data(), nullptr);
+
+    // The yielded object must be usable by anything expecting a string object
+    EXPECT_NO_THROW(cow_string{value});
+
+    EXPECT_FALSE(++it);
+}
+
+// The iterator skips objects internally, so it must evaluate the deadline
+// itself rather than relying on the caller doing so per yielded value
+TEST(TestTransformingIterator, TimeoutWhileSkippingNonStrings)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    auto object = object_builder_da::array();
+    for (unsigned i = 0; i < 1024; ++i) { object.emplace_back(owned_object::make_signed(i)); }
+
+    object_set_ref exclude;
+    ddwaf::timer deadline{0s};
+    EXPECT_THROW((transforming_iterator<kv_iterator>{object, transformers, exclude, deadline}),
+        ddwaf::timeout_exception);
+}
+
+// current_value() and operator* must expose the same value, the latter simply
+// wrapping it in a string object
+TEST(TestTransformingIterator, CurrentValueMatchesObject)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object = object_builder_da::array({"%72esource", "unmodified", "#"});
+
+    object_set_ref exclude;
+    ddwaf::timer deadline{2s};
+    transforming_iterator<kv_iterator> it(object, transformers, exclude, deadline);
+
+    for (const auto *expected : {"resource", "unmodified", "#"}) {
+        ASSERT_TRUE((bool)it);
+        EXPECT_STRV(it.current_value(), expected);
+        EXPECT_STRV((*it).as<std::string_view>(), expected);
+        ++it;
+    }
+
+    EXPECT_FALSE((bool)it);
+}
+
+// Note: operator++ performs the same check, but the deadline can't be expired
+// deterministically half-way through an iteration, as base_timer consults the
+// clock on its very first call. The detector-level regression test in
+// lfi_detector_test.cpp covers the skip loop as a whole.
+
+TEST(TestTransformingIterator, KeyPath)
+{
+    const std::vector<transformer_id> transformers{transformer_id::url_decode};
+
+    owned_object object =
+        object_builder_da::map({{"key", object_builder_da::array({"%72esource"})}});
+
+    object_set_ref exclude;
+    ddwaf::timer deadline{2s};
+    transforming_iterator<kv_iterator> it(object, transformers, exclude, deadline);
+    ASSERT_TRUE((bool)it);
+
+    // The first value yielded by the kv_iterator is the key itself
+    EXPECT_STRV((*it).as<std::string_view>(), "key");
+    EXPECT_TRUE(++it);
+
+    EXPECT_STRV((*it).as<std::string_view>(), "resource");
+    auto path = it.get_current_path();
+    ASSERT_EQ(path.size(), 2);
+    EXPECT_STRV(std::get<std::string_view>(path[0]), "key");
+    EXPECT_EQ(std::get<int64_t>(path[1]), 0);
+
+    EXPECT_FALSE(++it);
+}
+
+} // namespace


### PR DESCRIPTION
This PR makes the following improvements:

- Added `transforming_iterator`, an iterator adapter which yields transformed string values. This is used by lfi, cmdi and `match_iterator`.
- Removed the double transform in `cmdi_impl`, parameters are now transformed once instead of once per check.
- `match_iterator` refactored to move most logic to `transforming_iterator`.
- Added deadline to both iterators, given the newly introduced costs.
- Fixed a empty string transform resulting in a null buffer.
- Added regression tests for both fixes across all five detectors, plus unit tests for the new iterator.