### PR TITLE
Add large array and map representations

### DIFF
--- a/benchmark/object_generator.cpp
+++ b/benchmark/object_generator.cpp
@@ -124,7 +124,7 @@ void generate_objects(ddwaf_object &root, const object_specification &s)
                 --intermediate;
             }
 
-            if (object->type == DDWAF_OBJ_MAP) {
+            if (ddwaf_object_is_map(object)) {
                 auto *str = generate_random_string(s.key_length);
                 *ddwaf_object_insert_key(object, str, s.key_length, alloc) = next;
             } else {
@@ -140,7 +140,7 @@ void generate_objects(ddwaf_object &root, const object_specification &s)
             for (unsigned i = 0, j = 0; i < ddwaf_object_get_size(object); ++i) {
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                 auto *child = const_cast<ddwaf_object *>(ddwaf_object_at_value(object, i));
-                if (child->type == DDWAF_OBJ_MAP || child->type == DDWAF_OBJ_ARRAY) {
+                if (ddwaf_object_is_map(child) || ddwaf_object_is_array(child)) {
                     object_queue.emplace_back(
                         child, level + 1, next_level[j].intermediate, next_level[j].terminal);
                     ++j;

--- a/benchmark/run_fixture.cpp
+++ b/benchmark/run_fixture.cpp
@@ -42,7 +42,7 @@ void run_fixture::warmup()
             for (; i < ddwaf_object_get_size(current); ++i) {
                 const auto &next = *ddwaf_object_at_value(current, i);
                 if (object_stack.size() <= max_depth &&
-                    (next.type == DDWAF_OBJ_ARRAY || next.type == DDWAF_OBJ_MAP)) {
+                    (ddwaf_object_is_array(&next) || ddwaf_object_is_map(&next))) {
                     break;
                 }
             }

--- a/benchmark/utils.cpp
+++ b/benchmark/utils.cpp
@@ -67,6 +67,7 @@ void object_to_json_helper(
             ddwaf_object_get_string(&obj, nullptr), ddwaf_object_get_length(&obj), alloc);
     } break;
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         output.SetObject();
         for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             rapidjson::Value key;
@@ -82,6 +83,7 @@ void object_to_json_helper(
         }
         break;
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         output.SetArray();
         for (unsigned i = 0; i < ddwaf_object_get_size(&obj); i++) {
             rapidjson::Value value;
@@ -146,6 +148,7 @@ ddwaf_object object_dup(const ddwaf_object &o) noexcept
             &copy, ddwaf_object_get_string(&o, nullptr), ddwaf_object_get_length(&o), alloc);
         break;
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         ddwaf_object_set_array(&copy, ddwaf_object_get_size(&o), alloc);
         for (std::size_t i = 0; i < ddwaf_object_get_size(&o); i++) {
             auto *child_copy = ddwaf_object_insert(&copy, alloc);
@@ -153,6 +156,7 @@ ddwaf_object object_dup(const ddwaf_object &o) noexcept
         }
         break;
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         ddwaf_object_set_map(&copy, ddwaf_object_get_size(&o), alloc);
         for (std::size_t i = 0; i < ddwaf_object_get_size(&o); i++) {
             const auto *child_key = ddwaf_object_at_key(&o, i);

--- a/benchmark/yaml_helpers.cpp
+++ b/benchmark/yaml_helpers.cpp
@@ -113,6 +113,7 @@ YAML::Emitter &operator<<(YAML::Emitter &out, const ddwaf_object &o)
         out << std::string{ddwaf_object_get_string(&o, nullptr), ddwaf_object_get_length(&o)};
         break;
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         out << YAML::BeginSeq;
         for (std::size_t i = 0; i < ddwaf_object_get_size(&o); i++) {
             out << *ddwaf_object_at_value(&o, i);
@@ -120,6 +121,7 @@ YAML::Emitter &operator<<(YAML::Emitter &out, const ddwaf_object &o)
         out << YAML::EndSeq;
         break;
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         out << YAML::BeginMap;
         for (std::size_t i = 0; i < ddwaf_object_get_size(&o); i++) {
             out << YAML::Key << *ddwaf_object_at_key(&o, i);

--- a/docs/c-api/api.md
+++ b/docs/c-api/api.md
@@ -42,6 +42,8 @@ Specifies the type of a ddwaf::object.
 | `DDWAF_OBJ_SMALL_STRING` | `= 0x14` | UTF-8 string of up to 14 bytes in length |
 | `DDWAF_OBJ_ARRAY` | `= 0x20` | Array of ddwaf_object, up to max(uint16) capacity |
 | `DDWAF_OBJ_MAP` | `= 0x40` | Array of ddwaf_object_kv, up to max(uint16) capacity |
+| `DDWAF_OBJ_LARGE_ARRAY` | `= 0xA0` | Array of ddwaf_object with size_t capacity |
+| `DDWAF_OBJ_LARGE_MAP` | `= 0xC0` | Array of ddwaf_object_kv with size_t capacity |
 
 ### DDWAF_RET_CODE
 
@@ -653,10 +655,12 @@ Creates an object using a double, the resulting object will contain a double as 
 #### ddwaf_object_set_array
 
 ```c
-ddwaf_object * ddwaf_object_set_array(ddwaf_object * object, uint16_t capacity, ddwaf_allocator alloc)
+ddwaf_object * ddwaf_object_set_array(ddwaf_object * object, size_t capacity, ddwaf_allocator alloc)
 ```
 
-Creates an array object, for sequential storage.
+Creates an array object for sequential storage. Capacities up to 65,535 use
+`DDWAF_OBJ_ARRAY`; larger capacities use `DDWAF_OBJ_LARGE_ARRAY`. A compact
+array is automatically promoted when insertion grows it beyond 65,535 elements.
 
 **Parameters:**
 
@@ -669,10 +673,12 @@ Creates an array object, for sequential storage.
 #### ddwaf_object_set_map
 
 ```c
-ddwaf_object * ddwaf_object_set_map(ddwaf_object * object, uint16_t capacity, ddwaf_allocator alloc)
+ddwaf_object * ddwaf_object_set_map(ddwaf_object * object, size_t capacity, ddwaf_allocator alloc)
 ```
 
-Creates a map object, for key-value storage.
+Creates a map object for key-value storage. Capacities up to 65,535 use
+`DDWAF_OBJ_MAP`; larger capacities use `DDWAF_OBJ_LARGE_MAP`. A compact map is
+automatically promoted when insertion grows it beyond 65,535 entries.
 
 **Parameters:**
 
@@ -837,6 +843,9 @@ Inserts a new object into an array object.
 
 **Returns:** A pointer to the newly inserted object or NULL if the operation failed.
 
+> **Note:** An insertion that grows or promotes the array invalidates pointers to
+> its existing elements.
+
 #### ddwaf_object_insert_key
 
 ```c
@@ -854,6 +863,9 @@ Inserts a new object into a map object, using a key.
 
 **Returns:** A pointer to the newly inserted object or NULL if the operation failed.
 
+> **Note:** An insertion that grows or promotes the map invalidates pointers to
+> its existing keys and values.
+
 #### ddwaf_object_insert_literal_key
 
 ```c
@@ -870,6 +882,9 @@ Inserts a new object into a map object, using a literal key.
 - `alloc`: Allocator to use for memory allocation. (nonnull)
 
 **Returns:** A pointer to the newly inserted object or NULL if the operation failed.
+
+> **Note:** An insertion that grows or promotes the map invalidates pointers to
+> its existing keys and values.
 
 #### ddwaf_object_insert_key_nocopy
 
@@ -889,6 +904,9 @@ Inserts a new object into a map object, using a key and its length, but without 
 **Returns:** A pointer to the newly inserted object or NULL if the operation failed.
 
 > **Note:** The provided string must have been allocated with the same allocator used with ddwaf_object_destroy.
+
+> **Note:** An insertion that grows or promotes the map invalidates pointers to
+> its existing keys and values.
 
 #### ddwaf_object_at_key
 

--- a/docs/c-api/api.md
+++ b/docs/c-api/api.md
@@ -42,8 +42,8 @@ Specifies the type of a ddwaf::object.
 | `DDWAF_OBJ_SMALL_STRING` | `= 0x14` | UTF-8 string of up to 14 bytes in length |
 | `DDWAF_OBJ_ARRAY` | `= 0x20` | Array of ddwaf_object, up to max(uint16) capacity |
 | `DDWAF_OBJ_MAP` | `= 0x40` | Array of ddwaf_object_kv, up to max(uint16) capacity |
-| `DDWAF_OBJ_LARGE_ARRAY` | `= 0xA0` | Array of ddwaf_object with size_t capacity |
-| `DDWAF_OBJ_LARGE_MAP` | `= 0xC0` | Array of ddwaf_object_kv with size_t capacity |
+| `DDWAF_OBJ_LARGE_ARRAY` | `= 0xA0` | Array of ddwaf_object with up to 28-bit capacity |
+| `DDWAF_OBJ_LARGE_MAP` | `= 0xC0` | Array of ddwaf_object_kv with up to 28-bit capacity |
 
 ### DDWAF_RET_CODE
 
@@ -661,8 +661,10 @@ ddwaf_object * ddwaf_object_set_array(ddwaf_object * object, size_t capacity, dd
 Creates an array object for sequential storage. Capacities up to 65,535 use
 `DDWAF_OBJ_ARRAY`; larger capacities use `DDWAF_OBJ_LARGE_ARRAY`. A compact
 array is automatically promoted when insertion grows it beyond 65,535 elements.
-
-**Parameters:**
+Large arrays use 28-bit metadata fields for size and capacity. Their capacity
+is limited to the smaller of 268,435,455 elements and
+`SIZE_MAX / sizeof(ddwaf_object)`. An insertion that grows or promotes the array
+invalidates its element pointer and pointers to existing elements.
 
 - `object`: Object to perform the operation on. (nonnull)
 - `capacity`: Initial capacity of the array.
@@ -678,7 +680,11 @@ ddwaf_object * ddwaf_object_set_map(ddwaf_object * object, size_t capacity, ddwa
 
 Creates a map object for key-value storage. Capacities up to 65,535 use
 `DDWAF_OBJ_MAP`; larger capacities use `DDWAF_OBJ_LARGE_MAP`. A compact map is
-automatically promoted when insertion grows it beyond 65,535 entries.
+automatically promoted when insertion grows it beyond 65,535 entries. Large
+maps use 28-bit metadata fields for size and capacity. Their capacity is
+limited to the smaller of 268,435,455 entries and
+`SIZE_MAX / sizeof(ddwaf_object_kv)`. An insertion that grows or promotes the
+map invalidates its element pointer and pointers to existing keys and values.
 
 **Parameters:**
 

--- a/docs/c-api/api.md
+++ b/docs/c-api/api.md
@@ -666,6 +666,13 @@ is limited to the smaller of 268,435,455 elements and
 `SIZE_MAX / sizeof(ddwaf_object)`. An insertion that grows or promotes the array
 invalidates its element pointer and pointers to existing elements.
 
+In this header, `ddwaf_object_set_array` is defined as
+`ddwaf_object_set_array_large`. The old `ddwaf_object_set_array` binary symbol,
+which takes a `uint16_t` capacity, is deprecated and retained only for binary
+compatibility. Source code should continue using `ddwaf_object_set_array`.
+Do not call `ddwaf_object_set_array_large` directly; it is a transitional ABI
+symbol and will be removed in version 3.
+
 - `object`: Object to perform the operation on. (nonnull)
 - `capacity`: Initial capacity of the array.
 - `alloc`: Allocator to use for memory allocation. (nonnull)
@@ -686,7 +693,12 @@ limited to the smaller of 268,435,455 entries and
 `SIZE_MAX / sizeof(ddwaf_object_kv)`. An insertion that grows or promotes the
 map invalidates its element pointer and pointers to existing keys and values.
 
-**Parameters:**
+In this header, `ddwaf_object_set_map` is defined as
+`ddwaf_object_set_map_large`. The old `ddwaf_object_set_map` binary symbol,
+which takes a `uint16_t` capacity, is deprecated and retained only for binary
+compatibility. Source code should continue using `ddwaf_object_set_map`.
+Do not call `ddwaf_object_set_map_large` directly; it is a transitional ABI
+symbol and will be removed in version 3.
 
 - `object`: Object to perform the operation on. (nonnull)
 - `capacity`: Initial capacity of the map.

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -42,7 +42,7 @@ template <> struct as_if<ddwaf_object, void> {
         std::list<std::tuple<ddwaf_object *, YAML::Node, YAML::Node::const_iterator>> stack;
 
         ddwaf_object root = yaml_to_object_helper(node, alloc);
-        if (root.type == DDWAF_OBJ_MAP || root.type == DDWAF_OBJ_ARRAY) {
+        if (ddwaf_object_is_map(&root) || ddwaf_object_is_array(&root)) {
             stack.emplace_back(&root, node, node.begin());
         }
 
@@ -54,16 +54,16 @@ template <> struct as_if<ddwaf_object, void> {
                 YAML::Node child_node = parent_node.IsMap() ? it->second : *it;
                 auto child_obj = yaml_to_object_helper(child_node, alloc);
                 ddwaf_object *child_ptr = nullptr;
-                if (parent_obj->type == DDWAF_OBJ_MAP) {
+                if (ddwaf_object_is_map(parent_obj)) {
                     auto key = it->first.as<std::string>();
                     child_ptr = ddwaf_object_insert_key(parent_obj, key.c_str(), key.size(), alloc);
                     *child_ptr = child_obj;
-                } else if (parent_obj->type == DDWAF_OBJ_ARRAY) {
+                } else if (ddwaf_object_is_array(parent_obj)) {
                     child_ptr = ddwaf_object_insert(parent_obj, alloc);
                     *child_ptr = child_obj;
                 }
 
-                if (child_obj.type == DDWAF_OBJ_MAP || child_obj.type == DDWAF_OBJ_ARRAY) {
+                if (ddwaf_object_is_map(&child_obj) || ddwaf_object_is_array(&child_obj)) {
                     stack.emplace_back(child_ptr, child_node, child_node.begin());
                     ++it;
                     break;
@@ -110,9 +110,11 @@ YAML::Node object_to_yaml_helper(const ddwaf_object &obj)
         }
         break;
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         output = YAML::Load("{}");
         break;
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         output = YAML::Load("[]");
         break;
     case DDWAF_OBJ_INVALID:
@@ -130,7 +132,7 @@ YAML::Node object_to_yaml(const ddwaf_object &obj)
     std::list<std::tuple<const ddwaf_object &, YAML::Node, std::size_t>> stack;
 
     YAML::Node root = object_to_yaml_helper(obj);
-    if (obj.type == DDWAF_OBJ_MAP || obj.type == DDWAF_OBJ_ARRAY) {
+    if (ddwaf_object_is_map(&obj) || ddwaf_object_is_array(&obj)) {
         stack.emplace_back(obj, root, 0);
     }
 
@@ -141,7 +143,7 @@ YAML::Node object_to_yaml(const ddwaf_object &obj)
         size_t size = ddwaf_object_get_size(&parent_obj);
         for (; index < size; ++index) {
             const ddwaf_object *child_obj = nullptr;
-            if (parent_obj.type == DDWAF_OBJ_MAP) {
+            if (ddwaf_object_is_map(&parent_obj)) {
                 child_obj = ddwaf_object_at_value(&parent_obj, index);
                 auto *key_obj = ddwaf_object_at_key(&parent_obj, index);
                 size_t key_len;
@@ -151,17 +153,17 @@ YAML::Node object_to_yaml(const ddwaf_object &obj)
                 auto child_node = object_to_yaml_helper(*child_obj);
                 parent_node[key] = child_node;
 
-                if (child_obj->type == DDWAF_OBJ_MAP || child_obj->type == DDWAF_OBJ_ARRAY) {
+                if (ddwaf_object_is_map(child_obj) || ddwaf_object_is_array(child_obj)) {
                     stack.emplace_back(*child_obj, child_node, 0);
                     ++index;
                     break;
                 }
-            } else if (parent_obj.type == DDWAF_OBJ_ARRAY) {
+            } else if (ddwaf_object_is_array(&parent_obj)) {
                 child_obj = ddwaf_object_at_value(&parent_obj, index);
                 auto child_node = object_to_yaml_helper(*child_obj);
                 parent_node.push_back(child_node);
 
-                if (child_obj->type == DDWAF_OBJ_MAP || child_obj->type == DDWAF_OBJ_ARRAY) {
+                if (ddwaf_object_is_map(child_obj) || ddwaf_object_is_array(child_obj)) {
                     stack.emplace_back(*child_obj, child_node, 0);
                     ++index;
                     break;

--- a/fuzzer/global/src/helpers.cpp
+++ b/fuzzer/global/src/helpers.cpp
@@ -49,6 +49,7 @@ void _print_object(ddwaf_object entry, uint8_t depth)
 
     switch (entry.type) {
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         if (ddwaf_object_get_size(&entry) == 0) {
             std::cerr << "{}";
         } else {
@@ -79,6 +80,7 @@ void _print_object(ddwaf_object entry, uint8_t depth)
         break;
 
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         if (ddwaf_object_get_size(&entry) == 0) {
             indent(depth);
             std::cerr << "[]";

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -173,37 +173,22 @@ struct _ddwaf_object_map {
 
 // Large-container metadata uses 28-bit fields for size and capacity, for a
 // maximum of 268,435,455 elements (potentially lower on 32-bit platforms due
-// to allocation-size limits). metadata._type overlays the direct uint8_t type
-// view, and ptr points directly to the contiguous elements. Any insertion that
-// grows the container invalidates ptr and pointers to its elements.
+// to allocation-size limits). _type overlays the direct uint8_t type view of
+// ddwaf_object, and ptr points directly to the contiguous elements. Any
+// insertion that grows the container invalidates ptr and pointers to its
+// elements.
 struct _ddwaf_object_large_array {
-    union {
-        uint8_t type;
-        struct {
-            uint64_t _type : 8;
-            uint64_t size : 28;
-            uint64_t capacity : 28;
-        } metadata;
-    };
-    union {
-        uint64_t _padding;
-        union _ddwaf_object *ptr;
-    };
+    uint64_t _type : 8;
+    uint64_t size : 28;
+    uint64_t capacity : 28;
+    union _ddwaf_object *ptr;
 };
 
 struct _ddwaf_object_large_map {
-    union {
-        uint8_t type;
-        struct {
-            uint64_t _type : 8;
-            uint64_t size : 28;
-            uint64_t capacity : 28;
-        } metadata;
-    };
-    union {
-        uint64_t _padding;
-        struct _ddwaf_object_kv *ptr;
-    };
+    uint64_t _type : 8;
+    uint64_t size : 28;
+    uint64_t capacity : 28;
+    struct _ddwaf_object_kv *ptr;
 };
 
 /**

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -171,12 +171,6 @@ struct _ddwaf_object_map {
     struct _ddwaf_object_kv *ptr;
 };
 
-// Large-container metadata uses 28-bit fields for size and capacity, for a
-// maximum of 268,435,455 elements (potentially lower on 32-bit platforms due
-// to allocation-size limits). _type overlays the direct uint8_t type view of
-// ddwaf_object, and ptr points directly to the contiguous elements. Any
-// insertion that grows the container invalidates ptr and pointers to its
-// elements.
 struct _ddwaf_object_large_array {
     uint64_t _type : 8;
     uint64_t size : 28;
@@ -936,11 +930,7 @@ ddwaf_object* ddwaf_object_set_bool(ddwaf_object *object, bool value);
 ddwaf_object* ddwaf_object_set_float(ddwaf_object *object, double value);
 
 /**
- * Creates an array object for sequential storage. Capacities up to 65,535 use
- * DDWAF_OBJ_ARRAY; larger capacities use DDWAF_OBJ_LARGE_ARRAY. A compact array
- * is promoted automatically when insertion grows it beyond 65,535 elements.
- * Large arrays are limited to the smaller of 268,435,455 elements and
- * SIZE_MAX / sizeof(ddwaf_object).
+ * Creates an array object for sequential storage.
  *
  * @param object Object to perform the operation on. (nonnull)
  * @param capacity Initial capacity of the array.
@@ -948,14 +938,27 @@ ddwaf_object* ddwaf_object_set_float(ddwaf_object *object, double value);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_set_array(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc);
+ddwaf_object* ddwaf_object_set_array(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc);
 
 /**
- * Creates a map object for key-value storage. Capacities up to 65,535 use
- * DDWAF_OBJ_MAP; larger capacities use DDWAF_OBJ_LARGE_MAP. A compact map is
- * promoted automatically when insertion grows it beyond 65,535 entries. Large
- * maps are limited to the smaller of 268,435,455 entries and
- * SIZE_MAX / sizeof(ddwaf_object_kv).
+ * Creates an array object for sequential storage with a size_t initial
+ * capacity. Capacities above 65,535 use DDWAF_OBJ_LARGE_ARRAY. Large arrays are
+ * limited to the smaller of 268,435,455 elements and
+ * SIZE_MAX / sizeof(ddwaf_object).
+ *
+ * @warning This is a transitional ABI symbol. Source code must use
+ * ddwaf_object_set_array. This symbol will be removed in version 3.
+ *
+ * @param object Object to perform the operation on. (nonnull)
+ * @param capacity Initial capacity of the array.
+ * @param alloc Allocator to use for memory allocation. (nonnull)
+ *
+ * @return A pointer to the passed object or NULL if the operation failed.
+ **/
+ddwaf_object* ddwaf_object_set_array_large(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc);
+
+/**
+ * Creates a map object for key-value storage.
  *
  * @param object Object to perform the operation on. (nonnull)
  * @param capacity Initial capacity of the map.
@@ -963,7 +966,23 @@ ddwaf_object* ddwaf_object_set_array(ddwaf_object *object, size_t capacity, ddwa
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_set_map(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc);
+ddwaf_object* ddwaf_object_set_map(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc);
+
+/**
+ * Creates a map object for key-value storage with a size_t initial capacity.
+ * Capacities above 65,535 use DDWAF_OBJ_LARGE_MAP. Large maps are limited to
+ * the smaller of 268,435,455 entries and SIZE_MAX / sizeof(ddwaf_object_kv).
+ *
+ * @warning This is a transitional ABI symbol. Source code must use
+ * ddwaf_object_set_map. This symbol will be removed in version 3.
+ *
+ * @param object Object to perform the operation on. (nonnull)
+ * @param capacity Initial capacity of the map.
+ * @param alloc Allocator to use for memory allocation. (nonnull)
+ *
+ * @return A pointer to the passed object or NULL if the operation failed.
+ **/
+ddwaf_object* ddwaf_object_set_map_large(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc);
 
 /**
  * Inserts a new object into an array object.
@@ -1277,5 +1296,13 @@ bool ddwaf_set_log_cb(ddwaf_log_cb cb, DDWAF_LOG_LEVEL min_level);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#define ddwaf_object_set_array ddwaf_object_set_array_large
+#define ddwaf_object_set_map ddwaf_object_set_map_large
+
+/* The aliases above remain valid because they predate the poisoned identifiers. */
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(DDWAF_DISABLE_API_POISON)
+#pragma GCC poison ddwaf_object_set_array_large ddwaf_object_set_map_large
+#endif
 
 #endif /*DDWAF_H */

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -63,6 +63,10 @@ typedef enum
     DDWAF_OBJ_ARRAY    = 0x20,
     /** Array of ddwaf_object_kv, up to max(uint16) capacity **/
     DDWAF_OBJ_MAP      = 0x40,
+    /** Array of ddwaf_object with size_t capacity **/
+    DDWAF_OBJ_LARGE_ARRAY = 0xA0,
+    /** Array of ddwaf_object_kv with size_t capacity **/
+    DDWAF_OBJ_LARGE_MAP = 0xC0,
 } DDWAF_OBJ_TYPE;
 
 /**
@@ -167,6 +171,29 @@ struct _ddwaf_object_map {
     struct _ddwaf_object_kv *ptr;
 };
 
+// Large-container ptr fields point directly to the contiguous elements. Their
+// size and capacity are stored in a private allocation header immediately
+// before the referenced elements and must be queried through the public
+// accessors. Any insertion that grows the container invalidates ptr and
+// pointers to its elements.
+struct _ddwaf_object_large_array {
+    uint8_t type;
+    uint8_t reserved[7];
+    union {
+        uint64_t _padding;
+        union _ddwaf_object *ptr;
+    };
+};
+
+struct _ddwaf_object_large_map {
+    uint8_t type;
+    uint8_t reserved[7];
+    union {
+        uint64_t _padding;
+        struct _ddwaf_object_kv *ptr;
+    };
+};
+
 /**
  * @struct ddwaf_object
  *
@@ -187,6 +214,8 @@ union __attribute__((may_alias)) _ddwaf_object {
         struct _ddwaf_object_small_string sstr;
         struct _ddwaf_object_array array;
         struct _ddwaf_object_map map;
+        struct _ddwaf_object_large_array large_array;
+        struct _ddwaf_object_large_map large_map;
     } via;
 };
 
@@ -202,6 +231,8 @@ struct _ddwaf_object_kv {
 
 static_assert(sizeof(union _ddwaf_object) == 16);
 static_assert(sizeof(struct _ddwaf_object_kv) == 32);
+static_assert(offsetof(struct _ddwaf_object_large_array, ptr) == 8);
+static_assert(offsetof(struct _ddwaf_object_large_map, ptr) == 8);
 #endif
 
 /**
@@ -919,7 +950,9 @@ ddwaf_object* ddwaf_object_set_bool(ddwaf_object *object, bool value);
 ddwaf_object* ddwaf_object_set_float(ddwaf_object *object, double value);
 
 /**
- * Creates an array object, for sequential storage.
+ * Creates an array object for sequential storage. Capacities up to 65,535 use
+ * DDWAF_OBJ_ARRAY; larger capacities use DDWAF_OBJ_LARGE_ARRAY. A compact array
+ * is promoted automatically when insertion grows it beyond 65,535 elements.
  *
  * @param object Object to perform the operation on. (nonnull)
  * @param capacity Initial capacity of the array.
@@ -927,10 +960,12 @@ ddwaf_object* ddwaf_object_set_float(ddwaf_object *object, double value);
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_set_array(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc);
+ddwaf_object* ddwaf_object_set_array(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc);
 
 /**
- * Creates a map object, for key-value storage.
+ * Creates a map object for key-value storage. Capacities up to 65,535 use
+ * DDWAF_OBJ_MAP; larger capacities use DDWAF_OBJ_LARGE_MAP. A compact map is
+ * promoted automatically when insertion grows it beyond 65,535 entries.
  *
  * @param object Object to perform the operation on. (nonnull)
  * @param capacity Initial capacity of the map.
@@ -938,7 +973,7 @@ ddwaf_object* ddwaf_object_set_array(ddwaf_object *object, uint16_t capacity, dd
  *
  * @return A pointer to the passed object or NULL if the operation failed.
  **/
-ddwaf_object* ddwaf_object_set_map(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc);
+ddwaf_object* ddwaf_object_set_map(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc);
 
 /**
  * Inserts a new object into an array object.
@@ -947,6 +982,9 @@ ddwaf_object* ddwaf_object_set_map(ddwaf_object *object, uint16_t capacity, ddwa
  * @param alloc Allocator to use for memory allocation. (nonnull)
  *
  * @return A pointer to the newly inserted object or NULL if the operation failed.
+ *
+ * @note An insertion that grows or promotes the array invalidates pointers to
+ * existing elements.
  **/
 
 ddwaf_object *ddwaf_object_insert(ddwaf_object *array, ddwaf_allocator alloc);
@@ -960,6 +998,9 @@ ddwaf_object *ddwaf_object_insert(ddwaf_object *array, ddwaf_allocator alloc);
  * @param alloc Allocator to use for memory allocation. (nonnull)
  *
  * @return A pointer to the newly inserted object or NULL if the operation failed.
+ *
+ * @note An insertion that grows or promotes the map invalidates pointers to
+ * existing keys and values.
  **/
 ddwaf_object *ddwaf_object_insert_key(ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc);
 
@@ -972,6 +1013,9 @@ ddwaf_object *ddwaf_object_insert_key(ddwaf_object *map, const char *key, uint32
  * @param alloc Allocator to use for memory allocation. (nonnull)
  *
  * @return A pointer to the newly inserted object or NULL if the operation failed.
+ *
+ * @note An insertion that grows or promotes the map invalidates pointers to
+ * existing keys and values.
  **/
 ddwaf_object *ddwaf_object_insert_literal_key(ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc);
 
@@ -989,6 +1033,8 @@ ddwaf_object *ddwaf_object_insert_literal_key(ddwaf_object *map, const char *key
  *
  * @note The provided string must have been allocated with the same allocator used
  * with ddwaf_object_destroy.
+ * @note An insertion that grows or promotes the map invalidates pointers to
+ * existing keys and values.
  **/
 ddwaf_object *ddwaf_object_insert_key_nocopy(ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc);
 

--- a/include/ddwaf.h
+++ b/include/ddwaf.h
@@ -63,9 +63,9 @@ typedef enum
     DDWAF_OBJ_ARRAY    = 0x20,
     /** Array of ddwaf_object_kv, up to max(uint16) capacity **/
     DDWAF_OBJ_MAP      = 0x40,
-    /** Array of ddwaf_object with size_t capacity **/
+    /** Array of ddwaf_object with up to 28-bit capacity **/
     DDWAF_OBJ_LARGE_ARRAY = 0xA0,
-    /** Array of ddwaf_object_kv with size_t capacity **/
+    /** Array of ddwaf_object_kv with up to 28-bit capacity **/
     DDWAF_OBJ_LARGE_MAP = 0xC0,
 } DDWAF_OBJ_TYPE;
 
@@ -171,14 +171,20 @@ struct _ddwaf_object_map {
     struct _ddwaf_object_kv *ptr;
 };
 
-// Large-container ptr fields point directly to the contiguous elements. Their
-// size and capacity are stored in a private allocation header immediately
-// before the referenced elements and must be queried through the public
-// accessors. Any insertion that grows the container invalidates ptr and
-// pointers to its elements.
+// Large-container metadata uses 28-bit fields for size and capacity, for a
+// maximum of 268,435,455 elements (potentially lower on 32-bit platforms due
+// to allocation-size limits). metadata._type overlays the direct uint8_t type
+// view, and ptr points directly to the contiguous elements. Any insertion that
+// grows the container invalidates ptr and pointers to its elements.
 struct _ddwaf_object_large_array {
-    uint8_t type;
-    uint8_t reserved[7];
+    union {
+        uint8_t type;
+        struct {
+            uint64_t _type : 8;
+            uint64_t size : 28;
+            uint64_t capacity : 28;
+        } metadata;
+    };
     union {
         uint64_t _padding;
         union _ddwaf_object *ptr;
@@ -186,8 +192,14 @@ struct _ddwaf_object_large_array {
 };
 
 struct _ddwaf_object_large_map {
-    uint8_t type;
-    uint8_t reserved[7];
+    union {
+        uint8_t type;
+        struct {
+            uint64_t _type : 8;
+            uint64_t size : 28;
+            uint64_t capacity : 28;
+        } metadata;
+    };
     union {
         uint64_t _padding;
         struct _ddwaf_object_kv *ptr;
@@ -223,17 +235,6 @@ struct _ddwaf_object_kv {
     union _ddwaf_object key;
     union _ddwaf_object val;
 };
-
-#if defined(_Static_assert) || defined(static_assert)
-#ifndef static_assert
-#define static_assert _Static_assert
-#endif
-
-static_assert(sizeof(union _ddwaf_object) == 16);
-static_assert(sizeof(struct _ddwaf_object_kv) == 32);
-static_assert(offsetof(struct _ddwaf_object_large_array, ptr) == 8);
-static_assert(offsetof(struct _ddwaf_object_large_map, ptr) == 8);
-#endif
 
 /**
  * @typedef ddwaf_log_cb
@@ -953,6 +954,8 @@ ddwaf_object* ddwaf_object_set_float(ddwaf_object *object, double value);
  * Creates an array object for sequential storage. Capacities up to 65,535 use
  * DDWAF_OBJ_ARRAY; larger capacities use DDWAF_OBJ_LARGE_ARRAY. A compact array
  * is promoted automatically when insertion grows it beyond 65,535 elements.
+ * Large arrays are limited to the smaller of 268,435,455 elements and
+ * SIZE_MAX / sizeof(ddwaf_object).
  *
  * @param object Object to perform the operation on. (nonnull)
  * @param capacity Initial capacity of the array.
@@ -965,7 +968,9 @@ ddwaf_object* ddwaf_object_set_array(ddwaf_object *object, size_t capacity, ddwa
 /**
  * Creates a map object for key-value storage. Capacities up to 65,535 use
  * DDWAF_OBJ_MAP; larger capacities use DDWAF_OBJ_LARGE_MAP. A compact map is
- * promoted automatically when insertion grows it beyond 65,535 entries.
+ * promoted automatically when insertion grows it beyond 65,535 entries. Large
+ * maps are limited to the smaller of 268,435,455 entries and
+ * SIZE_MAX / sizeof(ddwaf_object_kv).
  *
  * @param object Object to perform the operation on. (nonnull)
  * @param capacity Initial capacity of the map.

--- a/libddwaf.def
+++ b/libddwaf.def
@@ -38,7 +38,9 @@ EXPORTS
   ddwaf_object_set_string
   ddwaf_object_set_string_literal
   ddwaf_object_set_array
+  ddwaf_object_set_array_large
   ddwaf_object_set_map
+  ddwaf_object_set_map_large
   ddwaf_object_from_json
   ddwaf_object_insert
   ddwaf_object_insert_key

--- a/smoketest/smoke.c
+++ b/smoketest/smoke.c
@@ -177,13 +177,15 @@ static void _hstring_write_pwargs(hstring *str, size_t depth,
         HSTRING_APPEND_CONST(str, "\n");
         break;
     }
-    case DDWAF_OBJ_ARRAY: {
+    case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY: {
         HSTRING_APPEND_CONST(str, "<ARRAY>\n");
         for (size_t i = 0; i < ddwaf_object_get_size(pwargs); i++) {
             _hstring_write_pwargs(str, depth + 1, ddwaf_object_at_value(pwargs, i));
         }
         break;
-    case DDWAF_OBJ_MAP: {
+    case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP: {
         HSTRING_APPEND_CONST(str, "<MAP>\n");
         for (size_t i = 0; i < ddwaf_object_get_size(pwargs); i++) {
             const ddwaf_object *key = ddwaf_object_at_key(pwargs, i);

--- a/src/condition/cmdi_detector.cpp
+++ b/src/condition/cmdi_detector.cpp
@@ -29,7 +29,6 @@
 #include "iterator.hpp"
 #include "log.hpp"
 #include "object.hpp"
-#include "object_type.hpp"
 #include "platform.hpp"
 #include "tokenizer/shell.hpp"
 #include "transformer/base.hpp"

--- a/src/condition/cmdi_detector.cpp
+++ b/src/condition/cmdi_detector.cpp
@@ -438,7 +438,7 @@ bool cmdi_detector::eval_impl(const unary_argument<object_view> &resource,
     const variadic_argument<object_view> &params, condition_cache &cache,
     const object_set_ref &objects_excluded, ddwaf::timer &deadline) const
 {
-    if (resource.value.type() != object_type::array || resource.value.empty()) {
+    if (!resource.value.is_array() || resource.value.empty()) {
         return {};
     }
 

--- a/src/condition/exists.cpp
+++ b/src/condition/exists.cpp
@@ -33,13 +33,9 @@ object_view get_key(object_view root, const std::variant<std::string, int64_t> &
     }
 
     if (root.is_array() && std::holds_alternative<int64_t>(key)) {
-        auto index = std::get<int64_t>(key);
-        if (index >= 0 && root.size<int64_t>() > index) {
-            return root.at_value(index);
-        }
-
-        if (index < 0 && root.size<int64_t>() + index >= 0) {
-            return root.at_value(root.size<int64_t>() + index);
+        const auto index = detail::normalize_index(root.size(), std::get<int64_t>(key));
+        if (index) {
+            return root.at_value(*index);
         }
     }
 
@@ -55,11 +51,11 @@ search_outcome exists(object_view root,
     }
 
     auto it = key_path.begin();
-    if (std::holds_alternative<std::string>(*it) && root.type() != object_type::map) {
+    if (std::holds_alternative<std::string>(*it) && !root.is_map()) {
         return search_outcome::not_found;
     }
 
-    if (std::holds_alternative<int64_t>(*it) && root.type() != object_type::array) {
+    if (std::holds_alternative<int64_t>(*it) && !root.is_array()) {
         return search_outcome::not_found;
     }
 
@@ -74,11 +70,11 @@ search_outcome exists(object_view root,
             return search_outcome::found;
         }
 
-        if (std::holds_alternative<std::string>(*it) && root.type() != object_type::map) {
+        if (std::holds_alternative<std::string>(*it) && !root.is_map()) {
             return search_outcome::not_found;
         }
 
-        if (std::holds_alternative<int64_t>(*it) && root.type() != object_type::array) {
+        if (std::holds_alternative<int64_t>(*it) && !root.is_array()) {
             return search_outcome::not_found;
         }
     }

--- a/src/condition/exists.cpp
+++ b/src/condition/exists.cpp
@@ -17,7 +17,6 @@
 #include "exception.hpp"
 #include "exclusion/common.hpp"
 #include "object.hpp"
-#include "object_type.hpp"
 #include "utils.hpp"
 
 namespace ddwaf {

--- a/src/condition/shi_detector.cpp
+++ b/src/condition/shi_detector.cpp
@@ -118,7 +118,7 @@ bool shi_detector::eval_impl(const unary_argument<object_view> &resource,
         return eval_string(resource, params, cache, objects_excluded, deadline);
     }
 
-    if (resource.value.type() == object_type::array) {
+    if (resource.value.is_array()) {
         return eval_array(resource, params, cache, objects_excluded, deadline);
     }
 

--- a/src/condition/shi_detector.cpp
+++ b/src/condition/shi_detector.cpp
@@ -18,7 +18,6 @@
 #include "exclusion/common.hpp"
 #include "log.hpp"
 #include "object.hpp"
-#include "object_type.hpp"
 #include "tokenizer/shell.hpp"
 #include "utils.hpp"
 

--- a/src/configuration/common/raw_configuration.cpp
+++ b/src/configuration/common/raw_configuration.cpp
@@ -27,8 +27,10 @@ std::string strtype(object_type type)
 {
     switch (type) {
     case object_type::map:
+    case object_type::large_map:
         return "map";
     case object_type::array:
+    case object_type::large_array:
         return "array";
     case object_type::string:
     case object_type::literal_string:

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -4,6 +4,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+// This translation unit defines the transitional ABI entry points.
+#define DDWAF_DISABLE_API_POISON
+
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
@@ -835,7 +838,16 @@ ddwaf_object *ddwaf_object_float(ddwaf_object *object, double value)
     return ddwaf_object_set_float(object, value);
 }
 
-ddwaf_object *ddwaf_object_set_array(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc)
+#undef ddwaf_object_set_array
+#undef ddwaf_object_set_map
+
+ddwaf_object *ddwaf_object_set_array(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc)
+{
+    return ddwaf_object_set_array_large(object, capacity, alloc);
+}
+
+ddwaf_object *ddwaf_object_set_array_large(
+    ddwaf_object *object, size_t capacity, ddwaf_allocator alloc)
 {
     if (object == nullptr || alloc == nullptr) {
         return nullptr;
@@ -850,7 +862,13 @@ ddwaf_object *ddwaf_object_set_array(ddwaf_object *object, size_t capacity, ddwa
     return nullptr;
 }
 
-ddwaf_object *ddwaf_object_set_map(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc)
+ddwaf_object *ddwaf_object_set_map(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc)
+{
+    return ddwaf_object_set_map_large(object, capacity, alloc);
+}
+
+ddwaf_object *ddwaf_object_set_map_large(
+    ddwaf_object *object, size_t capacity, ddwaf_allocator alloc)
 {
     if (object == nullptr || alloc == nullptr) {
         return nullptr;

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -120,30 +120,23 @@ static_assert(offsetof(detail::object_map, ptr) == offsetof(_ddwaf_object_map, p
 // detail::object_large_array == _ddwaf_object_large_array
 static_assert(sizeof(detail::object_large_array) == sizeof(_ddwaf_object_large_array));
 static_assert(
-    offsetof(detail::object_large_array, type) == offsetof(_ddwaf_object_large_array, type));
-static_assert(offsetof(detail::object_large_array, metadata) ==
-              offsetof(_ddwaf_object_large_array, metadata));
-static_assert(sizeof(decltype(detail::object_large_array::metadata)) ==
-              sizeof(decltype(_ddwaf_object_large_array::metadata)));
-static_assert(
     offsetof(detail::object_large_array, ptr) == offsetof(_ddwaf_object_large_array, ptr));
-static_assert(std::is_same_v<decltype(detail::object_large_array::type), object_type>);
-static_assert(std::is_same_v<decltype(_ddwaf_object_large_array::type), uint8_t>);
 static_assert(std::is_same_v<decltype(detail::object_large_array::ptr), detail::object *>);
 static_assert(std::is_same_v<decltype(_ddwaf_object_large_array::ptr), ddwaf_object *>);
+#if defined(__GNUC__) && !defined(__clang__)
+constexpr _ddwaf_object_large_array ddwaf_object_large_array_type_byte_probe{._type = 0xFF};
+static_assert(__builtin_memcmp(&ddwaf_object_large_array_type_byte_probe, "\xFF", 1) == 0);
+#endif
 
 // detail::object_large_map == _ddwaf_object_large_map
 static_assert(sizeof(detail::object_large_map) == sizeof(_ddwaf_object_large_map));
-static_assert(offsetof(detail::object_large_map, type) == offsetof(_ddwaf_object_large_map, type));
-static_assert(
-    offsetof(detail::object_large_map, metadata) == offsetof(_ddwaf_object_large_map, metadata));
-static_assert(sizeof(decltype(detail::object_large_map::metadata)) ==
-              sizeof(decltype(_ddwaf_object_large_map::metadata)));
 static_assert(offsetof(detail::object_large_map, ptr) == offsetof(_ddwaf_object_large_map, ptr));
-static_assert(std::is_same_v<decltype(detail::object_large_map::type), object_type>);
-static_assert(std::is_same_v<decltype(_ddwaf_object_large_map::type), uint8_t>);
 static_assert(std::is_same_v<decltype(detail::object_large_map::ptr), detail::object_kv *>);
 static_assert(std::is_same_v<decltype(_ddwaf_object_large_map::ptr), ddwaf_object_kv *>);
+#if defined(__GNUC__) && !defined(__clang__)
+constexpr _ddwaf_object_large_map ddwaf_object_large_map_type_byte_probe{._type = 0xFF};
+static_assert(__builtin_memcmp(&ddwaf_object_large_map_type_byte_probe, "\xFF", 1) == 0);
+#endif
 
 // Allocator callback compatibility
 static_assert(std::is_same_v<ddwaf_alloc_fn_type, memory::user_resource::alloc_fn_type>);

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -50,6 +50,8 @@ static_assert(static_cast<uint8_t>(object_type::small_string) == DDWAF_OBJ_SMALL
 static_assert(static_cast<uint8_t>(object_type::literal_string) == DDWAF_OBJ_LITERAL_STRING);
 static_assert(static_cast<uint8_t>(object_type::array) == DDWAF_OBJ_ARRAY);
 static_assert(static_cast<uint8_t>(object_type::map) == DDWAF_OBJ_MAP);
+static_assert(static_cast<uint8_t>(object_type::large_array) == DDWAF_OBJ_LARGE_ARRAY);
+static_assert(static_cast<uint8_t>(object_type::large_map) == DDWAF_OBJ_LARGE_MAP);
 
 // Object compatibility
 
@@ -114,6 +116,26 @@ static_assert(offsetof(detail::object_map, type) == offsetof(_ddwaf_object_map, 
 static_assert(offsetof(detail::object_map, size) == offsetof(_ddwaf_object_map, size));
 static_assert(offsetof(detail::object_map, capacity) == offsetof(_ddwaf_object_map, capacity));
 static_assert(offsetof(detail::object_map, ptr) == offsetof(_ddwaf_object_map, ptr));
+
+// detail::object_large_array == _ddwaf_object_large_array
+static_assert(sizeof(detail::object_large_array) == sizeof(_ddwaf_object_large_array));
+static_assert(
+    offsetof(detail::object_large_array, type) == offsetof(_ddwaf_object_large_array, type));
+static_assert(offsetof(detail::object_large_array, reserved) ==
+              offsetof(_ddwaf_object_large_array, reserved));
+static_assert(
+    offsetof(detail::object_large_array, ptr) == offsetof(_ddwaf_object_large_array, ptr));
+static_assert(std::is_same_v<decltype(detail::object_large_array::ptr), detail::object *>);
+static_assert(std::is_same_v<decltype(_ddwaf_object_large_array::ptr), ddwaf_object *>);
+
+// detail::object_large_map == _ddwaf_object_large_map
+static_assert(sizeof(detail::object_large_map) == sizeof(_ddwaf_object_large_map));
+static_assert(offsetof(detail::object_large_map, type) == offsetof(_ddwaf_object_large_map, type));
+static_assert(
+    offsetof(detail::object_large_map, reserved) == offsetof(_ddwaf_object_large_map, reserved));
+static_assert(offsetof(detail::object_large_map, ptr) == offsetof(_ddwaf_object_large_map, ptr));
+static_assert(std::is_same_v<decltype(detail::object_large_map::ptr), detail::object_kv *>);
+static_assert(std::is_same_v<decltype(_ddwaf_object_large_map::ptr), ddwaf_object_kv *>);
 
 // Allocator callback compatibility
 static_assert(std::is_same_v<ddwaf_alloc_fn_type, memory::user_resource::alloc_fn_type>);
@@ -812,29 +834,34 @@ ddwaf_object *ddwaf_object_float(ddwaf_object *object, double value)
     return ddwaf_object_set_float(object, value);
 }
 
-ddwaf_object *ddwaf_object_set_array(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc)
+ddwaf_object *ddwaf_object_set_array(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc)
 {
     if (object == nullptr || alloc == nullptr) {
         return nullptr;
     }
-    // object may be uninitialized
-    auto *alloc_ptr = to_alloc_ptr(alloc);
-    auto new_array = owned_object::make_array(capacity, alloc_ptr);
-    to_ref(object) = new_array.move();
-    return object;
+
+    try {
+        // object may be uninitialized
+        auto new_array = owned_object::make_array(capacity, to_alloc_ptr(alloc));
+        to_ref(object) = new_array.move();
+        return object;
+    } catch (...) {} // NOLINT(bugprone-empty-catch)
+    return nullptr;
 }
 
-ddwaf_object *ddwaf_object_set_map(ddwaf_object *object, uint16_t capacity, ddwaf_allocator alloc)
+ddwaf_object *ddwaf_object_set_map(ddwaf_object *object, size_t capacity, ddwaf_allocator alloc)
 {
     if (object == nullptr || alloc == nullptr) {
         return nullptr;
     }
 
-    // object may be uninitialized
-    auto *alloc_ptr = to_alloc_ptr(alloc);
-    auto new_map = owned_object::make_map(capacity, alloc_ptr);
-    to_ref(object) = new_map.move();
-    return object;
+    try {
+        // object may be uninitialized
+        auto new_map = owned_object::make_map(capacity, to_alloc_ptr(alloc));
+        to_ref(object) = new_map.move();
+        return object;
+    } catch (...) {} // NOLINT(bugprone-empty-catch)
+    return nullptr;
 }
 
 bool ddwaf_object_from_json(
@@ -857,7 +884,8 @@ bool ddwaf_object_from_json(
 
 ddwaf_object *ddwaf_object_insert(ddwaf_object *array, ddwaf_allocator alloc)
 {
-    if (array == nullptr || array->type != DDWAF_OBJ_ARRAY || alloc == nullptr) {
+    if (array == nullptr || !ddwaf::is_array(static_cast<object_type>(array->type)) ||
+        alloc == nullptr) {
         return nullptr;
     }
 
@@ -875,7 +903,7 @@ ddwaf_object *ddwaf_object_insert(ddwaf_object *array, ddwaf_allocator alloc)
 ddwaf_object *ddwaf_object_insert_key(
     ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc)
 {
-    if (map == nullptr || map->type != DDWAF_OBJ_MAP || alloc == nullptr) {
+    if (map == nullptr || !ddwaf::is_map(static_cast<object_type>(map->type)) || alloc == nullptr) {
         return nullptr;
     }
 
@@ -895,7 +923,7 @@ ddwaf_object *ddwaf_object_insert_key(
 ddwaf_object *ddwaf_object_insert_key_nocopy(
     ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc)
 {
-    if (map == nullptr || map->type != DDWAF_OBJ_MAP || alloc == nullptr) {
+    if (map == nullptr || !ddwaf::is_map(static_cast<object_type>(map->type)) || alloc == nullptr) {
         return nullptr;
     }
 
@@ -918,7 +946,7 @@ ddwaf_object *ddwaf_object_insert_key_nocopy(
 ddwaf_object *ddwaf_object_insert_literal_key(
     ddwaf_object *map, const char *key, uint32_t length, ddwaf_allocator alloc)
 {
-    if (map == nullptr || map->type != DDWAF_OBJ_MAP || alloc == nullptr) {
+    if (map == nullptr || !ddwaf::is_map(static_cast<object_type>(map->type)) || alloc == nullptr) {
         return nullptr;
     }
 
@@ -1062,15 +1090,18 @@ ddwaf_object *ddwaf_object_clone(
     const ddwaf_object *source, ddwaf_object *destination, ddwaf_allocator alloc)
 {
     const object_view view{to_ptr(source)};
-    if (!view.has_value()) {
+    if (!view.has_value() || destination == nullptr || alloc == nullptr) {
         return nullptr;
     }
 
-    auto *alloc_ptr = to_alloc_ptr(alloc);
-    // destination may be uninitialized; don't use borrowed_object
-    auto output = view.clone(alloc_ptr);
-    to_ref(destination) = output.move();
-    return destination;
+    try {
+        auto *alloc_ptr = to_alloc_ptr(alloc);
+        // destination may be uninitialized; don't use borrowed_object
+        auto output = view.clone(alloc_ptr);
+        to_ref(destination) = output.move();
+        return destination;
+    } catch (...) {} // NOLINT(bugprone-empty-catch)
+    return nullptr;
 }
 
 bool ddwaf_object_is_invalid(const ddwaf_object *object)

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -121,10 +121,14 @@ static_assert(offsetof(detail::object_map, ptr) == offsetof(_ddwaf_object_map, p
 static_assert(sizeof(detail::object_large_array) == sizeof(_ddwaf_object_large_array));
 static_assert(
     offsetof(detail::object_large_array, type) == offsetof(_ddwaf_object_large_array, type));
-static_assert(offsetof(detail::object_large_array, reserved) ==
-              offsetof(_ddwaf_object_large_array, reserved));
+static_assert(offsetof(detail::object_large_array, metadata) ==
+              offsetof(_ddwaf_object_large_array, metadata));
+static_assert(sizeof(decltype(detail::object_large_array::metadata)) ==
+              sizeof(decltype(_ddwaf_object_large_array::metadata)));
 static_assert(
     offsetof(detail::object_large_array, ptr) == offsetof(_ddwaf_object_large_array, ptr));
+static_assert(std::is_same_v<decltype(detail::object_large_array::type), object_type>);
+static_assert(std::is_same_v<decltype(_ddwaf_object_large_array::type), uint8_t>);
 static_assert(std::is_same_v<decltype(detail::object_large_array::ptr), detail::object *>);
 static_assert(std::is_same_v<decltype(_ddwaf_object_large_array::ptr), ddwaf_object *>);
 
@@ -132,8 +136,12 @@ static_assert(std::is_same_v<decltype(_ddwaf_object_large_array::ptr), ddwaf_obj
 static_assert(sizeof(detail::object_large_map) == sizeof(_ddwaf_object_large_map));
 static_assert(offsetof(detail::object_large_map, type) == offsetof(_ddwaf_object_large_map, type));
 static_assert(
-    offsetof(detail::object_large_map, reserved) == offsetof(_ddwaf_object_large_map, reserved));
+    offsetof(detail::object_large_map, metadata) == offsetof(_ddwaf_object_large_map, metadata));
+static_assert(sizeof(decltype(detail::object_large_map::metadata)) ==
+              sizeof(decltype(_ddwaf_object_large_map::metadata)));
 static_assert(offsetof(detail::object_large_map, ptr) == offsetof(_ddwaf_object_large_map, ptr));
+static_assert(std::is_same_v<decltype(detail::object_large_map::type), object_type>);
+static_assert(std::is_same_v<decltype(_ddwaf_object_large_map::type), uint8_t>);
 static_assert(std::is_same_v<decltype(detail::object_large_map::ptr), detail::object_kv *>);
 static_assert(std::is_same_v<decltype(_ddwaf_object_large_map::ptr), ddwaf_object_kv *>);
 

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -54,7 +54,7 @@ std::vector<std::variant<std::string_view, int64_t>> iterator_base<T>::get_curre
     auto [parent, parent_index] = stack_.front();
     for (unsigned i = 1; i < stack_.size(); i++) {
         auto [key, child] = parent.at(parent_index - 1);
-        if (parent.type() == object_type::map) {
+        if (parent.is_map()) {
             keys.emplace_back(key.template as<std::string_view>());
         } else {
             keys.emplace_back(static_cast<int64_t>(parent_index - 1));
@@ -63,7 +63,7 @@ std::vector<std::variant<std::string_view, int64_t>> iterator_base<T>::get_curre
         parent_index = stack_[i].second;
     }
 
-    if (parent.type() == object_type::map) {
+    if (parent.is_map()) {
         keys.emplace_back(current_.first.as<std::string_view>());
     } else {
         keys.emplace_back(static_cast<int64_t>(parent_index - 1));
@@ -141,12 +141,9 @@ void value_iterator::initialise_cursor_with_path(
             }
         } else if (parent.is_array() && std::holds_alternative<int64_t>(key)) {
             const auto expected_index = std::get<int64_t>(key);
-            if (expected_index >= 0 && parent.size<int64_t>() > expected_index) {
-                child = parent.at(expected_index);
-                index = expected_index;
-            } else if (expected_index < 0 && (parent.size<int64_t>() + expected_index) >= 0) {
-                index = parent.size<int64_t>() + expected_index;
-                child = parent.at(index);
+            if (const auto normalized = detail::normalize_index(parent.size(), expected_index)) {
+                index = *normalized;
+                child = parent.at(*normalized);
             }
         }
 
@@ -285,10 +282,8 @@ void key_iterator::initialise_cursor_with_path(
             }
         } else if (parent.is_array() && std::holds_alternative<int64_t>(key)) {
             const auto expected_index = std::get<int64_t>(key);
-            if (expected_index >= 0 && parent.size<int64_t>() > expected_index) {
-                child = parent.at(expected_index);
-            } else if (expected_index < 0 && (parent.size<int64_t>() + expected_index) >= 0) {
-                child = parent.at(parent.size<int64_t>() + expected_index);
+            if (const auto normalized = detail::normalize_index(parent.size(), expected_index)) {
+                child = parent.at(*normalized);
             }
         }
 
@@ -430,10 +425,8 @@ void kv_iterator::initialise_cursor_with_path(
             }
         } else if (parent.is_array() && std::holds_alternative<int64_t>(key)) {
             const auto expected_index = std::get<int64_t>(key);
-            if (expected_index >= 0 && parent.size<int64_t>() > expected_index) {
-                child = parent.at(expected_index);
-            } else if (expected_index < 0 && (parent.size<int64_t>() + expected_index) >= 0) {
-                child = parent.at(parent.size<int64_t>() + expected_index);
+            if (const auto normalized = detail::normalize_index(parent.size(), expected_index)) {
+                child = parent.at(*normalized);
             }
         }
 

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -16,7 +16,6 @@
 #include "exclusion/common.hpp"
 #include "iterator.hpp"
 #include "object.hpp"
-#include "object_type.hpp"
 
 namespace ddwaf {
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -50,8 +50,6 @@ namespace detail {
 
 union object;
 struct object_kv;
-struct object_large_array_storage;
-struct object_large_map_storage;
 
 constexpr std::size_t small_string_size = 14;
 
@@ -87,8 +85,14 @@ struct object_map {
 };
 
 struct object_large_array {
-    object_type type;
-    uint8_t reserved[7];
+    union {
+        object_type type;
+        struct {
+            uint64_t _type : 8;
+            uint64_t size : 28;
+            uint64_t capacity : 28;
+        } metadata;
+    };
     union {
         uint64_t _padding;
         object *ptr;
@@ -96,8 +100,17 @@ struct object_large_array {
 };
 
 struct object_large_map {
-    object_type type;
-    uint8_t reserved[7];
+    // we don't do a plain
+    // object_type type : 8; here because of msvc
+    // (see also -mms-bitfields and the ms_struct type allocation on gcc)
+    union {
+        object_type type;
+        struct {
+            uint64_t _type : 8;
+            uint64_t size : 28;
+            uint64_t capacity : 28;
+        } metadata;
+    };
     union {
         uint64_t _padding;
         object_kv *ptr;
@@ -125,22 +138,10 @@ struct object_kv {
     object val;
 };
 
-struct alignas(object) object_large_array_storage {
-    std::size_t size;
-    std::size_t capacity;
-    object ptr[];
-};
-
-struct alignas(object_kv) object_large_map_storage {
-    std::size_t size;
-    std::size_t capacity;
-    object_kv ptr[];
-};
-
 static_assert(sizeof(object) == 16);
 static_assert(sizeof(object_kv) == 32);
-static_assert(sizeof(object_large_array) == sizeof(object));
-static_assert(sizeof(object_large_map) == sizeof(object));
+static_assert(sizeof(object_large_array) == 16);
+static_assert(sizeof(object_large_map) == 16);
 
 static_assert(std::is_standard_layout_v<object>);
 static_assert(std::is_trivially_copyable_v<object>);
@@ -161,23 +162,26 @@ static_assert(offsetof(object, type) == offsetof(object_small_string, type));
 static_assert(offsetof(object, type) == offsetof(object_array, type));
 static_assert(offsetof(object, type) == offsetof(object_map, type));
 static_assert(offsetof(object, type) == offsetof(object_large_array, type));
+#if defined(__GNUC__) && !defined(__clang__)
+static_assert(std::bit_cast<std::array<char, 8>>(decltype(object_large_array::metadata){
+                  ._type = 0xFF}) == std::array<char, 8>{'\xFF'});
+#endif
 static_assert(offsetof(object, type) == offsetof(object_large_map, type));
 
+#if defined(__GNUC__) && !defined(__clang__)
+static_assert(std::bit_cast<std::array<char, 8>>(decltype(object_large_map::metadata){
+                  ._type = 0xFF}) == std::array<char, 8>{'\xFF'});
+#endif
 static_assert(offsetof(object_map, size) == offsetof(object_array, size));
 static_assert(offsetof(object_map, capacity) == offsetof(object_array, capacity));
 static_assert(offsetof(object_map, ptr) == offsetof(object_array, ptr));
 
 static_assert(offsetof(object_array, ptr) == offsetof(object_large_array, ptr));
 static_assert(offsetof(object_map, ptr) == offsetof(object_large_map, ptr));
-static_assert(offsetof(object_large_array_storage, ptr) == sizeof(object_large_array_storage));
-static_assert(offsetof(object_large_map_storage, ptr) == sizeof(object_large_map_storage));
-static_assert(alignof(object_large_array_storage) >= alignof(object));
-static_assert(alignof(object_large_map_storage) >= alignof(object_kv));
+static_assert(offsetof(object_large_array, ptr) == 8);
+static_assert(offsetof(object_large_map, ptr) == 8);
 
 template <typename T> constexpr std::size_t maxof_v = std::numeric_limits<T>::max();
-
-#define DDWAF_CONTAINER_OF(pointer, type, member)                                                  \
-    reinterpret_cast<type *>(reinterpret_cast<std::byte *>(pointer) - offsetof(type, member))
 
 /*
  * Converts a signed index to an absolute container offset. Nonnegative indices
@@ -202,46 +206,85 @@ inline std::optional<std::size_t> normalize_index(std::size_t size, int64_t inde
     return size - static_cast<std::size_t>(distance);
 }
 
-template <typename Storage, typename Element>
-inline Storage *large_storage_from_data(Element *data) noexcept
+constexpr std::size_t large_container_metadata_capacity_limit = (uint32_t{1} << 28) - 1;
+constexpr std::size_t max_large_array_capacity =
+    std::min(large_container_metadata_capacity_limit, maxof_v<std::size_t> / sizeof(object));
+constexpr std::size_t max_large_map_capacity =
+    std::min(large_container_metadata_capacity_limit, maxof_v<std::size_t> / sizeof(object_kv));
+
+static_assert(max_large_array_capacity == large_container_metadata_capacity_limit);
+static_assert(max_large_map_capacity == (sizeof(std::size_t) == 4 ? 134'217'727 : 268'435'455));
+
+inline std::size_t large_container_size(const object &obj) noexcept
 {
-    if (data == nullptr) {
-        return nullptr;
+    // in optimized code, the type is not checked at all
+    assert(obj.type == object_type::large_array || obj.type == object_type::large_map);
+    if (obj.type == object_type::large_array) {
+        return obj.via.large_array.metadata.size;
     }
-    return DDWAF_CONTAINER_OF(data, Storage, ptr);
+    return obj.via.large_map.metadata.size;
 }
 
-#undef DDWAF_CONTAINER_OF
-
-inline object_large_array_storage *large_array_storage(object &obj) noexcept
+inline std::size_t large_container_capacity(const object &obj) noexcept
 {
-    return large_storage_from_data<object_large_array_storage>(obj.via.large_array.ptr);
+    assert(obj.type == object_type::large_array || obj.type == object_type::large_map);
+    if (obj.type == object_type::large_array) {
+        return obj.via.large_array.metadata.capacity;
+    }
+    return obj.via.large_map.metadata.capacity;
 }
 
-inline const object_large_array_storage *large_array_storage(const object &obj) noexcept
+inline void set_large_container_size(object &obj, std::size_t size) noexcept
 {
-    return large_storage_from_data<object_large_array_storage>(obj.via.large_array.ptr);
+    assert(obj.type == object_type::large_array || obj.type == object_type::large_map);
+    assert(size <= (obj.type == object_type::large_array ? max_large_array_capacity
+                                                         : max_large_map_capacity));
+    if (obj.type == object_type::large_array) {
+        obj.via.large_array.metadata.size = static_cast<uint64_t>(size);
+    } else {
+        obj.via.large_map.metadata.size = static_cast<uint64_t>(size);
+    }
 }
 
-inline object_large_map_storage *large_map_storage(object &obj) noexcept
+inline void set_large_container_capacity(object &obj, std::size_t capacity) noexcept
 {
-    return large_storage_from_data<object_large_map_storage>(obj.via.large_map.ptr);
+    assert(obj.type == object_type::large_array || obj.type == object_type::large_map);
+    assert(capacity <= (obj.type == object_type::large_array ? max_large_array_capacity
+                                                             : max_large_map_capacity));
+    if (obj.type == object_type::large_array) {
+        obj.via.large_array.metadata.capacity = static_cast<uint64_t>(capacity);
+    } else {
+        obj.via.large_map.metadata.capacity = static_cast<uint64_t>(capacity);
+    }
 }
 
-inline const object_large_map_storage *large_map_storage(const object &obj) noexcept
+inline object make_large_array_object(object *ptr, std::size_t size, std::size_t capacity) noexcept
 {
-    return large_storage_from_data<object_large_map_storage>(obj.via.large_map.ptr);
+    assert(size <= capacity);
+    assert(capacity <= max_large_array_capacity);
+    return {.via{.large_array{.metadata{._type = static_cast<uint8_t>(object_type::large_array),
+                                  .size = static_cast<uint64_t>(size),
+                                  .capacity = static_cast<uint64_t>(capacity)},
+        .ptr = ptr}}};
+}
+
+inline object make_large_map_object(object_kv *ptr, std::size_t size, std::size_t capacity) noexcept
+{
+    assert(size <= capacity);
+    assert(capacity <= max_large_map_capacity);
+    return {.via{.large_map{.metadata{._type = static_cast<uint8_t>(object_type::large_map),
+                                .size = static_cast<uint64_t>(size),
+                                .capacity = static_cast<uint64_t>(capacity)},
+        .ptr = ptr}}};
 }
 
 inline std::size_t container_size(const object &obj)
 {
     if (obj.type == object_type::large_array) [[unlikely]] {
-        const auto *storage = large_array_storage(obj);
-        return storage == nullptr ? 0 : storage->size;
+        return large_container_size(obj);
     }
     if (obj.type == object_type::large_map) [[unlikely]] {
-        const auto *storage = large_map_storage(obj);
-        return storage == nullptr ? 0 : storage->size;
+        return large_container_size(obj);
     }
     return obj.via.array.size;
 }
@@ -253,16 +296,18 @@ inline std::size_t container_size(const object &obj)
 template <typename Element> inline Element *container_data(object &obj) noexcept
 {
     Element *data;
+    // NOLINTNEXTLINE
     memcpy(&data, reinterpret_cast<const std::byte *>(&obj) + offsetof(object_array, ptr),
-        sizeof(data));
+        sizeof(data)); // NOLINT(bugprone-sizeof-expression)
     return data;
 }
 
 template <typename Element> inline const Element *container_data(const object &obj) noexcept
 {
     Element *data;
+    // NOLINTNEXTLINE
     memcpy(&data, reinterpret_cast<const std::byte *>(&obj) + offsetof(object_array, ptr),
-        sizeof(data));
+        sizeof(data)); // NOLINT(bugprone-sizeof-expression)
     return data;
 }
 
@@ -323,41 +368,44 @@ inline std::pair<T *, SizeType> realloc_helper(
     return {new_data, new_size};
 }
 
-template <typename Storage, typename Element>
-constexpr std::size_t max_large_storage_capacity =
-    (maxof_v<std::size_t> - sizeof(Storage)) / sizeof(Element);
+template <typename Element> struct large_container_traits;
 
-template <typename Storage, typename Element>
-inline std::size_t large_storage_bytes(std::size_t capacity)
+template <> struct large_container_traits<object> {
+    static constexpr std::size_t capacity_limit = max_large_array_capacity;
+};
+
+template <> struct large_container_traits<object_kv> {
+    static constexpr std::size_t capacity_limit = max_large_map_capacity;
+};
+
+template <typename Element> inline std::size_t large_container_bytes(std::size_t capacity)
 {
-    if (capacity > max_large_storage_capacity<Storage, Element>) [[unlikely]] {
+    if (capacity > large_container_traits<Element>::capacity_limit) [[unlikely]] {
         throw std::length_error("container capacity exceeds allocation limit");
     }
-    return sizeof(Storage) + capacity * sizeof(Element);
+    return capacity * sizeof(Element);
 }
 
-template <typename Storage, typename Element>
-inline Storage *alloc_large_storage(std::size_t capacity, memory::memory_resource &alloc)
+template <typename Element>
+inline Element *alloc_large_container(std::size_t capacity, memory::memory_resource &alloc)
 {
     if (capacity == 0) {
         return nullptr;
     }
 
-    const auto bytes = large_storage_bytes<Storage, Element>(capacity);
-    auto *storage = static_cast<Storage *>(alloc.allocate(bytes, alignof(Storage)));
-    if (storage == nullptr) [[unlikely]] {
+    const auto bytes = large_container_bytes<Element>(capacity);
+    auto *data = static_cast<Element *>(alloc.allocate(bytes, alignof(Element)));
+    if (data == nullptr) [[unlikely]] {
         throw std::bad_alloc();
     }
-    storage->size = 0;
-    storage->capacity = capacity;
-    return storage;
+    return data;
 }
 
-template <typename Storage, typename Element>
-inline void dealloc_large_storage(Storage *storage, memory::memory_resource &alloc)
+template <typename Element>
+inline void dealloc_large_container(
+    Element *data, std::size_t capacity, memory::memory_resource &alloc)
 {
-    const auto bytes = large_storage_bytes<Storage, Element>(storage->capacity);
-    alloc.deallocate(storage, bytes, alignof(Storage));
+    alloc.deallocate(data, large_container_bytes<Element>(capacity), alignof(Element));
 }
 
 inline std::size_t next_large_capacity(std::size_t capacity, std::size_t maximum)
@@ -373,59 +421,56 @@ inline std::size_t next_large_capacity(std::size_t capacity, std::size_t maximum
 
 inline void grow_large_array(object &obj, memory::memory_resource &alloc)
 {
-    auto *old_storage = large_array_storage(obj);
-    const auto old_capacity = old_storage == nullptr ? 0 : old_storage->capacity;
-    const auto old_size = old_storage == nullptr ? 0 : old_storage->size;
-    static constexpr auto maximum = max_large_storage_capacity<object_large_array_storage, object>;
-    const auto new_capacity = next_large_capacity(old_capacity, maximum);
-    auto *new_storage =
-        alloc_large_storage<object_large_array_storage, object>(new_capacity, alloc);
-    new_storage->size = old_size;
-    if (old_storage != nullptr) {
-        memcpy(new_storage->ptr, old_storage->ptr, old_size * sizeof(object));
-        dealloc_large_storage<object_large_array_storage, object>(old_storage, alloc);
+    auto *old_data = obj.via.large_array.ptr;
+    const auto old_capacity = large_container_capacity(obj);
+    const auto old_size = large_container_size(obj);
+    const auto new_capacity = next_large_capacity(old_capacity, max_large_array_capacity);
+    auto *new_data = alloc_large_container<object>(new_capacity, alloc);
+    if (old_size != 0) {
+        memcpy(new_data, old_data, old_size * sizeof(object));
     }
-    obj.via.large_array.ptr = new_storage->ptr;
+    if (old_data != nullptr) {
+        dealloc_large_container(old_data, old_capacity, alloc);
+    }
+    obj.via.large_array.ptr = new_data;
+    set_large_container_capacity(obj, new_capacity);
 }
 
 inline void grow_large_map(object &obj, memory::memory_resource &alloc)
 {
-    auto *old_storage = large_map_storage(obj);
-    const auto old_capacity = old_storage == nullptr ? 0 : old_storage->capacity;
-    const auto old_size = old_storage == nullptr ? 0 : old_storage->size;
-    static constexpr auto maximum = max_large_storage_capacity<object_large_map_storage, object_kv>;
-    const auto new_capacity = next_large_capacity(old_capacity, maximum);
-    auto *new_storage =
-        alloc_large_storage<object_large_map_storage, object_kv>(new_capacity, alloc);
-    new_storage->size = old_size;
-    if (old_storage != nullptr) {
-        memcpy(new_storage->ptr, old_storage->ptr, old_size * sizeof(object_kv));
-        dealloc_large_storage<object_large_map_storage, object_kv>(old_storage, alloc);
+    auto *old_data = obj.via.large_map.ptr;
+    const auto old_capacity = large_container_capacity(obj);
+    const auto old_size = large_container_size(obj);
+    const auto new_capacity = next_large_capacity(old_capacity, max_large_map_capacity);
+    auto *new_data = alloc_large_container<object_kv>(new_capacity, alloc);
+    if (old_size != 0) {
+        memcpy(new_data, old_data, old_size * sizeof(object_kv));
     }
-    obj.via.large_map.ptr = new_storage->ptr;
+    if (old_data != nullptr) {
+        dealloc_large_container(old_data, old_capacity, alloc);
+    }
+    obj.via.large_map.ptr = new_data;
+    set_large_container_capacity(obj, new_capacity);
 }
 
 inline void promote_array(object &obj, memory::memory_resource &alloc)
 {
     constexpr std::size_t promoted_capacity = maxof_v<uint16_t> * std::size_t{2};
-    auto *storage =
-        alloc_large_storage<object_large_array_storage, object>(promoted_capacity, alloc);
-    storage->size = obj.via.array.size;
-    memcpy(storage->ptr, obj.via.array.ptr, storage->size * sizeof(object));
+    const auto size = obj.via.array.size;
+    auto *data = alloc_large_container<object>(promoted_capacity, alloc);
+    memcpy(data, obj.via.array.ptr, size * sizeof(object));
     dealloc_helper(obj.via.array.ptr, obj.via.array.capacity, alloc);
-    obj = {
-        .via{.large_array{.type = object_type::large_array, .reserved = {}, .ptr = storage->ptr}}};
+    obj = make_large_array_object(data, size, promoted_capacity);
 }
 
 inline void promote_map(object &obj, memory::memory_resource &alloc)
 {
     constexpr std::size_t promoted_capacity = maxof_v<uint16_t> * std::size_t{2};
-    auto *storage =
-        alloc_large_storage<object_large_map_storage, object_kv>(promoted_capacity, alloc);
-    storage->size = obj.via.map.size;
-    memcpy(storage->ptr, obj.via.map.ptr, storage->size * sizeof(object_kv));
+    const auto size = obj.via.map.size;
+    auto *data = alloc_large_container<object_kv>(promoted_capacity, alloc);
+    memcpy(data, obj.via.map.ptr, size * sizeof(object_kv));
     dealloc_helper(obj.via.map.ptr, obj.via.map.capacity, alloc);
-    obj = {.via{.large_map{.type = object_type::large_map, .reserved = {}, .ptr = storage->ptr}}};
+    obj = make_large_map_object(data, size, promoted_capacity);
 }
 
 template <typename SizeType>
@@ -449,8 +494,7 @@ inline void object_destroy(object &obj, nonnull_ptr<memory::memory_resource> all
         for (std::size_t i = 0; i < size; ++i) { object_destroy(data[i], alloc); }
         if (obj.type == object_type::large_array && obj.via.large_array.ptr != nullptr)
             [[unlikely]] {
-            dealloc_large_storage<object_large_array_storage, object>(
-                large_array_storage(obj), *alloc);
+            dealloc_large_container(obj.via.large_array.ptr, large_container_capacity(obj), *alloc);
         } else if (obj.type == object_type::array && obj.via.array.ptr != nullptr) {
             dealloc_helper(obj.via.array.ptr, obj.via.array.capacity, *alloc);
         }
@@ -462,8 +506,7 @@ inline void object_destroy(object &obj, nonnull_ptr<memory::memory_resource> all
             object_destroy(data[i].val, alloc);
         }
         if (obj.type == object_type::large_map && obj.via.large_map.ptr != nullptr) [[unlikely]] {
-            dealloc_large_storage<object_large_map_storage, object_kv>(
-                large_map_storage(obj), *alloc);
+            dealloc_large_container(obj.via.large_map.ptr, large_container_capacity(obj), *alloc);
         } else if (obj.type == object_type::map && obj.via.map.ptr != nullptr) {
             dealloc_helper(obj.via.map.ptr, obj.via.map.capacity, *alloc);
         }
@@ -1249,13 +1292,8 @@ public:
     static owned_object make_large_array(
         std::size_t capacity, nonnull_ptr<memory::memory_resource> alloc)
     {
-        auto *storage =
-            detail::alloc_large_storage<detail::object_large_array_storage, detail::object>(
-                capacity, *alloc);
-        return owned_object{{.via{.large_array{.type = object_type::large_array,
-                                .reserved = {},
-                                .ptr = storage == nullptr ? nullptr : storage->ptr}}},
-            alloc};
+        auto *data = detail::alloc_large_container<detail::object>(capacity, *alloc);
+        return owned_object{detail::make_large_array_object(data, 0, capacity), alloc};
     }
 
     static owned_object make_map(std::size_t capacity, nonnull_ptr<memory::memory_resource> alloc)
@@ -1287,13 +1325,8 @@ public:
     static owned_object make_large_map(
         std::size_t capacity, nonnull_ptr<memory::memory_resource> alloc)
     {
-        auto *storage =
-            detail::alloc_large_storage<detail::object_large_map_storage, detail::object_kv>(
-                capacity, *alloc);
-        return owned_object{{.via{.large_map{.type = object_type::large_map,
-                                .reserved = {},
-                                .ptr = storage == nullptr ? nullptr : storage->ptr}}},
-            alloc};
+        auto *data = detail::alloc_large_container<detail::object_kv>(capacity, *alloc);
+        return owned_object{detail::make_large_map_object(data, 0, capacity), alloc};
     }
 
     detail::object move()
@@ -1465,13 +1498,14 @@ borrowed_object writable_object<Derived>::emplace_back(owned_object &&value)
     }
 
     if (container.type == object_type::large_array) [[unlikely]] {
-        auto *storage = detail::large_array_storage(container);
-        if (storage == nullptr || storage->size == storage->capacity) {
+        if (detail::large_container_size(container) ==
+            detail::large_container_capacity(container)) {
             detail::grow_large_array(container, alloc());
-            storage = detail::large_array_storage(container);
         }
 
-        borrowed_object slot{&storage->ptr[storage->size++], alloc()};
+        const auto size = detail::large_container_size(container);
+        borrowed_object slot{&container.via.large_array.ptr[size], alloc()};
+        detail::set_large_container_size(container, size + 1);
         *slot.ptr() = value.move();
         return slot;
     }
@@ -1483,8 +1517,9 @@ borrowed_object writable_object<Derived>::emplace_back(owned_object &&value)
     } else if (container.via.array.capacity == container.via.array.size) {
         if (container.via.array.capacity == detail::maxof_v<uint16_t>) [[unlikely]] {
             detail::promote_array(container, alloc());
-            auto *storage = detail::large_array_storage(container);
-            borrowed_object slot{&storage->ptr[storage->size++], alloc()};
+            const auto size = detail::large_container_size(container);
+            borrowed_object slot{&container.via.large_array.ptr[size], alloc()};
+            detail::set_large_container_size(container, size + 1);
             *slot.ptr() = value.move();
             return slot;
         }
@@ -1524,15 +1559,15 @@ borrowed_object writable_object<Derived>::emplace(owned_object &&key, owned_obje
     }
 
     if (container.type == object_type::large_map) {
-        auto *storage = detail::large_map_storage(container);
-        if (storage == nullptr || storage->size == storage->capacity) {
+        if (detail::large_container_size(container) ==
+            detail::large_container_capacity(container)) {
             detail::grow_large_map(container, alloc());
-            storage = detail::large_map_storage(container);
         }
 
-        borrowed_object key_slot{storage->ptr[storage->size].key, alloc()};
-        borrowed_object val_slot{storage->ptr[storage->size].val, alloc()};
-        ++storage->size;
+        const auto size = detail::large_container_size(container);
+        borrowed_object key_slot{container.via.large_map.ptr[size].key, alloc()};
+        borrowed_object val_slot{container.via.large_map.ptr[size].val, alloc()};
+        detail::set_large_container_size(container, size + 1);
         *key_slot.ptr() = key.move();
         *val_slot.ptr() = value.move();
         return val_slot;
@@ -1545,10 +1580,10 @@ borrowed_object writable_object<Derived>::emplace(owned_object &&key, owned_obje
     } else if (container.via.map.capacity == container.via.map.size) {
         if (container.via.map.capacity == detail::maxof_v<uint16_t>) {
             detail::promote_map(container, alloc());
-            auto *storage = detail::large_map_storage(container);
-            borrowed_object key_slot{storage->ptr[storage->size].key, alloc()};
-            borrowed_object val_slot{storage->ptr[storage->size].val, alloc()};
-            ++storage->size;
+            const auto size = detail::large_container_size(container);
+            borrowed_object key_slot{container.via.large_map.ptr[size].key, alloc()};
+            borrowed_object val_slot{container.via.large_map.ptr[size].val, alloc()};
+            detail::set_large_container_size(container, size + 1);
             *key_slot.ptr() = key.move();
             *val_slot.ptr() = value.move();
             return val_slot;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -98,13 +98,6 @@ struct object_large_map {
     object_kv *ptr;
 };
 
-#if defined(__GNUC__) && !defined(__clang__)
-constexpr object_large_array object_large_array_type_byte_probe{._type = 0xFF};
-static_assert(__builtin_memcmp(&object_large_array_type_byte_probe, "\xFF", 1) == 0);
-constexpr object_large_map object_large_map_type_byte_probe{._type = 0xFF};
-static_assert(__builtin_memcmp(&object_large_map_type_byte_probe, "\xFF", 1) == 0);
-#endif
-
 union [[gnu::may_alias]] object {
     object_type type;
     union {
@@ -181,13 +174,13 @@ inline std::optional<std::size_t> normalize_index(std::size_t size, int64_t inde
     return size - static_cast<std::size_t>(distance);
 }
 
-constexpr std::size_t large_container_metadata_capacity_limit = (uint32_t{1} << 28) - 1;
+constexpr std::size_t large_container_capacity_limit = (uint32_t{1} << 28) - 1;
 constexpr std::size_t max_large_array_capacity =
-    std::min(large_container_metadata_capacity_limit, maxof_v<std::size_t> / sizeof(object));
+    std::min(large_container_capacity_limit, maxof_v<std::size_t> / sizeof(object));
 constexpr std::size_t max_large_map_capacity =
-    std::min(large_container_metadata_capacity_limit, maxof_v<std::size_t> / sizeof(object_kv));
+    std::min(large_container_capacity_limit, maxof_v<std::size_t> / sizeof(object_kv));
 
-static_assert(max_large_array_capacity == large_container_metadata_capacity_limit);
+static_assert(max_large_array_capacity == large_container_capacity_limit);
 static_assert(max_large_map_capacity == (sizeof(std::size_t) == 4 ? 134'217'727 : 268'435'455));
 
 inline std::size_t large_container_size(const object &obj) noexcept
@@ -264,37 +257,28 @@ inline std::size_t container_size(const object &obj)
     return obj.via.array.size;
 }
 
-/*
- * Compact and large containers store the same element pointer type at this
- * offset. Copying its representation avoids reading an inactive union member.
- */
-template <typename Element> inline Element *container_data(object &obj) noexcept
+inline object *array_data(object &obj) noexcept
 {
-    Element *data;
-    // NOLINTNEXTLINE
-    memcpy(&data, reinterpret_cast<const std::byte *>(&obj) + offsetof(object_array, ptr),
-        sizeof(data)); // NOLINT(bugprone-sizeof-expression)
-    return data;
+    assert(ddwaf::is_array(obj.type));
+    return obj.type == object_type::large_array ? obj.via.large_array.ptr : obj.via.array.ptr;
 }
 
-template <typename Element> inline const Element *container_data(const object &obj) noexcept
+inline const object *array_data(const object &obj) noexcept
 {
-    Element *data;
-    // NOLINTNEXTLINE
-    memcpy(&data, reinterpret_cast<const std::byte *>(&obj) + offsetof(object_array, ptr),
-        sizeof(data)); // NOLINT(bugprone-sizeof-expression)
-    return data;
+    assert(ddwaf::is_array(obj.type));
+    return obj.type == object_type::large_array ? obj.via.large_array.ptr : obj.via.array.ptr;
 }
 
-inline object *array_data(object &obj) noexcept { return container_data<object>(obj); }
-
-inline const object *array_data(const object &obj) noexcept { return container_data<object>(obj); }
-
-inline object_kv *map_data(object &obj) noexcept { return container_data<object_kv>(obj); }
+inline object_kv *map_data(object &obj) noexcept
+{
+    assert(ddwaf::is_map(obj.type));
+    return obj.type == object_type::large_map ? obj.via.large_map.ptr : obj.via.map.ptr;
+}
 
 inline const object_kv *map_data(const object &obj) noexcept
 {
-    return container_data<object_kv>(obj);
+    assert(ddwaf::is_map(obj.type));
+    return obj.type == object_type::large_map ? obj.via.large_map.ptr : obj.via.map.ptr;
 }
 
 inline bool requires_allocator(object_type type)
@@ -356,7 +340,7 @@ template <> struct large_container_traits<object_kv> {
 template <typename Element> inline std::size_t large_container_bytes(std::size_t capacity)
 {
     if (capacity > large_container_traits<Element>::capacity_limit) [[unlikely]] {
-        throw std::length_error("container capacity exceeds allocation limit");
+        throw std::bad_alloc();
     }
     return capacity * sizeof(Element);
 }
@@ -369,11 +353,7 @@ inline Element *alloc_large_container(std::size_t capacity, memory::memory_resou
     }
 
     const auto bytes = large_container_bytes<Element>(capacity);
-    auto *data = static_cast<Element *>(alloc.allocate(bytes, alignof(Element)));
-    if (data == nullptr) [[unlikely]] {
-        throw std::bad_alloc();
-    }
-    return data;
+    return static_cast<Element *>(alloc.allocate(bytes, alignof(Element)));
 }
 
 template <typename Element>
@@ -386,7 +366,7 @@ inline void dealloc_large_container(
 inline std::size_t next_large_capacity(std::size_t capacity, std::size_t maximum)
 {
     if (capacity >= maximum) [[unlikely]] {
-        throw std::length_error("container has reached its maximum capacity");
+        throw std::bad_alloc();
     }
     if (capacity == 0) {
         return std::min<std::size_t>(8, maximum);

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -85,37 +85,25 @@ struct object_map {
 };
 
 struct object_large_array {
-    union {
-        object_type type;
-        struct {
-            uint64_t _type : 8;
-            uint64_t size : 28;
-            uint64_t capacity : 28;
-        } metadata;
-    };
-    union {
-        uint64_t _padding;
-        object *ptr;
-    };
+    uint64_t _type : 8;
+    uint64_t size : 28;
+    uint64_t capacity : 28;
+    object *ptr;
 };
 
 struct object_large_map {
-    // we don't do a plain
-    // object_type type : 8; here because of msvc
-    // (see also -mms-bitfields and the ms_struct type allocation on gcc)
-    union {
-        object_type type;
-        struct {
-            uint64_t _type : 8;
-            uint64_t size : 28;
-            uint64_t capacity : 28;
-        } metadata;
-    };
-    union {
-        uint64_t _padding;
-        object_kv *ptr;
-    };
+    uint64_t _type : 8;
+    uint64_t size : 28;
+    uint64_t capacity : 28;
+    object_kv *ptr;
 };
+
+#if defined(__GNUC__) && !defined(__clang__)
+constexpr object_large_array object_large_array_type_byte_probe{._type = 0xFF};
+static_assert(__builtin_memcmp(&object_large_array_type_byte_probe, "\xFF", 1) == 0);
+constexpr object_large_map object_large_map_type_byte_probe{._type = 0xFF};
+static_assert(__builtin_memcmp(&object_large_map_type_byte_probe, "\xFF", 1) == 0);
+#endif
 
 union [[gnu::may_alias]] object {
     object_type type;
@@ -140,8 +128,6 @@ struct object_kv {
 
 static_assert(sizeof(object) == 16);
 static_assert(sizeof(object_kv) == 32);
-static_assert(sizeof(object_large_array) == 16);
-static_assert(sizeof(object_large_map) == 16);
 
 static_assert(std::is_standard_layout_v<object>);
 static_assert(std::is_trivially_copyable_v<object>);
@@ -161,17 +147,6 @@ static_assert(offsetof(object, type) == offsetof(object_small_string, type));
 
 static_assert(offsetof(object, type) == offsetof(object_array, type));
 static_assert(offsetof(object, type) == offsetof(object_map, type));
-static_assert(offsetof(object, type) == offsetof(object_large_array, type));
-#if defined(__GNUC__) && !defined(__clang__)
-static_assert(std::bit_cast<std::array<char, 8>>(decltype(object_large_array::metadata){
-                  ._type = 0xFF}) == std::array<char, 8>{'\xFF'});
-#endif
-static_assert(offsetof(object, type) == offsetof(object_large_map, type));
-
-#if defined(__GNUC__) && !defined(__clang__)
-static_assert(std::bit_cast<std::array<char, 8>>(decltype(object_large_map::metadata){
-                  ._type = 0xFF}) == std::array<char, 8>{'\xFF'});
-#endif
 static_assert(offsetof(object_map, size) == offsetof(object_array, size));
 static_assert(offsetof(object_map, capacity) == offsetof(object_array, capacity));
 static_assert(offsetof(object_map, ptr) == offsetof(object_array, ptr));
@@ -220,18 +195,18 @@ inline std::size_t large_container_size(const object &obj) noexcept
     // in optimized code, the type is not checked at all
     assert(obj.type == object_type::large_array || obj.type == object_type::large_map);
     if (obj.type == object_type::large_array) {
-        return obj.via.large_array.metadata.size;
+        return obj.via.large_array.size;
     }
-    return obj.via.large_map.metadata.size;
+    return obj.via.large_map.size;
 }
 
 inline std::size_t large_container_capacity(const object &obj) noexcept
 {
     assert(obj.type == object_type::large_array || obj.type == object_type::large_map);
     if (obj.type == object_type::large_array) {
-        return obj.via.large_array.metadata.capacity;
+        return obj.via.large_array.capacity;
     }
-    return obj.via.large_map.metadata.capacity;
+    return obj.via.large_map.capacity;
 }
 
 inline void set_large_container_size(object &obj, std::size_t size) noexcept
@@ -240,9 +215,9 @@ inline void set_large_container_size(object &obj, std::size_t size) noexcept
     assert(size <= (obj.type == object_type::large_array ? max_large_array_capacity
                                                          : max_large_map_capacity));
     if (obj.type == object_type::large_array) {
-        obj.via.large_array.metadata.size = static_cast<uint64_t>(size);
+        obj.via.large_array.size = static_cast<uint64_t>(size);
     } else {
-        obj.via.large_map.metadata.size = static_cast<uint64_t>(size);
+        obj.via.large_map.size = static_cast<uint64_t>(size);
     }
 }
 
@@ -252,9 +227,9 @@ inline void set_large_container_capacity(object &obj, std::size_t capacity) noex
     assert(capacity <= (obj.type == object_type::large_array ? max_large_array_capacity
                                                              : max_large_map_capacity));
     if (obj.type == object_type::large_array) {
-        obj.via.large_array.metadata.capacity = static_cast<uint64_t>(capacity);
+        obj.via.large_array.capacity = static_cast<uint64_t>(capacity);
     } else {
-        obj.via.large_map.metadata.capacity = static_cast<uint64_t>(capacity);
+        obj.via.large_map.capacity = static_cast<uint64_t>(capacity);
     }
 }
 
@@ -262,9 +237,9 @@ inline object make_large_array_object(object *ptr, std::size_t size, std::size_t
 {
     assert(size <= capacity);
     assert(capacity <= max_large_array_capacity);
-    return {.via{.large_array{.metadata{._type = static_cast<uint8_t>(object_type::large_array),
-                                  .size = static_cast<uint64_t>(size),
-                                  .capacity = static_cast<uint64_t>(capacity)},
+    return {.via{.large_array{._type = static_cast<uint8_t>(object_type::large_array),
+        .size = static_cast<uint64_t>(size),
+        .capacity = static_cast<uint64_t>(capacity),
         .ptr = ptr}}};
 }
 
@@ -272,9 +247,9 @@ inline object make_large_map_object(object_kv *ptr, std::size_t size, std::size_
 {
     assert(size <= capacity);
     assert(capacity <= max_large_map_capacity);
-    return {.via{.large_map{.metadata{._type = static_cast<uint8_t>(object_type::large_map),
-                                .size = static_cast<uint64_t>(size),
-                                .capacity = static_cast<uint64_t>(capacity)},
+    return {.via{.large_map{._type = static_cast<uint8_t>(object_type::large_map),
+        .size = static_cast<uint64_t>(size),
+        .capacity = static_cast<uint64_t>(capacity),
         .ptr = ptr}}};
 }
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -13,6 +13,7 @@
 #include "traits.hpp"
 #include "utils.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstddef>
@@ -22,6 +23,7 @@
 #include <functional>
 #include <initializer_list>
 #include <limits>
+#include <optional>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -48,6 +50,8 @@ namespace detail {
 
 union object;
 struct object_kv;
+struct object_large_array_storage;
+struct object_large_map_storage;
 
 constexpr std::size_t small_string_size = 14;
 
@@ -82,6 +86,24 @@ struct object_map {
     object_kv *ptr;
 };
 
+struct object_large_array {
+    object_type type;
+    uint8_t reserved[7];
+    union {
+        uint64_t _padding;
+        object *ptr;
+    };
+};
+
+struct object_large_map {
+    object_type type;
+    uint8_t reserved[7];
+    union {
+        uint64_t _padding;
+        object_kv *ptr;
+    };
+};
+
 union [[gnu::may_alias]] object {
     object_type type;
     union {
@@ -93,6 +115,8 @@ union [[gnu::may_alias]] object {
         object_small_string sstr;
         object_array array;
         object_map map;
+        object_large_array large_array;
+        object_large_map large_map;
     } via;
 };
 
@@ -101,8 +125,22 @@ struct object_kv {
     object val;
 };
 
+struct alignas(object) object_large_array_storage {
+    std::size_t size;
+    std::size_t capacity;
+    object ptr[];
+};
+
+struct alignas(object_kv) object_large_map_storage {
+    std::size_t size;
+    std::size_t capacity;
+    object_kv ptr[];
+};
+
 static_assert(sizeof(object) == 16);
 static_assert(sizeof(object_kv) == 32);
+static_assert(sizeof(object_large_array) == sizeof(object));
+static_assert(sizeof(object_large_map) == sizeof(object));
 
 static_assert(std::is_standard_layout_v<object>);
 static_assert(std::is_trivially_copyable_v<object>);
@@ -122,12 +160,122 @@ static_assert(offsetof(object, type) == offsetof(object_small_string, type));
 
 static_assert(offsetof(object, type) == offsetof(object_array, type));
 static_assert(offsetof(object, type) == offsetof(object_map, type));
+static_assert(offsetof(object, type) == offsetof(object_large_array, type));
+static_assert(offsetof(object, type) == offsetof(object_large_map, type));
 
 static_assert(offsetof(object_map, size) == offsetof(object_array, size));
 static_assert(offsetof(object_map, capacity) == offsetof(object_array, capacity));
 static_assert(offsetof(object_map, ptr) == offsetof(object_array, ptr));
 
+static_assert(offsetof(object_array, ptr) == offsetof(object_large_array, ptr));
+static_assert(offsetof(object_map, ptr) == offsetof(object_large_map, ptr));
+static_assert(offsetof(object_large_array_storage, ptr) == sizeof(object_large_array_storage));
+static_assert(offsetof(object_large_map_storage, ptr) == sizeof(object_large_map_storage));
+static_assert(alignof(object_large_array_storage) >= alignof(object));
+static_assert(alignof(object_large_map_storage) >= alignof(object_kv));
+
 template <typename T> constexpr std::size_t maxof_v = std::numeric_limits<T>::max();
+
+#define DDWAF_CONTAINER_OF(pointer, type, member)                                                  \
+    reinterpret_cast<type *>(reinterpret_cast<std::byte *>(pointer) - offsetof(type, member))
+
+/*
+ * Converts a signed index to an absolute container offset. Nonnegative indices
+ * count from the front, negative indices count from the back (-1 is last), and
+ * indices outside the container return std::nullopt.
+ */
+inline std::optional<std::size_t> normalize_index(std::size_t size, int64_t index) noexcept
+{
+    if (index >= 0) {
+        const auto unsigned_index = static_cast<uint64_t>(index);
+        if (unsigned_index < size) {
+            return static_cast<std::size_t>(unsigned_index);
+        }
+        return std::nullopt;
+    }
+
+    // Avoid negating INT64_MIN directly, which would overflow.
+    const auto distance = static_cast<uint64_t>(-(index + 1)) + uint64_t{1};
+    if (distance > size) {
+        return std::nullopt;
+    }
+    return size - static_cast<std::size_t>(distance);
+}
+
+template <typename Storage, typename Element>
+inline Storage *large_storage_from_data(Element *data) noexcept
+{
+    if (data == nullptr) {
+        return nullptr;
+    }
+    return DDWAF_CONTAINER_OF(data, Storage, ptr);
+}
+
+#undef DDWAF_CONTAINER_OF
+
+inline object_large_array_storage *large_array_storage(object &obj) noexcept
+{
+    return large_storage_from_data<object_large_array_storage>(obj.via.large_array.ptr);
+}
+
+inline const object_large_array_storage *large_array_storage(const object &obj) noexcept
+{
+    return large_storage_from_data<object_large_array_storage>(obj.via.large_array.ptr);
+}
+
+inline object_large_map_storage *large_map_storage(object &obj) noexcept
+{
+    return large_storage_from_data<object_large_map_storage>(obj.via.large_map.ptr);
+}
+
+inline const object_large_map_storage *large_map_storage(const object &obj) noexcept
+{
+    return large_storage_from_data<object_large_map_storage>(obj.via.large_map.ptr);
+}
+
+inline std::size_t container_size(const object &obj)
+{
+    if (obj.type == object_type::large_array) [[unlikely]] {
+        const auto *storage = large_array_storage(obj);
+        return storage == nullptr ? 0 : storage->size;
+    }
+    if (obj.type == object_type::large_map) [[unlikely]] {
+        const auto *storage = large_map_storage(obj);
+        return storage == nullptr ? 0 : storage->size;
+    }
+    return obj.via.array.size;
+}
+
+/*
+ * Compact and large containers store the same element pointer type at this
+ * offset. Copying its representation avoids reading an inactive union member.
+ */
+template <typename Element> inline Element *container_data(object &obj) noexcept
+{
+    Element *data;
+    memcpy(&data, reinterpret_cast<const std::byte *>(&obj) + offsetof(object_array, ptr),
+        sizeof(data));
+    return data;
+}
+
+template <typename Element> inline const Element *container_data(const object &obj) noexcept
+{
+    Element *data;
+    memcpy(&data, reinterpret_cast<const std::byte *>(&obj) + offsetof(object_array, ptr),
+        sizeof(data));
+    return data;
+}
+
+inline object *array_data(object &obj) noexcept { return container_data<object>(obj); }
+
+inline const object *array_data(const object &obj) noexcept { return container_data<object>(obj); }
+
+inline object_kv *map_data(object &obj) noexcept { return container_data<object_kv>(obj); }
+
+inline const object_kv *map_data(const object &obj) noexcept
+{
+    return container_data<object_kv>(obj);
+}
 
 inline bool requires_allocator(object_type type)
 {
@@ -175,6 +323,111 @@ inline std::pair<T *, SizeType> realloc_helper(
     return {new_data, new_size};
 }
 
+template <typename Storage, typename Element>
+constexpr std::size_t max_large_storage_capacity =
+    (maxof_v<std::size_t> - sizeof(Storage)) / sizeof(Element);
+
+template <typename Storage, typename Element>
+inline std::size_t large_storage_bytes(std::size_t capacity)
+{
+    if (capacity > max_large_storage_capacity<Storage, Element>) [[unlikely]] {
+        throw std::length_error("container capacity exceeds allocation limit");
+    }
+    return sizeof(Storage) + capacity * sizeof(Element);
+}
+
+template <typename Storage, typename Element>
+inline Storage *alloc_large_storage(std::size_t capacity, memory::memory_resource &alloc)
+{
+    if (capacity == 0) {
+        return nullptr;
+    }
+
+    const auto bytes = large_storage_bytes<Storage, Element>(capacity);
+    auto *storage = static_cast<Storage *>(alloc.allocate(bytes, alignof(Storage)));
+    if (storage == nullptr) [[unlikely]] {
+        throw std::bad_alloc();
+    }
+    storage->size = 0;
+    storage->capacity = capacity;
+    return storage;
+}
+
+template <typename Storage, typename Element>
+inline void dealloc_large_storage(Storage *storage, memory::memory_resource &alloc)
+{
+    const auto bytes = large_storage_bytes<Storage, Element>(storage->capacity);
+    alloc.deallocate(storage, bytes, alignof(Storage));
+}
+
+inline std::size_t next_large_capacity(std::size_t capacity, std::size_t maximum)
+{
+    if (capacity >= maximum) [[unlikely]] {
+        throw std::length_error("container has reached its maximum capacity");
+    }
+    if (capacity == 0) {
+        return std::min<std::size_t>(8, maximum);
+    }
+    return capacity > maximum / 2 ? maximum : capacity * 2;
+}
+
+inline void grow_large_array(object &obj, memory::memory_resource &alloc)
+{
+    auto *old_storage = large_array_storage(obj);
+    const auto old_capacity = old_storage == nullptr ? 0 : old_storage->capacity;
+    const auto old_size = old_storage == nullptr ? 0 : old_storage->size;
+    static constexpr auto maximum = max_large_storage_capacity<object_large_array_storage, object>;
+    const auto new_capacity = next_large_capacity(old_capacity, maximum);
+    auto *new_storage =
+        alloc_large_storage<object_large_array_storage, object>(new_capacity, alloc);
+    new_storage->size = old_size;
+    if (old_storage != nullptr) {
+        memcpy(new_storage->ptr, old_storage->ptr, old_size * sizeof(object));
+        dealloc_large_storage<object_large_array_storage, object>(old_storage, alloc);
+    }
+    obj.via.large_array.ptr = new_storage->ptr;
+}
+
+inline void grow_large_map(object &obj, memory::memory_resource &alloc)
+{
+    auto *old_storage = large_map_storage(obj);
+    const auto old_capacity = old_storage == nullptr ? 0 : old_storage->capacity;
+    const auto old_size = old_storage == nullptr ? 0 : old_storage->size;
+    static constexpr auto maximum = max_large_storage_capacity<object_large_map_storage, object_kv>;
+    const auto new_capacity = next_large_capacity(old_capacity, maximum);
+    auto *new_storage =
+        alloc_large_storage<object_large_map_storage, object_kv>(new_capacity, alloc);
+    new_storage->size = old_size;
+    if (old_storage != nullptr) {
+        memcpy(new_storage->ptr, old_storage->ptr, old_size * sizeof(object_kv));
+        dealloc_large_storage<object_large_map_storage, object_kv>(old_storage, alloc);
+    }
+    obj.via.large_map.ptr = new_storage->ptr;
+}
+
+inline void promote_array(object &obj, memory::memory_resource &alloc)
+{
+    constexpr std::size_t promoted_capacity = maxof_v<uint16_t> * std::size_t{2};
+    auto *storage =
+        alloc_large_storage<object_large_array_storage, object>(promoted_capacity, alloc);
+    storage->size = obj.via.array.size;
+    memcpy(storage->ptr, obj.via.array.ptr, storage->size * sizeof(object));
+    dealloc_helper(obj.via.array.ptr, obj.via.array.capacity, alloc);
+    obj = {
+        .via{.large_array{.type = object_type::large_array, .reserved = {}, .ptr = storage->ptr}}};
+}
+
+inline void promote_map(object &obj, memory::memory_resource &alloc)
+{
+    constexpr std::size_t promoted_capacity = maxof_v<uint16_t> * std::size_t{2};
+    auto *storage =
+        alloc_large_storage<object_large_map_storage, object_kv>(promoted_capacity, alloc);
+    storage->size = obj.via.map.size;
+    memcpy(storage->ptr, obj.via.map.ptr, storage->size * sizeof(object_kv));
+    dealloc_helper(obj.via.map.ptr, obj.via.map.capacity, alloc);
+    obj = {.via{.large_map{.type = object_type::large_map, .reserved = {}, .ptr = storage->ptr}}};
+}
+
 template <typename SizeType>
 inline char *copy_string(const char *str, SizeType length, memory::memory_resource &alloc)
 {
@@ -190,19 +443,28 @@ inline void object_destroy(object &obj, nonnull_ptr<memory::memory_resource> all
         return;
     }
 
-    if (obj.type == object_type::array) {
-        for (std::size_t i = 0; i < obj.via.array.size; ++i) {
-            object_destroy(obj.via.array.ptr[i], alloc);
-        }
-        if (obj.via.array.ptr != nullptr) {
+    if (ddwaf::is_array(obj.type)) {
+        const auto size = container_size(obj);
+        auto *data = array_data(obj);
+        for (std::size_t i = 0; i < size; ++i) { object_destroy(data[i], alloc); }
+        if (obj.type == object_type::large_array && obj.via.large_array.ptr != nullptr)
+            [[unlikely]] {
+            dealloc_large_storage<object_large_array_storage, object>(
+                large_array_storage(obj), *alloc);
+        } else if (obj.type == object_type::array && obj.via.array.ptr != nullptr) {
             dealloc_helper(obj.via.array.ptr, obj.via.array.capacity, *alloc);
         }
-    } else if (obj.type == object_type::map) {
-        for (std::size_t i = 0; i < obj.via.map.size; ++i) {
-            object_destroy(obj.via.map.ptr[i].key, alloc);
-            object_destroy(obj.via.map.ptr[i].val, alloc);
+    } else if (ddwaf::is_map(obj.type)) {
+        const auto size = container_size(obj);
+        auto *data = map_data(obj);
+        for (std::size_t i = 0; i < size; ++i) {
+            object_destroy(data[i].key, alloc);
+            object_destroy(data[i].val, alloc);
         }
-        if (obj.via.map.ptr != nullptr) {
+        if (obj.type == object_type::large_map && obj.via.large_map.ptr != nullptr) [[unlikely]] {
+            dealloc_large_storage<object_large_map_storage, object_kv>(
+                large_map_storage(obj), *alloc);
+        } else if (obj.type == object_type::map && obj.via.map.ptr != nullptr) {
             dealloc_helper(obj.via.map.ptr, obj.via.map.capacity, *alloc);
         }
     } else if (obj.type == object_type::string) {
@@ -226,20 +488,18 @@ public:
     //   - When using at, the accessed indexed is within bounds (using size*())
     //   - When using as, the accessed field matches the underlying object type (using is*())
 
-    template <typename SizeType = std::size_t>
-    [[nodiscard]] SizeType size() const noexcept
-        requires std::is_integral_v<SizeType> && (sizeof(SizeType) >= 4)
+    [[nodiscard]] std::size_t size() const noexcept
     {
         const auto t = type();
         if (t == object_type::small_string) {
-            return static_cast<SizeType>(object_ref().via.sstr.size);
+            return object_ref().via.sstr.size;
         }
 
         if (t == object_type::string || t == object_type::literal_string) {
-            return static_cast<SizeType>(object_ref().via.str.size);
+            return object_ref().via.str.size;
         }
         // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
-        return static_cast<SizeType>(object_ref().via.array.size);
+        return detail::container_size(object_ref());
     }
 
     [[nodiscard]] bool empty() const noexcept { return size() == 0; }
@@ -260,8 +520,8 @@ public:
     [[nodiscard]] bool is_container() const noexcept { return ddwaf::is_container(type()); }
     [[nodiscard]] bool is_scalar() const noexcept { return ddwaf::is_scalar(type()); }
 
-    [[nodiscard]] bool is_map() const noexcept { return type() == object_type::map; }
-    [[nodiscard]] bool is_array() const noexcept { return type() == object_type::array; }
+    [[nodiscard]] bool is_map() const noexcept { return ddwaf::is_map(type()); }
+    [[nodiscard]] bool is_array() const noexcept { return ddwaf::is_array(type()); }
     [[nodiscard]] bool is_string() const noexcept { return (type() & object_type::string) != 0; }
 
     [[nodiscard]] bool is_valid() const noexcept { return type() != object_type::invalid; }
@@ -459,24 +719,27 @@ public:
     [[nodiscard]] std::pair<object_view, object_view> at(std::size_t index) const noexcept
     {
         assert(obj_ != nullptr && index < size());
-        if (type() == object_type::map) {
-            assert(obj_->via.map.ptr != nullptr);
-            const auto &slot = obj_->via.map.ptr[index];
+        if (is_map()) {
+            const auto *data = detail::map_data(*obj_);
+            assert(data != nullptr);
+            const auto &slot = data[index];
             return {slot.key, slot.val};
         }
-        assert(obj_->via.array.ptr != nullptr);
-        return {{}, obj_->via.array.ptr[index]};
+        const auto *data = detail::array_data(*obj_);
+        assert(data != nullptr);
+        return {{}, data[index]};
     }
 
     // Access the key at index. If the container is an array, the key will be an empty string.
     [[nodiscard]] object_view at_key(std::size_t index) const noexcept
     {
         assert(obj_ != nullptr && index < size());
-        if (type() == object_type::map) {
-            assert(obj_->via.map.ptr != nullptr);
-            return obj_->via.map.ptr[index].key;
+        if (is_map()) {
+            const auto *data = detail::map_data(*obj_);
+            assert(data != nullptr);
+            return data[index].key;
         }
-        assert(obj_->via.array.ptr != nullptr);
+        assert(detail::array_data(*obj_) != nullptr);
         return {};
     }
 
@@ -484,17 +747,19 @@ public:
     [[nodiscard]] object_view at_value(std::size_t index) const noexcept
     {
         assert(obj_ != nullptr && index < size());
-        if (type() == object_type::map) {
-            assert(obj_->via.map.ptr != nullptr);
-            return obj_->via.map.ptr[index].val;
+        if (is_map()) {
+            const auto *data = detail::map_data(*obj_);
+            assert(data != nullptr);
+            return data[index].val;
         }
-        assert(obj_->via.array.ptr != nullptr);
-        return obj_->via.array.ptr[index];
+        const auto *data = detail::array_data(*obj_);
+        assert(data != nullptr);
+        return data[index];
     }
 
     [[nodiscard]] object_view find(std::string_view expected_key) const noexcept
     {
-        assert(obj_ != nullptr && type() == object_type::map);
+        assert(obj_ != nullptr && is_map());
 
         for (std::size_t i = 0; i < size(); ++i) {
             auto [key, value] = at(i);
@@ -538,12 +803,8 @@ public:
                             return {};
                         }
 
-                        if (expected_key >= 0 && root.size<int64_t>() > expected_key) {
-                            return root.at_value(expected_key);
-                        }
-
-                        if (expected_key < 0 && (root.size<int64_t>() + expected_key) >= 0) {
-                            return root.at_value(root.size<int64_t>() + expected_key);
+                        if (const auto index = detail::normalize_index(root.size(), expected_key)) {
+                            return root.at_value(*index);
                         }
                     }
                     return {};
@@ -571,11 +832,11 @@ public:
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     array_view(const detail::object *o)
     {
-        if (o == nullptr || o->type != object_type::array) {
+        if (o == nullptr || !ddwaf::is_array(o->type)) {
             throw std::invalid_argument("array_view initialised with null or incompatible type");
         }
-        data_ = o->via.array.ptr;
-        size_ = o->via.array.size;
+        data_ = detail::array_data(*o);
+        size_ = detail::container_size(*o);
     }
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     array_view(const detail::object &o) : array_view(&o) {}
@@ -643,7 +904,7 @@ public:
 protected:
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     const detail::object *data_{nullptr};
-    uint16_t size_{0};
+    std::size_t size_{0};
 };
 
 static_assert(sizeof(array_view) <= 16);
@@ -655,12 +916,12 @@ public:
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     map_view(const detail::object *o)
     {
-        if (o == nullptr || o->type != object_type::map) {
+        if (o == nullptr || !ddwaf::is_map(o->type)) {
             throw std::invalid_argument("map_view initialised with null or incompatible type");
         }
 
-        data_ = o->via.map.ptr;
-        size_ = o->via.map.size;
+        data_ = detail::map_data(*o);
+        size_ = detail::container_size(*o);
     }
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     map_view(const detail::object &o) : map_view(&o) {}
@@ -757,7 +1018,7 @@ public:
 protected:
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     const detail::object_kv *data_{nullptr};
-    std::uint16_t size_{0};
+    std::size_t size_{0};
 };
 
 static_assert(sizeof(map_view) <= 16);
@@ -958,8 +1219,13 @@ public:
         return make_string(str.data(), str.size(), alloc);
     }
 
-    static owned_object make_array(uint16_t capacity, nonnull_ptr<memory::memory_resource> alloc)
+    static owned_object make_array(std::size_t capacity, nonnull_ptr<memory::memory_resource> alloc)
     {
+        if (capacity > detail::maxof_v<uint16_t>) [[unlikely]] {
+            return make_large_array(capacity, alloc);
+        }
+
+        const auto compact_capacity = static_cast<uint16_t>(capacity);
         if (capacity == 0) {
             return owned_object{
                 {.via{
@@ -970,8 +1236,8 @@ public:
         return owned_object{
             {.via{.array{.type = object_type::array,
                 .size = 0,
-                .capacity = capacity,
-                .ptr = detail::alloc_helper<detail::object, uint16_t>(capacity, *alloc)}}},
+                .capacity = compact_capacity,
+                .ptr = detail::alloc_helper<detail::object, uint16_t>(compact_capacity, *alloc)}}},
             alloc};
     }
 
@@ -980,25 +1246,54 @@ public:
         return make_array(0, alloc);
     }
 
-    static owned_object make_map(uint16_t capacity, nonnull_ptr<memory::memory_resource> alloc)
+    static owned_object make_large_array(
+        std::size_t capacity, nonnull_ptr<memory::memory_resource> alloc)
     {
+        auto *storage =
+            detail::alloc_large_storage<detail::object_large_array_storage, detail::object>(
+                capacity, *alloc);
+        return owned_object{{.via{.large_array{.type = object_type::large_array,
+                                .reserved = {},
+                                .ptr = storage == nullptr ? nullptr : storage->ptr}}},
+            alloc};
+    }
+
+    static owned_object make_map(std::size_t capacity, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        if (capacity > detail::maxof_v<uint16_t>) [[unlikely]] {
+            return make_large_map(capacity, alloc);
+        }
+
+        const auto compact_capacity = static_cast<uint16_t>(capacity);
         if (capacity == 0) {
             return owned_object{
                 {.via{.map{.type = object_type::map, .size = 0, .capacity = 0, .ptr = nullptr}}},
                 alloc};
         }
 
-        return owned_object{
-            {.via{.map{.type = object_type::map,
-                .size = 0,
-                .capacity = capacity,
-                .ptr = detail::alloc_helper<detail::object_kv, uint16_t>(capacity, *alloc)}}},
+        return owned_object{{.via{.map{.type = object_type::map,
+                                .size = 0,
+                                .capacity = compact_capacity,
+                                .ptr = detail::alloc_helper<detail::object_kv, uint16_t>(
+                                    compact_capacity, *alloc)}}},
             alloc};
     }
 
     static owned_object make_map(nonnull_ptr<memory::memory_resource> alloc)
     {
         return make_map(0, alloc);
+    }
+
+    static owned_object make_large_map(
+        std::size_t capacity, nonnull_ptr<memory::memory_resource> alloc)
+    {
+        auto *storage =
+            detail::alloc_large_storage<detail::object_large_map_storage, detail::object_kv>(
+                capacity, *alloc);
+        return owned_object{{.via{.large_map{.type = object_type::large_map,
+                                .reserved = {},
+                                .ptr = storage == nullptr ? nullptr : storage->ptr}}},
+            alloc};
     }
 
     detail::object move()
@@ -1073,8 +1368,10 @@ template <typename Derived>
         case object_type::null:
             return owned_object::make_null();
         case object_type::map:
+        case object_type::large_map:
             return owned_object::make_map(source.size(), alloc);
         case object_type::array:
+        case object_type::large_array:
             return owned_object::make_array(source.size(), alloc);
         case object_type::invalid:
         default:
@@ -1146,13 +1443,13 @@ template <typename Derived>
 
     assert(is_container(static_cast<object_type>(container.type)));
 
-    if (container.type == object_type::map) {
-        assert(idx < static_cast<std::size_t>(container.via.map.size));
-        return borrowed_object{&container.via.map.ptr[idx].val, alloc()};
+    if (ddwaf::is_map(container.type)) {
+        assert(idx < detail::container_size(container));
+        return borrowed_object{&detail::map_data(container)[idx].val, alloc()};
     }
 
-    assert(idx < static_cast<std::size_t>(container.via.array.size));
-    return borrowed_object{&container.via.array.ptr[idx], alloc()};
+    assert(idx < detail::container_size(container));
+    return borrowed_object{&detail::array_data(container)[idx], alloc()};
 }
 
 template <typename Derived>
@@ -1161,10 +1458,22 @@ borrowed_object writable_object<Derived>::emplace_back(owned_object &&value)
 {
     auto &container = object_ref();
 
-    assert(static_cast<object_type>(container.type) == object_type::array);
+    assert(ddwaf::is_array(container.type));
 
     if (detail::requires_allocator(value.type()) && !detail::alloc_equal(alloc(), value.alloc())) {
         throw std::runtime_error("emplace: incompatible allocators");
+    }
+
+    if (container.type == object_type::large_array) [[unlikely]] {
+        auto *storage = detail::large_array_storage(container);
+        if (storage == nullptr || storage->size == storage->capacity) {
+            detail::grow_large_array(container, alloc());
+            storage = detail::large_array_storage(container);
+        }
+
+        borrowed_object slot{&storage->ptr[storage->size++], alloc()};
+        *slot.ptr() = value.move();
+        return slot;
     }
 
     // We preallocate 8 entries
@@ -1172,6 +1481,14 @@ borrowed_object writable_object<Derived>::emplace_back(owned_object &&value)
         container.via.array.ptr = detail::alloc_helper<detail::object, uint16_t>(8U, alloc());
         container.via.array.capacity = 8;
     } else if (container.via.array.capacity == container.via.array.size) {
+        if (container.via.array.capacity == detail::maxof_v<uint16_t>) [[unlikely]] {
+            detail::promote_array(container, alloc());
+            auto *storage = detail::large_array_storage(container);
+            borrowed_object slot{&storage->ptr[storage->size++], alloc()};
+            *slot.ptr() = value.move();
+            return slot;
+        }
+
         auto [new_array, new_capacity] = detail::realloc_helper<detail::object, uint16_t>(
             container.via.array.ptr, container.via.array.capacity, alloc());
         container.via.array.ptr = new_array;
@@ -1198,7 +1515,7 @@ borrowed_object writable_object<Derived>::emplace(owned_object &&key, owned_obje
 {
     auto &container = object_ref();
 
-    assert(static_cast<object_type>(container.type) == object_type::map);
+    assert(ddwaf::is_map(container.type));
 
     if ((detail::requires_allocator(key.type()) && !detail::alloc_equal(alloc(), key.alloc())) ||
         (detail::requires_allocator(value.type()) &&
@@ -1206,11 +1523,37 @@ borrowed_object writable_object<Derived>::emplace(owned_object &&key, owned_obje
         throw std::runtime_error("emplace: incompatible allocators");
     }
 
+    if (container.type == object_type::large_map) {
+        auto *storage = detail::large_map_storage(container);
+        if (storage == nullptr || storage->size == storage->capacity) {
+            detail::grow_large_map(container, alloc());
+            storage = detail::large_map_storage(container);
+        }
+
+        borrowed_object key_slot{storage->ptr[storage->size].key, alloc()};
+        borrowed_object val_slot{storage->ptr[storage->size].val, alloc()};
+        ++storage->size;
+        *key_slot.ptr() = key.move();
+        *val_slot.ptr() = value.move();
+        return val_slot;
+    }
+
     // We preallocate 8 entries
     if (container.via.map.capacity == 0) {
         container.via.map.ptr = detail::alloc_helper<detail::object_kv, uint16_t>(8U, alloc());
         container.via.map.capacity = 8;
     } else if (container.via.map.capacity == container.via.map.size) {
+        if (container.via.map.capacity == detail::maxof_v<uint16_t>) {
+            detail::promote_map(container, alloc());
+            auto *storage = detail::large_map_storage(container);
+            borrowed_object key_slot{storage->ptr[storage->size].key, alloc()};
+            borrowed_object val_slot{storage->ptr[storage->size].val, alloc()};
+            ++storage->size;
+            *key_slot.ptr() = key.move();
+            *val_slot.ptr() = value.move();
+            return val_slot;
+        }
+
         auto [new_map, new_capacity] = detail::realloc_helper<detail::object_kv, uint16_t>(
             container.via.map.ptr, container.via.map.capacity, alloc());
         container.via.map.ptr = new_map;

--- a/src/object_type.hpp
+++ b/src/object_type.hpp
@@ -31,7 +31,12 @@ enum class object_type : uint8_t {
     array = 0x20,    // 0b00100000
     map = 0x40,      // 0b01000000
     hash_map = 0x60, // 0b01100000
+
+    large_array = 0xA0, // 0b10100000
+    large_map = 0xC0,   // 0b11000000
 };
+
+constexpr uint8_t logical_container_type_mask = 0x7f;
 
 template <typename T>
 constexpr object_type operator|(object_type left, T right)
@@ -72,9 +77,21 @@ inline bool is_scalar(object_type type)
                        object_type::small_string)) != 0;
 }
 
+inline bool is_array(object_type type)
+{
+    return (static_cast<uint8_t>(type) & logical_container_type_mask) ==
+           static_cast<uint8_t>(object_type::array);
+}
+
+inline bool is_map(object_type type)
+{
+    return (static_cast<uint8_t>(type) & logical_container_type_mask) ==
+           static_cast<uint8_t>(object_type::map);
+}
+
 inline bool is_container(object_type type)
 {
-    return (type & (object_type::array | object_type::map)) != 0;
+    return is_array(type) || is_map(type) || type == object_type::hash_map;
 }
 
 template <typename T> inline bool is_compatible_type(object_type /*type*/) { return false; }
@@ -121,8 +138,10 @@ T object_type_to_string(object_type type)
 {
     switch (type) {
     case object_type::map:
+    case object_type::large_map:
         return "map";
     case object_type::array:
+    case object_type::large_array:
         return "array";
     case object_type::string:
     case object_type::literal_string:

--- a/src/processor/extract_schema.cpp
+++ b/src/processor/extract_schema.cpp
@@ -283,7 +283,8 @@ base_node generate_helper(object_view object, std::string_view key,
     case object_type::int64:
     case object_type::uint64:
         return node_scalar{.type = scalar_type::integer};
-    case object_type::map: {
+    case object_type::map:
+    case object_type::large_map: {
         auto length = object.size();
         node_record_ptr record = std::make_unique<node_record>();
         if (length > extract_schema::max_record_nodes) {
@@ -303,7 +304,8 @@ base_node generate_helper(object_view object, std::string_view key,
         }
         return record;
     }
-    case object_type::array: {
+    case object_type::array:
+    case object_type::large_array: {
         auto length = object.size();
         node_array_ptr array = std::make_unique<node_array>();
         array->length = length;

--- a/tests/common/json_utils.cpp
+++ b/tests/common/json_utils.cpp
@@ -68,8 +68,9 @@ void object_to_json_helper(
             ddwaf_object_get_string(&obj, nullptr), ddwaf_object_get_length(&obj), alloc);
     } break;
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         output.SetObject();
-        for (unsigned i = 0; i < obj.via.map.size; i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             rapidjson::Value key;
             rapidjson::Value value;
 
@@ -82,8 +83,9 @@ void object_to_json_helper(
         }
         break;
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         output.SetArray();
-        for (unsigned i = 0; i < obj.via.array.size; i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             rapidjson::Value value;
             const auto *child = ddwaf_object_at_value(&obj, i);
             object_to_json_helper(*child, value, alloc);
@@ -185,7 +187,7 @@ rapidjson::Document object_to_rapidjson(const ddwaf_object &obj)
 std::unordered_map<std::string_view, std::string_view> object_to_map(const ddwaf_object &obj)
 {
     std::unordered_map<std::string_view, std::string_view> map;
-    for (unsigned i = 0; i < obj.via.map.size; ++i) {
+    for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); ++i) {
         const auto *key = ddwaf_object_at_key(&obj, i);
         const auto *value = ddwaf_object_at_value(&obj, i);
 

--- a/tests/integration/conditions/rasp_transformers/test.cpp
+++ b/tests/integration/conditions/rasp_transformers/test.cpp
@@ -32,7 +32,7 @@ void set_string_map(ddwaf_object *map,
     const std::vector<std::pair<std::string_view, std::string_view>> &entries,
     ddwaf_allocator alloc)
 {
-    ddwaf_object_set_map(map, static_cast<uint16_t>(entries.size()), alloc);
+    ddwaf_object_set_map(map, entries.size(), alloc);
     for (const auto &[key, value] : entries) {
         ddwaf_object_set_string(ddwaf_object_insert_key(map, key.data(), key.size(), alloc),
             value.data(), value.size(), alloc);

--- a/tests/integration/interface/object/test.cpp
+++ b/tests/integration/interface/object/test.cpp
@@ -4,7 +4,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021 Datadog, Inc.
 
+// This translation unit verifies both the legacy and transitional ABI entry points.
+#define DDWAF_DISABLE_API_POISON
 #include "ddwaf.h"
+#undef ddwaf_object_set_array
+#undef ddwaf_object_set_map
+
 #include "memory_resource.hpp"
 #include "utils.hpp"
 
@@ -215,11 +220,11 @@ TEST(TestObjectIntegration, TestContainerRepresentationSelection)
     ddwaf_object array;
     ddwaf_object map;
 
-    ASSERT_EQ(ddwaf_object_set_array(&array, compact_capacity, alloc), &array);
+    ASSERT_EQ(ddwaf_object_set_array_large(&array, compact_capacity, alloc), &array);
     EXPECT_EQ(ddwaf_object_get_type(&array), DDWAF_OBJ_ARRAY);
     ddwaf_object_destroy(&array, alloc);
 
-    ASSERT_EQ(ddwaf_object_set_array(&array, large_capacity, alloc), &array);
+    ASSERT_EQ(ddwaf_object_set_array_large(&array, large_capacity, alloc), &array);
     EXPECT_EQ(ddwaf_object_get_type(&array), DDWAF_OBJ_LARGE_ARRAY);
     EXPECT_TRUE(ddwaf_object_is_array(&array));
     EXPECT_FALSE(ddwaf_object_is_map(&array));
@@ -231,11 +236,11 @@ TEST(TestObjectIntegration, TestContainerRepresentationSelection)
     EXPECT_EQ(array.via.large_array.capacity, large_capacity);
     ddwaf_object_destroy(&array, alloc);
 
-    ASSERT_EQ(ddwaf_object_set_map(&map, compact_capacity, alloc), &map);
+    ASSERT_EQ(ddwaf_object_set_map_large(&map, compact_capacity, alloc), &map);
     EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_MAP);
     ddwaf_object_destroy(&map, alloc);
 
-    ASSERT_EQ(ddwaf_object_set_map(&map, large_capacity, alloc), &map);
+    ASSERT_EQ(ddwaf_object_set_map_large(&map, large_capacity, alloc), &map);
     EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_LARGE_MAP);
     EXPECT_TRUE(ddwaf_object_is_map(&map));
     EXPECT_FALSE(ddwaf_object_is_array(&map));
@@ -255,7 +260,7 @@ TEST(TestObjectIntegration, TestLargeArrayOperations)
         static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1;
     ddwaf_object array;
 
-    ASSERT_EQ(ddwaf_object_set_array(&array, large_capacity, alloc), &array);
+    ASSERT_EQ(ddwaf_object_set_array_large(&array, large_capacity, alloc), &array);
     ASSERT_NE(array.via.large_array.ptr, nullptr);
     const auto *initial_data = array.via.large_array.ptr;
 
@@ -292,7 +297,7 @@ TEST(TestObjectIntegration, TestLargeMapOperations)
         static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1;
     ddwaf_object map;
 
-    ASSERT_EQ(ddwaf_object_set_map(&map, large_capacity, alloc), &map);
+    ASSERT_EQ(ddwaf_object_set_map_large(&map, large_capacity, alloc), &map);
     ASSERT_NE(map.via.large_map.ptr, nullptr);
     const auto *initial_data = map.via.large_map.ptr;
 
@@ -334,21 +339,21 @@ TEST(TestObjectIntegration, TestLargeContainerCapacityOverflow)
     ddwaf_object object;
     ddwaf_object_set_signed(&object, 42);
 
-    EXPECT_EQ(ddwaf_object_set_array(&object, unrepresentable_capacity, alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_set_array_large(&object, unrepresentable_capacity, alloc), nullptr);
     EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
     EXPECT_EQ(ddwaf_object_get_signed(&object), 42);
 
-    EXPECT_EQ(ddwaf_object_set_map(&object, unrepresentable_capacity, alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_set_map_large(&object, unrepresentable_capacity, alloc), nullptr);
     EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
     EXPECT_EQ(ddwaf_object_get_signed(&object), 42);
 
-    EXPECT_EQ(
-        ddwaf_object_set_array(&object, std::numeric_limits<std::size_t>::max(), alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_set_array_large(&object, std::numeric_limits<std::size_t>::max(), alloc),
+        nullptr);
     EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
     EXPECT_EQ(ddwaf_object_get_signed(&object), 42);
 
-    EXPECT_EQ(
-        ddwaf_object_set_map(&object, std::numeric_limits<std::size_t>::max(), alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_set_map_large(&object, std::numeric_limits<std::size_t>::max(), alloc),
+        nullptr);
     EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
     EXPECT_EQ(ddwaf_object_get_signed(&object), 42);
 }

--- a/tests/integration/interface/object/test.cpp
+++ b/tests/integration/interface/object/test.cpp
@@ -225,7 +225,10 @@ TEST(TestObjectIntegration, TestContainerRepresentationSelection)
     EXPECT_FALSE(ddwaf_object_is_map(&array));
     EXPECT_EQ(ddwaf_object_get_size(&array), 0);
     EXPECT_NE(array.via.large_array.ptr, nullptr);
-    for (const auto byte : array.via.large_array.reserved) { EXPECT_EQ(byte, 0); }
+    EXPECT_EQ(array.via.large_array.type, DDWAF_OBJ_LARGE_ARRAY);
+    EXPECT_EQ(array.via.large_array.metadata._type, DDWAF_OBJ_LARGE_ARRAY);
+    EXPECT_EQ(array.via.large_array.metadata.size, 0);
+    EXPECT_EQ(array.via.large_array.metadata.capacity, large_capacity);
     ddwaf_object_destroy(&array, alloc);
 
     ASSERT_EQ(ddwaf_object_set_map(&map, compact_capacity, alloc), &map);
@@ -238,7 +241,10 @@ TEST(TestObjectIntegration, TestContainerRepresentationSelection)
     EXPECT_FALSE(ddwaf_object_is_array(&map));
     EXPECT_EQ(ddwaf_object_get_size(&map), 0);
     EXPECT_NE(map.via.large_map.ptr, nullptr);
-    for (const auto byte : map.via.large_map.reserved) { EXPECT_EQ(byte, 0); }
+    EXPECT_EQ(map.via.large_map.type, DDWAF_OBJ_LARGE_MAP);
+    EXPECT_EQ(map.via.large_map.metadata._type, DDWAF_OBJ_LARGE_MAP);
+    EXPECT_EQ(map.via.large_map.metadata.size, 0);
+    EXPECT_EQ(map.via.large_map.metadata.capacity, large_capacity);
     ddwaf_object_destroy(&map, alloc);
 }
 
@@ -256,6 +262,8 @@ TEST(TestObjectIntegration, TestLargeArrayOperations)
     ddwaf_object_set_signed(ddwaf_object_insert(&array, alloc), -1);
     ddwaf_object_set_unsigned(ddwaf_object_insert(&array, alloc), 2);
     EXPECT_EQ(array.via.large_array.ptr, initial_data);
+    EXPECT_EQ(array.via.large_array.metadata.size, 2);
+    EXPECT_EQ(array.via.large_array.metadata.capacity, large_capacity);
     EXPECT_EQ(ddwaf_object_at_value(&array, 0), &array.via.large_array.ptr[0]);
     EXPECT_EQ(ddwaf_object_at_value(&array, 1), &array.via.large_array.ptr[1]);
 
@@ -292,6 +300,8 @@ TEST(TestObjectIntegration, TestLargeMapOperations)
     auto *nested = ddwaf_object_insert_literal_key(&map, STRL("nested"), alloc);
     ddwaf_object_set_array(nested, 1, alloc);
     EXPECT_EQ(map.via.large_map.ptr, initial_data);
+    EXPECT_EQ(map.via.large_map.metadata.size, 2);
+    EXPECT_EQ(map.via.large_map.metadata.capacity, large_capacity);
 
     ASSERT_NE(nested, nullptr);
     ddwaf_object_set_string(
@@ -320,8 +330,17 @@ TEST(TestObjectIntegration, TestLargeMapOperations)
 TEST(TestObjectIntegration, TestLargeContainerCapacityOverflow)
 {
     auto *alloc = ddwaf_get_default_allocator();
+    constexpr auto unrepresentable_capacity = std::size_t{1} << 28;
     ddwaf_object object;
     ddwaf_object_set_signed(&object, 42);
+
+    EXPECT_EQ(ddwaf_object_set_array(&object, unrepresentable_capacity, alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
+    EXPECT_EQ(ddwaf_object_get_signed(&object), 42);
+
+    EXPECT_EQ(ddwaf_object_set_map(&object, unrepresentable_capacity, alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
+    EXPECT_EQ(ddwaf_object_get_signed(&object), 42);
 
     EXPECT_EQ(
         ddwaf_object_set_array(&object, std::numeric_limits<std::size_t>::max(), alloc), nullptr);
@@ -361,6 +380,9 @@ TEST(TestObjectIntegration, TestCompactArrayPromotion)
     EXPECT_EQ(ddwaf_object_get_type(&array), DDWAF_OBJ_LARGE_ARRAY);
     EXPECT_TRUE(ddwaf_object_is_array(&array));
     EXPECT_EQ(ddwaf_object_get_size(&array), compact_limit + std::size_t{1});
+    EXPECT_EQ(array.via.large_array.metadata._type, DDWAF_OBJ_LARGE_ARRAY);
+    EXPECT_EQ(array.via.large_array.metadata.size, compact_limit + std::size_t{1});
+    EXPECT_EQ(array.via.large_array.metadata.capacity, static_cast<std::size_t>(compact_limit) * 2);
     EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_at_value(&array, compact_limit - 1)),
         compact_limit - 1);
     EXPECT_EQ(
@@ -396,6 +418,9 @@ TEST(TestObjectIntegration, TestCompactMapPromotion)
     EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_LARGE_MAP);
     EXPECT_TRUE(ddwaf_object_is_map(&map));
     EXPECT_EQ(ddwaf_object_get_size(&map), compact_limit + std::size_t{1});
+    EXPECT_EQ(map.via.large_map.metadata._type, DDWAF_OBJ_LARGE_MAP);
+    EXPECT_EQ(map.via.large_map.metadata.size, compact_limit + std::size_t{1});
+    EXPECT_EQ(map.via.large_map.metadata.capacity, static_cast<std::size_t>(compact_limit) * 2);
     EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_find(&map, STRL("last"))), compact_limit);
     EXPECT_STRV(object_to_view(*ddwaf_object_at_key(&map, compact_limit)), "last");
 

--- a/tests/integration/interface/object/test.cpp
+++ b/tests/integration/interface/object/test.cpp
@@ -225,10 +225,10 @@ TEST(TestObjectIntegration, TestContainerRepresentationSelection)
     EXPECT_FALSE(ddwaf_object_is_map(&array));
     EXPECT_EQ(ddwaf_object_get_size(&array), 0);
     EXPECT_NE(array.via.large_array.ptr, nullptr);
-    EXPECT_EQ(array.via.large_array.type, DDWAF_OBJ_LARGE_ARRAY);
-    EXPECT_EQ(array.via.large_array.metadata._type, DDWAF_OBJ_LARGE_ARRAY);
-    EXPECT_EQ(array.via.large_array.metadata.size, 0);
-    EXPECT_EQ(array.via.large_array.metadata.capacity, large_capacity);
+    EXPECT_EQ(array.type, DDWAF_OBJ_LARGE_ARRAY);
+    EXPECT_EQ(array.via.large_array._type, DDWAF_OBJ_LARGE_ARRAY);
+    EXPECT_EQ(array.via.large_array.size, 0);
+    EXPECT_EQ(array.via.large_array.capacity, large_capacity);
     ddwaf_object_destroy(&array, alloc);
 
     ASSERT_EQ(ddwaf_object_set_map(&map, compact_capacity, alloc), &map);
@@ -241,10 +241,10 @@ TEST(TestObjectIntegration, TestContainerRepresentationSelection)
     EXPECT_FALSE(ddwaf_object_is_array(&map));
     EXPECT_EQ(ddwaf_object_get_size(&map), 0);
     EXPECT_NE(map.via.large_map.ptr, nullptr);
-    EXPECT_EQ(map.via.large_map.type, DDWAF_OBJ_LARGE_MAP);
-    EXPECT_EQ(map.via.large_map.metadata._type, DDWAF_OBJ_LARGE_MAP);
-    EXPECT_EQ(map.via.large_map.metadata.size, 0);
-    EXPECT_EQ(map.via.large_map.metadata.capacity, large_capacity);
+    EXPECT_EQ(map.type, DDWAF_OBJ_LARGE_MAP);
+    EXPECT_EQ(map.via.large_map._type, DDWAF_OBJ_LARGE_MAP);
+    EXPECT_EQ(map.via.large_map.size, 0);
+    EXPECT_EQ(map.via.large_map.capacity, large_capacity);
     ddwaf_object_destroy(&map, alloc);
 }
 
@@ -262,8 +262,8 @@ TEST(TestObjectIntegration, TestLargeArrayOperations)
     ddwaf_object_set_signed(ddwaf_object_insert(&array, alloc), -1);
     ddwaf_object_set_unsigned(ddwaf_object_insert(&array, alloc), 2);
     EXPECT_EQ(array.via.large_array.ptr, initial_data);
-    EXPECT_EQ(array.via.large_array.metadata.size, 2);
-    EXPECT_EQ(array.via.large_array.metadata.capacity, large_capacity);
+    EXPECT_EQ(array.via.large_array.size, 2);
+    EXPECT_EQ(array.via.large_array.capacity, large_capacity);
     EXPECT_EQ(ddwaf_object_at_value(&array, 0), &array.via.large_array.ptr[0]);
     EXPECT_EQ(ddwaf_object_at_value(&array, 1), &array.via.large_array.ptr[1]);
 
@@ -300,8 +300,8 @@ TEST(TestObjectIntegration, TestLargeMapOperations)
     auto *nested = ddwaf_object_insert_literal_key(&map, STRL("nested"), alloc);
     ddwaf_object_set_array(nested, 1, alloc);
     EXPECT_EQ(map.via.large_map.ptr, initial_data);
-    EXPECT_EQ(map.via.large_map.metadata.size, 2);
-    EXPECT_EQ(map.via.large_map.metadata.capacity, large_capacity);
+    EXPECT_EQ(map.via.large_map.size, 2);
+    EXPECT_EQ(map.via.large_map.capacity, large_capacity);
 
     ASSERT_NE(nested, nullptr);
     ddwaf_object_set_string(
@@ -380,9 +380,9 @@ TEST(TestObjectIntegration, TestCompactArrayPromotion)
     EXPECT_EQ(ddwaf_object_get_type(&array), DDWAF_OBJ_LARGE_ARRAY);
     EXPECT_TRUE(ddwaf_object_is_array(&array));
     EXPECT_EQ(ddwaf_object_get_size(&array), compact_limit + std::size_t{1});
-    EXPECT_EQ(array.via.large_array.metadata._type, DDWAF_OBJ_LARGE_ARRAY);
-    EXPECT_EQ(array.via.large_array.metadata.size, compact_limit + std::size_t{1});
-    EXPECT_EQ(array.via.large_array.metadata.capacity, static_cast<std::size_t>(compact_limit) * 2);
+    EXPECT_EQ(array.via.large_array._type, DDWAF_OBJ_LARGE_ARRAY);
+    EXPECT_EQ(array.via.large_array.size, compact_limit + std::size_t{1});
+    EXPECT_EQ(array.via.large_array.capacity, static_cast<std::size_t>(compact_limit) * 2);
     EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_at_value(&array, compact_limit - 1)),
         compact_limit - 1);
     EXPECT_EQ(
@@ -418,9 +418,9 @@ TEST(TestObjectIntegration, TestCompactMapPromotion)
     EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_LARGE_MAP);
     EXPECT_TRUE(ddwaf_object_is_map(&map));
     EXPECT_EQ(ddwaf_object_get_size(&map), compact_limit + std::size_t{1});
-    EXPECT_EQ(map.via.large_map.metadata._type, DDWAF_OBJ_LARGE_MAP);
-    EXPECT_EQ(map.via.large_map.metadata.size, compact_limit + std::size_t{1});
-    EXPECT_EQ(map.via.large_map.metadata.capacity, static_cast<std::size_t>(compact_limit) * 2);
+    EXPECT_EQ(map.via.large_map._type, DDWAF_OBJ_LARGE_MAP);
+    EXPECT_EQ(map.via.large_map.size, compact_limit + std::size_t{1});
+    EXPECT_EQ(map.via.large_map.capacity, static_cast<std::size_t>(compact_limit) * 2);
     EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_find(&map, STRL("last"))), compact_limit);
     EXPECT_STRV(object_to_view(*ddwaf_object_at_key(&map, compact_limit)), "last");
 

--- a/tests/integration/interface/object/test.cpp
+++ b/tests/integration/interface/object/test.cpp
@@ -12,6 +12,10 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
 using namespace ddwaf;
 
 namespace {
@@ -200,6 +204,202 @@ TEST(TestObjectIntegration, TestCreateMap)
     EXPECT_TRUE(ddwaf_object_is_map(&container));
 
     ddwaf_object_destroy(&container, alloc);
+}
+
+TEST(TestObjectIntegration, TestContainerRepresentationSelection)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+    constexpr auto compact_capacity =
+        static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max());
+    constexpr auto large_capacity = compact_capacity + 1;
+    ddwaf_object array;
+    ddwaf_object map;
+
+    ASSERT_EQ(ddwaf_object_set_array(&array, compact_capacity, alloc), &array);
+    EXPECT_EQ(ddwaf_object_get_type(&array), DDWAF_OBJ_ARRAY);
+    ddwaf_object_destroy(&array, alloc);
+
+    ASSERT_EQ(ddwaf_object_set_array(&array, large_capacity, alloc), &array);
+    EXPECT_EQ(ddwaf_object_get_type(&array), DDWAF_OBJ_LARGE_ARRAY);
+    EXPECT_TRUE(ddwaf_object_is_array(&array));
+    EXPECT_FALSE(ddwaf_object_is_map(&array));
+    EXPECT_EQ(ddwaf_object_get_size(&array), 0);
+    EXPECT_NE(array.via.large_array.ptr, nullptr);
+    for (const auto byte : array.via.large_array.reserved) { EXPECT_EQ(byte, 0); }
+    ddwaf_object_destroy(&array, alloc);
+
+    ASSERT_EQ(ddwaf_object_set_map(&map, compact_capacity, alloc), &map);
+    EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_MAP);
+    ddwaf_object_destroy(&map, alloc);
+
+    ASSERT_EQ(ddwaf_object_set_map(&map, large_capacity, alloc), &map);
+    EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_LARGE_MAP);
+    EXPECT_TRUE(ddwaf_object_is_map(&map));
+    EXPECT_FALSE(ddwaf_object_is_array(&map));
+    EXPECT_EQ(ddwaf_object_get_size(&map), 0);
+    EXPECT_NE(map.via.large_map.ptr, nullptr);
+    for (const auto byte : map.via.large_map.reserved) { EXPECT_EQ(byte, 0); }
+    ddwaf_object_destroy(&map, alloc);
+}
+
+TEST(TestObjectIntegration, TestLargeArrayOperations)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+    constexpr auto large_capacity =
+        static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1;
+    ddwaf_object array;
+
+    ASSERT_EQ(ddwaf_object_set_array(&array, large_capacity, alloc), &array);
+    ASSERT_NE(array.via.large_array.ptr, nullptr);
+    const auto *initial_data = array.via.large_array.ptr;
+
+    ddwaf_object_set_signed(ddwaf_object_insert(&array, alloc), -1);
+    ddwaf_object_set_unsigned(ddwaf_object_insert(&array, alloc), 2);
+    EXPECT_EQ(array.via.large_array.ptr, initial_data);
+    EXPECT_EQ(ddwaf_object_at_value(&array, 0), &array.via.large_array.ptr[0]);
+    EXPECT_EQ(ddwaf_object_at_value(&array, 1), &array.via.large_array.ptr[1]);
+
+    ddwaf_object_set_string(
+        ddwaf_object_insert(&array, alloc), STRL("third element is allocated"), alloc);
+    EXPECT_EQ(array.via.large_array.ptr, initial_data);
+    EXPECT_EQ(ddwaf_object_get_size(&array), 3);
+    EXPECT_EQ(ddwaf_object_get_signed(ddwaf_object_at_value(&array, 0)), -1);
+    EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_at_value(&array, 1)), 2);
+    EXPECT_STRV(object_to_view(*ddwaf_object_at_value(&array, 2)), "third element is allocated");
+
+    ddwaf_object clone;
+    ASSERT_EQ(ddwaf_object_clone(&array, &clone, alloc), &clone);
+    EXPECT_EQ(ddwaf_object_get_type(&clone), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_size(&clone), 3);
+    EXPECT_STRV(object_to_view(*ddwaf_object_at_value(&clone, 2)), "third element is allocated");
+
+    ddwaf_object_destroy(&clone, alloc);
+    ddwaf_object_destroy(&array, alloc);
+}
+
+TEST(TestObjectIntegration, TestLargeMapOperations)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+    constexpr auto large_capacity =
+        static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max()) + 1;
+    ddwaf_object map;
+
+    ASSERT_EQ(ddwaf_object_set_map(&map, large_capacity, alloc), &map);
+    ASSERT_NE(map.via.large_map.ptr, nullptr);
+    const auto *initial_data = map.via.large_map.ptr;
+
+    ddwaf_object_set_unsigned(ddwaf_object_insert_literal_key(&map, STRL("first"), alloc), 1);
+    auto *nested = ddwaf_object_insert_literal_key(&map, STRL("nested"), alloc);
+    ddwaf_object_set_array(nested, 1, alloc);
+    EXPECT_EQ(map.via.large_map.ptr, initial_data);
+
+    ASSERT_NE(nested, nullptr);
+    ddwaf_object_set_string(
+        ddwaf_object_insert(nested, alloc), STRL("recursively allocated value"), alloc);
+
+    EXPECT_EQ(ddwaf_object_get_size(&map), 2);
+    EXPECT_EQ(ddwaf_object_at_key(&map, 0), &map.via.large_map.ptr[0].key);
+    EXPECT_EQ(ddwaf_object_at_value(&map, 0), &map.via.large_map.ptr[0].val);
+    EXPECT_STRV(object_to_view(*ddwaf_object_at_key(&map, 0)), "first");
+    EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_find(&map, STRL("first"))), 1);
+    ASSERT_NE(ddwaf_object_find(&map, STRL("nested")), nullptr);
+
+    ddwaf_object clone;
+    ASSERT_EQ(ddwaf_object_clone(&map, &clone, alloc), &clone);
+    EXPECT_EQ(ddwaf_object_get_type(&clone), DDWAF_OBJ_MAP);
+    const auto *cloned_nested = ddwaf_object_find(&clone, STRL("nested"));
+    ASSERT_NE(cloned_nested, nullptr);
+    EXPECT_EQ(ddwaf_object_get_type(cloned_nested), DDWAF_OBJ_ARRAY);
+    EXPECT_STRV(
+        object_to_view(*ddwaf_object_at_value(cloned_nested, 0)), "recursively allocated value");
+
+    ddwaf_object_destroy(&clone, alloc);
+    ddwaf_object_destroy(&map, alloc);
+}
+
+TEST(TestObjectIntegration, TestLargeContainerCapacityOverflow)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+    ddwaf_object object;
+    ddwaf_object_set_signed(&object, 42);
+
+    EXPECT_EQ(
+        ddwaf_object_set_array(&object, std::numeric_limits<std::size_t>::max(), alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
+    EXPECT_EQ(ddwaf_object_get_signed(&object), 42);
+
+    EXPECT_EQ(
+        ddwaf_object_set_map(&object, std::numeric_limits<std::size_t>::max(), alloc), nullptr);
+    EXPECT_EQ(ddwaf_object_get_type(&object), DDWAF_OBJ_SIGNED);
+    EXPECT_EQ(ddwaf_object_get_signed(&object), 42);
+}
+
+TEST(TestObjectIntegration, TestCompactArrayPromotion)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+    ddwaf_object array;
+    constexpr auto compact_limit = std::numeric_limits<std::uint16_t>::max();
+
+    ASSERT_EQ(ddwaf_object_set_array(&array, compact_limit, alloc), &array);
+    for (std::size_t i = 0; i < compact_limit; ++i) {
+        auto *element = ddwaf_object_insert(&array, alloc);
+        ASSERT_NE(element, nullptr);
+        if (i == 0 || i + 1 == compact_limit) {
+            ddwaf_object_set_unsigned(element, i);
+        }
+    }
+
+    EXPECT_EQ(ddwaf_object_get_type(&array), DDWAF_OBJ_ARRAY);
+    EXPECT_EQ(ddwaf_object_get_size(&array), compact_limit);
+    EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_at_value(&array, 0)), 0);
+    EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_at_value(&array, compact_limit - 1)),
+        compact_limit - 1);
+
+    auto *promoted_element = ddwaf_object_insert(&array, alloc);
+    ASSERT_NE(promoted_element, nullptr);
+    ddwaf_object_set_unsigned(promoted_element, compact_limit);
+    EXPECT_EQ(ddwaf_object_get_type(&array), DDWAF_OBJ_LARGE_ARRAY);
+    EXPECT_TRUE(ddwaf_object_is_array(&array));
+    EXPECT_EQ(ddwaf_object_get_size(&array), compact_limit + std::size_t{1});
+    EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_at_value(&array, compact_limit - 1)),
+        compact_limit - 1);
+    EXPECT_EQ(
+        ddwaf_object_get_unsigned(ddwaf_object_at_value(&array, compact_limit)), compact_limit);
+
+    ddwaf_object_destroy(&array, alloc);
+}
+
+TEST(TestObjectIntegration, TestCompactMapPromotion)
+{
+    auto *alloc = ddwaf_get_default_allocator();
+    ddwaf_object map;
+    constexpr auto compact_limit = std::numeric_limits<std::uint16_t>::max();
+
+    ASSERT_EQ(ddwaf_object_set_map(&map, compact_limit, alloc), &map);
+    for (std::size_t i = 0; i < compact_limit; ++i) {
+        auto *element = ddwaf_object_insert_literal_key(&map, STRL("key"), alloc);
+        ASSERT_NE(element, nullptr);
+        if (i == 0 || i + 1 == compact_limit) {
+            ddwaf_object_set_unsigned(element, i);
+        }
+    }
+
+    EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_MAP);
+    EXPECT_EQ(ddwaf_object_get_size(&map), compact_limit);
+    EXPECT_STRV(object_to_view(*ddwaf_object_at_key(&map, compact_limit - 1)), "key");
+    EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_at_value(&map, compact_limit - 1)),
+        compact_limit - 1);
+
+    auto *promoted_element = ddwaf_object_insert_literal_key(&map, STRL("last"), alloc);
+    ASSERT_NE(promoted_element, nullptr);
+    ddwaf_object_set_unsigned(promoted_element, compact_limit);
+    EXPECT_EQ(ddwaf_object_get_type(&map), DDWAF_OBJ_LARGE_MAP);
+    EXPECT_TRUE(ddwaf_object_is_map(&map));
+    EXPECT_EQ(ddwaf_object_get_size(&map), compact_limit + std::size_t{1});
+    EXPECT_EQ(ddwaf_object_get_unsigned(ddwaf_object_find(&map, STRL("last"))), compact_limit);
+    EXPECT_STRV(object_to_view(*ddwaf_object_at_key(&map, compact_limit)), "last");
+
+    ddwaf_object_destroy(&map, alloc);
 }
 
 TEST(TestObjectIntegration, TestAddArray)

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -382,24 +382,23 @@ TEST(TestObject, LargeArrayAllocationGrowthAndFailure)
         auto root = owned_object::make_large_array(initial_capacity, &alloc);
         EXPECT_EQ(root.type(), object_type::large_array);
         EXPECT_TRUE(root.is_array());
-        EXPECT_EQ(root.ref().via.large_array.metadata._type,
-            static_cast<uint8_t>(object_type::large_array));
-        EXPECT_EQ(root.ref().via.large_array.metadata.size, 0);
-        EXPECT_EQ(root.ref().via.large_array.metadata.capacity, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_array._type, static_cast<uint8_t>(object_type::large_array));
+        EXPECT_EQ(root.ref().via.large_array.size, 0);
+        EXPECT_EQ(root.ref().via.large_array.capacity, initial_capacity);
         EXPECT_EQ(alloc.last_allocation_bytes(), initial_capacity * sizeof(detail::object));
         EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object));
 
         root.emplace_back(1U);
         root.emplace_back(2U);
         const auto *initial_data = root.ref().via.large_array.ptr;
-        EXPECT_EQ(root.ref().via.large_array.metadata.size, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_array.size, initial_capacity);
 
         alloc.fail_allocations(true);
         EXPECT_THROW(root.emplace_back(3U), std::bad_alloc);
         EXPECT_EQ(alloc.failed_allocations(), 1);
         EXPECT_EQ(root.ref().via.large_array.ptr, initial_data);
-        EXPECT_EQ(root.ref().via.large_array.metadata.size, initial_capacity);
-        EXPECT_EQ(root.ref().via.large_array.metadata.capacity, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_array.size, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_array.capacity, initial_capacity);
         EXPECT_EQ(root.size(), initial_capacity);
         EXPECT_EQ(root.at(0).as<std::uint64_t>(), 1);
         EXPECT_EQ(root.at(1).as<std::uint64_t>(), 2);
@@ -408,8 +407,8 @@ TEST(TestObject, LargeArrayAllocationGrowthAndFailure)
         root.emplace_back(3U);
         EXPECT_NE(root.ref().via.large_array.ptr, initial_data);
         EXPECT_EQ(root.size(), 3);
-        EXPECT_EQ(root.ref().via.large_array.metadata.size, 3);
-        EXPECT_EQ(root.ref().via.large_array.metadata.capacity, grown_capacity);
+        EXPECT_EQ(root.ref().via.large_array.size, 3);
+        EXPECT_EQ(root.ref().via.large_array.capacity, grown_capacity);
         EXPECT_EQ(alloc.last_allocation_bytes(), grown_capacity * sizeof(detail::object));
         EXPECT_EQ(alloc.last_deallocation_bytes(), initial_capacity * sizeof(detail::object));
         EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object));
@@ -431,23 +430,22 @@ TEST(TestObject, LargeMapAllocationGrowthAndFailure)
         auto root = owned_object::make_large_map(initial_capacity, &alloc);
         EXPECT_EQ(root.type(), object_type::large_map);
         EXPECT_TRUE(root.is_map());
-        EXPECT_EQ(
-            root.ref().via.large_map.metadata._type, static_cast<uint8_t>(object_type::large_map));
-        EXPECT_EQ(root.ref().via.large_map.metadata.size, 0);
-        EXPECT_EQ(root.ref().via.large_map.metadata.capacity, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_map._type, static_cast<uint8_t>(object_type::large_map));
+        EXPECT_EQ(root.ref().via.large_map.size, 0);
+        EXPECT_EQ(root.ref().via.large_map.capacity, initial_capacity);
         EXPECT_EQ(alloc.last_allocation_bytes(), initial_capacity * sizeof(detail::object_kv));
         EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_kv));
 
         root.emplace("one", 1U);
         const auto *initial_data = root.ref().via.large_map.ptr;
-        EXPECT_EQ(root.ref().via.large_map.metadata.size, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_map.size, initial_capacity);
 
         alloc.fail_allocations(true);
         EXPECT_THROW(root.emplace("two", 2U), std::bad_alloc);
         EXPECT_EQ(alloc.failed_allocations(), 1);
         EXPECT_EQ(root.ref().via.large_map.ptr, initial_data);
-        EXPECT_EQ(root.ref().via.large_map.metadata.size, initial_capacity);
-        EXPECT_EQ(root.ref().via.large_map.metadata.capacity, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_map.size, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_map.capacity, initial_capacity);
         EXPECT_EQ(root.size(), initial_capacity);
         EXPECT_EQ(root.at(0).as<std::uint64_t>(), 1);
 
@@ -455,8 +453,8 @@ TEST(TestObject, LargeMapAllocationGrowthAndFailure)
         root.emplace("two", 2U);
         EXPECT_NE(root.ref().via.large_map.ptr, initial_data);
         EXPECT_EQ(root.size(), 2);
-        EXPECT_EQ(root.ref().via.large_map.metadata.size, 2);
-        EXPECT_EQ(root.ref().via.large_map.metadata.capacity, grown_capacity);
+        EXPECT_EQ(root.ref().via.large_map.size, 2);
+        EXPECT_EQ(root.ref().via.large_map.capacity, grown_capacity);
         EXPECT_EQ(alloc.last_allocation_bytes(), grown_capacity * sizeof(detail::object_kv));
         EXPECT_EQ(alloc.last_deallocation_bytes(), initial_capacity * sizeof(detail::object_kv));
         EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_kv));
@@ -530,10 +528,9 @@ TEST(TestObject, CompactContainerPromotionAllocation)
         root.emplace_back(42U);
         EXPECT_EQ(root.type(), object_type::large_array);
         EXPECT_EQ(root.size(), compact_capacity + std::size_t{1});
-        EXPECT_EQ(root.ref().via.large_array.metadata._type,
-            static_cast<uint8_t>(object_type::large_array));
-        EXPECT_EQ(root.ref().via.large_array.metadata.size, compact_capacity + std::size_t{1});
-        EXPECT_EQ(root.ref().via.large_array.metadata.capacity, promoted_capacity);
+        EXPECT_EQ(root.ref().via.large_array._type, static_cast<uint8_t>(object_type::large_array));
+        EXPECT_EQ(root.ref().via.large_array.size, compact_capacity + std::size_t{1});
+        EXPECT_EQ(root.ref().via.large_array.capacity, promoted_capacity);
         EXPECT_EQ(root.at(compact_capacity).as<std::uint64_t>(), 42);
         EXPECT_EQ(alloc.last_allocation_bytes(), promoted_capacity * sizeof(detail::object));
         EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object));
@@ -550,10 +547,9 @@ TEST(TestObject, CompactContainerPromotionAllocation)
         root.emplace("last", 42U);
         EXPECT_EQ(root.type(), object_type::large_map);
         EXPECT_EQ(root.size(), compact_capacity + std::size_t{1});
-        EXPECT_EQ(
-            root.ref().via.large_map.metadata._type, static_cast<uint8_t>(object_type::large_map));
-        EXPECT_EQ(root.ref().via.large_map.metadata.size, compact_capacity + std::size_t{1});
-        EXPECT_EQ(root.ref().via.large_map.metadata.capacity, promoted_capacity);
+        EXPECT_EQ(root.ref().via.large_map._type, static_cast<uint8_t>(object_type::large_map));
+        EXPECT_EQ(root.ref().via.large_map.size, compact_capacity + std::size_t{1});
+        EXPECT_EQ(root.ref().via.large_map.capacity, promoted_capacity);
         EXPECT_EQ(root.at(compact_capacity).as<std::uint64_t>(), 42);
         EXPECT_EQ(alloc.last_allocation_bytes(), promoted_capacity * sizeof(detail::object_kv));
         EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_kv));

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -9,9 +9,12 @@
 #include "memory_resource.hpp"
 #include "object.hpp"
 
+#include <cstring>
+#include <limits>
 #include <stdexcept>
 
 using namespace ddwaf;
+
 using namespace ddwaf::test;
 using namespace std::literals;
 
@@ -68,9 +71,83 @@ private:
     std::size_t deallocations_{0};
 };
 
+class tracking_resource : public memory::memory_resource {
+public:
+    void fail_allocations(bool fail) { fail_allocations_ = fail; }
+
+    [[nodiscard]] std::size_t allocations() const { return allocations_; }
+    [[nodiscard]] std::size_t failed_allocations() const { return failed_allocations_; }
+    [[nodiscard]] std::size_t deallocations() const { return deallocations_; }
+    [[nodiscard]] std::size_t last_allocation_bytes() const { return last_allocation_bytes_; }
+    [[nodiscard]] std::size_t last_allocation_alignment() const
+    {
+        return last_allocation_alignment_;
+    }
+    [[nodiscard]] std::size_t last_deallocation_bytes() const { return last_deallocation_bytes_; }
+    [[nodiscard]] std::size_t last_deallocation_alignment() const
+    {
+        return last_deallocation_alignment_;
+    }
+
+private:
+    void *do_allocate(std::size_t bytes, std::size_t alignment) override
+    {
+        if (fail_allocations_) {
+            ++failed_allocations_;
+            throw std::bad_alloc();
+        }
+        ++allocations_;
+        last_allocation_bytes_ = bytes;
+        last_allocation_alignment_ = alignment;
+        return resource_->allocate(bytes, alignment);
+    }
+
+    void do_deallocate(void *ptr, std::size_t bytes, std::size_t alignment) override
+    {
+        ++deallocations_;
+        last_deallocation_bytes_ = bytes;
+        last_deallocation_alignment_ = alignment;
+        resource_->deallocate(ptr, bytes, alignment);
+    }
+
+    [[nodiscard]] bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override
+    {
+        return this == &other;
+    }
+
+    bool fail_allocations_{false};
+    std::size_t allocations_{0};
+    std::size_t failed_allocations_{0};
+    std::size_t deallocations_{0};
+    std::size_t last_allocation_bytes_{0};
+    std::size_t last_allocation_alignment_{0};
+    std::size_t last_deallocation_bytes_{0};
+    std::size_t last_deallocation_alignment_{0};
+    memory::memory_resource *resource_{memory::get_default_resource()};
+};
+
 TEST(TestObject, NullBorrowedObject)
 {
     EXPECT_THROW(borrowed_object(nullptr, memory::get_default_resource()), std::invalid_argument);
+}
+
+TEST(TestObject, NormalizeSignedIndex)
+{
+    EXPECT_EQ(detail::normalize_index(3, 0), 0);
+    EXPECT_EQ(detail::normalize_index(3, 2), 2);
+    EXPECT_EQ(detail::normalize_index(3, -1), 2);
+    EXPECT_EQ(detail::normalize_index(3, -3), 0);
+    EXPECT_FALSE(detail::normalize_index(3, 3).has_value());
+    EXPECT_FALSE(detail::normalize_index(3, -4).has_value());
+    EXPECT_FALSE(detail::normalize_index(3, std::numeric_limits<int64_t>::min()).has_value());
+
+    if constexpr (sizeof(std::size_t) >= sizeof(uint64_t)) {
+        constexpr auto large_size =
+            static_cast<std::size_t>(std::numeric_limits<int64_t>::max()) + std::size_t{2};
+        EXPECT_EQ(detail::normalize_index(large_size, std::numeric_limits<int64_t>::max()),
+            static_cast<std::size_t>(std::numeric_limits<int64_t>::max()));
+        EXPECT_EQ(detail::normalize_index(large_size, std::numeric_limits<int64_t>::min()), 1);
+    }
 }
 
 TEST(TestObject, InvalidObject)
@@ -293,6 +370,175 @@ TEST(TestObject, EmptyPreallocatedArrayObjectWithAllocator)
 
     EXPECT_EQ(alloc.allocations(), 1);
     EXPECT_EQ(alloc.deallocations(), 1);
+}
+
+TEST(TestObject, LargeArrayAllocationGrowthAndFailure)
+{
+    tracking_resource alloc;
+    constexpr std::size_t initial_capacity = 2;
+    constexpr std::size_t grown_capacity = initial_capacity * 2;
+
+    {
+        auto root = owned_object::make_large_array(initial_capacity, &alloc);
+        EXPECT_EQ(root.type(), object_type::large_array);
+        EXPECT_TRUE(root.is_array());
+        EXPECT_EQ(alloc.last_allocation_bytes(),
+            sizeof(detail::object_large_array_storage) + initial_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_large_array_storage));
+
+        root.emplace_back(1U);
+        root.emplace_back(2U);
+        const auto *initial_data = root.ref().via.large_array.ptr;
+        const auto *initial_storage = detail::large_array_storage(root.ref());
+        ASSERT_NE(initial_storage, nullptr);
+        EXPECT_EQ(initial_storage->ptr, initial_data);
+
+        alloc.fail_allocations(true);
+        EXPECT_THROW(root.emplace_back(3U), std::bad_alloc);
+        EXPECT_EQ(alloc.failed_allocations(), 1);
+        EXPECT_EQ(root.ref().via.large_array.ptr, initial_data);
+        EXPECT_EQ(detail::large_array_storage(root.ref()), initial_storage);
+        EXPECT_EQ(root.size(), initial_capacity);
+        EXPECT_EQ(root.at(0).as<std::uint64_t>(), 1);
+        EXPECT_EQ(root.at(1).as<std::uint64_t>(), 2);
+
+        alloc.fail_allocations(false);
+        root.emplace_back(3U);
+        EXPECT_NE(root.ref().via.large_array.ptr, initial_data);
+        EXPECT_NE(detail::large_array_storage(root.ref()), initial_storage);
+        EXPECT_EQ(root.size(), 3);
+        EXPECT_EQ(alloc.last_allocation_bytes(),
+            sizeof(detail::object_large_array_storage) + grown_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_deallocation_bytes(),
+            sizeof(detail::object_large_array_storage) + initial_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_large_array_storage));
+    }
+
+    EXPECT_EQ(alloc.allocations(), 2);
+    EXPECT_EQ(alloc.deallocations(), 2);
+    EXPECT_EQ(alloc.last_deallocation_bytes(),
+        sizeof(detail::object_large_array_storage) + grown_capacity * sizeof(detail::object));
+}
+
+TEST(TestObject, LargeMapAllocationGrowthAndFailure)
+{
+    tracking_resource alloc;
+    constexpr std::size_t initial_capacity = 1;
+    constexpr std::size_t grown_capacity = initial_capacity * 2;
+
+    {
+        auto root = owned_object::make_large_map(initial_capacity, &alloc);
+        EXPECT_EQ(root.type(), object_type::large_map);
+        EXPECT_TRUE(root.is_map());
+        EXPECT_EQ(alloc.last_allocation_bytes(), sizeof(detail::object_large_map_storage) +
+                                                     initial_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_large_map_storage));
+
+        root.emplace("one", 1U);
+        const auto *initial_data = root.ref().via.large_map.ptr;
+        const auto *initial_storage = detail::large_map_storage(root.ref());
+        ASSERT_NE(initial_storage, nullptr);
+        EXPECT_EQ(initial_storage->ptr, initial_data);
+
+        alloc.fail_allocations(true);
+        EXPECT_THROW(root.emplace("two", 2U), std::bad_alloc);
+        EXPECT_EQ(alloc.failed_allocations(), 1);
+        EXPECT_EQ(root.ref().via.large_map.ptr, initial_data);
+        EXPECT_EQ(detail::large_map_storage(root.ref()), initial_storage);
+        EXPECT_EQ(root.size(), initial_capacity);
+        EXPECT_EQ(root.at(0).as<std::uint64_t>(), 1);
+
+        alloc.fail_allocations(false);
+        root.emplace("two", 2U);
+        EXPECT_NE(root.ref().via.large_map.ptr, initial_data);
+        EXPECT_NE(detail::large_map_storage(root.ref()), initial_storage);
+        EXPECT_EQ(root.size(), 2);
+        EXPECT_EQ(alloc.last_allocation_bytes(),
+            sizeof(detail::object_large_map_storage) + grown_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(
+            alloc.last_deallocation_bytes(), sizeof(detail::object_large_map_storage) +
+                                                 initial_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_large_map_storage));
+    }
+
+    EXPECT_EQ(alloc.allocations(), 2);
+    EXPECT_EQ(alloc.deallocations(), 2);
+    EXPECT_EQ(alloc.last_deallocation_bytes(),
+        sizeof(detail::object_large_map_storage) + grown_capacity * sizeof(detail::object_kv));
+}
+
+TEST(TestObject, LargeContainerOverflowAndExhaustedCapacity)
+{
+    tracking_resource alloc;
+    const auto maximum = std::numeric_limits<std::size_t>::max();
+
+    EXPECT_THROW(owned_object::make_large_array(maximum, &alloc), std::length_error);
+    EXPECT_THROW(owned_object::make_large_map(maximum, &alloc), std::length_error);
+    EXPECT_THROW(detail::next_large_capacity(maximum, maximum), std::length_error);
+    EXPECT_EQ(alloc.allocations(), 0);
+}
+
+TEST(TestObject, LargeContainerRecursiveDestruction)
+{
+    tracking_resource alloc;
+    {
+        auto root = owned_object::make_large_map(1, &alloc);
+        auto nested = owned_object::make_large_array(1, &alloc);
+        nested.emplace_back(owned_object::make_string("an allocated nested string", &alloc));
+        root.emplace("nested", std::move(nested));
+        EXPECT_EQ(alloc.allocations(), 3);
+    }
+    EXPECT_EQ(alloc.deallocations(), 3);
+}
+
+TEST(TestObject, CompactContainerPromotionAllocation)
+{
+    static constexpr auto compact_capacity = std::numeric_limits<std::uint16_t>::max();
+    static constexpr std::size_t promoted_capacity = compact_capacity * std::size_t{2};
+
+    {
+        tracking_resource alloc;
+        auto root = owned_object::make_array(compact_capacity, &alloc);
+        std::memset(root.ref().via.array.ptr, 0, compact_capacity * sizeof(detail::object));
+        root.ref().via.array.size = compact_capacity;
+        const auto *compact_data = root.ref().via.array.ptr;
+
+        alloc.fail_allocations(true);
+        EXPECT_THROW(root.emplace_back(42U), std::bad_alloc);
+        EXPECT_EQ(root.type(), object_type::array);
+        EXPECT_EQ(root.size(), compact_capacity);
+        EXPECT_EQ(root.ref().via.array.ptr, compact_data);
+
+        alloc.fail_allocations(false);
+        root.emplace_back(42U);
+        EXPECT_EQ(root.type(), object_type::large_array);
+        EXPECT_EQ(root.size(), compact_capacity + std::size_t{1});
+        EXPECT_EQ(detail::large_array_storage(root.ref())->capacity, promoted_capacity);
+        EXPECT_EQ(root.at(compact_capacity).as<std::uint64_t>(), 42);
+        EXPECT_EQ(alloc.last_allocation_bytes(), sizeof(detail::object_large_array_storage) +
+                                                     promoted_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_large_array_storage));
+        EXPECT_EQ(alloc.last_deallocation_bytes(), compact_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object));
+    }
+
+    {
+        tracking_resource alloc;
+        auto root = owned_object::make_map(compact_capacity, &alloc);
+        std::memset(root.ref().via.map.ptr, 0, compact_capacity * sizeof(detail::object_kv));
+        root.ref().via.map.size = compact_capacity;
+
+        root.emplace("last", 42U);
+        EXPECT_EQ(root.type(), object_type::large_map);
+        EXPECT_EQ(root.size(), compact_capacity + std::size_t{1});
+        EXPECT_EQ(detail::large_map_storage(root.ref())->capacity, promoted_capacity);
+        EXPECT_EQ(root.at(compact_capacity).as<std::uint64_t>(), 42);
+        EXPECT_EQ(alloc.last_allocation_bytes(), sizeof(detail::object_large_map_storage) +
+                                                     promoted_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_large_map_storage));
+        EXPECT_EQ(alloc.last_deallocation_bytes(), compact_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_kv));
+    }
 }
 
 TEST(TestObject, ArrayObjectEmplaceBack)

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -382,22 +382,24 @@ TEST(TestObject, LargeArrayAllocationGrowthAndFailure)
         auto root = owned_object::make_large_array(initial_capacity, &alloc);
         EXPECT_EQ(root.type(), object_type::large_array);
         EXPECT_TRUE(root.is_array());
-        EXPECT_EQ(alloc.last_allocation_bytes(),
-            sizeof(detail::object_large_array_storage) + initial_capacity * sizeof(detail::object));
-        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_large_array_storage));
+        EXPECT_EQ(root.ref().via.large_array.metadata._type,
+            static_cast<uint8_t>(object_type::large_array));
+        EXPECT_EQ(root.ref().via.large_array.metadata.size, 0);
+        EXPECT_EQ(root.ref().via.large_array.metadata.capacity, initial_capacity);
+        EXPECT_EQ(alloc.last_allocation_bytes(), initial_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object));
 
         root.emplace_back(1U);
         root.emplace_back(2U);
         const auto *initial_data = root.ref().via.large_array.ptr;
-        const auto *initial_storage = detail::large_array_storage(root.ref());
-        ASSERT_NE(initial_storage, nullptr);
-        EXPECT_EQ(initial_storage->ptr, initial_data);
+        EXPECT_EQ(root.ref().via.large_array.metadata.size, initial_capacity);
 
         alloc.fail_allocations(true);
         EXPECT_THROW(root.emplace_back(3U), std::bad_alloc);
         EXPECT_EQ(alloc.failed_allocations(), 1);
         EXPECT_EQ(root.ref().via.large_array.ptr, initial_data);
-        EXPECT_EQ(detail::large_array_storage(root.ref()), initial_storage);
+        EXPECT_EQ(root.ref().via.large_array.metadata.size, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_array.metadata.capacity, initial_capacity);
         EXPECT_EQ(root.size(), initial_capacity);
         EXPECT_EQ(root.at(0).as<std::uint64_t>(), 1);
         EXPECT_EQ(root.at(1).as<std::uint64_t>(), 2);
@@ -405,19 +407,18 @@ TEST(TestObject, LargeArrayAllocationGrowthAndFailure)
         alloc.fail_allocations(false);
         root.emplace_back(3U);
         EXPECT_NE(root.ref().via.large_array.ptr, initial_data);
-        EXPECT_NE(detail::large_array_storage(root.ref()), initial_storage);
         EXPECT_EQ(root.size(), 3);
-        EXPECT_EQ(alloc.last_allocation_bytes(),
-            sizeof(detail::object_large_array_storage) + grown_capacity * sizeof(detail::object));
-        EXPECT_EQ(alloc.last_deallocation_bytes(),
-            sizeof(detail::object_large_array_storage) + initial_capacity * sizeof(detail::object));
-        EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_large_array_storage));
+        EXPECT_EQ(root.ref().via.large_array.metadata.size, 3);
+        EXPECT_EQ(root.ref().via.large_array.metadata.capacity, grown_capacity);
+        EXPECT_EQ(alloc.last_allocation_bytes(), grown_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_deallocation_bytes(), initial_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object));
     }
 
     EXPECT_EQ(alloc.allocations(), 2);
     EXPECT_EQ(alloc.deallocations(), 2);
-    EXPECT_EQ(alloc.last_deallocation_bytes(),
-        sizeof(detail::object_large_array_storage) + grown_capacity * sizeof(detail::object));
+    EXPECT_EQ(alloc.last_deallocation_bytes(), grown_capacity * sizeof(detail::object));
+    EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object));
 }
 
 TEST(TestObject, LargeMapAllocationGrowthAndFailure)
@@ -430,51 +431,67 @@ TEST(TestObject, LargeMapAllocationGrowthAndFailure)
         auto root = owned_object::make_large_map(initial_capacity, &alloc);
         EXPECT_EQ(root.type(), object_type::large_map);
         EXPECT_TRUE(root.is_map());
-        EXPECT_EQ(alloc.last_allocation_bytes(), sizeof(detail::object_large_map_storage) +
-                                                     initial_capacity * sizeof(detail::object_kv));
-        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_large_map_storage));
+        EXPECT_EQ(
+            root.ref().via.large_map.metadata._type, static_cast<uint8_t>(object_type::large_map));
+        EXPECT_EQ(root.ref().via.large_map.metadata.size, 0);
+        EXPECT_EQ(root.ref().via.large_map.metadata.capacity, initial_capacity);
+        EXPECT_EQ(alloc.last_allocation_bytes(), initial_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_kv));
 
         root.emplace("one", 1U);
         const auto *initial_data = root.ref().via.large_map.ptr;
-        const auto *initial_storage = detail::large_map_storage(root.ref());
-        ASSERT_NE(initial_storage, nullptr);
-        EXPECT_EQ(initial_storage->ptr, initial_data);
+        EXPECT_EQ(root.ref().via.large_map.metadata.size, initial_capacity);
 
         alloc.fail_allocations(true);
         EXPECT_THROW(root.emplace("two", 2U), std::bad_alloc);
         EXPECT_EQ(alloc.failed_allocations(), 1);
         EXPECT_EQ(root.ref().via.large_map.ptr, initial_data);
-        EXPECT_EQ(detail::large_map_storage(root.ref()), initial_storage);
+        EXPECT_EQ(root.ref().via.large_map.metadata.size, initial_capacity);
+        EXPECT_EQ(root.ref().via.large_map.metadata.capacity, initial_capacity);
         EXPECT_EQ(root.size(), initial_capacity);
         EXPECT_EQ(root.at(0).as<std::uint64_t>(), 1);
 
         alloc.fail_allocations(false);
         root.emplace("two", 2U);
         EXPECT_NE(root.ref().via.large_map.ptr, initial_data);
-        EXPECT_NE(detail::large_map_storage(root.ref()), initial_storage);
         EXPECT_EQ(root.size(), 2);
-        EXPECT_EQ(alloc.last_allocation_bytes(),
-            sizeof(detail::object_large_map_storage) + grown_capacity * sizeof(detail::object_kv));
-        EXPECT_EQ(
-            alloc.last_deallocation_bytes(), sizeof(detail::object_large_map_storage) +
-                                                 initial_capacity * sizeof(detail::object_kv));
-        EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_large_map_storage));
+        EXPECT_EQ(root.ref().via.large_map.metadata.size, 2);
+        EXPECT_EQ(root.ref().via.large_map.metadata.capacity, grown_capacity);
+        EXPECT_EQ(alloc.last_allocation_bytes(), grown_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(alloc.last_deallocation_bytes(), initial_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_kv));
     }
 
     EXPECT_EQ(alloc.allocations(), 2);
     EXPECT_EQ(alloc.deallocations(), 2);
-    EXPECT_EQ(alloc.last_deallocation_bytes(),
-        sizeof(detail::object_large_map_storage) + grown_capacity * sizeof(detail::object_kv));
+    EXPECT_EQ(alloc.last_deallocation_bytes(), grown_capacity * sizeof(detail::object_kv));
+    EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_kv));
 }
 
 TEST(TestObject, LargeContainerOverflowAndExhaustedCapacity)
 {
     tracking_resource alloc;
-    const auto maximum = std::numeric_limits<std::size_t>::max();
+    constexpr auto array_maximum = detail::max_large_array_capacity;
+    constexpr auto map_maximum = detail::max_large_map_capacity;
 
-    EXPECT_THROW(owned_object::make_large_array(maximum, &alloc), std::length_error);
-    EXPECT_THROW(owned_object::make_large_map(maximum, &alloc), std::length_error);
-    EXPECT_THROW(detail::next_large_capacity(maximum, maximum), std::length_error);
+    static_assert(array_maximum <= detail::large_container_metadata_capacity_limit);
+    static_assert(map_maximum <= detail::large_container_metadata_capacity_limit);
+    EXPECT_THROW(owned_object::make_large_array(array_maximum + 1, &alloc), std::length_error);
+    EXPECT_THROW(owned_object::make_large_map(map_maximum + 1, &alloc), std::length_error);
+    EXPECT_THROW(detail::next_large_capacity(array_maximum, array_maximum), std::length_error);
+    EXPECT_THROW(detail::next_large_capacity(map_maximum, map_maximum), std::length_error);
+
+    auto exhausted_array = detail::make_large_array_object(nullptr, array_maximum, array_maximum);
+    EXPECT_THROW(detail::grow_large_array(exhausted_array, alloc), std::length_error);
+    EXPECT_EQ(exhausted_array.via.large_array.ptr, nullptr);
+    EXPECT_EQ(detail::large_container_size(exhausted_array), array_maximum);
+    EXPECT_EQ(detail::large_container_capacity(exhausted_array), array_maximum);
+
+    auto exhausted_map = detail::make_large_map_object(nullptr, map_maximum, map_maximum);
+    EXPECT_THROW(detail::grow_large_map(exhausted_map, alloc), std::length_error);
+    EXPECT_EQ(exhausted_map.via.large_map.ptr, nullptr);
+    EXPECT_EQ(detail::large_container_size(exhausted_map), map_maximum);
+    EXPECT_EQ(detail::large_container_capacity(exhausted_map), map_maximum);
     EXPECT_EQ(alloc.allocations(), 0);
 }
 
@@ -513,11 +530,13 @@ TEST(TestObject, CompactContainerPromotionAllocation)
         root.emplace_back(42U);
         EXPECT_EQ(root.type(), object_type::large_array);
         EXPECT_EQ(root.size(), compact_capacity + std::size_t{1});
-        EXPECT_EQ(detail::large_array_storage(root.ref())->capacity, promoted_capacity);
+        EXPECT_EQ(root.ref().via.large_array.metadata._type,
+            static_cast<uint8_t>(object_type::large_array));
+        EXPECT_EQ(root.ref().via.large_array.metadata.size, compact_capacity + std::size_t{1});
+        EXPECT_EQ(root.ref().via.large_array.metadata.capacity, promoted_capacity);
         EXPECT_EQ(root.at(compact_capacity).as<std::uint64_t>(), 42);
-        EXPECT_EQ(alloc.last_allocation_bytes(), sizeof(detail::object_large_array_storage) +
-                                                     promoted_capacity * sizeof(detail::object));
-        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_large_array_storage));
+        EXPECT_EQ(alloc.last_allocation_bytes(), promoted_capacity * sizeof(detail::object));
+        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object));
         EXPECT_EQ(alloc.last_deallocation_bytes(), compact_capacity * sizeof(detail::object));
         EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object));
     }
