### PR TITLE
Upload ELF debug symbols on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,3 +401,55 @@ jobs:
             ./artifacts/**/*.sha256
             ./artifacts/**/*.nupkg
             ./artifacts/**/*.json
+
+  upload-elf-debug-symbols:
+    needs: [release]
+    runs-on: ubuntu-24.04
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download Linux packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: libddwaf-*-linux-musl
+          path: artifacts
+
+      - name: Extract ELF debug symbols
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p debug-symbols
+          while IFS= read -r -d '' archive; do
+            destination="debug-symbols/$(basename "$(dirname "$archive")")"
+            mkdir -p "$destination"
+            tar --extract --gzip --file="$archive" --directory="$destination" \
+              --wildcards --no-anchored '*.debug'
+          done < <(find artifacts -type f -name '*.tar.gz' ! -name '*-i386-*' -print0)
+
+          if ! find debug-symbols -type f -name '*.debug' -print -quit | grep -q .; then
+            echo "No supported ELF debug symbols found" >&2
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26
+
+      - name: Install datadog-ci
+        run: npm install --global @datadog/datadog-ci@5.21.2
+
+      - name: Obtain Datadog Org 2 credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@639d841c72f15e4e77747bd726ef8105ce971da2 # v1.0.5
+        with:
+          policy: libddwaf-release
+
+      - name: Upload ELF debug symbols
+        env:
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DATADOG_SITE: datadoghq.com
+          DD_BETA_COMMANDS_ENABLED: 1
+        run: datadog-ci elf-symbols upload --disable-git debug-symbols


### PR DESCRIPTION
## Summary

- add a tag-only job after the draft release is created
- download Linux musl packages and extract ELF `.debug` files, excluding unsupported i386
- mint short-lived Org 2 credentials with dd-sts and upload via `datadog-ci`

## Why

Publishing release debug symbols lets Datadog symbolize profiles that contain libddwaf frames without storing a long-lived Datadog API key in GitHub.

## Implementation

- Node 26, floating within the major version
- `@datadog/datadog-ci` 5.21.2, the current npm release
- latest stable action revisions pinned to full commit hashes: `download-artifact` v8.0.1, `setup-node` v7.0.0, and `dd-sts-action` v1.0.5
- upload x86_64, ARMv7, and AArch64 symbols; exclude i386 because `datadog-ci` does not support it

## Validation

- actionlint 1.7.12 schema and expression validation
- `yq` parsing and `git diff --check`
- Linux `datadog-ci --dry-run` against the three supported libddwaf 2.0.1 release archives: 3/3 symbols handled successfully

Companion dd-source policy PR: https://github.com/ddoghq/dd-source/pull/39414