@@ -531,11 +550,13 @@ TEST(TestObject, CompactContainerPromotionAllocation)
         root.emplace("last", 42U);
         EXPECT_EQ(root.type(), object_type::large_map);
         EXPECT_EQ(root.size(), compact_capacity + std::size_t{1});
-        EXPECT_EQ(detail::large_map_storage(root.ref())->capacity, promoted_capacity);
+        EXPECT_EQ(
+            root.ref().via.large_map.metadata._type, static_cast<uint8_t>(object_type::large_map));
+        EXPECT_EQ(root.ref().via.large_map.metadata.size, compact_capacity + std::size_t{1});
+        EXPECT_EQ(root.ref().via.large_map.metadata.capacity, promoted_capacity);
         EXPECT_EQ(root.at(compact_capacity).as<std::uint64_t>(), 42);
-        EXPECT_EQ(alloc.last_allocation_bytes(), sizeof(detail::object_large_map_storage) +
-                                                     promoted_capacity * sizeof(detail::object_kv));
-        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_large_map_storage));
+        EXPECT_EQ(alloc.last_allocation_bytes(), promoted_capacity * sizeof(detail::object_kv));
+        EXPECT_EQ(alloc.last_allocation_alignment(), alignof(detail::object_kv));
         EXPECT_EQ(alloc.last_deallocation_bytes(), compact_capacity * sizeof(detail::object_kv));
         EXPECT_EQ(alloc.last_deallocation_alignment(), alignof(detail::object_kv));
     }

--- a/tests/unit/object_test.cpp
+++ b/tests/unit/object_test.cpp
@@ -472,21 +472,21 @@ TEST(TestObject, LargeContainerOverflowAndExhaustedCapacity)
     constexpr auto array_maximum = detail::max_large_array_capacity;
     constexpr auto map_maximum = detail::max_large_map_capacity;
 
-    static_assert(array_maximum <= detail::large_container_metadata_capacity_limit);
-    static_assert(map_maximum <= detail::large_container_metadata_capacity_limit);
-    EXPECT_THROW(owned_object::make_large_array(array_maximum + 1, &alloc), std::length_error);
-    EXPECT_THROW(owned_object::make_large_map(map_maximum + 1, &alloc), std::length_error);
-    EXPECT_THROW(detail::next_large_capacity(array_maximum, array_maximum), std::length_error);
-    EXPECT_THROW(detail::next_large_capacity(map_maximum, map_maximum), std::length_error);
+    static_assert(array_maximum <= detail::large_container_capacity_limit);
+    static_assert(map_maximum <= detail::large_container_capacity_limit);
+    EXPECT_THROW(owned_object::make_large_array(array_maximum + 1, &alloc), std::bad_alloc);
+    EXPECT_THROW(owned_object::make_large_map(map_maximum + 1, &alloc), std::bad_alloc);
+    EXPECT_THROW(detail::next_large_capacity(array_maximum, array_maximum), std::bad_alloc);
+    EXPECT_THROW(detail::next_large_capacity(map_maximum, map_maximum), std::bad_alloc);
 
     auto exhausted_array = detail::make_large_array_object(nullptr, array_maximum, array_maximum);
-    EXPECT_THROW(detail::grow_large_array(exhausted_array, alloc), std::length_error);
+    EXPECT_THROW(detail::grow_large_array(exhausted_array, alloc), std::bad_alloc);
     EXPECT_EQ(exhausted_array.via.large_array.ptr, nullptr);
     EXPECT_EQ(detail::large_container_size(exhausted_array), array_maximum);
     EXPECT_EQ(detail::large_container_capacity(exhausted_array), array_maximum);
 
     auto exhausted_map = detail::make_large_map_object(nullptr, map_maximum, map_maximum);
-    EXPECT_THROW(detail::grow_large_map(exhausted_map, alloc), std::length_error);
+    EXPECT_THROW(detail::grow_large_map(exhausted_map, alloc), std::bad_alloc);
     EXPECT_EQ(exhausted_map.via.large_map.ptr, nullptr);
     EXPECT_EQ(detail::large_container_size(exhausted_map), map_maximum);
     EXPECT_EQ(detail::large_container_capacity(exhausted_map), map_maximum);

--- a/tests/unit/object_view_test.cpp
+++ b/tests/unit/object_view_test.cpp
@@ -1019,6 +1019,21 @@ TEST(TestArrayView, Default)
     for (auto value : view) { EXPECT_FALSE(value.has_value()); }
 }
 
+TEST(TestArrayView, LargeArray)
+{
+    auto root = owned_object::make_large_array(2, memory::get_default_resource());
+    root.emplace_back(1U);
+    root.emplace_back(2U);
+    root.emplace_back(3U);
+
+    array_view view(root);
+    EXPECT_EQ(view.size(), 3);
+    EXPECT_EQ(view.at(0).as<std::uint64_t>(), 1);
+
+    std::uint64_t expected = 1;
+    for (const auto value : view) { EXPECT_EQ(value.as<std::uint64_t>(), expected++); }
+}
+
 TEST(TestArrayView, AtAccess)
 {
     auto root = test::ddwaf_object_da::make_array();
@@ -1068,6 +1083,25 @@ TEST(TestMapView, Default)
         EXPECT_FALSE(key.has_value());
         EXPECT_FALSE(value.has_value());
     }
+}
+
+TEST(TestMapView, LargeMap)
+{
+    auto root = owned_object::make_large_map(1, memory::get_default_resource());
+    root.emplace("one", 1U);
+    root.emplace("two", 2U);
+
+    map_view view(root);
+    EXPECT_EQ(view.size(), 2);
+    EXPECT_EQ(view.find("one").as<std::uint64_t>(), 1);
+    EXPECT_EQ(view.at_value(1).as<std::uint64_t>(), 2);
+
+    std::size_t entries = 0;
+    for (const auto &[key, value] : view) {
+        EXPECT_TRUE(key.is_string());
+        EXPECT_EQ(value.as<std::uint64_t>(), ++entries);
+    }
+    EXPECT_EQ(entries, 2);
 }
 
 TEST(TestMapView, AtAccess)

--- a/tools/common/utils.cpp
+++ b/tools/common/utils.cpp
@@ -124,8 +124,9 @@ void object_to_yaml_helper(const ddwaf_object &obj, YAML::Node &output)
         output = std::string{ddwaf_object_get_string(&obj, nullptr), ddwaf_object_get_length(&obj)};
         break;
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         output = YAML::Load("{}");
-        for (unsigned i = 0; i < obj.via.map.size; i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             const auto *child = ddwaf_object_at_key(&obj, i);
             std::string key{ddwaf_object_get_string(child, nullptr), ddwaf_object_get_length(child)};
 
@@ -135,12 +136,13 @@ void object_to_yaml_helper(const ddwaf_object &obj, YAML::Node &output)
         }
         break;
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         output = YAML::Load("[]");
-        for (unsigned i = 0; i < obj.via.array.size; i++) {
-            auto child = obj.via.array.ptr[i];
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
+            const auto *child = ddwaf_object_at_value(&obj, i);
 
             YAML::Node value;
-            object_to_yaml_helper(child, value);
+            object_to_yaml_helper(*child, value);
             output.push_back(value);
         }
         break;
@@ -282,13 +284,13 @@ void object_to_json_helper(
             ddwaf_object_get_string(&obj, nullptr), ddwaf_object_get_length(&obj), alloc);
     } break;
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         output.SetObject();
-        for (unsigned i = 0; i < obj.via.map.size; i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             rapidjson::Value key;
             rapidjson::Value value;
 
-            auto child = obj.via.map.ptr[i];
-            object_to_json_helper(child.val, value, alloc);
+            object_to_json_helper(*ddwaf_object_at_value(&obj, i), value, alloc);
             const auto *child_key = ddwaf_object_at_key(&obj, i);
             key.SetString(ddwaf_object_get_string(child_key, nullptr),
                 ddwaf_object_get_length(child_key), alloc);
@@ -297,11 +299,11 @@ void object_to_json_helper(
         }
         break;
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         output.SetArray();
-        for (unsigned i = 0; i < obj.via.array.size; i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             rapidjson::Value value;
-            auto child = obj.via.array.ptr[i];
-            object_to_json_helper(child, value, alloc);
+            object_to_json_helper(*ddwaf_object_at_value(&obj, i), value, alloc);
             output.PushBack(value, alloc);
         }
         break;

--- a/validator/utils.cpp
+++ b/validator/utils.cpp
@@ -169,8 +169,9 @@ void object_to_yaml_helper(const ddwaf_object &obj, YAML::Node &output)
         output = std::string{ddwaf_object_get_string(&obj, nullptr), ddwaf_object_get_length(&obj)};
         break;
     case DDWAF_OBJ_MAP:
+    case DDWAF_OBJ_LARGE_MAP:
         output = YAML::Load("{}");
-        for (unsigned i = 0; i < obj.via.map.size; i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             const auto *child_key = ddwaf_object_at_key(&obj, i);
             std::string key{
                 ddwaf_object_get_string(child_key, nullptr), ddwaf_object_get_length(child_key)};
@@ -181,8 +182,9 @@ void object_to_yaml_helper(const ddwaf_object &obj, YAML::Node &output)
         }
         break;
     case DDWAF_OBJ_ARRAY:
+    case DDWAF_OBJ_LARGE_ARRAY:
         output = YAML::Load("[]");
-        for (unsigned i = 0; i < obj.via.array.size; i++) {
+        for (std::size_t i = 0; i < ddwaf_object_get_size(&obj); i++) {
             const auto *child = ddwaf_object_at_value(&obj, i);
 
             YAML::Node value;


### PR DESCRIPTION
Store large-array and large-map metadata in the object itself while preserving
the 16-byte layout and the element-pointer offset shared with compact
containers.

## Representation

Large containers use the first 64 bits of the object for:

- an 8-bit type
- a 28-bit size
- a 28-bit capacity

The second 64 bits holds the direct element pointer. This removes the private
allocation headers and their flexible arrays; large-container allocations now
contain only elements and use the element type's alignment.

## Capacity limits

The maximum capacities are compile-time constants and are validated before
allocation:

- arrays: `min(268,435,455, SIZE_MAX / sizeof(ddwaf_object))`
- maps: `min(268,435,455, SIZE_MAX / sizeof(ddwaf_object_kv))`

On 32-bit platforms this allows 268,435,455 array elements and 134,217,727 map
entries. On wider platforms both limits are 268,435,455. Oversized creation and
exhausted growth fail without modifying the existing object.
